### PR TITLE
AX: area elements with no title attribute are totally inaccessible to VoiceOver

### DIFF
--- a/LayoutTests/accessibility/area-element-bounding-box-expected.txt
+++ b/LayoutTests/accessibility/area-element-bounding-box-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we compute a non-zero size for area elements.
+
+PASS: link.width > 100 === true
+PASS: link.height > 50 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/area-element-bounding-box.html
+++ b/LayoutTests/accessibility/area-element-bounding-box.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<map name="imagemap1">
+    <area id="link" shape="rect" coords="10,10,133,72" href="http://www.apple.com"/>
+</map>
+<img src="resources/cake.png" border="0" align="left" usemap="#imagemap1" vspace="1">
+
+<script>
+var output = "This test ensures we compute a non-zero size for area elements.\n\n";
+
+if (window.accessibilityController) {
+    var link = accessibilityController.accessibleElementById("link");
+    // The actual width and height don't really matter, so long as they're within some reasonable range.
+    output += expect("link.width > 100", "true");
+    output += expect("link.height > 50", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2313,6 +2313,7 @@ fast/dom/linkify-phone-numbers.html [ Pass ]
 
 accessibility/table-exposure-updates-dynamically.html [ Pass ]
 accessibility/accessibility-node-reparent.html [ Pass ]
+accessibility/area-element-bounding-box.html [ Pass ]
 accessibility/aria-braillelabel.html [ Pass ]
 accessibility/aria-brailleroledescription.html [ Pass ]
 accessibility/aria-checked-mixed-value.html [ Pass ]

--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -66,7 +66,7 @@ std::optional<IntRect> AXGeometryManager::cachedRectForID(AXID axID)
     return std::nullopt;
 }
 
-void AXGeometryManager::cacheRect(AXID axID, IntRect&& rect)
+bool AXGeometryManager::cacheRectIfNeeded(AXID axID, IntRect&& rect)
 {
     // We shouldn't call this method on a geometry manager that has no page ID.
     AX_DEBUG_ASSERT(m_cache->pageID());
@@ -85,12 +85,13 @@ void AXGeometryManager::cacheRect(AXID axID, IntRect&& rect)
     }
 
     if (!rectChanged)
-        return;
+        return false;
 
     RefPtr tree = AXIsolatedTree::treeForPageID(*m_cache->pageID());
     if (!tree)
-        return;
+        return false;
     tree->updateFrame(axID, WTFMove(rect));
+    return true;
 }
 
 void AXGeometryManager::scheduleObjectRegionsUpdate(bool scheduleImmediately)

--- a/Source/WebCore/accessibility/AXGeometryManager.h
+++ b/Source/WebCore/accessibility/AXGeometryManager.h
@@ -52,7 +52,8 @@ public:
     void willUpdateObjectRegions();
     void scheduleObjectRegionsUpdate(bool /* scheduleImmediately */);
 
-    void cacheRect(AXID, IntRect&&);
+    // Returns true if the given rect was cached.
+    bool cacheRectIfNeeded(AXID, IntRect&&);
     // std::nullopt if there is no cached rect for the given ID (i.e. because it hasn't been cached yet via paint or otherwise, or cannot be painted / cached at all).
     std::optional<IntRect> cachedRectForID(AXID);
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -36,6 +36,7 @@
 #include "AXTreeStore.h"
 #include "AXTreeStoreInlines.h"
 #include "AXUtilities.h"
+#include "AccessibilityImageMapLink.h"
 #include "AccessibilityTableCell.h"
 #include "AccessibilityTableRow.h"
 #include "DocumentInlines.h"
@@ -1929,8 +1930,9 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             // The GeometryManager does not have a relative frame for ScrollViews, WebAreas, or scrollbars yet. We need to get it from the
             // live object so that we don't need to hit the main thread in the case a request comes in while the whole isolated tree is being built.
             setProperty(AXProperty::RelativeFrame, enclosingIntRect(object.relativeFrame()));
-        } else if (!object.renderer() && object.node() && is<AccessibilityNodeObject>(object)) {
+        } else if (!object.renderer() && object.node() && is<AccessibilityNodeObject>(object) && !is<AccessibilityImageMapLink>(object)) {
             // The frame of node-only AX objects is made up of their children.
+            // This excludes image-map links (a.k.a. <area> elements), which will never have rendered children.
             getsGeometryFromChildren = true;
         } else if (object.isMenuListPopup()) {
             // AccessibilityMenuListPopup's elementRect is hardcoded to return an empty rect, so preserve that behavior.


### PR DESCRIPTION
#### 934f88404e9fa471e2254c6ddaef34af3fafe7a4
<pre>
AX: area elements with no title attribute are totally inaccessible to VoiceOver
<a href="https://bugs.webkit.org/show_bug.cgi?id=297287">https://bugs.webkit.org/show_bug.cgi?id=297287</a>
<a href="https://rdar.apple.com/158159505">rdar://158159505</a>

Reviewed by Joshua Hoffman.

This happened because we computed a zero-width, zero-height rect for area elements. This in turn happened because these
elements have no renderers, and thus are never painted.

Fix this by detecting the presence of associated area elements when painting a RenderImage, and updating their rect at
the same time.

* LayoutTests/accessibility/area-element-bounding-box-expected.txt: Added.
* LayoutTests/accessibility/area-element-bounding-box.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::cacheRectIfNeeded):
(WebCore::AXGeometryManager::cacheRect): Deleted.
* Source/WebCore/accessibility/AXGeometryManager.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onScrollbarFrameRectChange):
(WebCore::AXObjectCache::onPaint const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):

Canonical link: <a href="https://commits.webkit.org/299019@main">https://commits.webkit.org/299019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34223f5da638751236fcf83d2a6d55943304db44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69365 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93d46769-d33e-411a-b2c3-3cc1eb146da6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89069 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43736 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/562648a6-800a-4b71-884d-00d7023b7b5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30033 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69576 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3299850e-f4a8-46a9-a766-5081ac32e690) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67150 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126598 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44275 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33267 "Found 1 new test failure: ipc/send-gradient.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97737 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97531 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24854 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42891 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20826 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40625 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49807 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45300 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->