### PR TITLE
REGRESSION (294191@main): Extremely slow applying a large style

### DIFF
--- a/LayoutTests/fast/selectors/attribute-invalidation-large-expected.txt
+++ b/LayoutTests/fast/selectors/attribute-invalidation-large-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't time out.

--- a/LayoutTests/fast/selectors/attribute-invalidation-large.html
+++ b/LayoutTests/fast/selectors/attribute-invalidation-large.html
@@ -1,0 +1,15 @@
+<style id=s></style>
+<div id=t>This test passes if it doesn't time out.</div>
+<script>
+window.testRunner?.dumpAsText();
+
+function makeStylesheet(count) {
+    let text = "";
+    for (let i = 0; i < count; ++i)
+        text += `[class *= v${i}] { color: rgb(${Math.round(i / count*25500)/100}, 0, 0) }\n`;
+    return text;
+}
+s.textContent = makeStylesheet(20000);
+t.offsetTop;
+t.classList.add("foo");
+</script>

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -138,6 +138,31 @@ CSSSelectorList CSSSelectorList::makeJoining(const CSSSelectorList& a, const CSS
     return CSSSelectorList { WTFMove(selectorArray) };
 }
 
+CSSSelectorList CSSSelectorList::makeJoining(const Vector<const CSSSelectorList*>& lists)
+{
+    size_t totalComponentCount = 0;
+    for (auto list : lists)
+        totalComponentCount += list->componentCount();
+
+    if (!totalComponentCount)
+        return { };
+
+    auto selectorArray = makeUniqueArray<CSSSelector>(totalComponentCount);
+
+    size_t componentIndex = 0;
+    for (auto list : lists) {
+        auto count = list->componentCount();
+        for (size_t i = 0; i < count; ++i)
+            new (NotNull, &selectorArray[componentIndex++]) CSSSelector(list->m_selectorArray[i]);
+        selectorArray[componentIndex - 1].m_isLastInSelectorList = false;
+    }
+
+    ASSERT(componentIndex == totalComponentCount);
+    selectorArray[componentIndex - 1].m_isLastInSelectorList = true;
+
+    return CSSSelectorList { WTFMove(selectorArray) };
+}
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 unsigned CSSSelectorList::componentCount() const
 {

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -49,6 +49,7 @@ public:
     static CSSSelectorList makeCopyingSimpleSelector(const CSSSelector&);
     static CSSSelectorList makeCopyingComplexSelector(const CSSSelector&);
     static CSSSelectorList makeJoining(const CSSSelectorList&, const CSSSelectorList&);
+    static CSSSelectorList makeJoining(const Vector<const CSSSelectorList*>&);
 
     bool isEmpty() const { return !m_selectorArray; }
     const CSSSelector* first() const { return m_selectorArray.get(); }

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -311,13 +311,21 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
         if (!features)
             return nullptr;
 
-        HashMap<std::tuple<uint8_t, bool, bool>, InvalidationRuleSet> invalidationRuleSetMap;
+        struct Builder {
+            RefPtr<RuleSet> ruleSet;
+            Vector<const CSSSelectorList*> invalidationSelectors;
+            MatchElement matchElement;
+            IsNegation isNegation;
+        };
+        using BuilderKey = std::tuple<uint8_t, bool, bool>;
+
+        HashMap<BuilderKey, Builder> builderMap;
 
         for (auto& feature : *features) {
-            auto key = std::tuple { static_cast<uint8_t>(feature.matchElement), static_cast<bool>(feature.isNegation), true };
+            auto key = BuilderKey { static_cast<uint8_t>(feature.matchElement), static_cast<bool>(feature.isNegation), true };
 
-            auto& invalidationRuleSet = invalidationRuleSetMap.ensure(key, [&] {
-                return InvalidationRuleSet {
+            auto& builder = builderMap.ensure(key, [&] {
+                return Builder {
                     RuleSet::create(),
                     { },
                     feature.matchElement,
@@ -325,15 +333,20 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
                 };
             }).iterator->value;
 
-            invalidationRuleSet.ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
+            builder.ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
 
             if constexpr (std::is_same<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>::value)
-                invalidationRuleSet.invalidationSelectors = CSSSelectorList::makeJoining(invalidationRuleSet.invalidationSelectors, feature.invalidationSelector);
+                builder.invalidationSelectors.append(&feature.invalidationSelector);
         }
 
-        return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(invalidationRuleSetMap.values(), [](auto&& invalidationRuleSet) {
-            invalidationRuleSet.ruleSet->shrinkToFit();
-            return WTFMove(invalidationRuleSet);
+        return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(builderMap.values(), [](auto&& builder) {
+            builder.ruleSet->shrinkToFit();
+            return InvalidationRuleSet {
+                WTFMove(builder.ruleSet),
+                CSSSelectorList::makeJoining(builder.invalidationSelectors),
+                builder.matchElement,
+                builder.isNegation
+            };
         }));
     }).iterator->value.get();
 }


### PR DESCRIPTION
#### 0ac2f442652f3c0730a5a83b1f63ef68f35961d7
<pre>
REGRESSION (294191@main): Extremely slow applying a large style
<a href="https://bugs.webkit.org/show_bug.cgi?id=297591">https://bugs.webkit.org/show_bug.cgi?id=297591</a>
<a href="https://rdar.apple.com/158700409">rdar://158700409</a>

Reviewed by Alan Baradlay.

If there is a stylesheet with lots if attribute selectors like

[someattr *= foo1]
[someattr *= foo2]
...

targeting a single attribute then the invalidation selector list for that attribute can grow large.
The current code for appending to this selector list is O(n^2) so things can get slow when constructing
a large list.

* LayoutTests/fast/selectors/attribute-invalidation-large-expected.txt: Added.
* LayoutTests/fast/selectors/attribute-invalidation-large.html: Added.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::makeJoining):

Add a version of makeJoining that takes a vector of selector lists.

* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):

Collect the relevant selector lists using a vector and only join them at the end.

Canonical link: <a href="https://commits.webkit.org/299018@main">https://commits.webkit.org/299018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ad39f47fb94e783908ff5acf3f154d9bd7d52c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69470 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c2d0476-aea0-4de6-b8c2-5a90500294c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45736 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89159 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/44342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8c1e2f0-3b59-4eed-9383-8a853fb1ea7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30141 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105340 "Build is being retried. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; api tests running") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69668 "Found 42 new API test failures: /TestJSC:/jsc/basic, /WPE/TestWebKitNetworkSession:beforeAll, /TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot, /WPE/TestNetworkProcessMemoryPressure:beforeAll, /WPE/TestSSL:beforeAll, /WPE/TestWebKitWebContext:beforeAll, /WPE/TestWebKitURIUtilities:beforeAll, /WPE/TestWebKitWebView:beforeAll, /WPEPlatform/TestDisplayDefault:/wpe-platform/Display/default, /WPE/TestFrame:beforeAll ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4395fb48-5cca-4f62-8688-872f6490995e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23454 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67254 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126699 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97832 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24853 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40730 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44249 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43706 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47050 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->