### PR TITLE
Web Automation: implement Set Storage Access endpoint

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -962,6 +962,7 @@ set(WebKit_WEBDRIVER_BIDI_PROTOCOL_GENERATOR_INPUTS
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiBrowser.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiBrowsingContext.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiLog.json
+    ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiPermissions.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiScript.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiSession.json
     ${WEBKIT_DIR}/UIProcess/Automation/protocol/BidiStorage.json

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -517,6 +517,7 @@ $(PROJECT_DIR)/UIProcess/Automation/WebAutomationSession.messages.in
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowser.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiBrowsingContext.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiLog.json
+$(PROJECT_DIR)/UIProcess/Automation/protocol/BidiPermissions.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiScript.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiSession.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiStorage.json

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -535,6 +535,7 @@ WEBDRIVER_BIDI_PROTOCOL_INPUT_FILES = \
     $(WebKit2)/UIProcess/Automation/protocol/BidiBrowser.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiBrowsingContext.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiLog.json \
+    $(WebKit2)/UIProcess/Automation/protocol/BidiPermissions.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiScript.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiSession.json \
     $(WebKit2)/UIProcess/Automation/protocol/BidiStorage.json \

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -574,6 +574,7 @@ UIProcess/Authentication/WebProtectionSpace.cpp
 // FIXME(206266): AutomationProtocolObjects.h's "namespace Protocol" conflicts with objc/runtime.h's "typedef struct objc_object Protocol"
 UIProcess/Automation/BidiBrowserAgent.cpp @no-unify
 UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify
+UIProcess/Automation/BidiPermissionsAgent.cpp @no-unify
 UIProcess/Automation/BidiScriptAgent.cpp @no-unify
 UIProcess/Automation/BidiStorageAgent.cpp @no-unify
 UIProcess/Automation/BidiUserContext.cpp @no-unify

--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -400,6 +400,17 @@
                 "ArchivePath",
                 "Base64"
             ]
+        },
+        {
+            "id": "PermissionState",
+            "type": "string",
+            "spec": "https://www.w3.org/TR/permissions/#dom-permissionstate",
+            "description": "Values represent the concept of a permission state.",
+            "enum": [
+                "granted",
+                "denied",
+                "prompt"
+            ]
         }
     ],
     "commands": [
@@ -906,6 +917,28 @@
             "condition": "defined(WTF_PLATFORM_MAC) && WTF_PLATFORM_MAC",
             "parameters": [
                 { "name": "identifier", "type": "string", "description": "The identifier of the extension to unload." }
+            ],
+            "async": true
+        },
+        {
+            "name": "setStorageAccessPermissionState",
+            "description": "Simulates user modification of a PermissionDescriptor's permission status for storage-access.",
+            "spec": "https://www.w3.org/TR/permissions/#webdriver-command-set-permission",
+            "parameters": [
+                { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the targeted browsing context." },
+                { "name": "state", "$ref": "PermissionState", "description": "The new state to be applied to the permission." },
+                { "name": "topFrameDomain", "type": "string", "description": "Origin whose storage is being accessed." },
+                { "name": "subFrameDomain", "type": "string", "description": "Origin of the subframe that should be granted non-partitioned storage access to the top frame's origin." }
+            ],
+            "async": true
+        },
+        {
+            "name": "setStorageAccessPolicy",
+            "description": "Modifies the storage access policy for the specified browsing context.",
+            "spec": "https://privacycg.github.io/storage-access/#set-storage-access-command",
+            "parameters": [
+                { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the browsing context." },
+                { "name": "blocked", "type": "boolean", "description": "Whether to block third-party cookie storage access." }
             ],
             "async": true
         },

--- a/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BidiPermissionsAgent.h"
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "AutomationProtocolObjects.h"
+#include "Logging.h"
+#include "PageLoadState.h"
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebDriverBidiProtocolObjects.h"
+#include "WebPageProxy.h"
+#include "WebProcessPool.h"
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/CallbackAggregator.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiPermissionsAgent);
+
+BidiPermissionsAgent::BidiPermissionsAgent(WebAutomationSession& session, BackendDispatcher& backendDispatcher)
+    : m_session(session)
+{
+}
+
+BidiPermissionsAgent::~BidiPermissionsAgent() = default;
+
+static Vector<Ref<WebPageProxy>> allPageProxiesFor(const WebAutomationSession& session)
+{
+    Vector<Ref<WebPageProxy>> pages;
+    for (Ref process : session.protectedProcessPool()->processes()) {
+        for (Ref page : process->pages()) {
+            if (!page->isControlledByAutomation())
+                continue;
+            pages.append(WTFMove(page));
+        }
+    }
+
+    return pages;
+}
+
+void BidiPermissionsAgent::setPermission(Ref<JSON::Object>&& descriptor, const String& origin, Inspector::Protocol::BidiPermissions::PermissionState state, const String& optionalUserContext, CommandCallback<void>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    auto permissionName = descriptor->getString("name"_s);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!permissionName, MissingParameter, "The parameter 'name' was not found."_s);
+
+    if (permissionName == "storage-access"_s) {
+        auto topFrameOrigin = RegistrableDomain { URL { origin } };
+        auto subFrameURLString = descriptor->getString("subFrameURL"_s);
+        bool embeddedOriginIsWildcard = subFrameURLString == "*"_s;
+        auto embeddedOrigin = RegistrableDomain { URL { subFrameURLString } };
+
+        Ref callbackAggregator = CallbackAggregator::create([callback = WTFMove(callback)]() {
+            callback({ });
+        });
+
+        for (auto page : allPageProxiesFor(*session)) {
+            auto pageOrigin = RegistrableDomain { page->protectedPageLoadState()->origin() };
+            if (pageOrigin != topFrameOrigin)
+                continue;
+
+            Ref store = page->websiteDataStore();
+            bool granted = state == Inspector::Protocol::BidiPermissions::PermissionState::Granted;
+            if (!granted)
+                store->clearResourceLoadStatisticsInWebProcesses([callbackAggregator] { });
+            store->setStorageAccessPermissionForTesting(granted, page->identifier(), topFrameOrigin.string(), (embeddedOriginIsWildcard ? topFrameOrigin : embeddedOrigin).string(), [callbackAggregator] () { });
+        }
+        return;
+    }
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NotImplemented, makeString("Permission '"_s, permissionName, "' not supported yet."_s));
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBDRIVER_BIDI)
+
+#include "WebDriverBidiBackendDispatchers.h"
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+class BidiPermissionsAgent final : public Inspector::BidiPermissionsBackendDispatcherHandler {
+    WTF_MAKE_TZONE_ALLOCATED(BidiPermissionsAgent);
+public:
+    BidiPermissionsAgent(WebAutomationSession&, Inspector::BackendDispatcher&);
+    ~BidiPermissionsAgent() override;
+
+    void setPermission(Ref<JSON::Object>&& descriptor, const String& origin, Inspector::Protocol::BidiPermissions::PermissionState, const String& opt_userContext, Inspector::CommandCallback<void>&&) override;
+
+private:
+    WeakPtr<WebAutomationSession> m_session;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBDRIVER_BIDI)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -270,6 +270,8 @@ public:
     void loadWebExtension(const Inspector::Protocol::Automation::WebExtensionResourceOptions, const String& resource, Inspector::CommandCallback<String>&&) override;
     void unloadWebExtension(const String& identifier, Inspector::CommandCallback<void>&&) override;
 #endif
+    void setStorageAccessPermissionState(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::Protocol::Automation::PermissionState, const String& topFrameOrigin, const String& subFrameOrigin, Inspector::CommandCallback<void>&&) override;
+    void setStorageAccessPolicy(const Inspector::Protocol::Automation::BrowsingContextHandle&, bool blocked, Inspector::CommandCallback<void>&&) override;
 
 #if ENABLE(WEBDRIVER_BIDI)
     Inspector::CommandResult<void> processBidiMessage(const String&) override;

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -33,6 +33,7 @@
 
 #include "BidiBrowserAgent.h"
 #include "BidiBrowsingContextAgent.h"
+#include "BidiPermissionsAgent.h"
 #include "BidiScriptAgent.h"
 #include "BidiStorageAgent.h"
 #include "Logging.h"
@@ -54,6 +55,7 @@ WebDriverBidiProcessor::WebDriverBidiProcessor(WebAutomationSession& session)
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_browserAgent(makeUniqueRef<BidiBrowserAgent>(session, m_backendDispatcher))
     , m_browsingContextAgent(makeUniqueRef<BidiBrowsingContextAgent>(session, m_backendDispatcher))
+    , m_permissionsAgent(makeUniqueRef<BidiPermissionsAgent>(session, m_backendDispatcher))
     , m_scriptAgent(makeUniqueRef<BidiScriptAgent>(session, m_backendDispatcher))
     , m_storageAgent(makeUniqueRef<BidiStorageAgent>(session, m_backendDispatcher))
     , m_browsingContextDomainNotifier(makeUniqueRef<BidiBrowsingContextFrontendDispatcher>(m_frontendRouter))

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -38,6 +38,7 @@ namespace WebKit {
 
 class BidiBrowserAgent;
 class BidiBrowsingContextAgent;
+class BidiPermissionsAgent;
 class BidiScriptAgent;
 class BidiStorageAgent;
 class WebAutomationSession;
@@ -71,6 +72,7 @@ private:
 
     const UniqueRef<BidiBrowserAgent> m_browserAgent;
     const UniqueRef<BidiBrowsingContextAgent> m_browsingContextAgent;
+    const UniqueRef<BidiPermissionsAgent> m_permissionsAgent;
     const UniqueRef<BidiScriptAgent> m_scriptAgent;
     const UniqueRef<BidiStorageAgent> m_storageAgent;
     const UniqueRef<Inspector::BidiBrowsingContextFrontendDispatcher> m_browsingContextDomainNotifier;

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiPermissions.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiPermissions.json
@@ -1,0 +1,44 @@
+{
+    "domain": "BidiPermissions",
+    "exposedAs": "permissions",
+    "condition": "ENABLE(WEBDRIVER_BIDI)",
+    "description": "The permissions module contains commands for managing the remote end browser permissions.",
+    "spec": "https://www.w3.org/TR/permissions/#webdriver-bidi-module-permissions",
+    "types": [
+        {
+            "id": "PermissionState",
+            "type": "string",
+            "spec": "https://www.w3.org/TR/permissions/#dom-permissionstate",
+            "description": "Values represent the concept of a permission state.",
+            "enum": [
+                "granted",
+                "denied",
+                "prompt"
+            ]
+        },
+        {
+            "id": "PermissionDescriptor",
+            "type": "object",
+            "spec": "https://www.w3.org/TR/permissions/#webdriver-bidi-type-permissions-PermissionDescriptor",
+            "description": "Describes a permission. Note that optional properties represent fields present in spec subclasses of PermissionDescriptor.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "The name of the permission." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "setPermission",
+            "description": "Simulates user modification of a PermissionDescriptor's permission state.",
+            "spec": "https://www.w3.org/TR/permissions/#webdriver-bidi-command-permissions-setPermission",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/external/permissions/set_permission",
+            "parameters": [
+                { "name": "descriptor", "$ref": "BidiPermissions.PermissionDescriptor", "description": "Extensible object describing a permission and any associated metadata." },
+                { "name": "origin", "type": "string", "description": "The origin from which the permission is being requested." },
+                { "name": "state", "$ref": "BidiPermissions.PermissionState", "description": "The state of the permission." },
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext", "optional": true }
+            ],
+            "async": true
+        }
+    ]
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1892,6 +1892,8 @@
 		9979659E25310A4900B31AE3 /* WebInspectorUIExtensionControllerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979659A25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessages.h */; };
 		997965A3253128C700B31AE3 /* _WKInspectorExtensionHost.h in Headers */ = {isa = PBXBuildFile; fileRef = 997965A2253128C700B31AE3 /* _WKInspectorExtensionHost.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9979CA58237F49F10039EC05 /* _WKInspectorPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979CA57237F49F00039EC05 /* _WKInspectorPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		997EB9DA2E5544FC002CFED7 /* BidiPermissionsAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */; };
+		997EB9DB2E5544FC002CFED7 /* BidiPermissionsAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */; };
 		99996A9F25004BCC004F7559 /* _WKInspectorPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 99996A9D25004BCB004F7559 /* _WKInspectorPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		99A514512D5AB7D500937177 /* WebDriverBidiProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 99A5144E2D5AB7D500937177 /* WebDriverBidiProcessor.h */; };
 		99A514642D5AC3E400937177 /* WebDriverBidiProtocolObjects.h in Headers */ = {isa = PBXBuildFile; fileRef = 99A514622D5AC33F00937177 /* WebDriverBidiProtocolObjects.h */; };
@@ -7262,6 +7264,9 @@
 		9979659B25310A4800B31AE3 /* WebInspectorUIExtensionControllerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUIExtensionControllerMessageReceiver.cpp; sourceTree = "<group>"; };
 		997965A2253128C700B31AE3 /* _WKInspectorExtensionHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorExtensionHost.h; sourceTree = "<group>"; };
 		9979CA57237F49F00039EC05 /* _WKInspectorPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorPrivate.h; sourceTree = "<group>"; };
+		997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiPermissionsAgent.h; sourceTree = "<group>"; };
+		997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiPermissionsAgent.cpp; sourceTree = "<group>"; };
+		997EB9DC2E554524002CFED7 /* BidiPermissions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiPermissions.json; sourceTree = "<group>"; };
 		99965A552DA096EF0039DFF5 /* BidiSession.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BidiSession.json; sourceTree = "<group>"; };
 		99996A9D25004BCB004F7559 /* _WKInspectorPrivateForTesting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKInspectorPrivateForTesting.h; sourceTree = "<group>"; };
 		99996A9E25004BCB004F7559 /* _WKInspectorTesting.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKInspectorTesting.mm; sourceTree = "<group>"; };
@@ -14341,6 +14346,8 @@
 				F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */,
 				F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */,
 				F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */,
+				997EB9D92E5544FC002CFED7 /* BidiPermissionsAgent.cpp */,
+				997EB9D82E5544FC002CFED7 /* BidiPermissionsAgent.h */,
 				F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */,
 				F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */,
 				5EEC724B2DC1B30700D012DD /* BidiStorageAgent.cpp */,
@@ -14365,6 +14372,7 @@
 				996D00402D7AA0CD0049C7D8 /* BidiBrowser.json */,
 				996D00412D7AA0CD0049C7D8 /* BidiBrowsingContext.json */,
 				996D00422D7AA0CD0049C7D8 /* BidiLog.json */,
+				997EB9DC2E554524002CFED7 /* BidiPermissions.json */,
 				996D00432D7AA0CD0049C7D8 /* BidiScript.json */,
 				99965A552DA096EF0039DFF5 /* BidiSession.json */,
 				5EB592AB2DC2049A0058664B /* BidiStorage.json */,
@@ -17265,6 +17273,7 @@
 				95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */,
 				F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */,
 				F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */,
+				997EB9DA2E5544FC002CFED7 /* BidiPermissionsAgent.h in Headers */,
 				F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */,
 				5EEC724E2DC1B31800D012DD /* BidiStorageAgent.h in Headers */,
 				F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */,
@@ -20784,6 +20793,7 @@
 				413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */,
 				F3EEEE5A2DB318270038CC1D /* BidiBrowserAgent.cpp in Sources */,
 				F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */,
+				997EB9DB2E5544FC002CFED7 /* BidiPermissionsAgent.cpp in Sources */,
 				F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */,
 				5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */,
 				F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */,


### PR DESCRIPTION
#### 19e192754fe6cf1083b9a87bd1bb532b2c7cde11
<pre>
Web Automation: implement Set Storage Access endpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=297368">https://bugs.webkit.org/show_bug.cgi?id=297368</a>
<a href="https://rdar.apple.com/158263193">rdar://158263193</a>

Reviewed by Charlie Wolfe.

Add new endpoints for setting storage access permission state and
granting storage access to embedded frames for specific origins.

These methods will be called via Automation protocol to implement the
WebDriver Classic endpoints in safaridriver. In a future patch, the
WebAutomationSession methods will be used by the WebDriver BiDi permissions agent.

* Source/WebKit/UIProcess/Automation/Automation.json:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::setStorageAccessPermissionState):
(WebKit::WebAutomationSession::grantStorageAccess):

[WebDriver BiDi] add support for permissions.setPermission command
<a href="https://bugs.webkit.org/show_bug.cgi?id=265621">https://bugs.webkit.org/show_bug.cgi?id=265621</a>
<a href="https://rdar.apple.com/119346759">rdar://119346759</a>

Reviewed by Charlie Wolfe.

Implement the remote end steps for Set Permission.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp: Added.
(WebKit::BidiPermissionsAgent::BidiPermissionsAgent):
(WebKit::allPageProxiesFor):
(WebKit::BidiPermissionsAgent::setPermission):
Added. Defer to WebSiteDataStore and NetworkProcess for the actual implementation.

* Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.h: Added.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::WebDriverBidiProcessor):
Add BidiPermissionAgent.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiPermissions.json: Added.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Add new domain and associated derived sources and project entries.

Canonical link: <a href="https://commits.webkit.org/299547@main">https://commits.webkit.org/299547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0fdd1163e0c6f9976cd53e2f573c95a017d1bba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4880b38c-9051-4f8f-bb36-7d71609aaed3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af45cfcc-f628-4975-b499-8e9e5f66fe02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71121 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77b4fc46-48a8-4d28-af37-72ea1f299ab0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30732 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69236 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128584 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99244 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44485 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42824 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51820 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45585 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->