### PR TITLE
[WPE][IPC] Add support for AHardwareBuffer attachments

### DIFF
--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -1,5 +1,6 @@
 list(APPEND WTF_SOURCES
     android/LoggingAndroid.cpp
+    android/RefPtrAndroid.cpp
 
     generic/MainThreadGeneric.cpp
     generic/MemoryFootprintGeneric.cpp
@@ -35,6 +36,8 @@ list(APPEND WTF_SOURCES
 )
 
 list(APPEND WTF_PUBLIC_HEADERS
+    android/RefPtrAndroid.h
+
     glib/Application.h
     glib/ChassisType.h
     glib/GMutexLocker.h
@@ -73,7 +76,7 @@ if (ENABLE_JOURNALD_LOG)
 endif ()
 
 if (ANDROID)
-    list(APPEND WTF_LIBRARIES Android::Log)
+    list(APPEND WTF_LIBRARIES Android::Android Android::Log)
 endif ()
 
 list(APPEND WTF_SYSTEM_INCLUDE_DIRECTORIES

--- a/Source/WTF/wtf/android/RefPtrAndroid.cpp
+++ b/Source/WTF/wtf/android/RefPtrAndroid.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "RefPtrAndroid.h"
+
+#if OS(ANDROID)
+
+#include <android/hardware_buffer.h>
+
+namespace WTF {
+
+AHardwareBuffer* DefaultRefDerefTraits<AHardwareBuffer>::refIfNotNull(AHardwareBuffer* ptr)
+{
+    if (ptr) [[likely]]
+        AHardwareBuffer_acquire(ptr);
+    return ptr;
+}
+
+void DefaultRefDerefTraits<AHardwareBuffer>::derefIfNotNull(AHardwareBuffer* ptr)
+{
+    if (ptr) [[likely]]
+        AHardwareBuffer_release(ptr);
+}
+
+} // namespace WTF
+
+#endif // OS(ANDROID)

--- a/Source/WTF/wtf/android/RefPtrAndroid.h
+++ b/Source/WTF/wtf/android/RefPtrAndroid.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if OS(ANDROID)
+
+#include <wtf/RefPtr.h>
+
+typedef struct AHardwareBuffer AHardwareBuffer;
+
+namespace WTF {
+
+template<>
+struct DefaultRefDerefTraits<AHardwareBuffer> {
+    static AHardwareBuffer* refIfNotNull(AHardwareBuffer*);
+    static void derefIfNotNull(AHardwareBuffer*);
+};
+
+} // namespace WTF
+
+#endif // OS(ANDROID)

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -42,8 +42,12 @@
 #include <wtf/Unexpected.h>
 #include <wtf/WallTime.h>
 
+#if OS(ANDROID)
+#include "ArgumentCodersAndroid.h"
+#endif
 #if USE(GLIB)
 #include "ArgumentCodersGlib.h"
+#include "RendererBufferFormat.h"
 #endif
 #if USE(UNIX_DOMAIN_SOCKETS)
 #include "ArgumentCodersUnix.h"

--- a/Source/WebKit/Platform/IPC/Attachment.h
+++ b/Source/WebKit/Platform/IPC/Attachment.h
@@ -30,6 +30,11 @@
 #include <wtf/MachSendRight.h>
 #endif
 
+#if OS(ANDROID)
+#include <wtf/Variant.h>
+#include <wtf/android/RefPtrAndroid.h>
+#endif
+
 #if USE(UNIX_DOMAIN_SOCKETS)
 #include <wtf/unix/UnixFileDescriptor.h>
 #endif
@@ -42,6 +47,8 @@ namespace IPC {
 using Attachment = MachSendRight;
 #elif OS(WINDOWS)
 struct Attachment { }; // Windows does not need attachments at the moment.
+#elif OS(ANDROID)
+using Attachment = Variant<UnixFileDescriptor, RefPtr<AHardwareBuffer>>;
 #elif USE(UNIX_DOMAIN_SOCKETS)
 using Attachment = UnixFileDescriptor;
 #else

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -67,6 +67,10 @@
 #include <wtf/WorkQueue.h>
 #include <wtf/text/CString.h>
 
+#if OS(ANDROID)
+#include <wtf/android/RefPtrAndroid.h>
+#endif
+
 #if OS(DARWIN)
 #include <mach/mach_port.h>
 #include <wtf/OSObjectPtr.h>
@@ -726,6 +730,15 @@ private:
     Vector<uint8_t> m_readBuffer;
     Vector<int> m_fileDescriptors;
     std::unique_ptr<UnixMessage> m_pendingOutputMessage;
+
+#if OS(ANDROID)
+    bool sendOutgoingHardwareBuffers();
+    bool receiveIncomingHardwareBuffers();
+
+    size_t m_pendingIncomingHardwareBufferCount { 0 };
+    Vector<RefPtr<AHardwareBuffer>, 2> m_incomingHardwareBuffers;
+    Vector<RefPtr<AHardwareBuffer>, 2> m_outgoingHardwareBuffers;
+#endif
 #if USE(GLIB)
     GRefPtr<GSocket> m_socket;
     GSocketMonitor m_readSocketMonitor;

--- a/Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.cpp
+++ b/Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "ArgumentCodersAndroid.h"
+
+#if OS(ANDROID)
+
+#include "ArgumentCodersUnix.h"
+#include "Decoder.h"
+#include "Encoder.h"
+#include <wtf/unix/UnixFileDescriptor.h>
+
+namespace IPC {
+
+std::optional<UnixFileDescriptor> ArgumentCoder<UnixFileDescriptor>::decode(Decoder& decoder)
+{
+    if (auto attachment = decoder.takeLastAttachment()) {
+        if (holdsAlternative<UnixFileDescriptor>(attachment.value()))
+            return { WTFMove(get<UnixFileDescriptor>(attachment.value())) };
+    }
+    return std::nullopt;
+}
+
+void ArgumentCoder<RefPtr<AHardwareBuffer>>::encode(Encoder& encoder, const RefPtr<AHardwareBuffer>& buffer)
+{
+    encoder.addAttachment(RefPtr { buffer });
+}
+
+void ArgumentCoder<RefPtr<AHardwareBuffer>>::encode(Encoder& encoder, RefPtr<AHardwareBuffer>&& buffer)
+{
+    encoder.addAttachment(WTFMove(buffer));
+}
+
+std::optional<RefPtr<AHardwareBuffer>> ArgumentCoder<RefPtr<AHardwareBuffer>>::decode(Decoder& decoder)
+{
+    if (auto attachment = decoder.takeLastAttachment()) {
+        if (holdsAlternative<RefPtr<AHardwareBuffer>>(attachment.value()))
+            return { WTFMove(get<RefPtr<AHardwareBuffer>>(attachment.value())) };
+    }
+    return std::nullopt;
+}
+
+}
+
+#endif // OS(ANDROID)

--- a/Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.h
+++ b/Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if OS(ANDROID)
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/android/RefPtrAndroid.h>
+
+namespace IPC {
+
+template<> struct ArgumentCoder<RefPtr<AHardwareBuffer>> {
+    static void encode(Encoder&, const RefPtr<AHardwareBuffer>&);
+    static void encode(Encoder&, RefPtr<AHardwareBuffer>&&);
+    static std::optional<RefPtr<AHardwareBuffer>> decode(Decoder&);
+};
+
+}
+
+#endif // OS(ANDROID)

--- a/Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.cpp
@@ -42,9 +42,11 @@ void ArgumentCoder<UnixFileDescriptor>::encode(Encoder& encoder, UnixFileDescrip
     encoder.addAttachment(WTFMove(fd));
 }
 
+#if !OS(ANDROID)
 std::optional<UnixFileDescriptor> ArgumentCoder<UnixFileDescriptor>::decode(Decoder& decoder)
 {
     return decoder.takeLastAttachment();
 }
+#endif // OS(ANDROID)
 
 }

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -387,6 +387,7 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${FORWARDING_HEADERS_WPE_EXTENSION_DIR}"
     "${WEBKIT_DIR}/NetworkProcess/glib"
     "${WEBKIT_DIR}/NetworkProcess/soup"
+    "${WEBKIT_DIR}/Platform/IPC/android"
     "${WEBKIT_DIR}/Platform/IPC/glib"
     "${WEBKIT_DIR}/Platform/IPC/unix"
     "${WEBKIT_DIR}/Platform/classifier"

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -54,6 +54,8 @@ NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
 NetworkProcess/webrtc/NetworkRTCMonitor.cpp
 NetworkProcess/webrtc/NetworkRTCProvider.cpp
 
+Platform/IPC/android/ArgumentCodersAndroid.cpp
+
 Platform/IPC/unix/ArgumentCodersUnix.cpp
 Platform/IPC/unix/ConnectionUnix.cpp
 Platform/IPC/unix/IPCSemaphoreUnix.cpp


### PR DESCRIPTION
#### 17242045db7fe32a02b655bc64304f3eb157099c
<pre>
[WPE][IPC] Add support for AHardwareBuffer attachments
<a href="https://bugs.webkit.org/show_bug.cgi?id=297592">https://bugs.webkit.org/show_bug.cgi?id=297592</a>

Reviewed by Carlos Garcia Campos.

When building for Android, make message attachments a variant to
allow passing both UnixFileDescriptor or AHardwareBuffer through
IPC. This involved the following related changes in how Attachment
objects are handled: a new AttachmentInfo::m_type member indicates
whether an attachment is an UnixFileDescriptor or an AHardwareBuffer,
and alternative code paths are needed used to act them.

The trickier part of actually sending and receiving AHardwareBuffer
objects: we cannot &quot;open up&quot; the inside of buffer, and passing them
around needs to be done with AHardwareBuffer_sendHandleToUnixSocket()
and AHardwareBuffer_recvHandleFromUnixSocket(). These function will
themselves send/receive a message for each AHardwareBuffer, out of
our control. Therefore, on the writing end:

  - When preparing to send a message, note the amount of buffer
    handles in a new MessageInfo::m_validHardwareBufferCount
    member (invalid/null handles are not sent).

  - Store the valid AHardwareBuffer handles to be sent later and
    send the message (sans buffer handles) in the usual fashion.

  - Send the AHardwareBuffer handles right after the message.
    At the end of Connection::sendOutputMessage(), store the buffer
    handles Connection::m_outgoingHardwareBuffers, and call
    ::sendOutgoingHardwareBuffers().

  - The ::sendOutgoingHardwareBuffers() function attempts to send
    as many handles as it can right away. If the operation would
    block, it makes use of the socket monitor to re-schedule calling
    itself when the socket is ready again for sending. This is
    repeated until there are no more buffers left.

On the receiving end things are a little bit trickier because the
socket monitor is always armed to invoke Connection::readyReadHandler()
and this means that we cannot start it independently to handle only
retiring AHardwareBuffer handles from the socket -- we need to thread
the code to retire buffer handles into the existing functions:

  - The ::readyReadHandler() function may be invoked either to
    retry sending the &quot;main&quot; message, or to retry sending buffer
    handles. The Connection::m_pendingIncomingHardwareBufferCount
    is used to determine which code path to follow.

  - First, if there are no pending buffer handles to receive, a
    message is read. At the moment the code assumes that message
    are always read in their entirety, which is the case with
    SOCK_SEQPACKET.

  - The read message up to this point includes both the payload and
    file descriptors. The MessageInfo in the header of the message
    indicates how many AHardwareBuffer handles we need to retire.
    This is saved in Connection::m_pendingIncomingHardwareBufferCount
    before calling ::receiveIncomingHardwareBuffers().

  - Then ::receiveIncomingHardwareBuffers() attempts retiring from
    the socket as many buffer handles as it can. If reading handles
    would block, the function returns immediately, and will rely on
    the next call to ::readyReadHandler() -- as the socket monitor
    is always kept armed and invoke it for reading.

  - When execution reaches ::readyReadHandler() again and, crucially,
    there are still AHardwareBuffer handles pending to be retired from
    the socket, it will call again ::receiveIncomingHardwareBuffers()
    to resume the task. When all the handles have been retired from
    the socket we still need a call to ::processMessage() at this point,
    but without going first through trying to read another complete
    message.

* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/android/RefPtrAndroid.cpp: Added.
(WTF::DefaultRefDerefTraits&lt;AHardwareBuffer&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;AHardwareBuffer&gt;::derefIfNotNull):
* Source/WTF/wtf/android/RefPtrAndroid.h: Added.
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/Attachment.h:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.cpp: Added.
(IPC::ArgumentCoder&lt;UnixFileDescriptor&gt;::decode):
(IPC::ArgumentCoder&lt;RefPtr&lt;AHardwareBuffer&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RefPtr&lt;AHardwareBuffer&gt;&gt;::decode):
* Source/WebKit/Platform/IPC/android/ArgumentCodersAndroid.h: Added.
* Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.cpp:
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::AttachmentInfo::AttachmentInfo):
(IPC::AttachmentInfo::type const):
(IPC::AttachmentInfo::setType):
(IPC::Connection::processMessage):
(IPC::Connection::readyReadHandler):
(IPC::Connection::platformCanSendOutgoingMessages const):
(IPC::Connection::sendOutputMessage):
(IPC::Connection::sendOutgoingHardwareBuffers):
(IPC::Connection::receiveIncomingHardwareBuffers):
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
(IPC::MessageInfo::MessageInfo):
(IPC::MessageInfo::hardwareBufferCount const):
(IPC::UnixMessage::UnixMessage):
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/299311@main">https://commits.webkit.org/299311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80b0c3c3e8e7eae66a0ebe31b28aabd6e661fd06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70649 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46853 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31035 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/106326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68424 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110708 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127828 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117104 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98422 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25020 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21864 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51045 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145800 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44830 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37489 "Found 1 new JSC binary failure: testapi, Found 18606 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->