### PR TITLE
[JSC] Rename remaining ImmutableButterfly to CellButterfly

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -388,7 +388,7 @@ op :new_array_with_size,
 op :new_array_buffer,
     args: {
         dst: VirtualRegister,
-        immutableButterfly: VirtualRegister,
+        cellButterfly: VirtualRegister,
         recommendedIndexingType: IndexingType
     },
     metadata: {

--- a/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
@@ -224,7 +224,7 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
     USES(OpCreateScopedArguments, scope)
     USES(OpCreateRest, arraySize)
     USES(OpGetFromArguments, arguments)
-    USES(OpNewArrayBuffer, immutableButterfly)
+    USES(OpNewArrayBuffer, cellButterfly)
 
     USES(OpGetByVal, base, property)
     USES(OpGetPrivateName, base, property)

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2742,9 +2742,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     }
                     ASSERT(isCopyOnWrite(structure->indexingMode()));
 
-                    JSCellButterfly* immutableButterfly = JSCellButterfly::fromButterfly(butterfly);
-                    if (index < immutableButterfly->length()) {
-                        JSValue value = immutableButterfly->get(index);
+                    JSCellButterfly* cellButterfly = JSCellButterfly::fromButterfly(butterfly);
+                    if (index < cellButterfly->length()) {
+                        JSValue value = cellButterfly->get(index);
                         ASSERT(value);
                         if (value.isCell())
                             setConstant(node, *m_graph.freeze(value.asCell()));

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -7005,17 +7005,17 @@ void ByteCodeParser::parseBlock(unsigned limit)
             auto bytecode = currentInstruction->as<OpNewArrayBuffer>();
             // Unfortunately, we can't allocate a new JSCellButterfly if the profile tells us new information because we
             // cannot allocate from compilation threads.
-            FrozenValue* frozen = get(VirtualRegister(bytecode.m_immutableButterfly))->constant();
+            FrozenValue* frozen = get(VirtualRegister(bytecode.m_cellButterfly))->constant();
             WTF::dependentLoadLoadFence();
 
-            JSCellButterfly* immutableButterfly = frozen->cast<JSCellButterfly*>();
+            JSCellButterfly* cellButterfly = frozen->cast<JSCellButterfly*>();
             NewArrayBufferData data { };
-            unsigned vectorLengthHint = immutableButterfly->toButterfly()->vectorLength();
+            unsigned vectorLengthHint = cellButterfly->toButterfly()->vectorLength();
 
             // If it is an empty array and there is larger vectorLengthHint, it is very likely that this array will be extended later and just initially starting with an empty array.
             // Let's use non CoW array in this case.
-            if (!immutableButterfly->length() && vectorLengthHint) {
-                IndexingType indexingType = immutableButterfly->indexingType();
+            if (!cellButterfly->length() && vectorLengthHint) {
+                IndexingType indexingType = cellButterfly->indexingType();
                 switch (indexingType) {
                 case CopyOnWriteArrayWithInt32:
                     indexingType = ArrayWithInt32;
@@ -7027,14 +7027,14 @@ void ByteCodeParser::parseBlock(unsigned limit)
                     indexingType = ArrayWithContiguous;
                     break;
                 default:
-                    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("immutableButterfly indexing type should be CoW");
+                    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("cellButterfly indexing type should be CoW");
                     break;
                 }
                 set(bytecode.m_dst, addToGraph(Node::VarArg, NewArray, OpInfo(indexingType), OpInfo(vectorLengthHint)));
                 NEXT_OPCODE(op_new_array_buffer);
             }
 
-            data.indexingMode = immutableButterfly->indexingMode();
+            data.indexingMode = cellButterfly->indexingMode();
             data.vectorLengthHint = vectorLengthHint;
             set(VirtualRegister(bytecode.m_dst), addToGraph(NewArrayBuffer, OpInfo(frozen), OpInfo(data.asQuadWord)));
             NEXT_OPCODE(op_new_array_buffer);

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1069,9 +1069,9 @@ private:
                     if (structureSet.isFinite() && structureSet.size() == 1) {
                         RegisteredStructure structure = structureSet.onlyStructure();
                         if (auto* rareData = structure->rareDataConcurrently()) {
-                            if (auto* immutableButterfly = rareData->cachedPropertyNamesConcurrently(node->cachedPropertyNamesKind())) {
+                            if (auto* cellButterfly = rareData->cachedPropertyNamesConcurrently(node->cachedPropertyNamesKind())) {
                                 if (m_graph.isWatchingHavingABadTimeWatchpoint(node)) {
-                                    node->convertToNewArrayBuffer(m_graph.freeze(immutableButterfly));
+                                    node->convertToNewArrayBuffer(m_graph.freeze(cellButterfly));
                                     changed = true;
                                     break;
                                 }
@@ -1089,9 +1089,9 @@ private:
                         Edge use = m_graph.varArgChild(node, 0);
                         if (use->op() == PhantomSpread) {
                             if (use->child1()->op() == PhantomNewArrayBuffer) {
-                                auto* immutableButterfly = use->child1()->castOperand<JSCellButterfly*>();
-                                if (hasContiguous(immutableButterfly->indexingType())) {
-                                    node->convertToNewArrayBuffer(m_graph.freeze(immutableButterfly));
+                                auto* cellButterfly = use->child1()->castOperand<JSCellButterfly*>();
+                                if (hasContiguous(cellButterfly->indexingType())) {
+                                    node->convertToNewArrayBuffer(m_graph.freeze(cellButterfly));
                                     changed = true;
                                     break;
                                 }

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -248,14 +248,14 @@ void Node::convertToLazyJSConstant(Graph& graph, LazyJSValue value)
     children.reset();
 }
 
-void Node::convertToNewArrayBuffer(FrozenValue* immutableButterfly)
+void Node::convertToNewArrayBuffer(FrozenValue* cellButterfly)
 {
     setOpAndDefaultFlags(NewArrayBuffer);
     NewArrayBufferData data { };
-    data.indexingMode = immutableButterfly->cast<JSCellButterfly*>()->indexingMode();
-    data.vectorLengthHint = immutableButterfly->cast<JSCellButterfly*>()->toButterfly()->vectorLength();
+    data.indexingMode = cellButterfly->cast<JSCellButterfly*>()->indexingMode();
+    data.vectorLengthHint = cellButterfly->cast<JSCellButterfly*>()->toButterfly()->vectorLength();
     children.reset();
-    m_opInfo = immutableButterfly;
+    m_opInfo = cellButterfly;
     m_opInfo2 = data.asQuadWord;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -914,7 +914,7 @@ public:
         m_opInfo2 = OpInfoWrapper();
     }
 
-    void convertToNewArrayBuffer(FrozenValue* immutableButterfly);
+    void convertToNewArrayBuffer(FrozenValue* cellButterfly);
     void convertToNewArrayWithSize();
     void convertToNewArrayWithConstantSize(Graph&, uint32_t);
     void convertToNewArrayWithSizeAndStructure(Graph&, RegisteredStructure);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2233,16 +2233,16 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSizeAndHint, char*, (JSGlobalObjec
     OPERATION_RETURN(scope, std::bit_cast<char*>(result));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationNewArrayBuffer, JSCell*, (VM* vmPointer, Structure* arrayStructure, JSCell* immutableButterflyCell))
+JSC_DEFINE_JIT_OPERATION(operationNewArrayBuffer, JSCell*, (VM* vmPointer, Structure* arrayStructure, JSCell* cellButterflyCell))
 {
     VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(!arrayStructure->outOfLineCapacity());
-    auto* immutableButterfly = jsCast<JSCellButterfly*>(immutableButterflyCell);
-    ASSERT(arrayStructure->indexingMode() == immutableButterfly->indexingMode() || hasAnyArrayStorage(arrayStructure->indexingMode()));
-    auto* result = CommonSlowPaths::allocateNewArrayBuffer(vm, arrayStructure, immutableButterfly);
+    auto* cellButterfly = jsCast<JSCellButterfly*>(cellButterflyCell);
+    ASSERT(arrayStructure->indexingMode() == cellButterfly->indexingMode() || hasAnyArrayStorage(arrayStructure->indexingMode()));
+    auto* result = CommonSlowPaths::allocateNewArrayBuffer(vm, arrayStructure, cellButterfly);
     ASSERT(result->indexingMode() == result->structure()->indexingMode());
     ASSERT(result->structure() == arrayStructure);
     OPERATION_RETURN(scope, result);
@@ -4441,7 +4441,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSpreadSlow, JSCell*, (JSGlobalObje
     OPERATION_RETURN(scope, result);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationCreateImmutableButterfly, JSCell*, (JSGlobalObject* globalObject, unsigned length))
+JSC_DEFINE_JIT_OPERATION(operationCreateCellButterfly, JSCell*, (JSGlobalObject* globalObject, unsigned length))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -397,7 +397,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueCo
 JSC_DECLARE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSpreadSlow, JSCell*, (JSGlobalObject*, void*, uint32_t));
-JSC_DECLARE_JIT_OPERATION(operationCreateImmutableButterfly, JSCell*, (JSGlobalObject*, unsigned length));
+JSC_DECLARE_JIT_OPERATION(operationCreateCellButterfly, JSCell*, (JSGlobalObject*, unsigned length));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSpeciesInt32, JSObject*, (JSGlobalObject*, int32_t, JSObject*, IndexingType));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSpecies, JSObject*, (JSGlobalObject*, EncodedJSValue, JSObject*, IndexingType));
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9223,13 +9223,13 @@ void SpeculativeJIT::compileNewArrayWithSpread(Node* node)
 
         if (node->numChildren() == 1 && bitVector->get(0)) {
             Edge use = m_graph.varArgChild(node, 0);
-            SpeculateCellOperand immutableButterfly(this, use);
+            SpeculateCellOperand cellButterfly(this, use);
             GPRTemporary result(this);
             GPRTemporary butterfly(this);
             GPRTemporary scratch1(this);
             GPRTemporary scratch2(this);
 
-            GPRReg immutableButterflyGPR = immutableButterfly.gpr();
+            GPRReg cellButterflyGPR = cellButterfly.gpr();
             GPRReg resultGPR = result.gpr();
             GPRReg butterflyGPR = butterfly.gpr();
             GPRReg scratch1GPR = scratch1.gpr();
@@ -9239,12 +9239,12 @@ void SpeculativeJIT::compileNewArrayWithSpread(Node* node)
 
             JumpList slowCases;
 
-            move(immutableButterflyGPR, butterflyGPR);
+            move(cellButterflyGPR, butterflyGPR);
             addPtr(TrustedImm32(JSCellButterfly::offsetOfData()), butterflyGPR);
 
             emitAllocateJSObject<JSArray>(resultGPR, TrustedImmPtr(structure), butterflyGPR, scratch1GPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);
 
-            addSlowPathGenerator(slowPathCall(slowCases, this, operationNewArrayBuffer, resultGPR, TrustedImmPtr(&vm()), structure, immutableButterflyGPR));
+            addSlowPathGenerator(slowPathCall(slowCases, this, operationNewArrayBuffer, resultGPR, TrustedImmPtr(&vm()), structure, cellButterflyGPR));
 
             cellResult(resultGPR, node);
             return;
@@ -9264,9 +9264,9 @@ void SpeculativeJIT::compileNewArrayWithSpread(Node* node)
             for (unsigned i = 0; i < node->numChildren(); ++i) {
                 if (bitVector->get(i)) {
                     Edge use = m_graph.varArgChild(node, i);
-                    SpeculateCellOperand immutableButterfly(this, use);
-                    GPRReg immutableButterflyGPR = immutableButterfly.gpr();
-                    speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchAdd32(Overflow, Address(immutableButterflyGPR, JSCellButterfly::offsetOfPublicLength()), lengthGPR));
+                    SpeculateCellOperand cellButterfly(this, use);
+                    GPRReg cellButterflyGPR = cellButterfly.gpr();
+                    speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branchAdd32(Overflow, Address(cellButterflyGPR, JSCellButterfly::offsetOfPublicLength()), lengthGPR));
                 }
             }
 
@@ -9292,30 +9292,30 @@ void SpeculativeJIT::compileNewArrayWithSpread(Node* node)
         for (unsigned i = 0; i < node->numChildren(); ++i) {
             Edge use = m_graph.varArgChild(node, i);
             if (bitVector->get(i)) {
-                SpeculateCellOperand immutableButterfly(this, use);
-                GPRReg immutableButterflyGPR = immutableButterfly.gpr();
+                SpeculateCellOperand cellButterfly(this, use);
+                GPRReg cellButterflyGPR = cellButterfly.gpr();
 
-                GPRTemporary immutableButterflyIndex(this);
-                GPRReg immutableButterflyIndexGPR = immutableButterflyIndex.gpr();
+                GPRTemporary cellButterflyIndex(this);
+                GPRReg cellButterflyIndexGPR = cellButterflyIndex.gpr();
 
                 GPRTemporary item(this);
                 GPRReg itemGPR = item.gpr();
 
-                GPRTemporary immutableButterflyLength(this);
-                GPRReg immutableButterflyLengthGPR = immutableButterflyLength.gpr();
+                GPRTemporary cellButterflyLength(this);
+                GPRReg cellButterflyLengthGPR = cellButterflyLength.gpr();
 
-                load32(Address(immutableButterflyGPR, JSCellButterfly::offsetOfPublicLength()), immutableButterflyLengthGPR);
-                move(TrustedImm32(0), immutableButterflyIndexGPR);
-                auto done = branchPtr(AboveOrEqual, immutableButterflyIndexGPR, immutableButterflyLengthGPR);
+                load32(Address(cellButterflyGPR, JSCellButterfly::offsetOfPublicLength()), cellButterflyLengthGPR);
+                move(TrustedImm32(0), cellButterflyIndexGPR);
+                auto done = branchPtr(AboveOrEqual, cellButterflyIndexGPR, cellButterflyLengthGPR);
                 auto loopStart = label();
                 load64(
-                    BaseIndex(immutableButterflyGPR, immutableButterflyIndexGPR, TimesEight, JSCellButterfly::offsetOfData()),
+                    BaseIndex(cellButterflyGPR, cellButterflyIndexGPR, TimesEight, JSCellButterfly::offsetOfData()),
                     itemGPR);
 
                 store64(itemGPR, BaseIndex(storageGPR, indexGPR, TimesEight));
-                addPtr(TrustedImm32(1), immutableButterflyIndexGPR);
+                addPtr(TrustedImm32(1), cellButterflyIndexGPR);
                 addPtr(TrustedImm32(1), indexGPR);
-                branchPtr(Below, immutableButterflyIndexGPR, immutableButterflyLengthGPR).linkTo(loopStart, this);
+                branchPtr(Below, cellButterflyIndexGPR, cellButterflyLengthGPR).linkTo(loopStart, this);
 
                 done.link(this);
             } else {
@@ -9340,9 +9340,9 @@ void SpeculativeJIT::compileNewArrayWithSpread(Node* node)
     for (unsigned i = 0; i < node->numChildren(); ++i) {
         Edge use = m_graph.m_varArgChildren[node->firstChild() + i];
         if (bitVector->get(i)) {
-            SpeculateCellOperand immutableButterfly(this, use);
-            GPRReg immutableButterflyGPR = immutableButterfly.gpr();
-            storeCell(immutableButterflyGPR, &buffer[i]);
+            SpeculateCellOperand cellButterfly(this, use);
+            GPRReg cellButterflyGPR = cellButterfly.gpr();
+            storeCell(cellButterflyGPR, &buffer[i]);
         } else {
             JSValueOperand input(this, use);
             JSValueRegs inputRegs = input.jsValueRegs();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -9561,29 +9561,29 @@ IGNORE_CLANG_WARNINGS_END
 
             if (m_node->numChildren() == 1 && bitVector->get(0)) {
                 Edge use = m_graph.varArgChild(m_node, 0);
-                LValue immutableButterfly = nullptr;
+                LValue cellButterfly = nullptr;
                 if (use->op() == PhantomSpread) {
                     if (use->child1()->op() == PhantomNewArrayBuffer)
-                        immutableButterfly = createContiguousImmutableButterflyFromPhantomNewArrayBuffer(globalObject, use->child1().node());
+                        cellButterfly = createContiguousCellButterflyFromPhantomNewArrayBuffer(globalObject, use->child1().node());
                     else {
                         RELEASE_ASSERT(use->child1()->op() == PhantomCreateRest);
-                        immutableButterfly = createContiguousImmutableButterflyFromPhantomCreateRest(globalObject, use->child1().node());
+                        cellButterfly = createContiguousCellButterflyFromPhantomCreateRest(globalObject, use->child1().node());
                     }
                 } else {
                     // If a node is producing JSCellButterfly, it must be contiguous.
-                    immutableButterfly = lowCell(use);
+                    cellButterfly = lowCell(use);
                 }
 
                 RegisteredStructure structure = m_graph.registerStructure(globalObject->arrayStructureForIndexingTypeDuringAllocation(CopyOnWriteArrayWithContiguous));
                 LBasicBlock slowPath = m_out.newBlock();
                 LBasicBlock continuation = m_out.newBlock();
 
-                LValue fastArray = allocateObject<JSArray>(structure, toButterfly(immutableButterfly), slowPath);
+                LValue fastArray = allocateObject<JSArray>(structure, toButterfly(cellButterfly), slowPath);
                 ValueFromBlock fastResult = m_out.anchor(fastArray);
                 m_out.jump(continuation);
 
                 m_out.appendTo(slowPath, continuation);
-                LValue slowArray = vmCall(Int64, operationNewArrayBuffer, m_vmValue, weakStructure(structure), immutableButterfly);
+                LValue slowArray = vmCall(Int64, operationNewArrayBuffer, m_vmValue, weakStructure(structure), cellButterfly);
                 ValueFromBlock slowResult = m_out.anchor(slowArray);
                 m_out.jump(continuation);
 
@@ -9625,8 +9625,8 @@ IGNORE_CLANG_WARNINGS_END
                             lengthCheck = m_out.speculateAdd(length, spreadLength);
                         }
                     } else {
-                        LValue immutableButterfly = lowCell(use);
-                        lengthCheck = m_out.speculateAdd(length, m_out.load32(toButterfly(immutableButterfly), m_heaps.Butterfly_publicLength));
+                        LValue cellButterfly = lowCell(use);
+                        lengthCheck = m_out.speculateAdd(length, m_out.load32(toButterfly(cellButterfly), m_heaps.Butterfly_publicLength));
                     }
 
                     if (lengthCheck) {
@@ -9704,36 +9704,36 @@ IGNORE_CLANG_WARNINGS_END
                         LBasicBlock loopStart = m_out.newBlock();
                         LBasicBlock continuation = m_out.newBlock();
 
-                        LValue immutableButterfly = lowCell(use);
-                        LValue immutableButterflyStorage = toButterfly(immutableButterfly);
+                        LValue cellButterfly = lowCell(use);
+                        LValue cellButterflyStorage = toButterfly(cellButterfly);
 
-                        ValueFromBlock immutableButterflyIndexStart = m_out.anchor(m_out.constIntPtr(0));
+                        ValueFromBlock cellButterflyIndexStart = m_out.anchor(m_out.constIntPtr(0));
                         ValueFromBlock arrayIndexStart = m_out.anchor(index);
                         ValueFromBlock arrayIndexStartForFinish = m_out.anchor(index);
 
-                        LValue immutableButterflySize = m_out.zeroExtPtr(m_out.load32(immutableButterflyStorage, m_heaps.Butterfly_publicLength));
+                        LValue cellButterflySize = m_out.zeroExtPtr(m_out.load32(cellButterflyStorage, m_heaps.Butterfly_publicLength));
 
                         m_out.branch(
-                            m_out.isZero64(immutableButterflySize),
+                            m_out.isZero64(cellButterflySize),
                             unsure(continuation), unsure(loopStart));
 
                         LBasicBlock lastNext = m_out.appendTo(loopStart, continuation);
 
                         LValue arrayIndex = m_out.phi(pointerType(), arrayIndexStart);
-                        LValue immutableButterflyIndex = m_out.phi(pointerType(), immutableButterflyIndexStart);
+                        LValue cellButterflyIndex = m_out.phi(pointerType(), cellButterflyIndexStart);
 
-                        LValue item = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, immutableButterflyStorage, immutableButterflyIndex));
+                        LValue item = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, cellButterflyStorage, cellButterflyIndex));
                         m_out.store64(item, m_out.baseIndex(m_heaps.indexedContiguousProperties, storage, arrayIndex));
 
                         LValue nextArrayIndex = m_out.add(arrayIndex, m_out.constIntPtr(1));
-                        LValue nextImmutableButterflyIndex = m_out.add(immutableButterflyIndex, m_out.constIntPtr(1));
+                        LValue nextCellButterflyIndex = m_out.add(cellButterflyIndex, m_out.constIntPtr(1));
                         ValueFromBlock arrayIndexLoopForFinish = m_out.anchor(nextArrayIndex);
 
-                        m_out.addIncomingToPhi(immutableButterflyIndex, m_out.anchor(nextImmutableButterflyIndex));
+                        m_out.addIncomingToPhi(cellButterflyIndex, m_out.anchor(nextCellButterflyIndex));
                         m_out.addIncomingToPhi(arrayIndex, m_out.anchor(nextArrayIndex));
 
                         m_out.branch(
-                            m_out.below(nextImmutableButterflyIndex, immutableButterflySize),
+                            m_out.below(nextCellButterflyIndex, cellButterflySize),
                             unsure(loopStart), unsure(continuation));
 
                         m_out.appendTo(continuation, lastNext);
@@ -9931,47 +9931,47 @@ IGNORE_CLANG_WARNINGS_END
         compileCreateInternalFieldObject<JSAsyncGenerator>(operationCreateAsyncGenerator);
     }
 
-    LValue createContiguousImmutableButterflyFromPhantomNewArrayBuffer(JSGlobalObject* globalObject, Node* newArrayBufferNode)
+    LValue createContiguousCellButterflyFromPhantomNewArrayBuffer(JSGlobalObject* globalObject, Node* newArrayBufferNode)
     {
         ASSERT(newArrayBufferNode->op() == PhantomNewArrayBuffer);
-        auto* immutableButterfly = newArrayBufferNode->castOperand<JSCellButterfly*>();
-        if (hasContiguous(immutableButterfly->indexingType()))
+        auto* cellButterfly = newArrayBufferNode->castOperand<JSCellButterfly*>();
+        if (hasContiguous(cellButterfly->indexingType()))
             return frozenPointer(newArrayBufferNode->cellOperand());
 
         LBasicBlock slowAllocation = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
-        ASSERT(immutableButterfly->length() <= MAX_STORAGE_VECTOR_LENGTH);
+        ASSERT(cellButterfly->length() <= MAX_STORAGE_VECTOR_LENGTH);
 
-        LValue fastImmutableButterflyValue = allocateVariableSizedCell<JSCellButterfly>(
-            m_out.constIntPtr(JSCellButterfly::allocationSize(immutableButterfly->length())),
+        LValue fastCellButterflyValue = allocateVariableSizedCell<JSCellButterfly>(
+            m_out.constIntPtr(JSCellButterfly::allocationSize(cellButterfly->length())),
             m_graph.m_vm.cellButterflyStructure(CopyOnWriteArrayWithContiguous), slowAllocation);
-        LValue fastImmutableButterflyStorage = toButterfly(fastImmutableButterflyValue);
-        m_out.store32(m_out.constInt32(immutableButterfly->length()), fastImmutableButterflyStorage, m_heaps.Butterfly_publicLength);
-        m_out.store32(m_out.constInt32(immutableButterfly->length()), fastImmutableButterflyStorage, m_heaps.Butterfly_vectorLength);
-        ValueFromBlock fastImmutableButterfly = m_out.anchor(fastImmutableButterflyValue);
+        LValue fastCellButterflyStorage = toButterfly(fastCellButterflyValue);
+        m_out.store32(m_out.constInt32(cellButterfly->length()), fastCellButterflyStorage, m_heaps.Butterfly_publicLength);
+        m_out.store32(m_out.constInt32(cellButterfly->length()), fastCellButterflyStorage, m_heaps.Butterfly_vectorLength);
+        ValueFromBlock fastCellButterfly = m_out.anchor(fastCellButterflyValue);
         m_out.jump(continuation);
 
         LBasicBlock lastNext = m_out.appendTo(slowAllocation, continuation);
-        ValueFromBlock slowImmutableButterfly = m_out.anchor(vmCall(pointerType(), operationCreateImmutableButterfly, weakPointer(globalObject), m_out.constInt32(immutableButterfly->length())));
+        ValueFromBlock slowCellButterfly = m_out.anchor(vmCall(pointerType(), operationCreateCellButterfly, weakPointer(globalObject), m_out.constInt32(cellButterfly->length())));
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
-        LValue immutableButterflyValue = m_out.phi(pointerType(), fastImmutableButterfly, slowImmutableButterfly);
-        LValue immutableButterflyStorage = toButterfly(immutableButterflyValue);
-        for (unsigned i = 0; i < immutableButterfly->length(); i++) {
+        LValue cellButterflyValue = m_out.phi(pointerType(), fastCellButterfly, slowCellButterfly);
+        LValue cellButterflyStorage = toButterfly(cellButterflyValue);
+        for (unsigned i = 0; i < cellButterfly->length(); i++) {
             // Because forwarded values are drained as JSValue, we should not generate value
             // in Double form even if PhantomNewArrayBuffer's indexingType is ArrayWithDouble.
-            int64_t value = JSValue::encode(immutableButterfly->get(i));
+            int64_t value = JSValue::encode(cellButterfly->get(i));
             m_out.store64(
                 m_out.constInt64(value),
-                m_out.baseIndex(m_heaps.indexedContiguousProperties, immutableButterflyStorage, m_out.constIntPtr(i), jsNumber(i)));
+                m_out.baseIndex(m_heaps.indexedContiguousProperties, cellButterflyStorage, m_out.constIntPtr(i), jsNumber(i)));
         }
         mutatorFence();
-        return immutableButterflyValue;
+        return cellButterflyValue;
     }
 
-    LValue createContiguousImmutableButterflyFromPhantomCreateRest(JSGlobalObject* globalObject, Node* restNode)
+    LValue createContiguousCellButterflyFromPhantomCreateRest(JSGlobalObject* globalObject, Node* restNode)
     {
         ASSERT(restNode->op() == PhantomCreateRest);
         LBasicBlock fastAllocation = m_out.newBlock();
@@ -9999,26 +9999,26 @@ IGNORE_CLANG_WARNINGS_END
         m_out.jump(loopHeader);
 
         m_out.appendTo(slowAllocation, loopHeader);
-        ValueFromBlock slowArray = m_out.anchor(vmCall(pointerType(), operationCreateImmutableButterfly, weakPointer(globalObject), length));
+        ValueFromBlock slowArray = m_out.anchor(vmCall(pointerType(), operationCreateCellButterfly, weakPointer(globalObject), length));
         m_out.jump(loopHeader);
 
         m_out.appendTo(loopHeader, loopBody);
-        LValue immutableButterfly = m_out.phi(pointerType(), fastArray, slowArray);
-        LValue immutableButterflyStorage = toButterfly(immutableButterfly);
+        LValue cellButterfly = m_out.phi(pointerType(), fastArray, slowArray);
+        LValue cellButterflyStorage = toButterfly(cellButterfly);
         ValueFromBlock startIndex = m_out.anchor(m_out.constIntPtr(0));
         m_out.branch(m_out.isZero32(length), unsure(continuation), unsure(loopBody));
 
         m_out.appendTo(loopBody, continuation);
         LValue index = m_out.phi(pointerType(), startIndex);
         LValue value = m_out.load64(m_out.baseIndex(m_heaps.variables, sourceStart, index));
-        m_out.store64(value, m_out.baseIndex(m_heaps.indexedContiguousProperties, immutableButterflyStorage, index));
+        m_out.store64(value, m_out.baseIndex(m_heaps.indexedContiguousProperties, cellButterflyStorage, index));
         LValue nextIndex = m_out.add(m_out.constIntPtr(1), index);
         m_out.addIncomingToPhi(index, m_out.anchor(nextIndex));
         m_out.branch(m_out.below(nextIndex, m_out.zeroExtPtr(length)), unsure(loopBody), unsure(continuation));
 
         m_out.appendTo(continuation, lastNext);
         mutatorFence();
-        return immutableButterfly;
+        return cellButterfly;
     }
 
     void compileSpread()
@@ -10027,7 +10027,7 @@ IGNORE_CLANG_WARNINGS_END
         if (m_node->child1()->op() == PhantomNewArrayBuffer) {
             ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(m_node->child1().node()));
             // FIXME: JSCellButterfly::createFromArray should support re-using non contiguous indexing types as well.
-            setJSValue(createContiguousImmutableButterflyFromPhantomNewArrayBuffer(globalObject, m_node->child1().node()));
+            setJSValue(createContiguousCellButterflyFromPhantomNewArrayBuffer(globalObject, m_node->child1().node()));
             return;
         }
 
@@ -10039,7 +10039,7 @@ IGNORE_CLANG_WARNINGS_END
             // the Spread but nothing escapes the CreateRest.
 
             ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(m_node->child1().node()));
-            setJSValue(createContiguousImmutableButterflyFromPhantomCreateRest(globalObject, m_node->child1().node()));
+            setJSValue(createContiguousCellButterflyFromPhantomCreateRest(globalObject, m_node->child1().node()));
             return;
         }
 
@@ -10152,13 +10152,13 @@ IGNORE_CLANG_WARNINGS_END
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         RegisteredStructure structure = m_graph.registerStructure(globalObject->arrayStructureForIndexingTypeDuringAllocation(
             m_node->indexingMode()));
-        auto* immutableButterfly = m_node->castOperand<JSCellButterfly*>();
+        auto* cellButterfly = m_node->castOperand<JSCellButterfly*>();
 
         if (!globalObject->isHavingABadTime() && !hasAnyArrayStorage(m_node->indexingMode())) {
             LBasicBlock slowPath = m_out.newBlock();
             LBasicBlock continuation = m_out.newBlock();
 
-            LValue fastArray = allocateObject<JSArray>(structure, m_out.constIntPtr(immutableButterfly->toButterfly()), slowPath);
+            LValue fastArray = allocateObject<JSArray>(structure, m_out.constIntPtr(cellButterfly->toButterfly()), slowPath);
             ValueFromBlock fastResult = m_out.anchor(fastArray);
             m_out.jump(continuation);
 
@@ -24794,9 +24794,9 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->setGenerator([=] (CCallHelpers&, const StackmapGenerationParams&) { });
     }
 
-    LValue toButterfly(LValue immutableButterfly)
+    LValue toButterfly(LValue cellButterfly)
     {
-        return m_out.addPtr(immutableButterfly, JSCellButterfly::offsetOfData());
+        return m_out.addPtr(cellButterfly, JSCellButterfly::offsetOfData());
     }
 
     LValue toIntegerOrInfinity(LValue doubleValue)

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -622,15 +622,15 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
     }
 
     case PhantomNewArrayBuffer: {
-        JSCellButterfly* immutableButterfly = nullptr;
+        JSCellButterfly* cellButterfly = nullptr;
         for (unsigned i = materialization->properties().size(); i--;) {
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location().kind() == NewArrayBufferPLoc) {
-                immutableButterfly = jsCast<JSCellButterfly*>(JSValue::decode(values[i]));
+                cellButterfly = jsCast<JSCellButterfly*>(JSValue::decode(values[i]));
                 break;
             }
         }
-        RELEASE_ASSERT(immutableButterfly);
+        RELEASE_ASSERT(cellButterfly);
 
         // For now, we use array allocation profile in the actual CodeBlock. It is OK since current NewArrayBuffer
         // and PhantomNewArrayBuffer are always bound to a specific op_new_array_buffer.
@@ -639,8 +639,8 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
         if (!currentInstruction->is<OpNewArrayBuffer>()) {
             // This case can happen if Object.keys, an OpCall, and others is first converted into a NewArrayBuffer which is then converted into a PhantomNewArrayBuffer.
             // There is no need to update the array allocation profile in that case.
-            Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(immutableButterfly->indexingMode());
-            return CommonSlowPaths::allocateNewArrayBuffer(vm, structure, immutableButterfly);
+            Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(cellButterfly->indexingMode());
+            return CommonSlowPaths::allocateNewArrayBuffer(vm, structure, cellButterfly);
         }
         auto newArrayBuffer = currentInstruction->as<OpNewArrayBuffer>();
         ArrayAllocationProfile* profile = &newArrayBuffer.metadata(codeBlock).m_arrayAllocationProfile;
@@ -651,21 +651,21 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
         ASSERT(isCopyOnWrite(indexingMode));
         ASSERT(!structure->outOfLineCapacity());
 
-        if (immutableButterfly->indexingMode() != indexingMode) [[unlikely]] {
-            auto* newButterfly = JSCellButterfly::create(vm, indexingMode, immutableButterfly->length());
-            for (unsigned i = 0; i < immutableButterfly->length(); ++i)
-                newButterfly->setIndex(vm, i, immutableButterfly->get(i));
-            immutableButterfly = newButterfly;
+        if (cellButterfly->indexingMode() != indexingMode) [[unlikely]] {
+            auto* newButterfly = JSCellButterfly::create(vm, indexingMode, cellButterfly->length());
+            for (unsigned i = 0; i < cellButterfly->length(); ++i)
+                newButterfly->setIndex(vm, i, cellButterfly->get(i));
+            cellButterfly = newButterfly;
 
             // FIXME: This is kinda gross and only works because we can't inline new_array_bufffer in the baseline.
             // We also cannot allocate a new butterfly from compilation threads since it's invalid to allocate cells from
             // a compilation thread.
             WTF::storeStoreFence();
-            codeBlock->constantRegister(newArrayBuffer.m_immutableButterfly).set(vm, codeBlock, immutableButterfly);
+            codeBlock->constantRegister(newArrayBuffer.m_cellButterfly).set(vm, codeBlock, cellButterfly);
             WTF::storeStoreFence();
         }
 
-        JSArray* result = CommonSlowPaths::allocateNewArrayBuffer(vm, structure, immutableButterfly);
+        JSArray* result = CommonSlowPaths::allocateNewArrayBuffer(vm, structure, cellButterfly);
         ArrayAllocationProfile::updateLastAllocationFor(profile, result);
         return result;
     }
@@ -683,8 +683,8 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
             if (property.location().kind() == NewArrayWithSpreadArgumentPLoc) {
                 ++numProperties;
                 JSValue value = JSValue::decode(values[i]);
-                if (JSCellButterfly* immutableButterfly = jsDynamicCast<JSCellButterfly*>(value))
-                    checkedArraySize += immutableButterfly->publicLength();
+                if (JSCellButterfly* cellButterfly = jsDynamicCast<JSCellButterfly*>(value))
+                    checkedArraySize += cellButterfly->publicLength();
                 else
                     checkedArraySize += 1;
             }
@@ -725,10 +725,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
 
         unsigned arrayIndex = 0;
         for (JSValue value : arguments) {
-            if (JSCellButterfly* immutableButterfly = jsDynamicCast<JSCellButterfly*>(value)) {
-                for (unsigned i = 0; i < immutableButterfly->publicLength(); i++) {
-                    ASSERT(immutableButterfly->get(i));
-                    result->putDirectIndex(globalObject, arrayIndex, immutableButterfly->get(i));
+            if (JSCellButterfly* cellButterfly = jsDynamicCast<JSCellButterfly*>(value)) {
+                for (unsigned i = 0; i < cellButterfly->publicLength(); i++) {
+                    ASSERT(cellButterfly->get(i));
+                    result->putDirectIndex(globalObject, arrayIndex, cellButterfly->get(i));
                     ++arrayIndex;
                 }
             } else {

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -350,7 +350,7 @@ Heap::Heap(VM& vm, HeapType heapType)
 
     // HeapCellTypes
     , auxiliaryHeapCellType(CellAttributes(DoesNotNeedDestruction, HeapCell::Auxiliary))
-    , immutableButterflyHeapCellType(CellAttributes(DoesNotNeedDestruction, HeapCell::JSCellWithIndexingHeader))
+    , cellButterflyHeapCellType(CellAttributes(DoesNotNeedDestruction, HeapCell::JSCellWithIndexingHeader))
     , cellHeapCellType(CellAttributes(DoesNotNeedDestruction, HeapCell::JSCell))
     , destructibleCellHeapCellType(CellAttributes(NeedsDestruction, HeapCell::JSCell))
     , apiGlobalObjectHeapCellType(IsoHeapCellType::Args<JSAPIGlobalObject>())
@@ -414,7 +414,7 @@ Heap::Heap(VM& vm, HeapType heapType)
     // Subspaces
     , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary"_s, *this, auxiliaryHeapCellType, primitiveGigacageAllocator.get()) // Hash:0x3e7cd762
     , auxiliarySpace("Auxiliary"_s, *this, auxiliaryHeapCellType, fastMallocAllocator.get()) // Hash:0x96255ba1
-    , immutableButterflyAuxiliarySpace("ImmutableButterfly JSCellWithIndexingHeader"_s, *this, immutableButterflyHeapCellType, fastMallocAllocator.get()) // Hash:0xaadcb3c1
+    , cellButterflyAuxiliarySpace("CellButterfly JSCellWithIndexingHeader"_s, *this, cellButterflyHeapCellType, fastMallocAllocator.get()) // Hash:0xaadcb3c1
     , cellSpace("JSCell"_s, *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xadfb5a79
     , destructibleObjectSpace("JSDestructibleObject"_s, *this, destructibleObjectHeapCellType, fastMallocAllocator.get()) // Hash:0x4f5ed7a9
     FOR_EACH_JSC_COMMON_ISO_SUBSPACE(INIT_SERVER_ISO_SUBSPACE)
@@ -2288,7 +2288,7 @@ void Heap::finalize()
 
     m_possiblyAccessedStringsFromConcurrentThreads.clear();
 
-    immutableButterflyToStringCache.clear();
+    cellButterflyToStringCache.clear();
     
     for (const HeapFinalizerCallback& callback : m_heapFinalizerCallbacks)
         callback.run(vm());

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -597,7 +597,7 @@ public:
     
     Seconds totalGCTime() const { return m_totalGCTime; }
 
-    UncheckedKeyHashMap<JSCellButterfly*, JSString*> immutableButterflyToStringCache;
+    UncheckedKeyHashMap<JSCellButterfly*, JSString*> cellButterflyToStringCache;
 
     bool isMarkingForGCVerifier() const { return m_isMarkingForGCVerifier; }
 
@@ -1001,7 +1001,7 @@ private:
 public:
     // HeapCellTypes
     HeapCellType auxiliaryHeapCellType;
-    HeapCellType immutableButterflyHeapCellType;
+    HeapCellType cellButterflyHeapCellType;
     HeapCellType cellHeapCellType;
     HeapCellType destructibleCellHeapCellType;
     IsoHeapCellType apiGlobalObjectHeapCellType;
@@ -1069,7 +1069,7 @@ public:
     // Subspaces
     CompleteSubspace primitiveGigacageAuxiliarySpace; // Typed arrays, strings, bitvectors, etc go here.
     CompleteSubspace auxiliarySpace; // Butterflies, arrays of JSValues, etc go here.
-    CompleteSubspace immutableButterflyAuxiliarySpace; // JSCellButterfly goes here.
+    CompleteSubspace cellButterflyAuxiliarySpace; // JSCellButterfly goes here.
 
     // We make cross-cutting assumptions about typed arrays being in the primitive Gigacage and butterflies
     // being in the JSValue gigacage. For some types, it's super obvious where they should go, and so we

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1261,31 +1261,31 @@ private:
 };
 
 class CachedJSValue;
-class CachedImmutableButterfly : public CachedObject<JSCellButterfly> {
+class CachedCellButterfly : public CachedObject<JSCellButterfly> {
 public:
-    CachedImmutableButterfly()
+    CachedCellButterfly()
         : m_cachedDoubles()
     {
     }
 
-    void encode(Encoder& encoder, JSCellButterfly& immutableButterfly)
+    void encode(Encoder& encoder, JSCellButterfly& cellButterfly)
     {
-        m_length = immutableButterfly.length();
-        m_indexingType = immutableButterfly.indexingTypeAndMisc();
+        m_length = cellButterfly.length();
+        m_indexingType = cellButterfly.indexingTypeAndMisc();
         if (hasDouble(m_indexingType))
-            m_cachedDoubles.encode(encoder, immutableButterfly.toButterfly()->contiguousDouble().data(), m_length);
+            m_cachedDoubles.encode(encoder, cellButterfly.toButterfly()->contiguousDouble().data(), m_length);
         else
-            m_cachedValues.encode(encoder, immutableButterfly.toButterfly()->contiguous().data(), m_length);
+            m_cachedValues.encode(encoder, cellButterfly.toButterfly()->contiguous().data(), m_length);
     }
 
     JSCellButterfly* decode(Decoder& decoder) const
     {
-        JSCellButterfly* immutableButterfly = JSCellButterfly::create(decoder.vm(), m_indexingType, m_length);
+        JSCellButterfly* cellButterfly = JSCellButterfly::create(decoder.vm(), m_indexingType, m_length);
         if (hasDouble(m_indexingType))
-            m_cachedDoubles.decode(decoder, immutableButterfly->toButterfly()->contiguousDouble().data(), m_length, immutableButterfly);
+            m_cachedDoubles.decode(decoder, cellButterfly->toButterfly()->contiguousDouble().data(), m_length, cellButterfly);
         else
-            m_cachedValues.decode(decoder, immutableButterfly->toButterfly()->contiguous().data(), m_length, immutableButterfly);
-        return immutableButterfly;
+            m_cachedValues.decode(decoder, cellButterfly->toButterfly()->contiguous().data(), m_length, cellButterfly);
+        return cellButterfly;
     }
 
 private:
@@ -1398,9 +1398,9 @@ public:
             return;
         }
 
-        if (auto* immutableButterfly = jsDynamicCast<JSCellButterfly*>(cell)) {
-            m_type = EncodedType::ImmutableButterfly;
-            this->allocate<CachedImmutableButterfly>(encoder)->encode(encoder, *immutableButterfly);
+        if (auto* cellButterfly = jsDynamicCast<JSCellButterfly*>(cell)) {
+            m_type = EncodedType::CellButterfly;
+            this->allocate<CachedCellButterfly>(encoder)->encode(encoder, *cellButterfly);
             return;
         }
 
@@ -1440,8 +1440,8 @@ public:
             v = jsString(decoder.vm(), adoptRef(*impl));
             break;
         }
-        case EncodedType::ImmutableButterfly:
-            v = this->buffer<CachedImmutableButterfly>()->decode(decoder);
+        case EncodedType::CellButterfly:
+            v = this->buffer<CachedCellButterfly>()->decode(decoder);
             break;
         case EncodedType::RegExp:
             v = this->buffer<CachedRegExp>()->decode(decoder);
@@ -1463,7 +1463,7 @@ private:
         JSValue,
         SymbolTable,
         String,
-        ImmutableButterfly,
+        CellButterfly,
         RegExp,
         TemplateObjectDescriptor,
         BigInt,

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -1370,8 +1370,8 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_buffer)
 {
     BEGIN();
     auto bytecode = pc->as<OpNewArrayBuffer>();
-    ASSERT(bytecode.m_immutableButterfly.isConstant());
-    JSCellButterfly* immutableButterfly = std::bit_cast<JSCellButterfly*>(GET_C(bytecode.m_immutableButterfly).jsValue().asCell());
+    ASSERT(bytecode.m_cellButterfly.isConstant());
+    JSCellButterfly* cellButterfly = std::bit_cast<JSCellButterfly*>(GET_C(bytecode.m_cellButterfly).jsValue().asCell());
     auto& profile = bytecode.metadata(codeBlock).m_arrayAllocationProfile;
 
     IndexingType indexingMode = profile.selectIndexingType();
@@ -1379,21 +1379,21 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_buffer)
     ASSERT(isCopyOnWrite(indexingMode));
     ASSERT(!structure->outOfLineCapacity());
 
-    if (immutableButterfly->indexingMode() != indexingMode) [[unlikely]] {
-        auto* newButterfly = JSCellButterfly::create(vm, indexingMode, immutableButterfly->length());
-        for (unsigned i = 0; i < immutableButterfly->length(); ++i)
-            newButterfly->setIndex(vm, i, immutableButterfly->get(i));
-        immutableButterfly = newButterfly;
+    if (cellButterfly->indexingMode() != indexingMode) [[unlikely]] {
+        auto* newButterfly = JSCellButterfly::create(vm, indexingMode, cellButterfly->length());
+        for (unsigned i = 0; i < cellButterfly->length(); ++i)
+            newButterfly->setIndex(vm, i, cellButterfly->get(i));
+        cellButterfly = newButterfly;
 
         // FIXME: This is kinda gross and only works because we can't inline new_array_bufffer in the baseline.
         // We also cannot allocate a new butterfly from compilation threads since it's invalid to allocate cells from
         // a compilation thread.
         WTF::storeStoreFence();
-        codeBlock->constantRegister(bytecode.m_immutableButterfly).set(vm, codeBlock, immutableButterfly);
+        codeBlock->constantRegister(bytecode.m_cellButterfly).set(vm, codeBlock, cellButterfly);
         WTF::storeStoreFence();
     }
 
-    JSArray* result = CommonSlowPaths::allocateNewArrayBuffer(vm, structure, immutableButterfly);
+    JSArray* result = CommonSlowPaths::allocateNewArrayBuffer(vm, structure, cellButterfly);
     ASSERT(isCopyOnWrite(result->indexingMode()) || globalObject->isHavingABadTime());
     ArrayAllocationProfile::updateLastAllocationFor(&profile, result);
     RETURN(result);

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -229,22 +229,22 @@ static ALWAYS_INLINE void putDirectAccessorWithReify(VM& vm, JSGlobalObject* glo
     baseObject->putDirectAccessor(globalObject, propertyName, accessor, attribute);
 }
 
-inline JSArray* allocateNewArrayBuffer(VM& vm, Structure* structure, JSCellButterfly* immutableButterfly)
+inline JSArray* allocateNewArrayBuffer(VM& vm, Structure* structure, JSCellButterfly* cellButterfly)
 {
     JSGlobalObject* globalObject = structure->globalObject();
-    Structure* originalStructure = globalObject->originalArrayStructureForIndexingType(immutableButterfly->indexingMode());
-    ASSERT(originalStructure->indexingMode() == immutableButterfly->indexingMode());
-    ASSERT(isCopyOnWrite(immutableButterfly->indexingMode()));
+    Structure* originalStructure = globalObject->originalArrayStructureForIndexingType(cellButterfly->indexingMode());
+    ASSERT(originalStructure->indexingMode() == cellButterfly->indexingMode());
+    ASSERT(isCopyOnWrite(cellButterfly->indexingMode()));
     ASSERT(!structure->outOfLineCapacity());
 
-    JSArray* result = JSArray::createWithButterfly(vm, nullptr, originalStructure, immutableButterfly->toButterfly());
+    JSArray* result = JSArray::createWithButterfly(vm, nullptr, originalStructure, cellButterfly->toButterfly());
     // FIXME: This works but it's slow. If we cared enough about the perf when having a bad time then we could fix it.
     if (originalStructure != structure) [[unlikely]] {
         ASSERT(hasSlowPutArrayStorage(structure->indexingMode()));
         ASSERT(globalObject->isHavingABadTime());
 
         result->switchToSlowPutArrayStorage(vm);
-        ASSERT(result->butterfly() != immutableButterfly->toButterfly());
+        ASSERT(result->butterfly() != cellButterfly->toButterfly());
         ASSERT(!result->butterfly()->arrayStorage()->m_sparseMap.get());
         ASSERT(result->structureID() == structure->id());
     }

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1005,11 +1005,11 @@ JSString* JSArray::fastToString(JSGlobalObject* globalObject)
         const LChar comma = ',';
 
         bool isCoW = isCopyOnWrite(this->indexingMode());
-        JSCellButterfly* immutableButterfly = nullptr;
+        JSCellButterfly* cellButterfly = nullptr;
         if (isCoW) {
-            immutableButterfly = JSCellButterfly::fromButterfly(this->butterfly());
-            auto iter = vm.heap.immutableButterflyToStringCache.find(immutableButterfly);
-            if (iter != vm.heap.immutableButterflyToStringCache.end())
+            cellButterfly = JSCellButterfly::fromButterfly(this->butterfly());
+            auto iter = vm.heap.cellButterflyToStringCache.find(cellButterfly);
+            if (iter != vm.heap.cellButterflyToStringCache.end())
                 return iter->value;
         }
 
@@ -1019,8 +1019,8 @@ JSString* JSArray::fastToString(JSGlobalObject* globalObject)
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!sawHoles && !genericCase && result && isCoW) {
-            ASSERT(JSCellButterfly::fromButterfly(this->butterfly()) == immutableButterfly);
-            vm.heap.immutableButterflyToStringCache.add(immutableButterfly, jsCast<JSString*>(result));
+            ASSERT(JSCellButterfly::fromButterfly(this->butterfly()) == cellButterfly);
+            vm.heap.cellButterflyToStringCache.add(cellButterfly, jsCast<JSString*>(result));
         }
 
         return result;

--- a/Source/JavaScriptCore/runtime/JSCellButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSCellButterfly.h
@@ -178,7 +178,7 @@ public:
     static CompleteSubspace* subspaceFor(VM& vm)
     {
         // We allocate out of the JSValue gigacage as other code expects all butterflies to live there.
-        return &vm.immutableButterflyAuxiliarySpace();
+        return &vm.cellButterflyAuxiliarySpace();
     }
 
     // Only call this if you just allocated this butterfly.

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -1276,9 +1276,9 @@ JSArray* ownPropertyKeys(JSGlobalObject* globalObject, JSObject* object, Propert
 
     // We attempt to look up own property keys cache in Object.keys / Object.getOwnPropertyNames cases.
     if (!globalObject->isHavingABadTime()) [[likely]] {
-        if (auto* immutableButterfly = object->structure()->cachedPropertyNames(kind)) {
-            Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(immutableButterfly->indexingMode());
-            return JSArray::createWithButterfly(vm, nullptr, arrayStructure, immutableButterfly->toButterfly());
+        if (auto* cellButterfly = object->structure()->cachedPropertyNames(kind)) {
+            Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(cellButterfly->indexingMode());
+            return JSArray::createWithButterfly(vm, nullptr, arrayStructure, cellButterfly->toButterfly());
         }
     }
 

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -695,9 +695,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
     }
 
     if (limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime()) [[likely]] {
-        if (auto* immutableButterfly = vm.stringSplitCache.get(input, separator)) {
+        if (auto* cellButterfly = vm.stringSplitCache.get(input, separator)) {
             Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
-            return JSValue::encode(JSArray::createWithButterfly(vm, nullptr, arrayStructure, immutableButterfly->toButterfly()));
+            return JSValue::encode(JSArray::createWithButterfly(vm, nullptr, arrayStructure, cellButterfly->toButterfly()));
         }
     }
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -306,10 +306,10 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     symbolTableStructure.setWithoutWriteBarrier(SymbolTable::createStructure(*this, nullptr, jsNull()));
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    rawImmutableButterflyStructure(CopyOnWriteArrayWithInt32).setWithoutWriteBarrier(JSCellButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithInt32));
+    rawCellButterflyStructure(CopyOnWriteArrayWithInt32).setWithoutWriteBarrier(JSCellButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithInt32));
     Structure* copyOnWriteArrayWithContiguousStructure = JSCellButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithContiguous);
-    rawImmutableButterflyStructure(CopyOnWriteArrayWithDouble).setWithoutWriteBarrier(Options::allowDoubleShape() ? JSCellButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
-    rawImmutableButterflyStructure(CopyOnWriteArrayWithContiguous).setWithoutWriteBarrier(copyOnWriteArrayWithContiguousStructure);
+    rawCellButterflyStructure(CopyOnWriteArrayWithDouble).setWithoutWriteBarrier(Options::allowDoubleShape() ? JSCellButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
+    rawCellButterflyStructure(CopyOnWriteArrayWithContiguous).setWithoutWriteBarrier(copyOnWriteArrayWithContiguousStructure);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // This is only for JSCellButterfly filled with atom strings.

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -354,7 +354,7 @@ public:
     };
     JS_EXPORT_PRIVATE void performOpportunisticallyScheduledTasks(MonotonicTime deadline, OptionSet<SchedulerOptions>);
 
-    Structure* cellButterflyStructure(IndexingType indexingType) { return rawImmutableButterflyStructure(indexingType).get(); }
+    Structure* cellButterflyStructure(IndexingType indexingType) { return rawCellButterflyStructure(indexingType).get(); }
 
     // Keep super frequently accessed fields top in VM.
     unsigned disallowVMEntryCount { 0 };
@@ -394,7 +394,7 @@ private:
         m_entryScopeServices.remove(service);
     }
 
-    WriteBarrier<Structure>& rawImmutableButterflyStructure(IndexingType indexingType) { return cellButterflyStructures[arrayIndexFromIndexingType(indexingType) - NumberOfIndexingShapes]; }
+    WriteBarrier<Structure>& rawCellButterflyStructure(IndexingType indexingType) { return cellButterflyStructures[arrayIndexFromIndexingType(indexingType) - NumberOfIndexingShapes]; }
 
 public:
     Heap heap;
@@ -411,7 +411,7 @@ public:
     
     ALWAYS_INLINE CompleteSubspace& primitiveGigacageAuxiliarySpace() { return heap.primitiveGigacageAuxiliarySpace; }
     ALWAYS_INLINE CompleteSubspace& auxiliarySpace() { return heap.auxiliarySpace; }
-    ALWAYS_INLINE CompleteSubspace& immutableButterflyAuxiliarySpace() { return heap.immutableButterflyAuxiliarySpace; }
+    ALWAYS_INLINE CompleteSubspace& cellButterflyAuxiliarySpace() { return heap.cellButterflyAuxiliarySpace; }
     ALWAYS_INLINE CompleteSubspace& gigacageAuxiliarySpace(Gigacage::Kind kind) { return heap.gigacageAuxiliarySpace(kind); }
     ALWAYS_INLINE CompleteSubspace& cellSpace() { return heap.cellSpace; }
     ALWAYS_INLINE CompleteSubspace& destructibleObjectSpace() { return heap.destructibleObjectSpace; }


### PR DESCRIPTION
#### a51babdd91f074d7963a781f998c34753fb7fb1f
<pre>
[JSC] Rename remaining ImmutableButterfly to CellButterfly
<a href="https://bugs.webkit.org/show_bug.cgi?id=297705">https://bugs.webkit.org/show_bug.cgi?id=297705</a>
<a href="https://rdar.apple.com/158816433">rdar://158816433</a>

Reviewed by NOBODY (OOPS!).

Rename remaining immutable butterfiles.

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp:
(JSC::computeUsesForBytecodeIndexImpl):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToNewArrayBuffer):
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNewArrayWithSpread):
(JSC::FTL::DFG::LowerDFGToB3::createContiguousCellButterflyFromPhantomNewArrayBuffer):
(JSC::FTL::DFG::LowerDFGToB3::createContiguousCellButterflyFromPhantomCreateRest):
(JSC::FTL::DFG::LowerDFGToB3::compileSpread):
(JSC::FTL::DFG::LowerDFGToB3::compileNewArrayBuffer):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
(JSC::FTL::DFG::LowerDFGToB3::createContiguousImmutableButterflyFromPhantomNewArrayBuffer): Deleted.
(JSC::FTL::DFG::LowerDFGToB3::createContiguousImmutableButterflyFromPhantomCreateRest): Deleted.
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
(JSC::Heap::finalize):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedCellButterfly::CachedCellButterfly):
(JSC::CachedCellButterfly::encode):
(JSC::CachedCellButterfly::decode const):
(JSC::CachedJSValue::encode):
(JSC::CachedJSValue::decode const):
(JSC::CachedImmutableButterfly::CachedImmutableButterfly): Deleted.
(JSC::CachedImmutableButterfly::encode): Deleted.
(JSC::CachedImmutableButterfly::decode const): Deleted.
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
(JSC::CommonSlowPaths::allocateNewArrayBuffer):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastToString):
* Source/JavaScriptCore/runtime/JSCellButterfly.h:
(JSC::JSCellButterfly::subspaceFor):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::ownPropertyKeys):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::cellButterflyStructure):
(JSC::VM::rawCellButterflyStructure):
(JSC::VM::cellButterflyAuxiliarySpace):
(JSC::VM::rawImmutableButterflyStructure): Deleted.
(JSC::VM::immutableButterflyAuxiliarySpace): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a51babdd91f074d7963a781f998c34753fb7fb1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69409 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/893dc933-cbec-4d67-aa37-474f7aff5b3c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89109 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43770 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d601171f-2c9b-4682-abd9-827c23c2fb3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69618 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37542791-237a-43dd-9cac-a3cbab4d1d56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23398 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67192 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109525 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126640 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115927 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97775 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97569 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40667 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49849 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144627 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43647 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37223 "Found 1 new JSC binary failure: testapi, Found 20033 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Basics/equal.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug724121.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->