### PR TITLE
ASSERTION FAILED: InjectedBundle::singleton().isTestRunning() is constantly crashing fast/eventsource/eventsource-attribute-listeners.html

### DIFF
--- a/LayoutTests/fast/events/touch/page-scaled-touch-gesture-click.html
+++ b/LayoutTests/fast/events/touch/page-scaled-touch-gesture-click.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <style type="text/css">
 #touchtarget {
   width: 100px;
@@ -10,14 +11,19 @@
 }
 </style>
 </head>
-<body onload="runTest();">
+<body>
 <div id="touchtarget">
+<div id="endTestDiv">
 
 <p id="description"></p>
 <div id="console"></div>
 
 <script>
-var clickEventsReceived = 0;
+window.jsTestIsAsync = true;
+window.addEventListener('load', async () => {
+    await runTest();
+});
+
 var expectedMouseEvents = 4;
 var mouseEventsReceived = 0;
 var eventTypes = [ 'mousemove', 'mousedown', 'mouseup', 'click' ];
@@ -46,13 +52,6 @@ function quitKeyToEndTest(event) {
     endTest();
 }
 
-// Log that we still got the touch events.
-function touchEventCallback(event) {
-    touchEventsReceived++;
-    debug('have received: ' + touchEventsReceived + ' touch events');
-    return true;
-}
-
 function endTest()
 {
     if (mouseEventsReceived < expectedMouseEvents) {
@@ -60,33 +59,25 @@ function endTest()
     }
     // Bail.
     isSuccessfullyParsed();
-    testRunner.notifyDone();
+    finishJSTest();
 }
 
 async function runTest() {
-    if (window.testRunner) {
-        await window.testRunner.setPageScaleFactor(0.5, 0, 0);
-    }
+    window.testRunner?.dumpAsText();
+    await window.testRunner?.setPageScaleFactor(0.5, 0, 0);
 
-    var div = document.getElementById('touchtarget');
-    div.addEventListener("mousedown", gestureEventCallback, false);
-    div.addEventListener("click", gestureEventCallback, false);
-    div.addEventListener("mouseup", gestureEventCallback, false);
-    div.addEventListener("mousemove", gestureEventCallback, false);
-    document.addEventListener("keydown", quitKeyToEndTest, false);
-
-    if (window.testRunner)
-        testRunner.waitUntilDone();
+    var tapTarget = document.getElementById('touchtarget');
+    tapTarget.addEventListener("mousedown", gestureEventCallback, false);
+    tapTarget.addEventListener("click", gestureEventCallback, false);
+    tapTarget.addEventListener("mouseup", gestureEventCallback, false);
+    tapTarget.addEventListener("mousemove", gestureEventCallback, false);
+    var endTarget = document.getElementById('endTestDiv');
+    endTarget.addEventListener("mousedown", () => { endTest() }, false);
 
     if (window.eventSender) {
         description("This tests basic single touch gesture generation.");
-        if (eventSender.clearTouchPoints) {
-            eventSender.gestureTap(10, 12);
-            eventSender.leapForward(10);
-            eventSender.keyDown(' ');
-        } else {
-            endTest();
-        }
+        await UIHelper.activateElement(tapTarget);
+        await UIHelper.activateElement(endTarget);
     } else {
         debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
     }

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4553,7 +4553,7 @@ webkit.org/b/278719 fast/events/touch/multi-touch-grouped-targets.html [ Failure
 webkit.org/b/278719 fast/events/touch/multi-touch-inside-nested-iframes.html [ Timeout ]
 webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure ]
-webkit.org/b/278719 fast/events/touch/page-scaled-touch-gesture-click.html [ Failure ]
+webkit.org/b/278719 fast/events/touch/page-scaled-touch-gesture-click.html [ Timeout ]
 webkit.org/b/278719 fast/events/touch/prevent-default-touchmove-prevents-scrolling.html [ Crash ]
 webkit.org/b/278719 fast/events/touch/scroll-without-mouse-lacks-mousemove-events.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/send-oncancel-event.html [ Timeout ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8120,7 +8120,6 @@ webkit.org/b/296209 http/tests/workers/service/basic-timeout.https.html [ Pass F
 compositing/layer-creation/sticky-overlap-extent.html [ Failure ]
 editing/pasteboard/copy-paste-bidi.html [ Failure ]
 editing/selection/ios/show-selection-in-transformed-container-2.html [ Failure ]
-fast/events/touch/page-scaled-touch-gesture-click.html [ Failure ]
 fast/mediastream/play-newly-added-audio-track.html [ Failure ]
 http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html [ Failure ]
 http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https.html [ Failure ]
@@ -8205,8 +8204,6 @@ webkit.org/b/297081 http/tests/resourceLoadStatistics/exemptDomains/managed-doma
 # webkit.org/b/297122 2x imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside (layout-tests) tests are flaky text failures
 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-010.html [ Pass Failure ]
 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-013.html [ Pass Failure ]
-
-webkit.org/b/297141 [ Debug ] fast/eventsource/eventsource-attribute-listeners.html [ Pass Crash ]
 
 # Inactive window appearance for form controls is not supported on iOS.
 fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html [ Skip ]

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -225,7 +225,13 @@ void TestRunner::waitUntilDownloadFinished()
 
 void TestRunner::waitUntilDone()
 {
-    RELEASE_ASSERT(InjectedBundle::singleton().isTestRunning());
+    if (!InjectedBundle::singleton().isTestRunning()) {
+        [[maybe_unused]] WTF::String testURL = "(unknown test)"_s;
+        if (WKURLRef url = m_testURL.get())
+            testURL = toWTFString(adoptWK(WKURLCopyString(url)));
+        LOG_ERROR("(%s) testRunner.waitUntilDone() called after test has terminated. Possibly an async handler was not awaited.", testURL.utf8().data());
+        return;
+    }
 
     setWaitUntilDone(true);
 }


### PR DESCRIPTION
#### ad80cae882970a64828991d1848c225906493176
<pre>
ASSERTION FAILED: InjectedBundle::singleton().isTestRunning() is constantly crashing fast/eventsource/eventsource-attribute-listeners.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=297141">https://bugs.webkit.org/show_bug.cgi?id=297141</a>
<a href="https://rdar.apple.com/157879724">rdar://157879724</a>

Reviewed by Alexey Proskuryakov.

fast/eventsource/eventsource-attribute-listeners.html is crashing in
EWS, not because of any fault of its own, but because it usually runs in
succession to fast/events/touch/page-scaled-touch-gesture-click.html.

The bad test calls an asynchronous function in the body onload handler,
i.e. does not await. This can put the test infrastructure in a bad
state. We receive InjectedBundle::done() early because the test is so
quickly done with and as a result the injected bundle clears out its
held TestRunner instance. However, TestRunner has a positive refcount
because of InjectedBundlePage::frameDidChangeLocation() --&gt; dump(). We
end up in this code path because the test runner is _not_ currently
&quot;waiting for done&quot;, which we should have, had the test properly run its
runTest() method. Finally, when the runTest() method does eventually
finish executing, we reach TestRunner::waitUntilDone() (since it still
has a positive refcount), and crash at the release assert because the
injected bundle has already cleared out its test runner instance.

In the good case, we never end up having a high refcount through dump()
because the test runner would have been &quot;waiting for done&quot; already, but
more importantly, we don&apos;t think the test is done because the async test
code is actually awaited on. As a result, we don&apos;t accidentally wipe the
test runner instance held by the injected bundle singleton.

While the TestRunner being kept alive may seem confusing, the ref counts
are never unbalanced, and it&apos;s fair for TestRunner callers to keep it
alive. What&apos;s unfortunate is that we go against the standard practice
from elsewhere in TestRunner and just release assert over the absence of
a test runner instance in the injected bundle. Everywhere else just
early returns from the work it is supposed to do. This patch follows
suit so that tests do not unnecessarily crash if they&apos;re poorly written.
We do add an error log to surface some information.

To address the test&apos;s badness, we first extricate the async function call
into a proper &apos;load&apos; event handler. The test still times out, though, as
we already know in <a href="https://rdar.apple.com/80387340">rdar://80387340</a>. This patch also does the bare minimum
to move the test from a time out to a consistent failure by moving away
from unuspported EventSender API.

Finally, we make two test expectation changes:

1. Remove the crashing expectation for fast/eventsource/eventsource-attribute-listeners.html
2. Remove the &apos;failing&apos; expectation because fast/events/touch/page-scaled-touch-gesture-click.html
   still relies on touch event support which is missing from open source
   configurations, and hence should be skipped altogether, like all the
   other tests under fast/events/touch.

* LayoutTests/fast/events/touch/page-scaled-touch-gesture-click.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::waitUntilDone):

Canonical link: <a href="https://commits.webkit.org/299084@main">https://commits.webkit.org/299084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30bbdd9fe2416d8eae7159983f404565973a2775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69756 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/865b683f-4c0d-49a4-953d-1eb5a2a5a8a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/56206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b22df6d-af11-4302-ad53-226472fdf43e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105573 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69854 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83ff3f62-a834-43d6-af43-e28e616f2de2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67535 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126969 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98016 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97804 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21153 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41010 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18794 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44517 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43975 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47322 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->