### PR TITLE
[GLIB] Unreviewed test gardening

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3724,7 +3724,12 @@ webkit.org/b/199009 fast/text/variations/optical-sizing-units.html [ ImageOnlyFa
 # Timeout since https://commits.webkit.org/295725@main.
 webkit.org/b/199001 accessibility/set-selected-text-range-after-newline.html [ Skip ]
 
+# Test expects a timeout of 20s.
+imported/w3c/web-platform-tests/websockets/keeping-connection-open/001.html?wss [ Slow ]
+
 # Issues with WebSockets, many due to macOS/iOS and "glib" dealing with console messages differently
+webkit.org/b/206652 imported/w3c/web-platform-tests/websockets/constructor/011.html?default [ Failure ]
+webkit.org/b/206652 imported/w3c/web-platform-tests/websockets/constructor/011.html?wss [ Failure ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Close-1005.any.worker.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Close-2999-reason.any.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Close-2999-reason.any.worker.html?wss [ Failure Pass ]
@@ -3751,24 +3756,16 @@ webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Create-blocked-po
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Create-blocked-port.any.worker.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Create-extensions-empty.any.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Create-extensions-empty.any.worker.html?wss [ Failure Pass ]
-webkit.org/b/251347 imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.html [ Failure ]
-webkit.org/b/251347 imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker.html [ Failure ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Create-valid-url-array-protocols.any.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/Create-valid-url-array-protocols.any.worker.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/multi-globals/message-received.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/unload-a-document/003.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/unload-a-document/004.html?wss [ Failure Pass ]
-webkit.org/b/206652 imported/w3c/web-platform-tests/websockets/constructor/011.html?default [ Failure ]
-webkit.org/b/251347 imported/w3c/web-platform-tests/websockets/constructor/011.html?wss [ Failure ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/constructor/016.html?wss [ Failure Pass ]
-webkit.org/b/251347 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/close/close-basic.html?wss [ Failure Pass Timeout ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/readyState/008.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/send/005.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/send/008.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/send/010.html?wss [ Failure Pass ]
-webkit.org/b/251347 imported/w3c/web-platform-tests/websockets/keeping-connection-open/001.html?wss [ Failure ]
-webkit.org/b/251347 imported/w3c/web-platform-tests/websockets/opening-handshake/003.html?default [ Failure ]
-webkit.org/b/251347 imported/w3c/web-platform-tests/websockets/opening-handshake/003.html?wss [ Failure ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/opening-handshake/003-sets-origin.worker.html?wss [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/websockets/opening-handshake/005.html?wss [ Failure Pass ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any-expected.txt
@@ -1,0 +1,10 @@
+
+PASS new WebSocket("ws://foo bar.com/") should throw a "SyntaxError" DOMException
+PASS new WebSocket("wss://foo bar.com/") should throw a "SyntaxError" DOMException
+PASS new WebSocket("ftp://web-platform.test:8800/") should throw a "SyntaxError" DOMException
+PASS new WebSocket("mailto:example@example.org") should throw a "SyntaxError" DOMException
+PASS new WebSocket("about:blank") should throw a "SyntaxError" DOMException
+PASS new WebSocket("http://web-platform.test:8800/#") should throw a "SyntaxError" DOMException
+PASS new WebSocket("http://web-platform.test:8800/#test") should throw a "SyntaxError" DOMException
+PASS new WebSocket("#test") should throw a "SyntaxError" DOMException
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker-expected.txt
@@ -1,0 +1,10 @@
+
+PASS new WebSocket("ws://foo bar.com/") should throw a "SyntaxError" DOMException
+PASS new WebSocket("wss://foo bar.com/") should throw a "SyntaxError" DOMException
+PASS new WebSocket("ftp://web-platform.test:8800/") should throw a "SyntaxError" DOMException
+PASS new WebSocket("mailto:example@example.org") should throw a "SyntaxError" DOMException
+PASS new WebSocket("about:blank") should throw a "SyntaxError" DOMException
+PASS new WebSocket("http://web-platform.test:8800/#") should throw a "SyntaxError" DOMException
+PASS new WebSocket("http://web-platform.test:8800/#test") should throw a "SyntaxError" DOMException
+PASS new WebSocket("#test") should throw a "SyntaxError" DOMException
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/opening-handshake/003_default-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/opening-handshake/003_default-expected.txt
@@ -1,0 +1,3 @@
+
+PASS WebSockets: origin
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/opening-handshake/003_wss-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/opening-handshake/003_wss-expected.txt
@@ -1,0 +1,3 @@
+
+PASS WebSockets: origin
+


### PR DESCRIPTION
#### 2d4d278f7983c38456bd3ddde69dec4a9161118e
<pre>
[GLIB] Unreviewed test gardening

Closes bug 251347.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/opening-handshake/003_default-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/opening-handshake/003_wss-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/299003@main">https://commits.webkit.org/299003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24fd62f2aa4066872ffdb07d1d5ef882528aa40b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123558 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89139 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69648 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23434 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126678 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97599 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20907 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18748 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44228 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->