### PR TITLE
[jsc] Remove dependency on <os/thread_self_restrict.h>

### DIFF
--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -36,6 +36,7 @@ enum class MemoryRestriction {
 };
 
 #if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/FastJITPermissionsAdditions.h>
 #include <WebKitAdditions/JSGlobalObjectAdditions.h>
 #endif
 
@@ -110,31 +111,6 @@ static ALWAYS_INLINE void threadSelfRestrict()
         pthread_jit_write_protect_np(false);
     else if constexpr (restriction == MemoryRestriction::kRwxToRx)
         pthread_jit_write_protect_np(true);
-    else
-        RELEASE_ASSERT_NOT_REACHED();
-}
-
-#elif USE(APPLE_INTERNAL_SDK)
-#include <os/thread_self_restrict.h>
-
-template <MemoryRestriction restriction>
-SUPPRESS_ASAN static ALWAYS_INLINE bool threadSelfRestrictSupported()
-{
-    if constexpr ((restriction == MemoryRestriction::kRwxToRw)
-        || (restriction == MemoryRestriction::kRwxToRx)) {
-        return !!os_thread_self_restrict_rwx_is_supported();
-    }
-    return false;
-}
-
-template <MemoryRestriction restriction>
-static ALWAYS_INLINE void threadSelfRestrict()
-{
-    ASSERT(g_jscConfig.useFastJITPermissions);
-    if constexpr (restriction == MemoryRestriction::kRwxToRw)
-        os_thread_self_restrict_rwx_to_rw();
-    else if constexpr (restriction == MemoryRestriction::kRwxToRx)
-        os_thread_self_restrict_rwx_to_rx();
     else
         RELEASE_ASSERT_NOT_REACHED();
 }


### PR DESCRIPTION
#### 44049f526c117a5308e496a937c0e3ca7aafcfcf
<pre>
[jsc] Remove dependency on &lt;os/thread_self_restrict.h&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=297697">https://bugs.webkit.org/show_bug.cgi?id=297697</a>
<a href="https://rdar.apple.com/158809931">rdar://158809931</a>

Reviewed by Richard Robinson.

This breaks our builds when modules are enabled; since we no longer need
to use this pathway, we can just remove it.

Canonical link: <a href="https://commits.webkit.org/299082@main">https://commits.webkit.org/299082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd4f9575515ea0007705c8697fe604214e4956b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69766 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdcb3780-ffef-4e23-a860-9c8bcbd3dd08) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46012 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/56974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44e83fc7-fc3c-4717-b703-60d15ec5f567) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69861 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70a9e675-5105-4555-ad1a-ed95e256adb4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29412 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23696 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67545 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109863 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126979 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116261 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21161 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44527 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/50201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144959 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43985 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47332 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45676 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->