### PR TITLE
LibWebRTCMediaEndpoint should create its libwebrtc backend at creation time

### DIFF
--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -88,7 +88,7 @@ std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(Scri
 
 #else
 
-static std::unique_ptr<PeerConnectionBackend> createNoPeerConnectionBackend(RTCPeerConnection&)
+static std::unique_ptr<PeerConnectionBackend> createNoPeerConnectionBackend(RTCPeerConnection&, MediaEndpointConfiguration&&)
 {
     return nullptr;
 }

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -85,7 +85,7 @@ using SessionDescriptionPromise = DOMPromiseDeferred<IDLDictionary<RTCSessionDes
 using StatsPromise = DOMPromiseDeferred<IDLInterface<RTCStatsReport>>;
 }
 
-using CreatePeerConnectionBackend = const std::unique_ptr<PeerConnectionBackend> (*)(RTCPeerConnection&);
+using CreatePeerConnectionBackend = const std::unique_ptr<PeerConnectionBackend> (*)(RTCPeerConnection&, MediaEndpointConfiguration&&);
 
 class PeerConnectionBackend
     : public CanMakeWeakPtr<PeerConnectionBackend>

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -217,7 +217,7 @@ public:
 private:
     RTCPeerConnection(Document&);
 
-    ExceptionOr<void> initializeConfiguration(RTCConfiguration&&);
+    ExceptionOr<void> initializeWithConfiguration(RTCConfiguration&&);
 
     ExceptionOr<Ref<RTCRtpTransceiver>> addReceiveOnlyTransceiver(String&&);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -74,7 +74,7 @@ WebRTCLogObserver& webrtcLogObserverSingleton()
 }
 #endif // GST_DISABLE_GST_DEBUG
 
-static const std::unique_ptr<PeerConnectionBackend> createGStreamerPeerConnectionBackend(RTCPeerConnection& peerConnection)
+static const std::unique_ptr<PeerConnectionBackend> createGStreamerPeerConnectionBackend(RTCPeerConnection& peerConnection, MediaEndpointConfiguration&& configuration)
 {
     ensureGStreamerInitialized();
     static std::once_flag debugRegisteredFlag;
@@ -85,7 +85,10 @@ static const std::unique_ptr<PeerConnectionBackend> createGStreamerPeerConnectio
         WTFLogAlways("GstWebRTC plugin not found. Make sure to install gst-plugins-bad >= 1.20 with the webrtc plugin enabled.");
         return nullptr;
     }
-    return WTF::makeUniqueWithoutRefCountedCheck<GStreamerPeerConnectionBackend, PeerConnectionBackend>(peerConnection);
+    auto backend = WTF::makeUniqueWithoutRefCountedCheck<GStreamerPeerConnectionBackend, PeerConnectionBackend>(peerConnection);
+    bool status = backend->setConfiguration(WTFMove(configuration));
+    ASSERT_UNUSED(status, status);
+    return backend;
 }
 
 CreatePeerConnectionBackend PeerConnectionBackend::create = createGStreamerPeerConnectionBackend;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -70,13 +70,43 @@ IGNORE_CLANG_WARNINGS_END
 
 namespace WebCore {
 
-LibWebRTCMediaEndpoint::LibWebRTCMediaEndpoint(LibWebRTCPeerConnectionBackend& peerConnection, LibWebRTCProvider& client)
-    : m_peerConnectionBackend(peerConnection)
-    , m_peerConnectionFactory(*client.factory())
+static void prepareConfiguration(webrtc::PeerConnectionInterface::RTCConfiguration& configuration)
+{
+    configuration.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;
+    configuration.crypto_options = webrtc::CryptoOptions { };
+    configuration.crypto_options->srtp.enable_gcm_crypto_suites = true;
+}
+
+RefPtr<LibWebRTCMediaEndpoint> LibWebRTCMediaEndpoint::create(RTCPeerConnection& peerConnection, LibWebRTCProvider& client, Document& document, webrtc::PeerConnectionInterface::RTCConfiguration&& configuration)
+{
+    prepareConfiguration(configuration);
+
+    Ref endpoint = adoptRef(*new LibWebRTCMediaEndpoint(peerConnection, client, document));
+    RefPtr backend = toRefPtr(client.createPeerConnection(document.identifier(), endpoint, endpoint->m_rtcSocketFactory.get(), WTFMove(configuration)));
+    if (!backend)
+        return { };
+
+    lazyInitialize(endpoint->m_backend, backend.releaseNonNull());
+    return endpoint;
+}
+
+static std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> createLibWebRTCMediaEndpointSocketFactory(LibWebRTCProvider& client, Document& document)
+{
+    RegistrableDomain domain { document.url() };
+    bool isFirstParty = domain == RegistrableDomain(document.firstPartyForCookies());
+    auto rtcSocketFactory = client.createSocketFactory(document.userAgent(document.url()), document.identifier(), isFirstParty, WTFMove(domain));
+    if (!client.isSupportingMDNS() && rtcSocketFactory)
+        rtcSocketFactory->disableRelay();
+    return rtcSocketFactory;
+}
+
+LibWebRTCMediaEndpoint::LibWebRTCMediaEndpoint(RTCPeerConnection& peerConnection, LibWebRTCProvider& client, Document& document)
+    : m_peerConnectionFactory(*client.factory())
     , m_createSessionDescriptionObserver(*this)
     , m_setLocalSessionDescriptionObserver(*this)
     , m_setRemoteSessionDescriptionObserver(*this)
     , m_statsLogTimer(*this, &LibWebRTCMediaEndpoint::gatherStatsForLogging)
+    , m_rtcSocketFactory(createLibWebRTCMediaEndpointSocketFactory(client, document))
 #if !RELEASE_LOG_DISABLED
     , m_logger(peerConnection.logger())
     , m_logIdentifier(peerConnection.logIdentifier())
@@ -85,11 +115,17 @@ LibWebRTCMediaEndpoint::LibWebRTCMediaEndpoint(LibWebRTCPeerConnectionBackend& p
     ASSERT(isMainThread());
     ASSERT(client.factory());
 
-    if (!peerConnection.shouldEnableWebRTCL4S())
+    if (!document.settings().webRTCL4SEnabled())
         return;
 
     auto fieldTrials = "WebRTC-RFC8888CongestionControlFeedback/Enabled,force_send:true/"_s;
     webrtc::field_trial::InitFieldTrialsFromString(fieldTrials.characters());
+}
+
+void LibWebRTCMediaEndpoint::setPeerConnectionBackend(LibWebRTCPeerConnectionBackend& peerConnectionBackend)
+{
+    ASSERT(!m_peerConnectionBackend);
+    m_peerConnectionBackend = peerConnectionBackend;
 }
 
 void LibWebRTCMediaEndpoint::restartIce()
@@ -98,25 +134,9 @@ void LibWebRTCMediaEndpoint::restartIce()
         protectedBackend->RestartIce();
 }
 
-bool LibWebRTCMediaEndpoint::setConfiguration(LibWebRTCProvider& client, webrtc::PeerConnectionInterface::RTCConfiguration&& configuration)
+bool LibWebRTCMediaEndpoint::setConfiguration(webrtc::PeerConnectionInterface::RTCConfiguration&& configuration)
 {
-    configuration.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;
-    configuration.crypto_options = webrtc::CryptoOptions { };
-    configuration.crypto_options->srtp.enable_gcm_crypto_suites = true;
-
-    if (!m_backend) {
-        Ref peerConnectionBackend = *m_peerConnectionBackend;
-        Ref document = *downcast<Document>(peerConnectionBackend->protectedConnection()->scriptExecutionContext());
-        if (!m_rtcSocketFactory) {
-            RegistrableDomain domain { document->url() };
-            bool isFirstParty = domain == RegistrableDomain(document->firstPartyForCookies());
-            lazyInitialize(m_rtcSocketFactory, client.createSocketFactory(document->userAgent(document->url()), document->identifier(), isFirstParty, WTFMove(domain)));
-            if (!peerConnectionBackend->shouldFilterICECandidates() && m_rtcSocketFactory)
-                m_rtcSocketFactory->disableRelay();
-        }
-        m_backend = toRefPtr(client.createPeerConnection(document->identifier(), *this, m_rtcSocketFactory.get(), WTFMove(configuration)));
-        return !!m_backend;
-    }
+    prepareConfiguration(configuration);
 
     auto oldConfiguration = m_backend->GetConfiguration();
     configuration.certificates = oldConfiguration.certificates;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -82,11 +82,11 @@ class LibWebRTCMediaEndpoint
 #endif
 {
 public:
-    static Ref<LibWebRTCMediaEndpoint> create(LibWebRTCPeerConnectionBackend& peerConnection, LibWebRTCProvider& client) { return adoptRef(*new LibWebRTCMediaEndpoint(peerConnection, client)); }
+    static RefPtr<LibWebRTCMediaEndpoint> create(RTCPeerConnection&, LibWebRTCProvider&, Document&, webrtc::PeerConnectionInterface::RTCConfiguration&&);
     virtual ~LibWebRTCMediaEndpoint() = default;
 
     void restartIce();
-    bool setConfiguration(LibWebRTCProvider&, webrtc::PeerConnectionInterface::RTCConfiguration&&);
+    bool setConfiguration(webrtc::PeerConnectionInterface::RTCConfiguration&&);
 
     webrtc::PeerConnectionInterface& backend() const { ASSERT(m_backend); return *m_backend.get(); }
     void doSetLocalDescription(const RTCSessionDescription*);
@@ -130,8 +130,10 @@ public:
     void startRTCLogs();
     void stopRTCLogs();
 
+    void setPeerConnectionBackend(LibWebRTCPeerConnectionBackend&);
+
 private:
-    LibWebRTCMediaEndpoint(LibWebRTCPeerConnectionBackend&, LibWebRTCProvider&);
+    LibWebRTCMediaEndpoint(RTCPeerConnection&, LibWebRTCProvider&, Document&);
 
     // webrtc::PeerConnectionObserver API
     void OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState) final;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -63,10 +63,8 @@ class RealtimeOutgoingVideoSource;
 class LibWebRTCPeerConnectionBackend final : public PeerConnectionBackend {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCPeerConnectionBackend);
 public:
-    LibWebRTCPeerConnectionBackend(RTCPeerConnection&, LibWebRTCProvider&);
+    LibWebRTCPeerConnectionBackend(RTCPeerConnection&, Ref<LibWebRTCMediaEndpoint>&&);
     ~LibWebRTCPeerConnectionBackend();
-
-    bool shouldEnableWebRTCL4S() const;
 
 private:
     void close() final;


### PR DESCRIPTION
#### 26e59b88d51c6906b7df685715b4b9c00ed88935
<pre>
LibWebRTCMediaEndpoint should create its libwebrtc backend at creation time
<a href="https://bugs.webkit.org/show_bug.cgi?id=297722">https://bugs.webkit.org/show_bug.cgi?id=297722</a>
<a href="https://rdar.apple.com/158856248">rdar://158856248</a>

Reviewed by Jean-Yves Avenard.

Before the patch, the LibWebRTCMediaEndpoint setup would be like this:
- We create a LibWebRTCMediaEndpoint when creating the RTCPeerConnection.
- We create LibWebRTCMediaEndpoint&apos;s backend when applying the configuration given to RTCPeerConnection JS constructor.
- If LibWebRTCMediaEndpoint&apos;s backend creation fails, we would return early and the RTCPeerConnection JS constructor would throw.

This leaves LibWebRTCMediaEndpoint object with a nullptr backend for a short period of time, which makes the code difficult to reason about,
in particular whether to check for backend nullptr, or whether LibWebRTCMediaEndpoint is stopped (which is the point where the backend is currently back to nullptr_.

To make things simpler, we are now passing the configuration needed for LibWebRTCMediaEndpoint&apos;s backend creation as part of PeerConnectionBackend creation routine.
This allows LibWebRTCMediaEndpoint::create to try creating its backend.
If it fails, LibWebRTCMediaEndpoint::create will return nullptr and RTCPeerConnection JS constructor will throw as done previously.

This change requires a bunch of changes in RTCPeerConnection and LibWebRTCPeerConnectionBackend since we are not fully reusing the setConfiguration code path at initialization.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/299247@main">https://commits.webkit.org/299247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7444ad12094df681170252798914c0f0b51255bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69490 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29cfe412-3817-4a73-9f06-8bb622b17d55) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89156 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/44977 "Failed to checkout and rebase branch from PR 49716") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8103142a-7cd1-45ac-a462-f3b62c2a6c35) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105339 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69665 "Found 40 new API test failures: /TestJSC:/jsc/basic, /WPE/TestWebKitNetworkSession:beforeAll, /WPE/TestNetworkProcessMemoryPressure:beforeAll, /WPE/TestWebKitWebContext:beforeAll, /WPE/TestSSL:beforeAll, /WPE/TestWebKitURIUtilities:beforeAll, /WPE/TestWebKitWebView:beforeAll, /WPEPlatform/TestDisplayDefault:/wpe-platform/Display/default, /WPE/TestFrame:beforeAll, /TestWebCore:GStreamerTest.harnessParseMP4 ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d96e6fa2-1cde-43b5-9e82-8fbaa1f14f8e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23453 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67251 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126696 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44373 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33383 "Found 1 new test failure: ipc/send-gradient.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97833 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40727 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44246 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49928 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43703 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->