### PR TITLE
Web Automation: implement Set Storage Access endpoint

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -400,6 +400,17 @@
                 "ArchivePath",
                 "Base64"
             ]
+        },
+        {
+            "id": "PermissionState",
+            "type": "string",
+            "spec": "https://www.w3.org/TR/permissions/#dom-permissionstate",
+            "description": "Values represent the concept of a permission state.",
+            "enum": [
+                "granted",
+                "denied",
+                "prompt"
+            ]
         }
     ],
     "commands": [
@@ -906,6 +917,29 @@
             "condition": "defined(WTF_PLATFORM_MAC) && WTF_PLATFORM_MAC",
             "parameters": [
                 { "name": "identifier", "type": "string", "description": "The identifier of the extension to unload." }
+            ],
+            "async": true
+        },
+        {
+            "name": "setStorageAccessPermissionState",
+            "description": "Simulates user modification of a PermissionDescriptor's permission status for storage-access.",
+            "spec": "https://www.w3.org/TR/permissions/#webdriver-command-set-permission",
+            "parameters": [
+                { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the targeted browsing context." },
+                { "name": "state", "$ref": "PermissionState", "description": "The new state to be applied to the permission." },
+                { "name": "topFrameDomain", "type": "string", "description": "Origin whose storage is being accessed." },
+                { "name": "subFrameDomain", "type": "string", "description": "Origin of the subframe that should be granted non-partitioned storage access to the top frame's origin." }
+            ],
+            "async": true
+        },
+        {
+            "name": "grantStorageAccess",
+            "description": "Modifies the storage access policy for the specified browsing context.",
+            "spec": "https://privacycg.github.io/storage-access/#set-storage-access-command",
+            "parameters": [
+                { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the browsing context." },
+                { "name": "topFrameDomain", "type": "string", "description": "Origin whose storage is being accessed." },
+                { "name": "subFrameDomain", "type": "string", "description": "Origin of the subframe that should be granted non-partitioned storage access to the top frame's origin." }
             ],
             "async": true
         },

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1789,6 +1789,26 @@ CommandResult<void> WebAutomationSession::generateTestReport(const String& brows
     return { };
 }
 
+void WebAutomationSession::setStorageAccessPermissionState(const String& browsingContextHandle, Inspector::Protocol::Automation::PermissionState state, const String& topFrameOrigin, const String& subFrameOrigin, CommandCallback<void>&& callback)
+{
+    auto page = webPageProxyForHandle(browsingContextHandle);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
+
+    page->protectedWebsiteDataStore()->setStorageAccessPermissionForTesting(state == Inspector::Protocol::Automation::PermissionState::Granted, page->identifier(), topFrameOrigin, subFrameOrigin, [protectedThis = Ref { *this }, callback = WTFMove(callback)]() {
+        callback({ });
+    });
+}
+
+void WebAutomationSession::grantStorageAccess(const String& browsingContextHandle, const String& topFrameOrigin, const String& subFrameOrigin, CommandCallback<void>&& callback)
+{
+    auto page = webPageProxyForHandle(browsingContextHandle);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
+
+    page->protectedWebsiteDataStore()->grantStorageAccessForTesting(topFrameOrigin.isolatedCopy(), { subFrameOrigin.isolatedCopy() }, [protectedThis = Ref { *this }, callback = WTFMove(callback)]() {
+        callback({ });
+    });
+}
+
 #if ENABLE(WEBDRIVER_BIDI)
 CommandResult<void> WebAutomationSession::processBidiMessage(const String& message)
 {

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -266,6 +266,8 @@ public:
     void loadWebExtension(const Inspector::Protocol::Automation::WebExtensionResourceOptions, const String& resource, Inspector::CommandCallback<String>&&) override;
     void unloadWebExtension(const String& identifier, Inspector::CommandCallback<void>&&) override;
 #endif
+    void setStorageAccessPermissionState(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::Protocol::Automation::PermissionState, const String& topFrameOrigin, const String& subFrameOrigin, Inspector::CommandCallback<void>&&) override;
+    void grantStorageAccess(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& topFrameOrigin, const String& subFrameOrigin, Inspector::CommandCallback<void>&&) override;
 
 #if ENABLE(WEBDRIVER_BIDI)
     Inspector::CommandResult<void> processBidiMessage(const String&) override;


### PR DESCRIPTION
#### ef288f2dc7c602ad2d0726d4fab6a57d712ed5fc
<pre>
Web Automation: implement Set Storage Access endpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=297368">https://bugs.webkit.org/show_bug.cgi?id=297368</a>
<a href="https://rdar.apple.com/158263193">rdar://158263193</a>

Reviewed by NOBODY (OOPS!).

Add new endpoints for setting storage access permission state and
granting storage access to embedded frames for specific origins.

These methods will be called via Automation protocol to implement the
WebDriver Classic endpoints in safaridriver. In a future patch, the
WebAutomationSession methods will be used by the WebDriver BiDi permissions agent.

* Source/WebKit/UIProcess/Automation/Automation.json:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::setStorageAccessPermissionState):
(WebKit::WebAutomationSession::grantStorageAccess):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef288f2dc7c602ad2d0726d4fab6a57d712ed5fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69394 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/958b6be6-280b-4de8-9083-4a309d6e7d91) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89091 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43755 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18850dd6-be58-4bf3-9d62-5a59c457b0af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0121cfe-e2f6-4c08-8e40-515842efb618) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29119 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126626 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97757 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97551 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40653 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49835 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43633 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45328 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->