### PR TITLE
ASSERTION FAILED: threadLikeAssertion.isCurrent() in TestWebKitAPI.WebContentRestrictions.MultipleConfigurationFiles

### DIFF
--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -53,13 +53,16 @@ public:
     ContentFilterUnblockHandler unblockHandler() const override;
 #endif
     
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    void didReceiveAllowDecisionOnQueue(bool isAllowed, NSData *);
+#endif
+
 private:
     explicit ParentalControlsContentFilter(const PlatformContentFilter::FilterParameters&);
     bool enabled() const;
 
     void updateFilterState();
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    void didReceiveAllowDecisionOnQueue(bool isAllowed, NSData *);
     void updateFilterStateOnMain();
 #endif
 

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -36,6 +36,7 @@ class WorkQueue;
 namespace WebCore {
 
 struct ParentalControlsURLFilterParameters;
+class ParentalControlsContentFilter;
 
 class ParentalControlsURLFilter {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ParentalControlsURLFilter);
@@ -49,7 +50,7 @@ public:
 
     void resetIsEnabled();
     bool isEnabled() const;
-    void isURLAllowedWithQueue(const URL&, CompletionHandler<void(bool, NSData *)>&&, WTF::WorkQueue& completionHandlerQueue);
+    void isURLAllowed(const URL&, ParentalControlsContentFilter&);
     void allowURL(const URL&, CompletionHandler<void(bool)>&&);
 
 private:

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -29,6 +29,7 @@
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
 #import "Logging.h"
+#import "ParentalControlsContentFilter.h"
 #import "ParentalControlsURLFilterParameters.h"
 #import <wtf/CompletionHandler.h>
 #import <wtf/MainThread.h>
@@ -90,6 +91,12 @@ ParentalControlsURLFilter::ParentalControlsURLFilter() = default;
 
 #endif
 
+static WorkQueue& globalQueue()
+{
+    static MainThreadNeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("ParentalControlsContentFilter queue"_s);
+    return queue.get();
+}
+
 static void webContentFilterTypeDidChange(CFNotificationCenterRef, void*, CFStringRef, const void*, CFDictionaryRef)
 {
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
@@ -129,21 +136,23 @@ bool ParentalControlsURLFilter::isEnabled() const
     return *m_isEnabled;
 }
 
-void ParentalControlsURLFilter::isURLAllowedWithQueue(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler, WTF::WorkQueue& completionHandlerQueue)
+void ParentalControlsURLFilter::isURLAllowed(const URL& url, ParentalControlsContentFilter& filter)
 {
     ASSERT(isMainThread());
 
     RetainPtr wcrBrowserEngineClient = effectiveWCRBrowserEngineClient();
     if (!wcrBrowserEngineClient) {
-        completionHandlerQueue.dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(true, nullptr);
+        globalQueue().dispatch([weakFilter = ThreadSafeWeakPtr { filter }]() mutable {
+            if (RefPtr filter = weakFilter.get())
+                filter->didReceiveAllowDecisionOnQueue(true, nullptr);
         });
         return;
     }
 
-    [wcrBrowserEngineClient evaluateURL:url.createNSURL().get() withCompletion:makeBlockPtr([url = url.isolatedCopy(), completionHandler = WTFMove(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
-        completionHandler(!shouldBlock, replacementData);
-    }).get() onCompletionQueue:completionHandlerQueue.dispatchQueue()];
+    [wcrBrowserEngineClient evaluateURL:url.createNSURL().get() withCompletion:makeBlockPtr([weakFilter = ThreadSafeWeakPtr { filter }](BOOL shouldBlock, NSData *replacementData) mutable {
+        if (RefPtr filter = weakFilter.get())
+            filter->didReceiveAllowDecisionOnQueue(!shouldBlock, replacementData);
+    }).get() onCompletionQueue:globalQueue().dispatchQueue()];
 }
 
 void ParentalControlsURLFilter::allowURL(const URL& url, CompletionHandler<void(bool)>&& completionHandler)


### PR DESCRIPTION
#### 28395deeee71d97f1dc01edf78d30d099d201986
<pre>
ASSERTION FAILED: threadLikeAssertion.isCurrent() in TestWebKitAPI.WebContentRestrictions.MultipleConfigurationFiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=297688">https://bugs.webkit.org/show_bug.cgi?id=297688</a>
<a href="https://rdar.apple.com/158254318">rdar://158254318</a>

Reviewed by Per Arne Vollan.

The assertion verifies that CommpetionHandler is created and invoked on the same thread. However, isURLAllowedWithQueue
currently invokes CompletionHandler on a thread that is different from the creation thread. This is intended behavior
but violates CommpetionHandler&apos;s assumption. To fix the assertion failure, this patch makes isURLAllowedWithQueue take
ParentalControlsURLFilter instead of CommpetionHandler as argument, and directly invoke ParentalControlsURLFilter
function when results are available on the brackground thread.

* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::responseReceived):
(WebCore::globalQueue): Deleted.
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::globalQueue):
(WebCore::ParentalControlsURLFilter::isURLAllowed):
(WebCore::ParentalControlsURLFilter::isURLAllowedWithQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/299016@main">https://commits.webkit.org/299016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2502119f2393cd08125c0c9c6fafbde00845788a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69378 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a829b5c-be15-4b78-b0fb-ad9444334283) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89078 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43744 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d53e3a87-fccf-4ec0-a5dc-8db792133e3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69588 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f282f999-8aa5-4714-8151-84378054a932) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67162 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126610 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97539 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40637 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49819 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43616 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45312 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->