### PR TITLE
Bring up post-commit Sonoma Intel JSC test queue

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -16,6 +16,8 @@
 
                   { "name": "bot105", "platform": "mac-sonoma" },
                   { "name": "bot111", "platform": "mac-sonoma" },
+                  { "name": "bot113", "platform": "mac-sonoma" },
+                  { "name": "bot114", "platform": "mac-sonoma" },
                   { "name": "bot603", "platform": "mac-sonoma" },
                   { "name": "bot632", "platform": "mac-sonoma" },
 
@@ -260,7 +262,7 @@
                   "triggers": [
                       "sonoma-release-tests-test262", "sonoma-release-tests-wk1", "sonoma-release-tests-wk2",
                       "sonoma-release-applesilicon-tests-wk1", "sonoma-release-applesilicon-tests-wk2",
-                      "sonoma-applesilicon-release-tests-jsc"
+                      "sonoma-applesilicon-release-tests-jsc", "sonoma-intel-release-tests-jsc"
                   ],
                   "workernames": ["bot243", "bot244"]
                   },
@@ -291,6 +293,10 @@
                   { "name": "Apple-Sonoma-AppleSilicon-Release-JSC-Tests", "factory": "TestJSCFactory",
                     "platform": "mac-sonoma", "configuration": "release", "architectures": ["x86_64", "arm64"],
                     "workernames": ["bot111"]
+                  },
+                  { "name": "Apple-Sonoma-Intel-Release-JSC-Tests", "factory": "TestJSCFactory",
+                    "platform": "mac-sonoma", "configuration": "release", "architectures": ["x86_64", "arm64"],
+                    "workernames": ["bot113", "bot114"]
                   },
                   {
                     "name": "Apple-Sequoia-Safer-CPP-Checks", "factory": "SaferCPPStaticAnalyzerFactory",
@@ -815,6 +821,9 @@
                   },
                   { "type": "Triggerable", "name": "sonoma-applesilicon-release-tests-jsc",
                     "builderNames": ["Apple-Sonoma-AppleSilicon-Release-JSC-Tests"]
+                  },
+                  { "type": "Triggerable", "name": "sonoma-intel-release-tests-jsc",
+                    "builderNames": ["Apple-Sonoma-Intel-Release-JSC-Tests"]
                   },
                   { "type": "PlatformSpecificScheduler", "platform": "ios-18", "branch": "main", "treeStableTimer": 45.0,
                     "builderNames": ["Apple-iOS-18-Release-Build"]

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -690,6 +690,20 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'jscore-test'
         ],
+        'Apple-Sonoma-Intel-Release-JSC-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'prune-coresymbolicationd-cache-if-too-large',
+            'download-built-product',
+            'extract-built-product',
+            'jscore-test'
+        ],
         'Apple-iOS-18-Release-Build': [
             'configure-build',
             'configuration',

--- a/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
+++ b/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
@@ -59,6 +59,7 @@ WebKitBuildbot = function()
             "Apple-Sonoma-Release-Test262-Tests": {heading: "Release Test262 (Tests)"},
             "Apple-Sonoma-AppleSilicon-Debug-JSC-Tests": {heading: "Debug arm64 JSC (Tests)"},
             "Apple-Sonoma-AppleSilicon-Release-JSC-Tests": {heading: "Release arm64 JSC (Tests)"},
+            "Apple-Sonoma-Intel-Release-JSC-Tests": {heading: "Release x86_64 JSC (Tests)"},
         }},
         "Apple-iOS-18-Release-Build": {platform: Dashboard.Platform.iOS18Device, debug: false, builder: true, architecture: Buildbot.BuildArchitecture.SixtyFourBit},
         "Apple-iOS-18-Simulator-Release-Build": {platform: Dashboard.Platform.iOS18Simulator, debug: false, builder: true, architecture: Buildbot.BuildArchitecture.SixtyFourBit},


### PR DESCRIPTION
#### d6cf5dc7bc8924cc421bca6ad01a5aa2ad3387e3
<pre>
Bring up post-commit Sonoma Intel JSC test queue
<a href="https://rdar.apple.com/158799267">rdar://158799267</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297686">https://bugs.webkit.org/show_bug.cgi?id=297686</a>

Reviewed by Ryan Haddad.

This change is adding a new post-commit Intel JSC test queue in Opensource.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js:
(WebKitBuildbot):

Canonical link: <a href="https://commits.webkit.org/298984@main">https://commits.webkit.org/298984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee9c063ea4e54be1875317728357977c51b6ce23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123500 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/69389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60fc2e1b-236c-4b79-87f5-c840d71f966c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45658 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/69389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dec096e0-226d-41ab-860d-87d177843524) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120353 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/30061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e9afe21-1ca4-49d8-a56a-11d18702bfeb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/67173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126621 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44298 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/116821 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44656 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/101498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42911 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18736 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44171 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/43628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->