### PR TITLE
Mac inline controls do not match AVKit controls spec

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4789,6 +4789,20 @@ MediaControlsContextMenusEnabled:
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
+MediaControlsMacInlineSizeSpecsEnabled:
+  type: bool
+  status: testable
+  category: media
+  humanReadableName: "Media Controls Rounded Corners"
+  humanReadableDescription: "Adopt new size specs for media controls"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 MediaControlsScaleWithPageZoom:
   type: bool
   status: embedder

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
@@ -36,6 +36,10 @@ class MacOSInlineMediaControls extends InlineMediaControls
 
         this.element.classList.add("mac");
 
+        if (this.MediaControlsMacInlineSizeSpecsEnabled) {
+            this.element.classList.add("MacInlineSizeSpecs");
+        }
+
         this.timeControl.scrubber.knobStyle = Slider.KnobStyle.Bar;
 
         this._backgroundClickDelegateNotifier = new BackgroundClickDelegateNotifier(this);

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -42,12 +42,19 @@
     --primary-glyph-color: rgba(255, 255, 255, 0.75);
     --secondary-glyph-color: rgba(255, 255, 255, 0.55);
     --scrubber-margin: 5px;
+    --inline-controls-border-radius: 23px;
 }
 
 :host(audio), :host(video.media-document.audio), * {
     --inline-controls-bar-height: 31px;
 }
 
+:host(audio) .media-controls.mac,
+:host(video.media-document.audio) .media-controls.mac,
+.media-controls.mac.MacInlineSizeSpecs,
+.media-controls.mac.MacInlineSizeSpecs * {
+    --inline-controls-bar-height: 46px;
+}
 /* We need to use relative positioning due to webkit.org/b/163603 */
 .media-controls-container {
     all: initial;
@@ -115,6 +122,17 @@
 
 .media-controls > .controls-bar {
     position: absolute;
+}
+
+.media-controls.mac.MacInlineSizeSpecs .controls-bar.bottom,
+.media-controls.mac.MacInlineSizeSpecs .controls-bar.top-left {
+    border-radius: var(--inline-controls-border-radius);
+}
+
+.media-controls.mac.MacInlineSizeSpecs .controls-bar.bottom .background-tint,
+.media-controls.mac.MacInlineSizeSpecs .controls-bar.top-left .background-tint {
+    border-radius: var(--inline-controls-border-radius);
+    overflow: hidden;
 }
 
 .media-controls.fade-in {


### PR DESCRIPTION
#### ffbf854d2a78225955bfd808856af910b24e1b40
<pre>
Mac inline controls do not match AVKit controls spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=297690">https://bugs.webkit.org/show_bug.cgi?id=297690</a>
<a href="https://rdar.apple.com/156730307">rdar://156730307</a>

Reviewed by Jer Noble.

Updated the heigths of the bottomControlBar and topLeftControlBar and applied rounded corners to
match those of AVKit.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js:
* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(*):
(:host(audio) .media-controls.mac,):
(.media-controls.mac.MacInlineSizeSpecs .controls-bar.bottom,):
(.media-controls.mac.MacInlineSizeSpecs .controls-bar.bottom .background-tint,):

Canonical link: <a href="https://commits.webkit.org/299027@main">https://commits.webkit.org/299027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f68d28bd8350a07098cd6680259a7a18fed069

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69374 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74a4f91d-f950-45c4-9a45-56db8f55a681) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89082 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43745 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9494f06e-c7a5-43a2-8eee-3877e02696d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69592 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d5fe013-a8a5-4131-9175-150fd56585a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23368 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67158 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109491 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126606 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115893 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97749 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97543 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24859 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42905 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20842 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40633 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49815 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144593 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43612 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37218 "Found 1 new JSC binary failure: testapi, Found 20041 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45308 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->