### PR TITLE
[mixed-content] Check if an URL is potentially trustworthy to block/upgrade

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/sharedworker-import-data.https-expected.txt
@@ -1,12 +1,12 @@
 
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-https origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-https origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/sharedworker-import-data.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-import-data.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context.
 

--- a/Source/WebCore/fileapi/BlobURL.cpp
+++ b/Source/WebCore/fileapi/BlobURL.cpp
@@ -71,16 +71,14 @@ URL BlobURL::getOriginURL(const URL& url)
     return URL(SecurityOrigin::createForBlobURL(url)->toString());
 }
 
-bool BlobURL::isSecureBlobURL(const URL& url)
+const Document* BlobURL::getOwnerDocument(const URL& url)
 {
     ASSERT(url.protocolIsBlob());
 
-    // As per https://github.com/w3c/webappsec-mixed-content/issues/41, Blob URL is secure if the document that created it is secure.
     if (auto origin = ThreadableBlobRegistry::getCachedOrigin(url)) {
-        if (RefPtr document = blobOwner(*origin))
-            return document->isSecureContext();
+        return blobOwner(*origin);
     }
-    return SecurityOrigin::isSecure(getOriginURL(url));
+    return nullptr;
 }
 
 URL BlobURL::createBlobURL(StringView originString)

--- a/Source/WebCore/fileapi/BlobURL.h
+++ b/Source/WebCore/fileapi/BlobURL.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "Document.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -51,7 +52,7 @@ public:
     static URL createInternalURL();
 
     static URL getOriginURL(const URL&);
-    static bool isSecureBlobURL(const URL&);
+    static const Document* getOwnerDocument(const URL&);
 #if ASSERT_ENABLED
     static bool isInternalURL(const URL&);
 #endif

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "MixedContentChecker.h"
 
+#include "BlobURL.h"
 #include "DocumentInlines.h"
 #include "Document.h"
 #include "LegacySchemeRegistry.h"
@@ -40,45 +41,100 @@
 
 namespace WebCore {
 
-static bool isDocumentSecure(const Document& document)
+static bool isNonLocalHostPotentiallyTrustworthyOrigin(RefPtr<SecurityOrigin> origin)
 {
-    // FIXME: Use document.isDocumentSecure(), instead of comparing against "https" scheme, when all ports stop using loopback in LayoutTests
-    // sandboxed iframes have an opaque origin so we should perform the mixed content check considering the origin
-    // the iframe would have had if it were not sandboxed.
-    return document.securityOrigin().protocol() == "https"_s || (document.securityOrigin().isOpaque() && document.url().protocolIs("https"_s));
+    // We currently deviate from the mixed content spec, and do not consider localhost
+    // or loopback URLs as secure contexts if they do not use a secure scheme.
+    // https://bugs.webkit.org/show_bug.cgi?id=171934
+    if (SecurityOrigin::isLocalHostOrLoopbackIPAddress(origin->host()))
+        return LegacySchemeRegistry::shouldTreatURLSchemeAsSecure(origin->protocol());
+
+    return origin->isPotentiallyTrustworthy();
 }
 
-static bool isDataContextSecure(const LocalFrame& frame)
+static RefPtr<SecurityOrigin> getActualOrigin(const Document& document)
 {
-    RefPtr document = frame.document();
+    RefPtr origin = document.securityOrigin();
+    // sandboxed iframes have an opaque origin so we should perform the mixed content
+    // check considering the origin the iframe would have had if it were not sandboxed.
+    if (origin->isOpaque())
+        origin = SecurityOrigin::create(document.url());
+    return origin;
+}
 
-    while (document) {
-        if (isDocumentSecure(*document))
-            return true;
+static bool isNonLocalHostPotentiallyTrustworthyURL(const URL& url)
+{
+    if (!url.isValid())
+        return true;
 
-        RefPtr frame = document->frame();
-        if (!frame || frame->isMainFrame())
-            break;
+    // Secure Contexts
+    // W3C Candidate Recommendation Draft, 10 November 2023
+    // 3.2. Is url potentially trustworthy?
 
-        RefPtr parentFrame = frame->tree().parent();
-        if (!parentFrame)
-            break;
+    // 1. If url is "about:blank" or "about:srcdoc", return "Potentially Trustworthy".
+    // 2. If url’s scheme is "data", return "Potentially Trustworthy".
+    if (url.isAboutBlank() || url.isAboutSrcDoc() || url.protocolIsData())
+        return true;
 
-        if (RefPtr localParentFrame = dynamicDowncast<LocalFrame>(parentFrame.get()))
-            document = localParentFrame->document();
-        else {
-            // FIXME: <rdar://116259764> Make mixed content checks work correctly with site isolated iframes.
-            break;
-        }
+    // 3. Return the result of executing § 3.1 Is origin potentially trustworthy? on url’s origin.
+    // NOTE: The origin of blob: URLs is the origin of the context in which they were created.
+    //       Therefore, blobs created in a trustworthy origin will themselves be potentially
+    //       trustworthy.
+    RefPtr<SecurityOrigin> origin;
+    if (!url.protocolIsBlob())
+        origin = SecurityOrigin::create(url);
+    else if (RefPtr document = BlobURL::getOwnerDocument(url))
+        origin = getActualOrigin(*document);
+    else
+        origin = SecurityOrigin::createForBlobURL(url);
+
+    return isNonLocalHostPotentiallyTrustworthyOrigin(origin);
+}
+
+static bool prohibitsMixedSecurityContextsItself(const Document& document)
+{
+    RefPtr origin = getActualOrigin(document);
+
+    // We currently deviate from the mixed content spec, and allow loading of
+    // non-trustworthy resources from local documents or from documents with
+    // custom schemes handled by a scheme handler. Note that we otherwise
+    // consider these documents as trustworthy.
+    // https://bugs.webkit.org/show_bug.cgi?id=297785
+    if (origin->isLocal() || LegacySchemeRegistry::schemeIsHandledBySchemeHandler(origin->protocol()))
+        return false;
+
+    return isNonLocalHostPotentiallyTrustworthyOrigin(origin);
+}
+
+static bool prohibitsMixedSecurityContexts(const Document& document)
+{
+    // https://www.w3.org/TR/mixed-content/#upgrade-algorithm
+    // Editor’s Draft, 23 February 2023
+    // 4.3. Does settings prohibit mixed security contexts?
+
+    if (prohibitsMixedSecurityContextsItself(document))
+        return true;
+
+    const URL& url = document.url();
+    if (url.protocolIsData()) {
+        RefPtr<Frame> frame = document.frame();
+
+        do {
+            frame = frame->tree().parent();
+            if (!frame)
+                break;
+
+            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get())) {
+                RefPtr document = localFrame->document();
+
+                if (prohibitsMixedSecurityContextsItself(*document))
+                    return true;
+            } else {
+                // FIXME: <rdar://116259764> Make mixed content checks work correctly with site isolated iframes.
+                break;
+            }
+        } while (!frame->isMainFrame());
     }
-
-    return false;
-}
-
-static bool isMixedContent(const Document& document, const URL& url)
-{
-    if (isDocumentSecure(document) || (document.url().protocolIs("data"_s) && isDataContextSecure(*document.frame())))
-        return !SecurityOrigin::isSecure(url);
 
     return false;
 }
@@ -116,47 +172,73 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
 
     // https://www.w3.org/TR/mixed-content/#upgrade-algorithm
     // Editor’s Draft, 23 February 2023
-    // 4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate
-    if (!isMixedContent(*frame.document(), url))
+    // 4.1. Upgrade request to a potentially trustworthy URL, if appropriate
+
+    // 4.1.1.3 Does settings prohibit mixed security contexts? returns "Does Not Restrict Mixed Security Contents" when applied to request’s client.
+    if (!prohibitsMixedSecurityContexts(*document))
         return false;
 
-    auto shouldUpgradeIPAddressAndLocalhostForTesting = document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled();
-
-    // 4.1 The request's URL is not upgraded in the following cases.
+    // 4.1.1.1, 4.1.1.2, 4.1.1.4, 4.1.1.5
     if (!canModifyRequest(url, destination, initiator))
         return false;
 
-    logConsoleWarning(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);
-    return true;
+    // 4.1.2 If request’s URL’s scheme is http, set request’s URL’s scheme to https, and return.
+    if (url.protocolIs("http"_s)) {
+        auto shouldUpgradeIPAddressAndLocalhostForTesting = document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled();
+        logConsoleWarning(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);
+
+        return true;
+    }
+
+    return false;
 }
 
 bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator)
 {
-    // 4.1.1 request’s URL is a potentially trustworthy URL.
-    if (url.protocolIs("https"_s))
+    // 4.1.1.1 request’s URL is a potentially trustworthy URL.
+    if (isNonLocalHostPotentiallyTrustworthyURL(url))
         return false;
-    // 4.1.2 request’s URL’s host is an IP address.
-    if (URL::hostIsIPAddress(url.host()) && !shouldTreatAsPotentiallyTrustworthy(url))
+
+    // 4.1.1.2 request’s URL’s host is an IP address.
+    // We diverge from the spec when it comes to the loopback address, which consider as upgradable.
+    if (URL::hostIsIPAddress(url.host()) && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(url.host()))
         return false;
-    // 4.1.4 request’s destination is not "image", "audio", or "video".
+
+    // 4.1.1.4 request’s destination is not "image", "audio", or "video".
     if (!destinationIsImageAudioOrVideo(destination))
         return false;
-    // 4.1.5 request’s destination is "image" and request’s initiator is "imageset".
-    auto schemeIsHandledBySchemeHandler = LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol());
-    if (!schemeIsHandledBySchemeHandler && destinationIsImageAndInitiatorIsImageset(destination, initiator))
+
+    // 4.1.1.5 request’s destination is "image" and request’s initiator is "imageset".
+    if (destinationIsImageAndInitiatorIsImageset(destination, initiator))
         return false;
+
     return true;
 }
 
 bool MixedContentChecker::shouldBlockRequest(LocalFrame& frame, const URL& url, IsUpgradable isUpgradable)
 {
+    if (isUpgradable == IsUpgradable::Yes)
+        return false;
+
+    // https://www.w3.org/TR/mixed-content/#upgrade-algorithm
+    // Editor’s Draft, 23 February 2023
+    // 4.4. Should fetching request be blocked as mixed content?
+
     RefPtr document = frame.document();
     if (!document)
         return false;
-    if (!isMixedContent(*frame.document(), url))
+
+    // 4.4.1.1 Does settings prohibit mixed security contexts? returns "Does Not Restrict Mixed Security Contexts" when applied to request’s client.
+    if (!prohibitsMixedSecurityContexts(*frame.document()))
         return false;
-    if ((LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || shouldTreatAsPotentiallyTrustworthy(url)) && isUpgradable == IsUpgradable::Yes)
+
+    // 4.4.1.2  request’s URL is a potentially trustworthy URL.
+    if (isNonLocalHostPotentiallyTrustworthyURL(url))
         return false;
+
+    // 4.4.1.3 The user agent has been instructed to allow mixed content, as described in § 7.2 User Controls).
+    // 4.4.1.4 request’s destination is "document", and request’s target browsing context has no parent browsing context.
+
     logConsoleWarning(frame, /* blocked */ true, url, document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled());
     return true;
 }

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -240,8 +240,14 @@ bool SecurityOrigin::isSecure(const URL& url)
     if (!url.isValid() || LegacySchemeRegistry::shouldTreatURLSchemeAsSecure(url.protocol()))
         return true;
 
-    if (url.protocolIsBlob())
-        return BlobURL::isSecureBlobURL(url);
+    if (url.protocolIsBlob()) {
+        // As per https://github.com/w3c/webappsec-mixed-content/issues/41, Blob URL is secure
+        // if the document that created it is secure.
+        if (RefPtr document = BlobURL::getOwnerDocument(url))
+            return document->isSecureContext();
+
+        return SecurityOrigin::isSecure(BlobURL::getOriginURL(url));
+    }
 
     return false;
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
@@ -58,13 +58,16 @@ TEST(MixedContentChecker, CanModifyRequest)
         initiator
     ));
 
-    // Exception for 4.1.2 potentially truthworthy address
+    // Exception for 4.1.1 (request’s URL is a potentially trustworthy URL) and
+    // 4.1.2 (URL’s host is an IP address) when it comes to loopback
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "http://127.0.0.1"_s },
         destination,
         initiator
     ));
 
+    // Exception for 4.1.1 (request’s URL is a potentially trustworthy URL) when it
+    // comes to localhost
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "http://localhost"_s },
         destination,
@@ -97,12 +100,18 @@ TEST(MixedContentChecker, CanModifyRequest)
         Initiator::Imageset
     ));
 
-    // But if the scheme is handled by the handler, it is modifiable even if the initiator is "imageset".
+    // But if the scheme is handled by the handler, it is never modifiable
     LegacySchemeRegistry::registerURLSchemeAsHandledBySchemeHandler("custom"_s);
 
     ASSERT_TRUE(LegacySchemeRegistry::schemeIsHandledBySchemeHandler("custom"_s));
 
-    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        URL { "custom://example.com/cat.jpg"_s },
+        FetchOptions::Destination::Audio,
+        initiator
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         URL { "custom://example.com/cat.jpg"_s },
         destination,
         Initiator::Imageset
@@ -111,10 +120,10 @@ TEST(MixedContentChecker, CanModifyRequest)
     // This exception won't apply if the cheme is not registered.
     ASSERT_FALSE(LegacySchemeRegistry::schemeIsHandledBySchemeHandler("custom2"_s));
 
-    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "custom2://example.com/cat.jpg"_s },
-        destination,
-        Initiator::Imageset
+        FetchOptions::Destination::Audio,
+        initiator
     ));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -242,7 +242,7 @@ TEST(WebKit, ConfigurationDisableJavaScriptSVGAnimateElementComplex)
     EXPECT_WK_STREQ(bodyHTML, @"<svg><a><rect fill=\"green\" width=\"10\" height=\"10\"></rect><animate attributeName=\"href\" dur=\"4s\" calcMode=\"spline\" repeatCount=\"indefinite\" keyTimes=\"0; 0.25; 0.5; 0.75; 1\" keySplines=\"0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1\"></animate></a></svg>");
 }
 
-TEST(WebKit, ConfigurationMaskedURLSchemes_6)
+TEST(WebKit, ConfigurationMaskedURLSchemes_ok)
 {
     [TestProtocol registerWithScheme:@"https"];
 
@@ -321,7 +321,7 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_6)
     EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
 }
 
-TEST(WebKit, ConfigurationMaskedURLSchemes_7)
+TEST(WebKit, ConfigurationMaskedURLSchemes_A)
 {
     [TestProtocol registerWithScheme:@"https"];
     [TestProtocol registerWithScheme:@"http"];
@@ -401,10 +401,10 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_7)
     imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
     EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
 
-    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
 }
 
-TEST(WebKit, ConfigurationMaskedURLSchemes_8)
+TEST(WebKit, ConfigurationMaskedURLSchemes_B)
 {
     [TestProtocol registerWithScheme:@"https"];
     [TestProtocol registerWithScheme:@"http"];
@@ -484,280 +484,7 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_8)
     imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
     EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
 
-    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
-    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
-}
-
-
-TEST(WebKit, ConfigurationMaskedURLSchemes_9)
-{
-    [TestProtocol registerWithScheme:@"https"];
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
-    [configuration setWebExtensionController:extensionController.get()];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
-
-    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
-#endif
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
-
-    [configuration _setMaskedURLSchemes:[NSSet set]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestUIDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-
-    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
-    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
-    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
-
-    scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[1].src"];
-    EXPECT_WK_STREQ(scriptSource, @"http://apple.com/baz.js");
-}
-
-
-TEST(WebKit, ConfigurationMaskedURLSchemes_10)
-{
-    [TestProtocol registerWithScheme:@"https"];
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
-    [configuration setWebExtensionController:extensionController.get()];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
-
-    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
-#endif
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
-
-    [configuration _setMaskedURLSchemes:[NSSet set]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestUIDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-
-    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
-    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
-    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
-
-    scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[1].src"];
-    EXPECT_WK_STREQ(scriptSource, @"http://apple.com/baz.js");
-
-    [webView synchronouslyLoadHTMLString:@"<iframe src=\"test-scheme://foo.com/bar.html\"></iframe><iframe src=\"http://apple.com/baz.html\"></iframe>" baseURL:[NSURL URLWithString:@"https://example.com"]];
-}
-
-TEST(WebKit, ConfigurationMaskedURLSchemes_11)
-{
-    [TestProtocol registerWithScheme:@"https"];
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
-    [configuration setWebExtensionController:extensionController.get()];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
-
-    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
-#endif
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
-
-    [configuration _setMaskedURLSchemes:[NSSet set]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestUIDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-
-    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
-    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
-    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
-
-    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
-    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
-
-    scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[1].src"];
-    EXPECT_WK_STREQ(scriptSource, @"http://apple.com/baz.js");
-
-    [webView synchronouslyLoadHTMLString:@"<iframe src=\"test-scheme://foo.com/bar.html\"></iframe><iframe src=\"http://apple.com/baz.html\"></iframe>" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *htmlSource = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];
-    EXPECT_EQ([htmlSource containsString:@"<iframe src=\"webkit-masked-url://hidden/\"></iframe>"], YES);
+    [webView synchronouslyLoadHTMLString:@"<script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
 }
 
 TEST(WebKit, ConfigurationMaskedURLSchemes)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -242,151 +242,6 @@ TEST(WebKit, ConfigurationDisableJavaScriptSVGAnimateElementComplex)
     EXPECT_WK_STREQ(bodyHTML, @"<svg><a><rect fill=\"green\" width=\"10\" height=\"10\"></rect><animate attributeName=\"href\" dur=\"4s\" calcMode=\"spline\" repeatCount=\"indefinite\" keyTimes=\"0; 0.25; 0.5; 0.75; 1\" keySplines=\"0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1\"></animate></a></svg>");
 }
 
-TEST(WebKit, ConfigurationMaskedURLSchemes_1)
-{
-    [TestProtocol registerWithScheme:@"https"];
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
-    [configuration setWebExtensionController:extensionController.get()];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
-
-    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
-#endif
-}
-
-TEST(WebKit, ConfigurationMaskedURLSchemes_2)
-{
-    [TestProtocol registerWithScheme:@"https"];
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
-    [configuration setWebExtensionController:extensionController.get()];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
-
-    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
-#endif
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
-
-    [configuration _setMaskedURLSchemes:[NSSet set]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
-}
-
-TEST(WebKit, ConfigurationMaskedURLSchemes_3)
-{
-    [TestProtocol registerWithScheme:@"https"];
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
-    [configuration setWebExtensionController:extensionController.get()];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
-
-    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
-#endif
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
-
-    [configuration _setMaskedURLSchemes:[NSSet set]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestUIDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-
-    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-}
-
-
-
-TEST(WebKit, ConfigurationMaskedURLSchemes_5)
-{
-    [TestProtocol registerWithScheme:@"https"];
-
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
-    [configuration setWebExtensionController:extensionController.get()];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
-
-    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
-
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
-#endif
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
-
-    [configuration _setMaskedURLSchemes:[NSSet set]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
-
-    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
-    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestUIDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-
-    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
-
-    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
-    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-
-    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
-    EXPECT_WK_STREQ(imageSource, @"baz.png");
-}
-
 TEST(WebKit, ConfigurationMaskedURLSchemes_6)
 {
     [TestProtocol registerWithScheme:@"https"];
@@ -467,6 +322,349 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_6)
 }
 
 TEST(WebKit, ConfigurationMaskedURLSchemes_7)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+}
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_8)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
+    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
+}
+
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_9)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
+    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
+
+    scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[1].src"];
+    EXPECT_WK_STREQ(scriptSource, @"http://apple.com/baz.js");
+}
+
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_10)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
+    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
+
+    scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[1].src"];
+    EXPECT_WK_STREQ(scriptSource, @"http://apple.com/baz.js");
+
+    [webView synchronouslyLoadHTMLString:@"<iframe src=\"test-scheme://foo.com/bar.html\"></iframe><iframe src=\"http://apple.com/baz.html\"></iframe>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+}
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_11)
 {
     [TestProtocol registerWithScheme:@"https"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -242,6 +242,322 @@ TEST(WebKit, ConfigurationDisableJavaScriptSVGAnimateElementComplex)
     EXPECT_WK_STREQ(bodyHTML, @"<svg><a><rect fill=\"green\" width=\"10\" height=\"10\"></rect><animate attributeName=\"href\" dur=\"4s\" calcMode=\"spline\" repeatCount=\"indefinite\" keyTimes=\"0; 0.25; 0.5; 0.75; 1\" keySplines=\"0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1\"></animate></a></svg>");
 }
 
+TEST(WebKit, ConfigurationMaskedURLSchemes_1)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+}
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_2)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+}
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_3)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+}
+
+
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_5)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+}
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_6)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+}
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_7)
+{
+    [TestProtocol registerWithScheme:@"https"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    [webView synchronouslyLoadHTMLString:@"<script src=\"another-scheme://foo.com/bar.js\"></script><script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
+    EXPECT_WK_STREQ(scriptSource, @"webkit-masked-url://hidden/");
+
+    scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[1].src"];
+    EXPECT_WK_STREQ(scriptSource, @"http://apple.com/baz.js");
+
+    [webView synchronouslyLoadHTMLString:@"<iframe src=\"test-scheme://foo.com/bar.html\"></iframe><iframe src=\"http://apple.com/baz.html\"></iframe>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *htmlSource = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];
+    EXPECT_EQ([htmlSource containsString:@"<iframe src=\"webkit-masked-url://hidden/\"></iframe>"], YES);
+}
+
 TEST(WebKit, ConfigurationMaskedURLSchemes)
 {
     [TestProtocol registerWithScheme:@"https"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -324,6 +324,7 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_6)
 TEST(WebKit, ConfigurationMaskedURLSchemes_7)
 {
     [TestProtocol registerWithScheme:@"https"];
+    [TestProtocol registerWithScheme:@"http"];
     [TestProtocol registerWithScheme:@"another-scheme"];
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
@@ -406,6 +407,7 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_7)
 TEST(WebKit, ConfigurationMaskedURLSchemes_8)
 {
     [TestProtocol registerWithScheme:@"https"];
+    [TestProtocol registerWithScheme:@"http"];
     [TestProtocol registerWithScheme:@"another-scheme"];
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -324,6 +324,7 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_6)
 TEST(WebKit, ConfigurationMaskedURLSchemes_7)
 {
     [TestProtocol registerWithScheme:@"https"];
+    [TestProtocol registerWithScheme:@"another-scheme"];
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
 
@@ -405,6 +406,7 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_7)
 TEST(WebKit, ConfigurationMaskedURLSchemes_8)
 {
     [TestProtocol registerWithScheme:@"https"];
+    [TestProtocol registerWithScheme:@"another-scheme"];
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -588,13 +588,16 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_C)
 
             [webView loadHTMLString:@"<script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
 
-            TestWebKitAPI::Util::run(&finished);
+            TestWebKitAPI::Util::runFor(&finished, 5.0_s);
 
             navigationDelegate.get().didFinishNavigation = nil;
         }
 
         webView.get().navigationDelegate = oldNavigationDelegate;
     }
+
+    NSString *scriptSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"script\")[0].src"];
+    EXPECT_WK_STREQ(scriptSource, @"http://apple.com/baz.js");
 }
 
 TEST(WebKit, ConfigurationMaskedURLSchemes)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -484,7 +484,117 @@ TEST(WebKit, ConfigurationMaskedURLSchemes_B)
     imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
     EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
 
-    [webView synchronouslyLoadHTMLString:@"<script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+    // [webView synchronouslyLoadHTMLString:@"<script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+    {
+        [webView loadHTMLString:@"<script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+        EXPECT_TRUE(webView.get().isLoading);
+        [webView _test_waitForDidFinishNavigation];
+    }
+}
+
+TEST(WebKit, ConfigurationMaskedURLSchemes_C)
+{
+    [TestProtocol registerWithScheme:@"https"];
+    [TestProtocol registerWithScheme:@"http"];
+    [TestProtocol registerWithScheme:@"another-scheme"];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    [configuration setWebExtensionController:extensionController.get()];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
+
+    [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-scheme"];
+
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"webkit-extension", @"test-scheme", nil]));
+#endif
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObject:@"test-scheme"]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"test-scheme"]);
+
+    [configuration _setMaskedURLSchemes:[NSSet set]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
+
+    [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
+    EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    NSString *imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].src"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].src"];
+    EXPECT_WK_STREQ(imageSource, @"https://example.com/baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"src\")"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"src\").value"];
+    EXPECT_WK_STREQ(imageSource, @"baz.png");
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset=\"test-scheme://foo.com/bar.jpg 1x, bar.jpg 2x, another-scheme://foo.com/bar.gif 3x\"><img srcset=\"https://apple.com/baz.png 2x, baz.png 1x\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[0].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"webkit-masked-url://hidden/ 1x, bar.jpg 2x, webkit-masked-url://hidden/ 3x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].srcset"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttribute(\"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNS(null, \"srcset\")"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    imageSource = [webView stringByEvaluatingJavaScript:@"document.querySelectorAll(\"img\")[1].getAttributeNode(\"srcset\").value"];
+    EXPECT_WK_STREQ(imageSource, @"https://apple.com/baz.png 2x, baz.png 1x");
+
+    // [webView synchronouslyLoadHTMLString:@"<script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+    {
+        auto *oldNavigationDelegate = webView.get().navigationDelegate;
+
+        auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+        webView.get().navigationDelegate = navigationDelegate.get();
+
+        // [navigationDelegate waitForDidFinishNavigation];
+        {
+            __block bool finished = false;
+            navigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+                finished = true;
+            };
+
+            [webView loadHTMLString:@"<script src=\"http://apple.com/baz.js\"></script>" baseURL:[NSURL URLWithString:@"https://example.com"]];
+
+            TestWebKitAPI::Util::run(&finished);
+
+            navigationDelegate.get().didFinishNavigation = nil;
+        }
+
+        webView.get().navigationDelegate = oldNavigationDelegate;
+    }
 }
 
 TEST(WebKit, ConfigurationMaskedURLSchemes)


### PR DESCRIPTION
#### 3daacc928708d590bcb3dc6c7bb0c3ebf9992f8e
<pre>
[mixed-content] Check if an URL is potentially trustworthy to block/upgrade
<a href="https://bugs.webkit.org/show_bug.cgi?id=297536">https://bugs.webkit.org/show_bug.cgi?id=297536</a>

Reviewed by NOBODY (OOPS!).

The Mixed Content specification uses Secure Contexts&apos; &quot;potentially trustworthy&quot;
definition for URLs and origins to decide whether a request can be loaded as-is
or needs to be blocked/upgraded.

This is a larger bucket than just checking whether we have an HTTPs URL or not,
and includes embedder-defined custom protocols (such as, custom protocols
defined by WKWebView users). It matches the URLs for which
`window.isSecureContext` would return true.

This patch does not fully align WebKit&apos;s implementation with the Mixed Content
specification:
- handling of localhost URLs is left unchanged: they are always considered
  as potentially trustworthy, but we block HTTP loading of them in secure
  contexts (<a href="https://bugs.webkit.org/show_bug.cgi?id=171934)">https://bugs.webkit.org/show_bug.cgi?id=171934)</a>;
- loading of unsecure resources from file:// documents is still allowed
  (<a href="https://bugs.webkit.org/show_bug.cgi?id=297785).">https://bugs.webkit.org/show_bug.cgi?id=297785).</a>

These divergences are now explicitly marked and self-contained in the source
code, so that they can be easily changed if WebKit decides to align with
the spec.

* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/sharedworker-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/sharedworker-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-import-data.https-expected.txt:
* Source/WebCore/fileapi/BlobURL.cpp:
(WebCore::BlobURL::getOwnerDocument):
(WebCore::BlobURL::isSecureBlobURL): Deleted.
* Source/WebCore/fileapi/BlobURL.h:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::isNonLocalHostPotentiallyTrustworthyOrigin):
(WebCore::getActualOrigin):
(WebCore::isNonLocalHostPotentiallyTrustworthyURL):
(WebCore::prohibitsMixedSecurityContextsItself):
(WebCore::prohibitsMixedSecurityContexts):
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
(WebCore::MixedContentChecker::canModifyRequest):
(WebCore::MixedContentChecker::shouldBlockRequest):
(WebCore::MixedContentChecker::checkFormForMixedContent):
(WebCore::isDocumentSecure): Deleted.
(WebCore::isDataContextSecure): Deleted.
(WebCore::isMixedContent): Deleted.
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::isSecure):
* Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp:
(TestWebKitAPI::TEST(MixedContentChecker, CanModifyRequest)):
</pre>


My original goal with this patch was to allow loading custom schemes from HTTPS pages in WKWebView, which should be allowed according to the Mixed Content spec. However, I noticed that the WebKit implementation of Mixed Content significantly diverges from the spec, which made that change complex. I ended up aligning the two with a couple exceptions where changing  the current WebKit behavior might have a too high impact.

- https://github.com/WebKit/WebKit/pull/35552 marked custom schemes as "upgradable" for compatibility with WKWebView ([bugs.webkit.org/show_bug.cgi?id=281883](https://bugs.webkit.org/show_bug.cgi?id=281883)). However, I don't understand how it can possibly work: once we decide that a custom scheme is upgradable, how do we actually upgrade it? It's not like HTTP that has a clear mapping to HTTPS. As far as I can tell we only upgrade http and ws requests ([356f67e/Source/WebCore/page/csp/ContentSecurityPolicy.cpp#L1151](https://github.com/WebKit/WebKit/blob/356f67eae83172534ddf23df2a69a017fbd05978/Source/WebCore/page/csp/ContentSecurityPolicy.cpp#L1151)).

- We have a setting to control upgrading of localhost (iPAddressAndLocalhostMixedContentUpgradeTestingEnabled), but in MixedContentChecker.cpp is only used for building error messages. Would it make sense to move its handling to here, rather than in the shouldUpgradeInsecureContent callers? (separate PR?)

- We have tome test (like LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2.html and LayoutTests/fast/forms/form-associated-element-crash3.html) that we run with an origin whose protocol is file:, and that use non-trustworthy URLs (such as a `<form action="http:...">` in the first one, and a `<video src="javascript:...">`) in the second one. According to the Secure Contexts spec, file: URLs count as trustworthy so we should disallow mixed content in them. However, that breaks those tests and I don't know how to change the testing infrastructure to not serve them from file: but instead use http:. For now I'm preserving the old behavior of allowing insecure content to be used inside file:// and custom-scheme: documents ([bugs.webkit.org/show_bug.cgi?id=297785](https://bugs.webkit.org/show_bug.cgi?id=297785), https://github.com/w3c/webappsec-mixed-content/issues/73#issuecomment-3215055600).

- Right now I made sure to keep the spec divergence we have when it comes to http://127.0.0.1/ and http://localhost/ (they should both be considered secure, but we consider them upgradable instead - [bugs.webkit.org/show_bug.cgi?id=171934](https://bugs.webkit.org/show_bug.cgi?id=171934)). However, fixing it requires first changing how we run WPT (we use localhost in places where we shouldn't, I think?), which is way out of my knowledge level.

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f380b39e951beb61ea1c13ae4edad6bd213c792b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91626 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60890 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32761 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108139 "Found 2 new API test failures: TestWebKitAPI.WebKit.ConfigurationMaskedURLSchemes_B, TestWebKitAPI.WebKit.ConfigurationMaskedURLSchemes (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26243 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70634 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102247 "Found 2 new API test failures: TestWebKitAPI.WebKit.ConfigurationMaskedURLSchemes_B, TestWebKitAPI.WebKit.ConfigurationMaskedURLSchemes (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100250 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100091 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23561 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44218 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53125 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46889 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->