### PR TITLE
Remove extra mapping step between LengthPercentageUnit and SVGLengthType

### DIFF
--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -50,75 +50,41 @@ static float adjustValueForPercentageStorage(float value, SVGLengthType type)
     return value;
 }
 
-static inline SVGLengthType primitiveTypeToLengthType(CSSUnitType primitiveType)
+static inline SVGLengthType cssLengthUnitToSVGLengthType(CSS::LengthPercentageUnit unit)
 {
-    switch (primitiveType) {
-    case CSSUnitType::CSS_UNKNOWN:
-        return SVGLengthType::Unknown;
-    case CSSUnitType::CSS_NUMBER:
-        return SVGLengthType::Number;
-    case CSSUnitType::CSS_PERCENTAGE:
-        return SVGLengthType::Percentage;
-    case CSSUnitType::CSS_EM:
-        return SVGLengthType::Ems;
-    case CSSUnitType::CSS_EX:
-        return SVGLengthType::Exs;
-    case CSSUnitType::CSS_PX:
-        return SVGLengthType::Pixels;
-    case CSSUnitType::CSS_CM:
-        return SVGLengthType::Centimeters;
-    case CSSUnitType::CSS_MM:
-        return SVGLengthType::Millimeters;
-    case CSSUnitType::CSS_IN:
-        return SVGLengthType::Inches;
-    case CSSUnitType::CSS_PT:
-        return SVGLengthType::Points;
-    case CSSUnitType::CSS_PC:
-        return SVGLengthType::Picas;
-    case CSSUnitType::CSS_LH:
-        return SVGLengthType::Lh;
-    case CSSUnitType::CSS_CH:
-        return SVGLengthType::Ch;
-    default:
-        return SVGLengthType::Unknown;
+    switch (unit) {
+    case CSS::LengthPercentageUnit::Px:                 return SVGLengthType::Pixels;
+    case CSS::LengthPercentageUnit::Percentage:         return SVGLengthType::Percentage;
+    case CSS::LengthPercentageUnit::Em:                 return SVGLengthType::Ems;
+    case CSS::LengthPercentageUnit::Ex:                 return SVGLengthType::Exs;
+    case CSS::LengthPercentageUnit::Cm:                 return SVGLengthType::Centimeters;
+    case CSS::LengthPercentageUnit::Mm:                 return SVGLengthType::Millimeters;
+    case CSS::LengthPercentageUnit::In:                 return SVGLengthType::Inches;
+    case CSS::LengthPercentageUnit::Pt:                 return SVGLengthType::Points;
+    case CSS::LengthPercentageUnit::Pc:                 return SVGLengthType::Picas;
+    case CSS::LengthPercentageUnit::Lh:                 return SVGLengthType::Lh;
+    case CSS::LengthPercentageUnit::Ch:                 return SVGLengthType::Ch;
+    default:                                            return SVGLengthType::Unknown;
     }
-
-    return SVGLengthType::Unknown;
 }
 
-static inline CSSUnitType lengthTypeToPrimitiveType(SVGLengthType lengthType)
+static inline CSS::LengthPercentageUnit svgLengthTypeToCSSLengthUnit(SVGLengthType type)
 {
-    switch (lengthType) {
-    case SVGLengthType::Unknown:
-        return CSSUnitType::CSS_UNKNOWN;
-    case SVGLengthType::Number:
-        return CSSUnitType::CSS_NUMBER;
-    case SVGLengthType::Percentage:
-        return CSSUnitType::CSS_PERCENTAGE;
-    case SVGLengthType::Ems:
-        return CSSUnitType::CSS_EM;
-    case SVGLengthType::Exs:
-        return CSSUnitType::CSS_EX;
-    case SVGLengthType::Pixels:
-        return CSSUnitType::CSS_PX;
-    case SVGLengthType::Centimeters:
-        return CSSUnitType::CSS_CM;
-    case SVGLengthType::Millimeters:
-        return CSSUnitType::CSS_MM;
-    case SVGLengthType::Inches:
-        return CSSUnitType::CSS_IN;
-    case SVGLengthType::Points:
-        return CSSUnitType::CSS_PT;
-    case SVGLengthType::Picas:
-        return CSSUnitType::CSS_PC;
-    case SVGLengthType::Lh:
-        return CSSUnitType::CSS_LH;
-    case SVGLengthType::Ch:
-        return CSSUnitType::CSS_CH;
+    switch (type) {
+    case SVGLengthType::Number:       return CSS::LengthPercentageUnit::Px;
+    case SVGLengthType::Pixels:       return CSS::LengthPercentageUnit::Px;
+    case SVGLengthType::Percentage:   return CSS::LengthPercentageUnit::Percentage;
+    case SVGLengthType::Ems:          return CSS::LengthPercentageUnit::Em;
+    case SVGLengthType::Exs:          return CSS::LengthPercentageUnit::Ex;
+    case SVGLengthType::Centimeters:  return CSS::LengthPercentageUnit::Cm;
+    case SVGLengthType::Millimeters:  return CSS::LengthPercentageUnit::Mm;
+    case SVGLengthType::Inches:       return CSS::LengthPercentageUnit::In;
+    case SVGLengthType::Points:       return CSS::LengthPercentageUnit::Pt;
+    case SVGLengthType::Picas:        return CSS::LengthPercentageUnit::Pc;
+    case SVGLengthType::Lh:           return CSS::LengthPercentageUnit::Lh;
+    case SVGLengthType::Ch:           return CSS::LengthPercentageUnit::Ch;
+    default:                          return CSS::LengthPercentageUnit::Px;
     }
-
-    ASSERT_NOT_REACHED();
-    return CSSUnitType::CSS_UNKNOWN;
 }
 
 static Variant<CSS::Number<>, CSS::LengthPercentage<>> createVariantForLengthType(float value, SVGLengthType lengthType)
@@ -132,15 +98,7 @@ static Variant<CSS::Number<>, CSS::LengthPercentage<>> createVariantForLengthTyp
         return CSS::Number<>(value);
     }
 
-    auto unitType = lengthTypeToPrimitiveType(lengthType);
-    auto unit = CSS::toLengthPercentageUnit(unitType);
-
-    if (!unit) {
-        ASSERT_NOT_REACHED();
-        return CSS::Number<>(value);
-    }
-
-    return CSS::LengthPercentage<>(*unit, value);
+    return CSS::LengthPercentage<>(svgLengthTypeToCSSLengthUnit(lengthType), value);
 }
 
 
@@ -198,7 +156,7 @@ SVGLengthType SVGLengthValue::lengthType() const
         },
         [](const CSS::LengthPercentage<>& length) -> SVGLengthType {
             if (auto raw = length.raw())
-                return primitiveTypeToLengthType(toCSSUnitType(raw->unit));
+                return cssLengthUnitToSVGLengthType(raw->unit);
 
             return SVGLengthType::Unknown;
         }
@@ -323,7 +281,7 @@ ExceptionOr<float> SVGLengthValue::valueForBindings(const SVGLengthContext& cont
                 return Exception { ExceptionCode::NotSupportedError };
 
             if (auto raw = length.raw()) {
-                auto lengthType = primitiveTypeToLengthType(toCSSUnitType(raw->unit));
+                auto lengthType = cssLengthUnitToSVGLengthType(raw->unit);
                 return context.convertValueToUserUnits(raw->value, lengthType, m_lengthMode);
             }
 


### PR DESCRIPTION
#### 5701312dba4c15a1c46bf57662d1638eda398100
<pre>
Remove extra mapping step between LengthPercentageUnit and SVGLengthType
<a href="https://bugs.webkit.org/show_bug.cgi?id=297689">https://bugs.webkit.org/show_bug.cgi?id=297689</a>
<a href="https://rdar.apple.com/158802251">rdar://158802251</a>

Reviewed by Tim Nguyen.

Previously, conversions required an intermediate step through,
adding unnecessary overhead.

Before:
CSS::LengthPercentageUnit &gt; CSSUnitType &gt; SVGLengthType
SVGLengthType &lt; CSSUnitType &lt; CSS::LengthPercentageUnit

After:
CSS::LengthPercentageUnit &gt; SVGLengthType
SVGLengthType &lt; CSS::LengthPercentageUnit

* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::cssLengthUnitToSVGLengthType):
(WebCore::svgLengthTypeToCSSLengthUnit):
(WebCore::createVariantForLengthType):
(WebCore::SVGLengthValue::lengthType const):
(WebCore::SVGLengthValue::valueForBindings const):
(WebCore::primitiveTypeToLengthType): Deleted.
(WebCore::lengthTypeToPrimitiveType): Deleted.

Canonical link: <a href="https://commits.webkit.org/299005@main">https://commits.webkit.org/299005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f05a16e255c3ae8e3c1f692f7853822e89faa12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69377 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afc97a85-ab86-412b-b623-d00a4d01eaf3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89077 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43743 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78a41ec9-e6ea-45a8-9183-b684dc261712) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69587 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/667ec294-abf0-463f-9f5b-9463ea6c7281) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67161 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126609 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44286 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33278 "Found 1 new test failure: ipc/send-gradient.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97743 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97537 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40636 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18749 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49818 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46960 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->