### PR TITLE
REGRESSION(269745@main): Inserting a PathSeg with NaN coordinates into a <path> element can result in NaN StrokeBoundingBox

### DIFF
--- a/LayoutTests/svg/custom/path-seg-nan-coordinates-linecap-crash-expected.txt
+++ b/LayoutTests/svg/custom/path-seg-nan-coordinates-linecap-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/svg/custom/path-seg-nan-coordinates-linecap-crash.html
+++ b/LayoutTests/svg/custom/path-seg-nan-coordinates-linecap-crash.html
@@ -1,0 +1,13 @@
+<body>
+    <p>This test passes if it doesn't crash.</p>
+    <svg>
+        <path id="path" d="M0,0 L100, 100 z" stroke-linecap="square" marker-end="url(#no-link)" stroke="url(#no-link)" stroke-dasharray="0" />
+    </svg>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+        let pathSegList = path.pathSegList;
+        let pathSeg = path.createSVGPathSegMovetoAbs(NaN, NaN);
+        pathSegList.replaceItem(pathSeg, 1);
+    </script>
+</body>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -94,8 +94,11 @@ FloatRect LegacyRenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLin
 
     if (style().svgStyle().hasStroke()) {
         // FIXME: zero-length subpaths do not respect vector-effect = non-scaling-stroke.
-        for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i)
-            strokeBoundingBox.unite(zeroLengthSubpathRect(m_zeroLengthLinecapLocations[i], strokeWidth));
+        for (auto& zeroLengthLinecapLocation : m_zeroLengthLinecapLocations) {
+            auto subpathRect = zeroLengthSubpathRect(zeroLengthLinecapLocation, strokeWidth);
+            if (!subpathRect.isNaN())
+                strokeBoundingBox.unite(subpathRect);
+        }
     }
 
     return strokeBoundingBox;


### PR DESCRIPTION
#### e3aa940b07c165276a0e1f416ff92c45387da303
<pre>
REGRESSION(269745@main): Inserting a PathSeg with NaN coordinates into a &lt;path&gt; element can result in NaN StrokeBoundingBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=297730">https://bugs.webkit.org/show_bug.cgi?id=297730</a>
<a href="https://rdar.apple.com/157533330">rdar://157533330</a>

Reviewed by Simon Fraser.

A pathSeg with NaN cooridatnes and Linecap should not make the StrokeBoundingBox
of an SVGPathElement a NaN FloatRect.

* LayoutTests/svg/custom/path-seg-nan-coordinates-linecap-crash-expected.txt: Added.
* LayoutTests/svg/custom/path-seg-nan-coordinates-linecap-crash.html: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps const):

Canonical link: <a href="https://commits.webkit.org/299291@main">https://commits.webkit.org/299291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04ff20dc085fe80c3304ed287a1426bce508c0bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124464 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70352 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7933075e-8590-4d2a-9770-f45cfb307e48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89780 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59405 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4814b415-333e-4f8e-85a9-a9704ddb6b8e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70269 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef8e535f-c3d3-496c-a1f7-8292f9d70cc3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68127 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127536 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98456 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98242 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25010 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43641 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41683 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50753 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46227 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->