### PR TITLE
Crash under RenderLayer::clearClipRectsIncludingDescendants() with anchor positioning

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4681,6 +4681,9 @@ bool RenderLayer::setAnchorScrollAdjustment(LayoutSize offset)
     if (m_anchorScrollAdjustment == offset)
         return false;
 
+    if (renderer().renderTreeBeingDestroyed())
+        return false;
+
     // FIXME: Scroll offset should be adjusted in the scrolling tree so layers stay exactly in sync.
     m_anchorScrollAdjustment = offset;
     updateTransform();
@@ -4694,6 +4697,9 @@ bool RenderLayer::setAnchorScrollAdjustment(LayoutSize offset)
 void RenderLayer::clearAnchorScrollAdjustment()
 {
     if (!m_anchorScrollAdjustment)
+        return;
+
+    if (renderer().renderTreeBeingDestroyed())
         return;
 
     m_anchorScrollAdjustment = { };


### PR DESCRIPTION
#### 8595bed7b4560299bec349dffd6535db0eb1a5db
<pre>
Crash under RenderLayer::clearClipRectsIncludingDescendants() with anchor positioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=297693">https://bugs.webkit.org/show_bug.cgi?id=297693</a>
<a href="https://rdar.apple.com/158489734">rdar://158489734</a>

Reviewed by Alan Baradlay.

When an anchor RenderBox is being destroyed, it calls `RenderLayer::clearAnchorScrollAdjustment()`
on its layer, which calls `RenderLayer::updateTransform()` which calls
`RenderLayer::clearClipRectsIncludingDescendants()`.

`clearClipRectsIncludingDescendants()` is not safe to run when in render tree teardown because
we don&apos;t guarantee a clean RenderLayer hierarchy; we guard against this at other call sites,
so do this too in `setSnapshottedScrollOffsetForAnchorPositioning()` and
`clearSnapshottedScrollOffsetForAnchorPositioning()`.

The longer term fix of making `firstChild()`/`nextSibling()` use smart pointers is being done elsewhere.

This is exercised by imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-004.html

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setAnchorScrollAdjustment):
(WebCore::RenderLayer::clearAnchorScrollAdjustment):

Canonical link: <a href="https://commits.webkit.org/299014@main">https://commits.webkit.org/299014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4351a399dd82deab30fbee0cab31433bee9da2a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05abb885-b131-45e2-8104-4b5b93884163) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89089 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43753 "Too many flaky failures: css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, storage/domstorage/localstorage/access-storage-then-set-value-in-storage-after-window-close.html, storage/indexeddb/get-keyrange.html, storage/indexeddb/modern/idbtransaction-objectstores-1-private.html, storage/indexeddb/modern/idbtransaction-objectstores-1.html, webgl/2.0.0/conformance2/textures/image/tex-2d-rgba32f-rgba-float.html, webgl/2.0.0/conformance2/textures/image/tex-3d-r11f_g11f_b10f-rgb-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-2d-srgb8-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-3d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image/tex-3d-r11f_g11f_b10f-rgb-half_float.html, webgl/webgl-image-rendering.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1619c136-5306-48f4-9fc2-13fa8605b9fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69599 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18a3cb07-e333-4b63-8c78-f653bed3c46a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23380 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67175 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126623 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97755 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24851 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40650 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49832 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43630 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46974 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->