### PR TITLE
[iOS] mail.yahoo.com: Typing in the search field causes text cursor to appear in the wrong places

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-after-resizing-composited-layer-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-after-resizing-composited-layer-expected.txt
@@ -1,0 +1,12 @@
+Verifies that the caret rect is correct after resizing the layer containing the selection. The caret should still be visible after the box expands
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS caretRectBeforeResize.top is caretRectAfterResize.top
+PASS caretRectBeforeResize.left is caretRectAfterResize.left
+PASS caretRectBeforeResize.width is caretRectAfterResize.width
+PASS caretRectBeforeResize.height is caretRectAfterResize.height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-after-resizing-composited-layer.html
+++ b/LayoutTests/editing/selection/ios/selection-after-resizing-composited-layer.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true useHardwareKeyboardMode=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    margin: 0;
+}
+
+.container {
+    width: 200px;
+    height: 200px;
+    will-change: transform;
+    z-index: 1;
+    line-height: 200px;
+    font-size: 80px;
+    position: absolute;
+    background-color: white;
+    border: 1px solid tomato;
+    box-sizing: border-box;
+    top: 100px;
+    left: 100px;
+    outline: none;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the caret rect is correct after resizing the layer containing the selection. The caret should still be visible after the box expands");
+
+    container = document.querySelector(".container");
+    container.focus();
+    container.addEventListener("keydown", () => {
+        container.style = "top: 50px; left: 50px; padding: 50px; width: 300px; height: 300px;";
+    });
+
+    await UIHelper.activateElementAndWaitForInputSession(container);
+
+    caretRectBeforeResize = await UIHelper.getUICaretViewRect();
+
+    await UIHelper.keyDown("escape");
+    await UIHelper.ensurePresentationUpdate();
+
+    caretRectAfterResize = await UIHelper.getUICaretViewRect();
+
+    shouldBe("caretRectBeforeResize.top", "caretRectAfterResize.top");
+    shouldBe("caretRectBeforeResize.left", "caretRectAfterResize.left");
+    shouldBe("caretRectBeforeResize.width", "caretRectAfterResize.width");
+    shouldBe("caretRectBeforeResize.height", "caretRectAfterResize.height");
+
+    container.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="description"></div>
+    <div id="console"></div>
+    <div class="container" contenteditable></div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -596,6 +596,7 @@ struct ImageAnalysisContextMenuActionData {
 
     BOOL _waitingForEditorStateAfterScrollingSelectionContainer;
     std::optional<WebCore::IntPoint> _lastSelectionChildScrollViewContentOffset;
+    std::optional<CGPoint> _lastSelectionContainerViewOrigin;
 
     BOOL _hasSetUpInteractions;
     std::optional<BOOL> _cachedHasCustomTintColor;


### PR DESCRIPTION
#### ac9a639e7434eae4d509fad494dc25b379759db5
<pre>
[iOS] mail.yahoo.com: Typing in the search field causes text cursor to appear in the wrong places
<a href="https://bugs.webkit.org/show_bug.cgi?id=297703">https://bugs.webkit.org/show_bug.cgi?id=297703</a>
<a href="https://rdar.apple.com/157696497">rdar://157696497</a>

Reviewed by Ryosuke Niwa.

Currently, the UI-side selection views on iOS only update when the selection rects change. In this
specific scenario on Yahoo Mail, the layer containing the selection becomes wider, but the caret
rect in root view coordinates remains the exact same (i.e. the layer containing the text field
expands from the center).

This means that the selection geometry (in the composited selection container view&apos;s coordinate
space) doesn&apos;t change when it needs to, in order to account for the fact that the origin has
shifted, causing the selection caret rect to become stale.

To fix this, we identify this case where the selection container view&apos;s origin is shifted, and call
`-setNeedsSelectionUpdate` to force UIKit to recalculate and layout selection views again.

* LayoutTests/editing/selection/ios/selection-after-resizing-composited-layer-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-after-resizing-composited-layer.html: Added.

Add a layout test to exercise this fix.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView _updateChangedSelection:]):
(-[WKContentView _updateSelectionViewsIfNeeded]):

Rename this to `-_updateSelectionViewsIfNeeded`, since we now `-setNeedsSelectionUpdate` if the
containing subscroller has scrolled since the last selection update, or the origin of the selection
container changes.

(-[WKContentView _updateSelectionViewsInChildScrollViewIfNeeded]): Deleted.

Canonical link: <a href="https://commits.webkit.org/299011@main">https://commits.webkit.org/299011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c0251fda3419b2d01c4cd5426b3505fa44a0a63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69417 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/134191a2-1d06-4952-a08a-f907e504c980) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89114 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43778 "Too many flaky failures: css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/permissions/storage-access-permissions-query.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dom/customAccessor-defineProperty.html, js/stack-overflow-regexp.html, storage/indexeddb/modern/opencursor-failures.html, storage/indexeddb/optional-arguments.html, webgl/2.0.y/conformance/context/context-creation-and-destruction.html, webgl/2.0.y/conformance/extensions/webgl-compressed-texture-size-limit.html, webgl/2.0.y/conformance/extensions/webgl-debug-renderer-info.html, webgl/2.0.y/conformance/glsl/misc/shader-with-non-reserved-words-5-of-8.html, webgl/2.0.y/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html, webgl/2.0.y/conformance/rendering/blending.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27bac90c-5a52-4457-8c84-ce783ab2cb5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69623 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/646b37d9-c86c-46dc-b7fb-cfa6699fd965) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99488 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23588 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126648 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44325 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33319 "Found 1 new test failure: ipc/send-gradient.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97780 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97574 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24846 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40676 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49857 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43655 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46999 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->