### PR TITLE
[uBlock Origin Lite] Web page crashes with URL Tracking Filter list enabled

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.h
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.h
@@ -231,6 +231,7 @@ struct WEBCORE_EXPORT RedirectAction {
     static RedirectAction deserialize(std::span<const uint8_t>);
     static size_t serializedLength(std::span<const uint8_t>);
     void applyToRequest(ResourceRequest&, const URL&);
+    void modifyURL(URL& originalURL, const URL& extensionBaseURL);
 };
 
 struct ReportIdentifierAction {

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.h
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.h
@@ -99,7 +99,8 @@ private:
     HashMap<String, Ref<ContentExtension>> m_contentExtensions;
 };
 
-WEBCORE_EXPORT void applyResultsToRequest(ContentRuleListResults&&, Page*, ResourceRequest&);
+WEBCORE_EXPORT void applyResultsToRequest(ContentRuleListResults&&, Page*, ResourceRequest&, const URL& redirectURL = URL { });
+WEBCORE_EXPORT void applyResultsToRequestIfCrossOriginRedirect(ContentRuleListResults&&, Page*, ResourceRequest&);
 std::optional<String> customTrackerBlockingMessageForConsole(const ContentRuleListResults&, const URL& urlString = { }, const URL& mainDocumentURL = { });
 
 } // namespace WebCore::ContentExtensions

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -301,13 +301,13 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (frame->loader().documentLoader() && frame->loader().documentLoader()->hasActiveContentRuleListActions()) {
+        // FIXME: <https://webkit.org/b/297553> Ideally, we should be doing this in CachedResourceLoader.
         if (RefPtr page = frame->page()) {
             auto resourceType = frame->isMainFrame() ? ContentExtensions::ResourceType::TopDocument : ContentExtensions::ResourceType::ChildDocument;
             auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), resourceType, *frame->loader().documentLoader());
 
-            // Only apply the results if a redirct will occur. See https://webkit.org/b/297077.
-            if (results.summary.redirected)
-                ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), request);
+            // Only apply the results if a cross origin redirect will occur. See https://webkit.org/b/297077 and https://webkit.org/b/297554.
+            ContentExtensions::applyResultsToRequestIfCrossOriginRedirect(WTFMove(results), page.get(), request);
         }
     }
 #endif


### PR DESCRIPTION
#### c74275db2db57b94d310fd4f616538dc8f76191d
<pre>
[uBlock Origin Lite] Web page crashes with URL Tracking Filter list enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=297554">https://bugs.webkit.org/show_bug.cgi?id=297554</a>
<a href="https://rdar.apple.com/158180410">rdar://158180410</a>

Reviewed by Brian Weinstein.

Similar to <a href="https://webkit.org/b/297077">https://webkit.org/b/297077</a>, the web content process was crashing after performing an
extension redirect rule in PolicyChecker. Unlike bug 297077, the resource request was actually
being modified with a query transform rule. However, I was seeing the same error message about an
invalid WebPageProxy_DidStartProvisionalLoadForFrame message being sent so I think this bug was
hitting the same issue.

To address this, build on the fix for bug 297077 by only applying redirects rule for cross origin
redirects, since this was the only reason why this code was added. Since this is the second bug we&apos;ve
hit with this code, I think investigating <a href="https://webkit.org/b/297553">https://webkit.org/b/297553</a> is an appropriate follow up
if we see more bugs caused by applying the content blocking redirect rules before we decide the
policy for the navigation.

Testing:
- Added a test to verify the fix.
- Verified all WKContentExtensionStoreTests passed.

* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::RedirectAction::applyToRequest):
Use new helper method to modify the url.

(WebCore::ContentExtensions::RedirectAction::modifyURL):
Added new helper to modify the url when applying RedirectActions.

* Source/WebCore/contentextensions/ContentExtensionActions.h:
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::applyResultsToRequestIfCrossOriginRedirect):
Only modifies the request if a cross origin redirect will occur.

(WebCore::ContentExtensions::applyResultsToRequest):
Update method to take a redirect URL.

* Source/WebCore/contentextensions/ContentExtensionsBackend.h:
(WebCore::ContentExtensions::applyResultsToRequest):
If a redirectURL is passed, set the request URL to the redirect URL. Otherwise, call applyToRequest
to generate and apply the redirect URL.

* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
Only apply the rules for cross origin redirects.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, MainResourceSameOriginRedirect)):
Verifies that the page loads after a same origin redirect

Canonical link: <a href="https://commits.webkit.org/299173@main">https://commits.webkit.org/299173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82588bdebf860212a65c014329b5c74511663d8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117402 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69390 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5b23bf5-5948-4b25-97d5-1496b84d9773) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89088 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43752 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1702594c-4274-4dc1-b14a-baccbb71ca75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69598 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6343c2bf-dc7d-4105-8244-074621cf0251) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23375 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67174 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126622 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44299 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33291 "Found 1 new test failure: ipc/send-gradient.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97754 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97548 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20849 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40649 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18823 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49831 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43629 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45324 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->