### PR TITLE
[Site Isolation] Enter fullscreen animation begin needs coordinate transformation with site isolation on

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,8 +1,10 @@
 supportsFullScreen() == true
 enterFullScreenForElement()
 beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {800, 600}
+beganEnterFullScreen() - initialRect.origin: {-9992, 11282}, finalRect.origin: {9992, -11282}
 exitFullScreenForElement()
 beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
+beganExitFullScreen() - initialRect.origin: {9992, -11282}, finalRect.origin: {-9992, 11282}
 
 Size after entering fullscreen: 600x800
 iframe border style after transition: 0px none rgb(0, 0, 0)

--- a/LayoutTests/http/tests/site-isolation/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen.html
@@ -4,6 +4,7 @@
         testRunner.waitUntilDone();
         testRunner.dumpAsText()
         testRunner.dumpFullScreenCallbacks();
+        testRunner.dumpFullScreenOrigin();
     }
     addEventListener("message", (event) => {
         document.getElementById("mylog").innerHTML += event.data + "<br>";

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -128,7 +128,7 @@ public:
 private:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
 
-    Awaitable<bool> enterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails);
+    Awaitable<std::optional<WebCore::IntRect>> enterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails, WebCore::FrameIdentifier rootFrameID, WebCore::IntRect initialFrameInRootFrameCoordinates);
     void didEnterFullScreen(CompletionHandler<void(bool)>&&);
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(FullScreenMediaDetails&&);

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -28,7 +28,7 @@
     EnabledBy=FullScreenEnabled || VideoFullscreenRequiresElementFullscreen
 ]
 messages -> WebFullScreenManagerProxy {
-    EnterFullScreen(WebCore::FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails) -> (bool success)
+    EnterFullScreen(WebCore::FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails, WebCore::FrameIdentifier rootFrameID, WebCore::IntRect initialFrameInRootFrameCoordinates) -> (std::optional<WebCore::IntRect> transformedInitialFrame)
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     UpdateImageSource(struct WebKit::FullScreenMediaDetails mediaDetails)
 #endif

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -628,6 +628,20 @@ void TestController::beganEnterFullScreen(WKPageRef page, WKRect initialFrame, W
             "}\n"_s
         ));
     }
+
+    if (m_dumpFullScreenOrigin) {
+        protectedCurrentInvocation()->outputText(makeString(
+            "beganEnterFullScreen() - initialRect.origin: {"_s,
+            (initialFrame.origin.x - finalFrame.origin.x),
+            ", "_s,
+            (initialFrame.origin.y - finalFrame.origin.y),
+            "}, finalRect.origin: {"_s,
+            (finalFrame.origin.x - initialFrame.origin.x),
+            ", "_s,
+            (finalFrame.origin.y - initialFrame.origin.y),
+            "}\n"_s
+        ));
+    }
 }
 
 void TestController::exitFullScreen(WKPageRef page, const void* clientInfo)
@@ -658,6 +672,20 @@ void TestController::beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect 
         finalFrame.size.width,
         ", "_s,
         finalFrame.size.height,
+        "}\n"_s
+        ));
+    }
+
+    if (m_dumpFullScreenOrigin) {
+        protectedCurrentInvocation()->outputText(makeString(
+        "beganExitFullScreen() - initialRect.origin: {"_s,
+        (initialFrame.origin.x - finalFrame.origin.x),
+        ", "_s,
+        (initialFrame.origin.y - finalFrame.origin.y),
+        "}, finalRect.origin: {"_s,
+        (finalFrame.origin.x - initialFrame.origin.x),
+        ", "_s,
+        (finalFrame.origin.y - initialFrame.origin.y),
         "}\n"_s
         ));
     }
@@ -1601,6 +1629,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     m_shouldDownloadContentDispositionAttachments = true;
     m_dumpPolicyDelegateCallbacks = false;
     m_dumpFullScreenCallbacks = false;
+    m_dumpFullScreenOrigin = false;
     m_waitBeforeFinishingFullscreenExit = false;
     m_scrollDuringEnterFullscreen = false;
     if (m_finishExitFullscreenHandler)
@@ -1971,6 +2000,7 @@ if (window.testRunner) {
     testRunner.setBlockAllPlugins = value => post(['SetBlockAllPlugins', value]);
     testRunner.stopLoading = () => post(['StopLoading']);
     testRunner.dumpFullScreenCallbacks = () => post(['DumpFullScreenCallbacks']);
+    testRunner.dumpFullScreenOrigin = () => post(['DumpFullScreenOrigin']);
     testRunner.displayAndTrackRepaints = () => post(['DisplayAndTrackRepaints']);
     testRunner.clearBackForwardList = () => post(['ClearBackForwardList']);
     testRunner.addChromeInputField = async (callback) => { await post(['AddChromeInputField']); callback?.(); }; // NOLINT
@@ -2540,6 +2570,11 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
 
     if (WKStringIsEqualToUTF8CString(command, "DumpFullScreenCallbacks")) {
         dumpFullScreenCallbacks();
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "DumpFullScreenOrigin")) {
+        dumpFullScreenOrigin();
         return completionHandler(nullptr);
     }
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -202,6 +202,7 @@ public:
 
     void dumpPolicyDelegateCallbacks() { m_dumpPolicyDelegateCallbacks = true; }
     void dumpFullScreenCallbacks() { m_dumpFullScreenCallbacks = true; }
+    void dumpFullScreenOrigin() { m_dumpFullScreenOrigin = true; }
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
     void scrollDuringEnterFullscreen() { m_scrollDuringEnterFullscreen = true; }
     void finishFullscreenExit();
@@ -851,6 +852,7 @@ private:
     bool m_shouldDownloadContentDispositionAttachments { true };
     bool m_dumpPolicyDelegateCallbacks { false };
     bool m_dumpFullScreenCallbacks { false };
+    bool m_dumpFullScreenOrigin { false };
     bool m_waitBeforeFinishingFullscreenExit { false };
     bool m_scrollDuringEnterFullscreen { false };
     bool m_useWorkQueue { false };


### PR DESCRIPTION
#### 10bc7cf26356bbc80c3261052768d5c8ff8d7fc4
<pre>
[Site Isolation] Enter fullscreen animation begin needs coordinate transformation with site isolation on
<a href="https://bugs.webkit.org/show_bug.cgi?id=297673">https://bugs.webkit.org/show_bug.cgi?id=297673</a>
<a href="https://rdar.apple.com/153776866">rdar://153776866</a>

Reviewed by Alex Christensen and Andy Estes.

Previously, when attempting to full screen a cross origin video with site isolation
enabled, the animation would originate from the top left corner of the window.
This is because all transformations were done in the child frame and it was unable
to determine its position within the main frame&apos;s coordinate space, instead defaulting
to (0, 0). This change modifies IPC for the child frame to communicate with the
WebFullScreenManagerProxy in the UIProcess, which then recurses up the process boundary
to determine the coordinates in the main frame before sending those back to the UIProcess,
which converts them to screen space coordinates for use in the animation.

* LayoutTests/http/tests/site-isolation/fullscreen-expected.txt:
* LayoutTests/http/tests/site-isolation/fullscreen.html:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::rootViewRectOfContents):
(WebKit::getRootFrameCoordinatesAndIdentifier):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::willExitFullScreen):
(WebKit::screenRectOfContents):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::beganEnterFullScreen):
(WTR::TestController::beganExitFullScreen):
(WTR::TestController::resetStateToConsistentValues):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::dumpFullScreenOrigin):

Canonical link: <a href="https://commits.webkit.org/301065@main">https://commits.webkit.org/301065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09803232e4f394bad58da11873df52f90bdb1c24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52793 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94740 "Found 1 new test failure: http/wpt/service-workers/online.https.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62828 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75316 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29532 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103219 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48364 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26626 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48341 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57065 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->