### PR TITLE
Cannot change CSS scrollbar-width from none to auto

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scrollbar-width-none-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scrollbar-width-none-expected.txt
@@ -1,0 +1,18 @@
+Test scrollbar-width on overflow and main document
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Overflow should not have scrollbar-width:none
+
+PASS Scrollbar state:
+Overflow should have scrollbar-width:none
+none
+PASS Scrollbar state: none
+Overflow should not have scrollbar-width:none
+
+PASS Scrollbar state:
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/scrollbar-width-none.html
+++ b/LayoutTests/fast/scrolling/ios/scrollbar-width-none.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true MockScrollbarsEnabled=false ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 1000px;
+        }
+        .scroller {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            border: 1px solid black;
+            overflow: auto;
+            scrollbar-width: auto;
+        }
+        .contents {
+            width: 100%;
+            height: 200%;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        async function doTest()
+        {
+            description('Test scrollbar-width on overflow and main document');
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+            
+            const scroller = document.querySelector('.scroller');
+
+            debug('Overflow should not have scrollbar-width:none');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                debug(state);
+                let scrollbarWidth = state.indexOf('none') == -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+            
+            scroller.style.scrollbarWidth = 'none';
+            
+            debug('Overflow should have scrollbar-width:none');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                debug(state);
+                let scrollbarWidth = state.indexOf('none') != -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+            
+            scroller.style.scrollbarWidth = 'auto';
+            
+            debug('Overflow should not have scrollbar-width:none');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                debug(state);
+                let scrollbarWidth = state.indexOf('none') == -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -40,6 +40,7 @@
 #include "ContainerNodeInlines.h"
 #include "ContentVisibilityDocumentState.h"
 #include "DebugPageOverlays.h"
+#include "DeprecatedGlobalSettings.h"
 #include "DocumentFullscreen.h"
 #include "DocumentInlines.h"
 #include "DocumentLoader.h"
@@ -1685,6 +1686,8 @@ NativeScrollbarVisibility LocalFrameView::horizontalNativeScrollbarVisibility() 
         auto* scrollbar = horizontalScrollbar();
         return Scrollbar::nativeScrollbarVisibility(scrollbar);
     }
+    if (DeprecatedGlobalSettings::mockScrollbarsEnabled())
+        return NativeScrollbarVisibility::HiddenByStyle;
 
     return styleHidesScrollbarWithOrientation(ScrollbarOrientation::Horizontal) ? NativeScrollbarVisibility::HiddenByStyle : NativeScrollbarVisibility::Visible;
 }
@@ -1695,6 +1698,8 @@ NativeScrollbarVisibility LocalFrameView::verticalNativeScrollbarVisibility() co
         auto* scrollbar = verticalScrollbar();
         return Scrollbar::nativeScrollbarVisibility(scrollbar);
     }
+    if (DeprecatedGlobalSettings::mockScrollbarsEnabled())
+        return NativeScrollbarVisibility::HiddenByStyle;
 
     return styleHidesScrollbarWithOrientation(ScrollbarOrientation::Vertical) ? NativeScrollbarVisibility::HiddenByStyle : NativeScrollbarVisibility::Visible;
 }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -151,10 +151,6 @@ TextStream& operator<<(TextStream& ts, const ScrollableAreaParameters& scrollabl
         ts.dumpProperty("allows horizontal scrolling"_s, scrollableAreaParameters.allowsHorizontalScrolling);
     if (scrollableAreaParameters.allowsVerticalScrolling)
         ts.dumpProperty("allows vertical scrolling"_s, scrollableAreaParameters.allowsVerticalScrolling);
-    if (scrollableAreaParameters.horizontalNativeScrollbarVisibility == NativeScrollbarVisibility::HiddenByStyle)
-        ts.dumpProperty("horizontal scrollbar hidden by style"_s, scrollableAreaParameters.horizontalNativeScrollbarVisibility);
-    if (scrollableAreaParameters.verticalNativeScrollbarVisibility == NativeScrollbarVisibility::HiddenByStyle)
-        ts.dumpProperty("vertical scrollbar hidden by style"_s, scrollableAreaParameters.verticalNativeScrollbarVisibility);
 
     return ts;
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -414,6 +414,10 @@ void ScrollingStateScrollingNode::setScrollbarWidth(ScrollbarWidth scrollbarWidt
         return;
     m_scrollbarWidth = scrollbarWidth;
     setPropertyChanged(Property::ScrollbarWidth);
+    if (m_scrollableAreaParameters.scrollbarWidthStyle != scrollbarWidth) {
+        m_scrollableAreaParameters.scrollbarWidthStyle = scrollbarWidth;
+        setPropertyChanged(Property::ScrollableAreaParams);
+    }
 }
 
 void ScrollingStateScrollingNode::setUseDarkAppearanceForScrollbars(bool useDarkAppearanceForScrollbars)

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -676,6 +676,17 @@ OverscrollBehavior ScrollingTree::mainFrameHorizontalOverscrollBehavior() const
     return m_rootNode ? m_rootNode->horizontalOverscrollBehavior() : OverscrollBehavior::Auto;
 }
 
+NativeScrollbarVisibility ScrollingTree::mainFrameHorizontalScrollbarVisibility() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->horizontalScrollbarVisibility() : NativeScrollbarVisibility::Visible;
+}
+
+NativeScrollbarVisibility ScrollingTree::mainFrameVerticalScrollbarVisibility() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->verticalScrollbarVisibility() : NativeScrollbarVisibility::Visible;
+}
 
 ScrollbarWidth ScrollingTree::mainFrameScrollbarWidth() const
 {

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -235,6 +235,8 @@ public:
 
     WEBCORE_EXPORT FloatPoint mainFrameScrollPosition() const;
 
+    WEBCORE_EXPORT NativeScrollbarVisibility mainFrameHorizontalScrollbarVisibility() const;
+    WEBCORE_EXPORT NativeScrollbarVisibility mainFrameVerticalScrollbarVisibility() const;
     WEBCORE_EXPORT ScrollbarWidth mainFrameScrollbarWidth() const;
     WEBCORE_EXPORT std::optional<ScrollbarColor> mainFrameScrollbarColor() const;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -132,6 +132,8 @@ public:
     OverscrollBehavior horizontalOverscrollBehavior() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior; }
     OverscrollBehavior verticalOverscrollBehavior() const { return m_scrollableAreaParameters.verticalOverscrollBehavior; }
 
+    NativeScrollbarVisibility horizontalScrollbarVisibility() const { return m_scrollableAreaParameters.horizontalNativeScrollbarVisibility; }
+    NativeScrollbarVisibility verticalScrollbarVisibility() const { return m_scrollableAreaParameters.verticalNativeScrollbarVisibility; }
     ScrollbarWidth scrollbarWidthStyle() const { return m_scrollableAreaParameters.scrollbarWidthStyle; }
     std::optional<ScrollbarColor> scrollbarColorStyle() const { return m_scrollableAreaParameters.scrollbarColorStyle; }
 

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -518,9 +518,9 @@ bool Scrollbar::supportsUpdateOnSecondaryThread() const
 
 NativeScrollbarVisibility Scrollbar::nativeScrollbarVisibility(const Scrollbar* scrollbar)
 {
-    if (scrollbar && scrollbar->isHiddenByStyle())
+    if (DeprecatedGlobalSettings::mockScrollbarsEnabled() || (scrollbar && scrollbar->isHiddenByStyle()))
         return NativeScrollbarVisibility::HiddenByStyle;
-    if (DeprecatedGlobalSettings::mockScrollbarsEnabled() || (scrollbar && scrollbar->isCustomScrollbar()))
+    if (scrollbar && scrollbar->isCustomScrollbar())
         return NativeScrollbarVisibility::ReplacedByCustomScrollbar;
     return NativeScrollbarVisibility::Visible;
 }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -995,10 +995,9 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     [_scrollView setMinimumZoomScale:minimumScaleFactor];
     [_scrollView setMaximumZoomScale:maximumScaleFactor];
     [_scrollView _setZoomEnabledInternal:allowsUserScaling && self._allowsMagnification];
-    if ([_scrollView showsHorizontalScrollIndicator] && [_scrollView showsVerticalScrollIndicator]) {
-        [_scrollView setShowsHorizontalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None)];
-        [_scrollView setShowsVerticalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None)];
-    }
+
+    [_scrollView setShowsHorizontalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None && _page->scrollingCoordinatorProxy()->mainFrameHorizontalScrollbarVisibility() != WebCore::NativeScrollbarVisibility::HiddenByStyle)];
+    [_scrollView setShowsVerticalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None && _page->scrollingCoordinatorProxy()->mainFrameHorizontalScrollbarVisibility() != WebCore::NativeScrollbarVisibility::HiddenByStyle)];
 
 #if HAVE(UIKIT_SCROLLBAR_COLOR_SPI)
     auto scrollbarColor = _page->scrollingCoordinatorProxy()->mainFrameScrollbarColor();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -260,6 +260,16 @@ bool RemoteScrollingCoordinatorProxy::hasScrollableMainFrame() const
     return rootNode && rootNode->canHaveScrollbars();
 }
 
+NativeScrollbarVisibility RemoteScrollingCoordinatorProxy::mainFrameHorizontalScrollbarVisibility() const
+{
+    return m_scrollingTree->mainFrameHorizontalScrollbarVisibility();
+}
+
+NativeScrollbarVisibility RemoteScrollingCoordinatorProxy::mainFrameVerticalScrollbarVisibility() const
+{
+    return m_scrollingTree->mainFrameVerticalScrollbarVisibility();
+}
+
 WebCore::ScrollbarWidth RemoteScrollingCoordinatorProxy::mainFrameScrollbarWidth() const
 {
     return m_scrollingTree->mainFrameScrollbarWidth();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -118,6 +118,8 @@ public:
     bool hasScrollableMainFrame() const;
     bool hasScrollableOrZoomedMainFrame() const;
 
+    WebCore::NativeScrollbarVisibility mainFrameHorizontalScrollbarVisibility() const;
+    WebCore::NativeScrollbarVisibility mainFrameVerticalScrollbarVisibility() const;
     WebCore::ScrollbarWidth mainFrameScrollbarWidth() const;
     std::optional<WebCore::ScrollbarColor> mainFrameScrollbarColor() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -384,8 +384,8 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         UIScrollView *scrollView = this->scrollView();
 
-        [scrollView setShowsHorizontalScrollIndicator:!(scrollingNode().horizontalNativeScrollbarVisibility() == NativeScrollbarVisibility::HiddenByStyle)];
-        [scrollView setShowsVerticalScrollIndicator:!(scrollingNode().verticalNativeScrollbarVisibility() == NativeScrollbarVisibility::HiddenByStyle)];
+        [scrollView setShowsHorizontalScrollIndicator:scrollingNode().horizontalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle];
+        [scrollView setShowsVerticalScrollIndicator:scrollingNode().verticalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle];
         [scrollView setScrollEnabled:scrollingNode().canHaveScrollbars()];
 
         END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -52,6 +52,7 @@
 #include "RemoteGPUProxy.h"
 #include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
+#include "RemoteScrollbarsController.h"
 #include "RemoteTextDetectorProxy.h"
 #include "SharedBufferReference.h"
 #include "UserData.h"
@@ -166,7 +167,6 @@
 #endif
 
 #if PLATFORM(MAC)
-#include "RemoteScrollbarsController.h"
 #include <WebCore/ScrollbarsControllerMock.h>
 #endif
 
@@ -1414,7 +1414,7 @@ RefPtr<WebCore::ScrollingCoordinator> WebChromeClient::createScrollingCoordinato
 
 #endif
 
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
 void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea& area, bool update) const
 {
     RefPtr page = m_page.get();
@@ -1425,7 +1425,9 @@ void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea&
     auto* currentScrollbarsController = area.existingScrollbarsController();
 
     if (area.mockScrollbarsControllerEnabled() || (update && !currentScrollbarsController)) {
+#if PLATFORM(MAC)
         ASSERT(!currentScrollbarsController || is<ScrollbarsControllerMock>(currentScrollbarsController));
+#endif
         return;
     }
 
@@ -1450,9 +1452,7 @@ void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea&
         area.setScrollbarsController(makeUnique<RemoteScrollbarsController>(area, corePage.scrollingCoordinator()));
 #endif
 }
-
 #endif
-
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -313,7 +313,7 @@ private:
     RefPtr<WebCore::ScrollingCoordinator> createScrollingCoordinator(WebCore::Page&) const final;
 #endif
 
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
     void ensureScrollbarsController(WebCore::Page&, WebCore::ScrollableArea&, bool update = false) const final;
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
 
 #include <WebCore/NSScrollerImpDetails.h>
 #include <WebCore/ScrollbarsController.h>

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "RemoteScrollbarsController.h"
 
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
 
 #include <WebCore/ScrollableArea.h>
 #include <WebCore/ScrollbarThemeMac.h>


### PR DESCRIPTION
#### 3bc0333b6ac70ba56b367cdde01ad6d15fb10a3f
<pre>
Cannot change CSS scrollbar-width from none to auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=297501">https://bugs.webkit.org/show_bug.cgi?id=297501</a>
<a href="https://rdar.apple.com/158637000">rdar://158637000</a>

Reviewed by NOBODY (OOPS!).

Fix issue where going from scrollbar-width: none to auto on iOS wouldn&apos;t work.
Make use of RemoteScrollbarsController on iOS to properly send scrollbar width
updates to the UI process when changed via style.

* LayoutTests/fast/scrolling/ios/scrollbar-width-none-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/scrollbar-width-none.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::horizontalNativeScrollbarVisibility const):
(WebCore::LocalFrameView::verticalNativeScrollbarVisibility const):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::setScrollbarWidth):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::mainFrameHorizontalScrollbarVisibility const):
(WebCore::ScrollingTree::mainFrameVerticalScrollbarVisibility const):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::nativeScrollbarVisibility):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::mainFrameHorizontalScrollbarVisibility const):
(WebKit::RemoteScrollingCoordinatorProxy::mainFrameVerticalScrollbarVisibility const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::ensureScrollbarsController const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bc0333b6ac70ba56b367cdde01ad6d15fb10a3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117964 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69999 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4be756a-f8e2-4a7d-b3b8-753144d39b25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89517 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59126 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b609e6c9-21f1-4585-a45f-344cf720ee8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120916 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30531 "Found 2 new test failures: fast/scrolling/ios/scrollbar-hiding-iframes.html fast/scrolling/ios/scrollbar-hiding.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70010 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/328fae81-f4b7-4ce6-b84f-fe42cc45a40f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67774 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127192 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98183 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97971 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21357 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41301 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50413 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44199 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->