### PR TITLE
Reduce use of cacheTestRunnerCallback even more

### DIFF
--- a/LayoutTests/accessibility/deleting-iframe-destroys-axcache.html
+++ b/LayoutTests/accessibility/deleting-iframe-destroys-axcache.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ injectTestRunner=false ] -->
 <html>
 <head>
 <script src="../resources/js-test.js"></script>

--- a/Source/WebCore/page/WebKitJSHandle.cpp
+++ b/Source/WebCore/page/WebKitJSHandle.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 // FIXME: Make PairHashTraits work with PeekTypes and use a map<identifier, pair> instead of 2 hash lookups.
-using HandleMap = HashMap<JSHandleIdentifier, JSC::Weak<JSC::JSObject>>;
+using HandleMap = HashMap<JSHandleIdentifier, JSC::Strong<JSC::JSObject>>;
 static HandleMap& handleMap()
 {
     static MainThreadNeverDestroyed<HandleMap> map;
@@ -55,7 +55,7 @@ void WebKitJSHandle::jsHandleDestroyed(JSHandleIdentifier identifier)
 
 std::pair<RefPtr<Document>, JSC::JSObject*> WebKitJSHandle::objectForIdentifier(JSHandleIdentifier identifier)
 {
-    return { documentMap().get(identifier).get(), handleMap().get(identifier) };
+    return { documentMap().get(identifier).get(), handleMap().get(identifier).get() };
 }
 
 static Markable<FrameIdentifier> windowFrameIdentifier(JSC::JSObject* object)
@@ -71,7 +71,7 @@ WebKitJSHandle::WebKitJSHandle(Document& document, JSC::JSObject* object)
     : m_identifier(JSHandleIdentifier::generate())
     , m_windowFrameIdentifier(WebCore::windowFrameIdentifier(object))
 {
-    handleMap().add(m_identifier, JSC::Weak<JSC::JSObject> { object });
+    handleMap().add(m_identifier, JSC::Strong<JSC::JSObject> { document.vm(), object });
     documentMap().add(m_identifier, WeakPtr { document });
 }
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -244,6 +244,7 @@ typedef void (*WKPageEvaluateJavaScriptFunction)(WKTypeRef, WKErrorRef, void*);
 WK_EXPORT void WKPageEvaluateJavaScriptInMainFrame(WKPageRef page, WKStringRef script, void* context, WKPageEvaluateJavaScriptFunction function);
 WK_EXPORT void WKPageEvaluateJavaScriptInFrame(WKPageRef page, WKFrameInfoRef frame, WKStringRef script, void* context, WKPageEvaluateJavaScriptFunction function);
 WK_EXPORT void WKPageCallAsyncJavaScript(WKPageRef page, WKStringRef script, WKDictionaryRef arguments, WKFrameInfoRef frame, void* context, WKPageEvaluateJavaScriptFunction callback);
+WK_EXPORT void WKPageCallAsyncJavaScriptWithoutUserGesture(WKPageRef page, WKStringRef script, WKDictionaryRef arguments, WKFrameInfoRef frame, void* context, WKPageEvaluateJavaScriptFunction callback);
 
 typedef void (*WKPageGetSourceForFrameFunction)(WKStringRef, WKErrorRef, void*);
 WK_EXPORT void WKPageGetSourceForFrame(WKPageRef page, WKFrameRef frame, void* context, WKPageGetSourceForFrameFunction function);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -282,10 +282,6 @@ interface TestRunner {
 
     unsigned long imageCountInGeneralPasteboard();
 
-    // UI Process Testing
-    undefined runUIScript(DOMString script, object callback);
-    undefined runUIScriptImmediately(DOMString script, object callback);
-
     undefined accummulateLogsForChannel(DOMString channel);
 
     // Contextual menu actions

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -260,15 +260,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "CallUISideScriptCallback")) {
-        auto messageBodyDictionary = dictionaryValue(messageBody);
-        auto callbackID = uint64Value(messageBodyDictionary, "CallbackID");
-        auto resultString = stringValue(messageBodyDictionary, "Result");
-        if (m_testRunner)
-            m_testRunner->runUIScriptCallback(callbackID, toJS(resultString).get());
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "WorkQueueProcessedCallback")) {
         if (!topLoadingFrame() && m_testRunner && !m_testRunner->shouldWaitUntilDone())
             InjectedBundle::page()->dump(m_testRunner->shouldForceRepaint());

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -599,7 +599,6 @@ enum {
     TextDidChangeInTextFieldCallbackID = 1,
     TextFieldDidBeginEditingCallbackID,
     TextFieldDidEndEditingCallbackID,
-    FirstUIScriptCallbackID = 100
 };
 
 static void cacheTestRunnerCallback(JSContextRef context, unsigned index, JSValueRef callback)
@@ -1073,37 +1072,6 @@ void TestRunner::terminateServiceWorkers()
 void TestRunner::setUseSeparateServiceWorkerProcess(bool value)
 {
     postSynchronousPageMessage("SetUseSeparateServiceWorkerProcess", value);
-}
-
-static unsigned nextUIScriptCallbackID()
-{
-    static unsigned callbackID = FirstUIScriptCallbackID;
-    return callbackID++;
-}
-
-void TestRunner::runUIScript(JSContextRef context, JSStringRef script, JSValueRef callback)
-{
-    unsigned callbackID = nextUIScriptCallbackID();
-    cacheTestRunnerCallback(context, callbackID, callback);
-    postPageMessage("RunUIProcessScript", createWKDictionary({
-        { "Script", toWK(script) },
-        { "CallbackID", adoptWK(WKUInt64Create(callbackID)).get() },
-    }));
-}
-
-void TestRunner::runUIScriptImmediately(JSContextRef context, JSStringRef script, JSValueRef callback)
-{
-    unsigned callbackID = nextUIScriptCallbackID();
-    cacheTestRunnerCallback(context, callbackID, callback);
-    postPageMessage("RunUIProcessScriptImmediately", createWKDictionary({
-        { "Script", toWK(script) },
-        { "CallbackID", adoptWK(WKUInt64Create(callbackID)).get() },
-    }));
-}
-
-void TestRunner::runUIScriptCallback(unsigned callbackID, JSStringRef result)
-{
-    callTestRunnerCallback(callbackID, result);
 }
 
 void TestRunner::setAllowedMenuActions(JSContextRef context, JSValueRef actions)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -385,10 +385,6 @@ public:
     bool didCancelClientRedirect() const { return m_didCancelClientRedirect; }
     void setDidCancelClientRedirect(bool value) { m_didCancelClientRedirect = value; }
 
-    void runUIScript(JSContextRef, JSStringRef script, JSValueRef callback);
-    void runUIScriptImmediately(JSContextRef, JSStringRef script, JSValueRef callback);
-    void runUIScriptCallback(unsigned callbackID, JSStringRef result);
-
     // Contextual menu actions
     void setAllowedMenuActions(JSContextRef, JSValueRef);
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -467,6 +467,8 @@ public:
 
     void setHasMouseDeviceForTesting(bool);
 
+    void uiScriptDidComplete(const String& result, unsigned scriptCallbackID);
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;
@@ -815,6 +817,7 @@ private:
     Callbacks m_willEndSwipeCallbacks;
     Callbacks m_didEndSwipeCallbacks;
     Callbacks m_didRemoveSwipeSnapshotCallbacks;
+    HashMap<unsigned, Callbacks> m_uiScriptCallbacks;
 
     uint64_t m_serverTrustEvaluationCallbackCallsCount { 0 };
     bool m_shouldDismissJavaScriptAlertsAsynchronously { false };

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -83,6 +83,8 @@ public:
 
     void dumpResourceLoadStatisticsIfNecessary();
 
+    void runUISideScript(WKStringRef, unsigned callbackID);
+
 private:
     TestInvocation(WKURLRef, const TestOptions&);
 
@@ -113,18 +115,9 @@ private:
     bool compareActualHashToExpectedAndDumpResults(const std::string&);
 
     static void forceRepaintDoneCallback(WKErrorRef, void* context);
-    
-    struct UIScriptInvocationData {
-        unsigned callbackID;
-        WebKit::WKRetainPtr<WKStringRef> scriptString;
-        WeakPtr<TestInvocation> testInvocation;
-    };
-    static void runUISideScriptAfterUpdateCallback(WKErrorRef, void* context);
-    static void runUISideScriptImmediately(WKErrorRef, void* context);
 
     bool shouldLogHistoryClientCallbacks() const;
 
-    void runUISideScript(WKStringRef, unsigned callbackID);
     // UIScriptContextDelegate
     void uiScriptDidComplete(const String& result, unsigned callbackID) override;
 


### PR DESCRIPTION
#### d3b6be9ed4c39814076bb9729822fdfd87abe2f7
<pre>
Reduce use of cacheTestRunnerCallback even more
<a href="https://bugs.webkit.org/show_bug.cgi?id=297738">https://bugs.webkit.org/show_bug.cgi?id=297738</a>
<a href="https://rdar.apple.com/158876977">rdar://158876977</a>

Reviewed by Brady Eidson.

This removes state in the injected bundle, which doesn&apos;t work with site isolation.

In order to make this work without introducing flaky tests, I need to change the
memory management of _WKJSHandle from a weak reference to a strong reference.
Otherwise, a common pattern where the _WKJSHandle is the only thing pointing to
a JSObject causes the object to be unable to be found when
JavaScriptEvaluationResult::JSInserter::toJS comes along to use the _WKJSHandle.
This memory management should be ok because when the API::JSHandle is destroyed,
it tells the web process to drop the strong reference.

In order to keep 3 tests working in the fast/page-color-sampling directory, I needed
to make a function to call async JS without a simulated user interaction.  Otherwise,
Page::updateFixedContainerEdges would think the page had been interacted with since
the last navigation and it wouldn&apos;t update the top edge color.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::nextUIScriptCallbackID): Deleted.
(WTR::TestRunner::runUIScript): Deleted.
(WTR::TestRunner::runUIScriptImmediately): Deleted.
(WTR::TestRunner::runUIScriptCallback): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):
(WTR::runUISideScriptImmediately):
(WTR::TestController::uiScriptDidComplete):
(WTR::if):
(WTR::CompletionHandler&lt;void):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::uiScriptDidComplete):
(WTR::TestInvocation::runUISideScriptImmediately): Deleted.
(WTR::TestInvocation::runUISideScriptAfterUpdateCallback): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/299195@main">https://commits.webkit.org/299195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d0607789313e532f9674e5653f6448750147bb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70237 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac748875-d1b2-4560-9c5c-e3ba934b3dd8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89689 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59327 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d6f25b1-12c0-4bea-aa55-cc1d9436292a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70185 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8068985-acec-465a-a0fe-0bbd7afda631) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29790 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68021 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127429 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98371 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98159 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43555 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41565 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18832 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44972 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50646 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44432 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47777 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->