### PR TITLE
[OpenXR] Fallback to use GBM when EGL extension MESA_image_dma_buf_export is not available

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -33,6 +33,12 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
+#if USE(GBM)
+#include <WebCore/GBMDevice.h>
+#include <WebCore/GBMVersioning.h>
+#include <drm_fourcc.h>
+#endif
+
 #if ENABLE(WEBXR) && USE(OPENXR)
 
 namespace WebKit {
@@ -45,7 +51,18 @@ OpenXRLayer::OpenXRLayer(UniqueRef<OpenXRSwapchain>&& swapchain)
 {
 }
 
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTexture(PlatformGLObject openxrTexture)
+OpenXRLayer::~OpenXRLayer()
+{
+    ASSERT(WebCore::GLContext::current());
+#if USE(GBM)
+    if (m_fbosForBlitting[0])
+        glDeleteFramebuffers(2, m_fbosForBlitting);
+    for (auto texture : m_exportedTexturesMap.values())
+        glDeleteTextures(1, &texture);
+#endif
+}
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureDMABuf(WebCore::GLDisplay& display, WebCore::GLContext& context, PlatformGLObject openxrTexture)
 {
     // Texture must be bound to be exported.
     glBindTexture(GL_TEXTURE_2D, openxrTexture);
@@ -54,17 +71,11 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-    auto* glContext = WebCore::GLContext::current();
-    ASSERT(glContext);
+    auto image = display.createImage(context.platformContext(), EGL_GL_TEXTURE_2D, (EGLClientBuffer)(uint64_t)openxrTexture, { });
 
-    auto display = glContext->display();
-    ASSERT(display);
-    auto image = display->createImage(glContext->platformContext(), EGL_GL_TEXTURE_2D, (EGLClientBuffer)(uint64_t)openxrTexture, { });
-
-    auto releaseTextureOnError = makeScopeExit([&] {
+    auto releaseImageOnError = makeScopeExit([&] {
         if (image)
-            display->destroyImage(image);
-        m_swapchain->releaseImage();
+            display.destroyImage(image);
     });
 
     if (!image) {
@@ -74,7 +85,7 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
 
     int fourcc, planeCount;
     uint64_t modifier;
-    if (!eglExportDMABUFImageQueryMESA(display->eglDisplay(), image, &fourcc, &planeCount, &modifier)) {
+    if (!eglExportDMABUFImageQueryMESA(display.eglDisplay(), image, &fourcc, &planeCount, &modifier)) {
         RELEASE_LOG(XR, "eglExportDMABUFImageQueryMESA failed");
         return std::nullopt;
     }
@@ -82,14 +93,14 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
     Vector<int> fdsOut(planeCount);
     Vector<int> stridesOut(planeCount);
     Vector<int> offsetsOut(planeCount);
-    if (!eglExportDMABUFImageMESA(display->eglDisplay(), image, fdsOut.mutableSpan().data(), stridesOut.mutableSpan().data(), offsetsOut.mutableSpan().data())) {
+    if (!eglExportDMABUFImageMESA(display.eglDisplay(), image, fdsOut.mutableSpan().data(), stridesOut.mutableSpan().data(), offsetsOut.mutableSpan().data())) {
         RELEASE_LOG(XR, "eglExportDMABUFImageMESA failed");
         return std::nullopt;
     }
 
-    display->destroyImage(image);
+    display.destroyImage(image);
 
-    releaseTextureOnError.release();
+    releaseImageOnError.release();
 
     Vector<UnixFileDescriptor> fds = fdsOut.map([](int fd) {
         return UnixFileDescriptor(fd, UnixFileDescriptor::Adopt);
@@ -108,6 +119,155 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
         .fourcc = static_cast<uint32_t>(fourcc),
         .modifier = modifier,
     };
+}
+
+#if USE(GBM)
+void OpenXRLayer::setGBMDevice(RefPtr<WebCore::GBMDevice> gbmDevice)
+{
+    m_gbmDevice = gbmDevice;
+}
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureGBM(WebCore::GLDisplay& display, PlatformGLObject openxrTexture)
+{
+    auto preferredDMABufFormat = m_swapchain->format() == GL_RGBA8 ? DRM_FORMAT_ARGB8888 : DRM_FORMAT_XRGB8888;
+    WebCore::GLDisplay::DMABufFormat format;
+    const auto& supportedFormats = display.dmabufFormats();
+    for (const auto& supportedFormat : supportedFormats) {
+        if (supportedFormat.fourcc == preferredDMABufFormat) {
+            format = supportedFormat;
+            break;
+        }
+    }
+    if (!format.fourcc) {
+        RELEASE_LOG(XR, "OpenXR texture format not supported");
+        return std::nullopt;
+    }
+
+    auto* buffer = gbm_bo_create_with_modifiers2(m_gbmDevice->device(), m_swapchain->width(), m_swapchain->height(), format.fourcc, format.modifiers.span().data(), format.modifiers.size(), GBM_BO_USE_RENDERING);
+    if (!buffer)
+        buffer = gbm_bo_create(m_gbmDevice->device(), m_swapchain->width(), m_swapchain->height(), format.fourcc, GBM_BO_USE_RENDERING);
+    if (!buffer) {
+        RELEASE_LOG(XR, "Failed to allocate GBM buffer for OpenXR texture");
+        return std::nullopt;
+    }
+
+    Vector<UnixFileDescriptor> fds;
+    Vector<uint32_t> offsets;
+    Vector<uint32_t> strides;
+    uint32_t fourcc = gbm_bo_get_format(buffer);
+    uint64_t modifier = gbm_bo_get_modifier(buffer);
+    int planeCount = gbm_bo_get_plane_count(buffer);
+
+    Vector<EGLAttrib> attributes = {
+        EGL_WIDTH, static_cast<EGLAttrib>(gbm_bo_get_width(buffer)),
+        EGL_HEIGHT, static_cast<EGLAttrib>(gbm_bo_get_height(buffer)),
+        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(fourcc),
+    };
+
+#define ADD_PLANE_ATTRIBUTES(planeIndex) { \
+    fds.append(UnixFileDescriptor { gbm_bo_get_fd_for_plane(buffer, planeIndex), UnixFileDescriptor::Adopt }); \
+    offsets.append(gbm_bo_get_offset(buffer, planeIndex)); \
+    strides.append(gbm_bo_get_stride_for_plane(buffer, planeIndex)); \
+    std::array<EGLAttrib, 6> planeAttributes { \
+        EGL_DMA_BUF_PLANE##planeIndex##_FD_EXT, fds.last().value(), \
+        EGL_DMA_BUF_PLANE##planeIndex##_OFFSET_EXT, static_cast<EGLAttrib>(offsets.last()), \
+        EGL_DMA_BUF_PLANE##planeIndex##_PITCH_EXT, static_cast<EGLAttrib>(strides.last()) \
+    }; \
+    attributes.append(std::span<const EGLAttrib> { planeAttributes }); \
+    if (modifier != DRM_FORMAT_MOD_INVALID) { \
+        std::array<EGLAttrib, 4> modifierAttributes { \
+            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_HI_EXT, static_cast<EGLAttrib>(modifier >> 32), \
+            EGL_DMA_BUF_PLANE##planeIndex##_MODIFIER_LO_EXT, static_cast<EGLAttrib>(modifier & 0xffffffff) \
+        }; \
+        attributes.append(std::span<const EGLAttrib> { modifierAttributes }); \
+    } \
+    }
+
+    if (planeCount > 0)
+        ADD_PLANE_ATTRIBUTES(0);
+    if (planeCount > 1)
+        ADD_PLANE_ATTRIBUTES(1);
+    if (planeCount > 2)
+        ADD_PLANE_ATTRIBUTES(2);
+    if (planeCount > 3)
+        ADD_PLANE_ATTRIBUTES(3);
+
+#undef ADD_PLANE_ATTRIBS
+
+    attributes.append(EGL_NONE);
+
+    auto image = display.createImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+    gbm_bo_destroy(buffer);
+
+    if (!image) {
+        RELEASE_LOG(XR, "Failed to create EGL image from OpenXR texture");
+        return std::nullopt;
+    }
+
+    GLint boundTexture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
+    PlatformGLObject exportedTexture;
+    glGenTextures(1, &exportedTexture);
+    glBindTexture(GL_TEXTURE_2D, exportedTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    glBindTexture(GL_TEXTURE_2D, boundTexture);
+
+    display.destroyImage(image);
+
+    m_exportedTexturesMap.add(openxrTexture, exportedTexture);
+
+    return PlatformXR::FrameData::ExternalTexture {
+        .fds = WTFMove(fds),
+        .strides = WTFMove(strides),
+        .offsets = WTFMove(offsets),
+        .fourcc = fourcc,
+        .modifier = modifier
+    };
+}
+
+void OpenXRLayer::blitTexture() const
+{
+    auto openxrTexture = m_swapchain->acquiredTexture();
+    ASSERT(openxrTexture);
+
+    auto exportedTexture = m_exportedTexturesMap.get(openxrTexture);
+    ASSERT(exportedTexture);
+
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbosForBlitting[0]);
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, exportedTexture, 0);
+
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fbosForBlitting[1]);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, openxrTexture, 0);
+
+    auto width = m_swapchain->width();
+    auto height = m_swapchain->height();
+    glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+#endif
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTexture(PlatformGLObject openxrTexture)
+{
+    auto* glContext = WebCore::GLContext::current();
+    ASSERT(glContext);
+
+    auto display = glContext->display();
+    ASSERT(display);
+
+    if (display->extensions().MESA_image_dma_buf_export)
+        return exportOpenXRTextureDMABuf(*display, *glContext, openxrTexture);
+
+#if USE(GBM)
+    if (m_gbmDevice)
+        return exportOpenXRTextureGBM(*display, openxrTexture);
+#endif
+
+    RELEASE_LOG(XR, "Failed to export OpenXR texture");
+    return std::nullopt;
 }
 
 // OpenXRLayerProjection
@@ -145,8 +305,10 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
     m_nextReusableTextureIndex++;
 
     auto externalTexture = exportOpenXRTexture(*texture);
-    if (!externalTexture)
+    if (!externalTexture) {
+        m_swapchain->releaseImage();
         return std::nullopt;
+    }
     layerData.textureData->colorTexture = WTFMove(externalTexture.value());
 
     auto halfWidth = m_swapchain->width() / 2;
@@ -163,6 +325,13 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
 
 XrCompositionLayerBaseHeader* OpenXRLayerProjection::endFrame(const XRDeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
+#if USE(GBM)
+    if (m_gbmDevice) {
+        if (!m_fbosForBlitting[0])
+            glGenFramebuffers(2, m_fbosForBlitting);
+        blitTexture();
+    }
+#endif
     auto viewCount = frameViews.size();
     m_projectionViews.fill(createOpenXRStruct<XrCompositionLayerProjectionView, XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW>(), viewCount);
     for (uint32_t i = 0; i < viewCount; ++i) {

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -30,6 +30,12 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
+namespace WebCore {
+class GBMDevice;
+class GLContext;
+class GLDisplay;
+}
+
 namespace WebKit {
 
 struct XRDeviceLayer;
@@ -38,13 +44,22 @@ class OpenXRLayer {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRLayer);
     WTF_MAKE_NONCOPYABLE(OpenXRLayer);
 public:
-    virtual ~OpenXRLayer() = default;
+    virtual ~OpenXRLayer();
 
     virtual std::optional<PlatformXR::FrameData::LayerData> startFrame() = 0;
     virtual XrCompositionLayerBaseHeader* endFrame(const XRDeviceLayer&, XrSpace, const Vector<XrView>&) = 0;
 
+#if USE(GBM)
+    void setGBMDevice(RefPtr<WebCore::GBMDevice>);
+#endif
+
 protected:
     OpenXRLayer(UniqueRef<OpenXRSwapchain>&&);
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureDMABuf(WebCore::GLDisplay&, WebCore::GLContext&, PlatformGLObject);
+#if USE(GBM)
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureGBM(WebCore::GLDisplay&, PlatformGLObject);
+    void blitTexture() const;
+#endif
     std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTexture(PlatformGLObject);
 
     UniqueRef<OpenXRSwapchain> m_swapchain;
@@ -53,6 +68,11 @@ protected:
     using ReusableTextureIndex = uint64_t;
     HashMap<PlatformGLObject, ReusableTextureIndex> m_exportedTextures;
     ReusableTextureIndex m_nextReusableTextureIndex { 0 };
+#if USE(GBM)
+    RefPtr<WebCore::GBMDevice> m_gbmDevice;
+    HashMap<PlatformGLObject, PlatformGLObject> m_exportedTexturesMap;
+    PlatformGLObject m_fbosForBlitting[2] { 0, 0 };
+#endif
 };
 
 class OpenXRLayerProjection final: public OpenXRLayer  {

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
@@ -51,6 +51,8 @@ public:
     int32_t width() const { return m_createInfo.width; }
     int32_t height() const { return m_createInfo.height; }
     WebCore::IntSize size() const { return WebCore::IntSize(width(), height()); }
+    int64_t format() const { return m_createInfo.format; }
+    PlatformGLObject acquiredTexture() const { return m_acquiredTexture; }
 
 private:
     OpenXRSwapchain(XrSwapchain, const XrSwapchainCreateInfo&, Vector<XrSwapchainImageOpenGLESKHR>&&);

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -30,6 +30,7 @@
 #include <wtf/Threading.h>
 
 namespace WebCore {
+class GBMDevice;
 class GLContext;
 class GLDisplay;
 }
@@ -100,6 +101,9 @@ private:
     XrEnvironmentBlendMode m_arBlendMode;
     PlatformXR::SessionMode m_sessionMode;
     RefPtr<WebCore::GLDisplay> m_glDisplay;
+#if USE(GBM)
+    mutable RefPtr<WebCore::GBMDevice> m_gbmDevice;
+#endif
 
     XrSession m_session { XR_NULL_HANDLE };
     XrSessionState m_sessionState { XR_SESSION_STATE_UNKNOWN };


### PR DESCRIPTION
#### 8829cb72321e001331b5a5bee6c48e195fd4b353
<pre>
[OpenXR] Fallback to use GBM when EGL extension MESA_image_dma_buf_export is not available
<a href="https://bugs.webkit.org/show_bug.cgi?id=297717">https://bugs.webkit.org/show_bug.cgi?id=297717</a>

Reviewed by Adrian Perez de Castro.

We are currently using MESA_image_dma_buf_export unconditionally. When
not available we can use GBM to allocate our own buffer for the web
process to render into and then we copy it to the openxr texture on end
frame.

Canonical link: <a href="https://commits.webkit.org/299044@main">https://commits.webkit.org/299044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af89d0c38df45c5b3ee3a4f157fef2171b34e792

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89136 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43793 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29165 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126676 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97802 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97596 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40704 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18768 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49885 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47027 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->