### PR TITLE
Make window load event dispatch asynchronous to improve WPT compatibility.

### DIFF
--- a/LayoutTests/http/wpt/dom/events-async-expected.txt
+++ b/LayoutTests/http/wpt/dom/events-async-expected.txt
@@ -1,0 +1,3 @@
+
+PASS microtask should run before window.onload when events are async
+

--- a/LayoutTests/http/wpt/dom/events-async.html
+++ b/LayoutTests/http/wpt/dom/events-async.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ AsyncDocumentLifecycleEventsEnabled=true ] -->
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script type="module">
+
+promise_test(async t => {
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+}, "microtask should run before window.onload when events are async");
+</script>

--- a/LayoutTests/http/wpt/dom/events-sync-expected.txt
+++ b/LayoutTests/http/wpt/dom/events-sync-expected.txt
@@ -1,0 +1,3 @@
+
+PASS in microtask execution in module, window.onload should be fired first for sync events
+

--- a/LayoutTests/http/wpt/dom/events-sync.html
+++ b/LayoutTests/http/wpt/dom/events-sync.html
@@ -1,0 +1,12 @@
+<!-- webkit-test-runner [ AsyncDocumentLifecycleEventsEnabled=false ] -->
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script type="module">
+
+promise_test(async t => {
+  assert_equals(document.readyState, 'complete', 'document.readyState should be complete');
+  t.done();
+}, "in microtask execution in module, window.onload should be fired first for sync events");
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -554,6 +554,20 @@ AsyncClipboardAPIEnabled:
     WebCore:
       default: false
 
+AsyncDocumentLifecycleEventsEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Async Document Lifecycle Events"
+  humanReadableDescription: "Fire DOMContentLoaded, load, and pageshow events asynchronously"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 AsyncFrameScrollingEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1455,6 +1455,11 @@ public:
     bool isDelayingLoadEvent() const { return m_loadEventDelayCount; }
     WEBCORE_EXPORT void checkCompleted();
 
+    // Support for deferring setTimeout(0) until after DOMContentLoaded with async events
+    bool shouldDeferZeroDelayTimers() const;
+    void deferZeroDelayTimer(Function<void()>&&);
+    void flushDeferredZeroDelayTimers();
+
 #if ENABLE(IOS_TOUCH_EVENTS)
 #include <WebKitAdditions/DocumentIOS.h>
 #endif
@@ -2379,6 +2384,10 @@ private:
     Timer m_loadEventDelayTimer;
 
     CompletionHandler<void()> m_whenWindowLoadEventOrDestroyed;
+
+    // For deferring setTimeout(0) until after DOMContentLoaded with async events
+    Vector<Function<void()>> m_deferredZeroDelayTimers;
+    bool m_domContentLoadedEventWasDispatched { false };
 
     WeakHashMap<Node, std::unique_ptr<QuerySelectorAllResults>, WeakPtrImplWithEventTargetData> m_querySelectorAllResults;
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -84,7 +84,7 @@ const TestFeatures& TestOptions::defaults()
             { "AllowUniversalAccessFromFileURLs", true },
             { "AllowsInlineMediaPlayback", true },
             { "AppBadgeEnabled", true },
-            { "AsyncDocumentLifecycleEventsEnabled", false },
+            { "AsyncDocumentLifecycleEventsEnabled", true },
             { "AsyncFrameScrollingEnabled", false },
             { "AsyncOverflowScrollingEnabled", false },
             { "BuiltInNotificationsEnabled", false },

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -84,6 +84,7 @@ const TestFeatures& TestOptions::defaults()
             { "AllowUniversalAccessFromFileURLs", true },
             { "AllowsInlineMediaPlayback", true },
             { "AppBadgeEnabled", true },
+            { "AsyncDocumentLifecycleEventsEnabled", false },
             { "AsyncFrameScrollingEnabled", false },
             { "AsyncOverflowScrollingEnabled", false },
             { "BuiltInNotificationsEnabled", false },

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -213,12 +213,19 @@ static bool shouldEnableAsyncOverflowScrolling(const std::string& pathOrURL)
     return isWebPlatformTestURL({ { }, String::fromUTF8(pathOrURL.c_str()) });
 }
 
+static bool shouldEnableAsyncDocumentLifecycleEvents(const std::string& pathOrURL)
+{
+    return isWebPlatformTestURL({ { }, String::fromUTF8(pathOrURL.c_str()) });
+}
+
 TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCommand& command) const
 {
     TestFeatures features;
     features.boolTestRunnerFeatures.insert({ "useThreadedScrolling", true });
     if (shouldEnableAsyncOverflowScrolling(command.pathOrURL))
         features.boolWebPreferenceFeatures.insert({ "AsyncOverflowScrollingEnabled", true });
+    if (shouldEnableAsyncDocumentLifecycleEvents(command.pathOrURL))
+        features.boolWebPreferenceFeatures.insert({ "AsyncDocumentLifecycleEventsEnabled", true });
     return features;
 }
 


### PR DESCRIPTION
#### 65a7e91f24d7b6c19ceb6d6b3bc0264cb7d4d76e
<pre>
Defer setTimeout(0) until after DOMContentLoaded to fix test timeouts with async events

When async document lifecycle events are enabled, setTimeout(0) calls can execute
before DOMContentLoaded event handlers have run, breaking test assumptions.

This change defers zero-delay timers until after DOMContentLoaded has been dispatched,
ensuring jQuery ready handlers and similar patterns work correctly with async events.
</pre>
----------------------------------------------------------------------
#### c3d98ce6da02827557967413f2ec00ef59d0f5d8
<pre>
Make window load event dispatch asynchronous to improve WPT compatibility.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296649">https://bugs.webkit.org/show_bug.cgi?id=296649</a>
<a href="https://rdar.apple.com/157048720">rdar://157048720</a>

Reviewed by NOBODY (OOPS!).

Implementation Status

The proof-of-concept adds a feature flag AsyncDocumentLifecycleEventsEnabled that makes three key document lifecycle events fire asynchronously:
- DOMContentLoaded
- window load
- pageshow

When enabled, these events are queued via the event loop instead of firing synchronously. The feature is off by default but automatically enabled for WPT tests.

What Needs to Be Done

Immediate
- Run full WPT test suite to verify this fixes the compatibility issues
- Add more comprehensive test coverage beyond the two basic tests

Testing Required
- Event ordering with multiple event listeners
- Microtask/promise interaction timing
- Dynamic content loading scenarios
- iframe load event behavior
- Back/forward cache with async pageshow

Open Questions
- Does document.close() forced synchronous behavior need special handling?
- Any performance impact from async dispatch?
- Will this break existing WebKit-dependent content?

Technical Approach

- Uses incrementLoadEventDelayCount()/decrementLoadEventDelayCount() to prevent the document from thinking it&apos;s finished loading while events are queued.
- Events are dispatched via eventLoop().queueTask(TaskSource::DOMManipulation, ...).

* LayoutTests/http/wpt/dom/events-async-expected.txt: Added.
* LayoutTests/http/wpt/dom/events-async.html: Added.
* LayoutTests/http/wpt/dom/events-sync-expected.txt: Added.
* LayoutTests/http/wpt/dom/events-sync.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchWindowLoadEvent):
(WebCore::Document::finishedParsing):
(WebCore::Document::dispatchPageshowEvent):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::shouldEnableAsyncDocumentLifecycleEvents):
(WTR::TestController::platformSpecificFeatureDefaultsForTest const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65a7e91f24d7b6c19ceb6d6b3bc0264cb7d4d76e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69517 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/200e67cb-0a44-4bde-9461-03dab91ec7a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45770 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89187 "Failure limit exceed. At least found 248 new test failures: accessibility/iframe-within-cell.html animations/animation-set-effect.html compositing/repaint/inline-repaint-container.html contact-picker/contacts-interfaces.html css3/masking/clip-path-hit-test-iframe.html css3/masking/clip-path-hit-test-on-absolute-position-iframe-parent.html css3/masking/clip-path-hit-test-on-iframe-parent.html css3/masking/clip-path-hit-test-on-inline-iframe-parent.html dom/html/level1/core/documentinvalidcharacterexceptioncreatepi.html dom/html/level1/core/documentinvalidcharacterexceptioncreatepi1.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/45008 "Found 60 new test failures: animations/animation-add-events-in-handler.html animations/animation-set-effect.html animations/animation-shorthand-name-order.html animations/invalid-property-animation.html animations/leak-document-with-css-animation.html animations/legacy-encoding-timing-function.html compositing/repaint/inline-repaint-container.html compositing/transforms/transformed-replaced-with-shadow-children.html contact-picker/contacts-interfaces.html css3/filters/drop-shadow-current-color.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46a2b70b-ab21-4122-ad7b-4a5834f9b473) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120462 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30166 "Found 60 new test failures: animations/animation-add-events-in-handler.html compositing/backing/page-scale-overlap-in-iframe.html compositing/iframes/become-overlapped-iframe.html compositing/iframes/composited-parent-iframe.html compositing/iframes/connect-compositing-iframe-delayed.html compositing/iframes/connect-compositing-iframe2.html compositing/iframes/connect-compositing-iframe3.html compositing/iframes/iframe-size-to-zero.html compositing/iframes/invisible-nested-iframe-show.html compositing/iframes/overlapped-iframe-iframe.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105373 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69694 "Found 40 new API test failures: /WPE/TestDownloads:beforeAll, /WPE/TestWebKitPolicyClient:beforeAll, /WPE/TestWebKitSecurityOrigin:beforeAll, /WPE/TestEditor:beforeAll, /WPE/TestUIClient:beforeAll, /TestWebCore:GStreamerTest.harnessDecodeMP4Video, /WPE/TestFrame:beforeAll, /WPE/TestBackForwardList:beforeAll, /WPEPlatform/TestDisplayWayland:/wpe-platform/DisplayWayland/available-input-devices, /WPEPlatform/TestDisplayDefault:/wpe-platform/Display/default ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0066240a-99fb-41c6-bfe5-05ef3df5e89c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29227 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/file/send-file-form-controls.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-iso-2022-jp.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-punctuation.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-utf-8.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-windows-1252.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-x-user-defined.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form.html imported/w3c/web-platform-tests/FileAPI/url/multi-global-origin-serialization.sub.html imported/w3c/web-platform-tests/WebIDL/current-realm.html imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23490 "Found 60 new test failures: accessibility/iframe-bastardization.html accessibility/iframe-within-cell.html accessibility/mac/details-summary.html animations/animation-set-effect.html animations/invalid-property-animation.html compositing/iframes/connect-compositing-iframe2.html compositing/iframes/connect-compositing-iframe3.html compositing/iframes/invisible-nested-iframe-show.html compositing/iframes/remove-reinsert-webview-with-iframe.html compositing/iframes/repaint-after-losing-scrollbars.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67287 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109620 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99580 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23673 "Found 60 new test failures: accessibility/frame-disconnect-textmarker-cache-crash.html accessibility/iframe-with-role.html accessibility/iframe-within-cell.html accessibility/inline-block-assertion.html accessibility/mac/details-summary.html accessibility/mac/iframe-hit-testing.html accessibility/mac/iframe-relative-frame.html accessibility/mac/invalid-tree-root-at-iframe.html accessibility/mac/ordered-textmarker-crash.html accessibility/scroll-to-global-point-iframe.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126735 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116019 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44413 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33415 "Found 60 new test failures: accessibility/frame-disconnect-textmarker-cache-crash.html accessibility/iframe-within-cell.html accessibility/inline-block-assertion.html accessibility/mac/details-summary.html animations/animation-add-events-in-handler.html animations/animation-set-effect.html compositing/backing/animate-into-view.html compositing/backing/page-scale-overlap-in-iframe.html compositing/iframes/become-composited-nested-iframes.html compositing/iframes/become-overlapped-iframe.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97864 "Failure limit exceed. At least found 375 new test failures: accessibility/gtk/aria-busy-changed-notification.html accessibility/iframe-within-cell.html animations/animation-set-effect.html compositing/iframes/overlapped-nested-iframes.html compositing/iframes/resize-from-zero-size.html compositing/iframes/resizer.html compositing/repaint/inline-repaint-container.html compositing/rtl/rtl-iframe-absolute.html compositing/rtl/rtl-iframe-relative.html compositing/updates/no-updates-in-non-composited-iframe.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97652 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43017 "Found 1 new test failure: resize-observer/modify-frametree-in-callback.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20960 "Found 60 new test failures: accessibility/frame-disconnect-textmarker-cache-crash.html accessibility/iframe-with-role.html accessibility/iframe-within-cell.html accessibility/inline-block-assertion.html accessibility/mac/aria-menu-item-selected-notification.html accessibility/mac/details-summary.html accessibility/mac/iframe-hit-testing.html accessibility/mac/iframe-relative-frame.html accessibility/mac/ordered-textmarker-crash.html animations/animation-set-effect.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40771 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49959 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144717 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43741 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37247 "Found 1 new JSC binary failure: testapi, Found 20043 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/concat1.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Basics/flags.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->