### PR TITLE
Fix the default fallback of 'numOctaves' of the SVGFETurbulenceElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-initial-values-expected.txt
@@ -7,6 +7,6 @@ PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.ta
 PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.targetX (invalid value)
 PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.targetY (remove)
 PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.targetY (invalid value)
-FAIL SVGAnimatedInteger, initial values, SVGFETurbulenceElement.prototype.numOctaves (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedInteger, initial values, SVGFETurbulenceElement.prototype.numOctaves (invalid value) assert_equals: initial after expected 1 but got 0
+PASS SVGAnimatedInteger, initial values, SVGFETurbulenceElement.prototype.numOctaves (remove)
+PASS SVGAnimatedInteger, initial values, SVGFETurbulenceElement.prototype.numOctaves (invalid value)
 

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGFETurbulenceElement.h"
 
 #include "NodeName.h"
+#include "SVGDocumentExtensions.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include "SVGPropertyOwnerRegistry.h"
@@ -77,9 +78,18 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
     case AttributeNames::seedAttr:
         Ref { m_seed }->setBaseValInternal(newValue.toFloat());
         break;
-    case AttributeNames::numOctavesAttr:
-        Ref { m_numOctaves }->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
+    case AttributeNames::numOctavesAttr: {
+        auto result = parseInteger<int>(newValue);
+        if (!result)
+            Ref { m_numOctaves }->setBaseValInternal(initialOctavesValue);
+        else {
+            Ref { m_numOctaves }->setBaseValInternal(*result);
+
+            if (*result <= 0)
+                protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feTurbulence: problem parsing numOctaves=\""_s, newValue, "\". numOctaves must be > 0. Filtered element will not be displayed."_s));
+        }
         break;
+    }
     default:
         break;
     }

--- a/Source/WebCore/svg/SVGFETurbulenceElement.h
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.h
@@ -116,6 +116,8 @@ public:
 private:
     SVGFETurbulenceElement(const QualifiedName&, Document&);
 
+    static constexpr int initialOctavesValue = 1;
+
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
@@ -124,7 +126,7 @@ private:
 
     Ref<SVGAnimatedNumber> m_baseFrequencyX { SVGAnimatedNumber::create(this) };
     Ref<SVGAnimatedNumber> m_baseFrequencyY { SVGAnimatedNumber::create(this) };
-    Ref<SVGAnimatedInteger> m_numOctaves { SVGAnimatedInteger::create(this, 1) };
+    Ref<SVGAnimatedInteger> m_numOctaves { SVGAnimatedInteger::create(this, initialOctavesValue) };
     Ref<SVGAnimatedNumber> m_seed { SVGAnimatedNumber::create(this) };
     Ref<SVGAnimatedEnumeration> m_stitchTiles { SVGAnimatedEnumeration::create(this, SVG_STITCHTYPE_NOSTITCH) };
     Ref<SVGAnimatedEnumeration> m_type { SVGAnimatedEnumeration::create(this, TurbulenceType::Turbulence) };


### PR DESCRIPTION
#### 2c409f0776e6d7f6dcbfe3b045ebd3ef5c56c9bd
<pre>
Fix the default fallback of &apos;numOctaves&apos; of the SVGFETurbulenceElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=297720">https://bugs.webkit.org/show_bug.cgi?id=297720</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

As per specification [1], the initial value of numOctaves is &apos;1&apos; and it
should fallback to it in case of invalid or negative value since they are
not supported.

[1] <a href="https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-numoctaves">https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-numoctaves</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-initial-values-expected.txt:
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* Source/WebCore/svg/SVGFETurbulenceElement.h:

Canonical link: <a href="https://commits.webkit.org/299083@main">https://commits.webkit.org/299083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5049a4b40551f8617ca7a99b5715781724a302a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/336a0257-47e5-4a1c-a602-4ef0338b653f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/48317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6a31b94-b78e-48ed-8389-430d56ebe3af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105476 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69763 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 49712") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54b793ab-3751-4e3c-b9b9-7486c2a55f51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23590 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67423 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126861 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97935 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43098 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40902 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50084 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45559 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->