### PR TITLE
Add WKFrameInfo accessor to _WKJSHandle

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10514,11 +10514,6 @@ std::optional<PageIdentifier> Document::pageID() const
     return std::nullopt;
 }
 
-std::optional<FrameIdentifier> Document::frameID() const
-{
-    return m_frameIdentifier;
-}
-
 void Document::registerArticleElement(Element& article)
 {
     m_articleElements.add(article);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -796,7 +796,7 @@ public:
     void clearAXObjectCache();
 
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
-    std::optional<FrameIdentifier> frameID() const;
+    std::optional<FrameIdentifier> frameID() const { return m_frameIdentifier; }
 
     // to get visually ordered hebrew and arabic pages right
     void setVisuallyOrdered();

--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -59,6 +59,7 @@ set(WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/C/WKHitTestResult.h
     UIProcess/API/C/WKIconDatabase.h
     UIProcess/API/C/WKInspector.h
+    UIProcess/API/C/WKJSHandleRef.h
     UIProcess/API/C/WKLayoutMode.h
     UIProcess/API/C/WKMediaKeySystemPermissionCallback.h
     UIProcess/API/C/WKMessageListener.h

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -649,6 +649,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKJSHandleRef {
+    header "WKJSHandleRef.h"
+    export *
+  }
+
   explicit module WKKeyValueStorageManager {
     header "WKKeyValueStorageManager.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1351,6 +1351,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKJSHandleRef {
+    header "WKJSHandleRef.h"
+    export *
+  }
+
   explicit module WKKeyValueStorageManager {
     header "WKKeyValueStorageManager.h"
     export *

--- a/Source/WebKit/Shared/API/c/WKBase.h
+++ b/Source/WebKit/Shared/API/c/WKBase.h
@@ -106,6 +106,7 @@ typedef const struct OpaqueWKHitTestResult* WKHitTestResultRef;
 typedef const struct OpaqueWKIconDatabase* WKIconDatabaseRef;
 typedef const struct OpaqueWKInspector* WKInspectorRef;
 typedef const struct OpaqueWKInternalDebugFeature* WKInternalDebugFeatureRef;
+typedef const struct OpaqueWKJSHandle* WKJSHandleRef;
 typedef const struct OpaqueWKKeyValueStorageManager* WKKeyValueStorageManagerRef;
 typedef const struct OpaqueWKMessageListener* WKMessageListenerRef;
 typedef const struct OpaqueWKNavigationAction* WKNavigationActionRef;

--- a/Source/WebKit/Shared/JSHandleInfo.cpp
+++ b/Source/WebKit/Shared/JSHandleInfo.cpp
@@ -23,21 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKFoundation.h>
+#include "config.h"
+#include "JSHandleInfo.h"
 
-@class WKFrameInfo;
+namespace WebKit {
 
-NS_ASSUME_NONNULL_BEGIN
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(JSHandleInfo);
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-@interface _WKJSHandle : NSObject
+JSHandleInfo::JSHandleInfo(WebCore::JSHandleIdentifier identifier, FrameInfoData&& frameInfo, Markable<WebCore::FrameIdentifier> windowProxyFrameIdentifier)
+    : identifier(identifier)
+    , frameInfo(WTFMove(frameInfo))
+    , windowProxyFrameIdentifier(windowProxyFrameIdentifier) { }
 
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
-
-- (WKFrameInfo *)frame;
-- (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler;
-
-@end
-
-NS_ASSUME_NONNULL_END
+} // namespace WebKit

--- a/Source/WebKit/Shared/JSHandleInfo.h
+++ b/Source/WebKit/Shared/JSHandleInfo.h
@@ -36,7 +36,11 @@ using JSHandleIdentifier = ProcessQualified<ObjectIdentifier<JSHandleIdentifierT
 namespace WebKit {
 
 struct JSHandleInfo {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(JSHandleInfo);
+    JSHandleInfo(WebCore::JSHandleIdentifier, FrameInfoData&&, Markable<WebCore::FrameIdentifier>);
+
     WebCore::JSHandleIdentifier identifier;
+    FrameInfoData frameInfo;
     Markable<WebCore::FrameIdentifier> windowProxyFrameIdentifier;
 };
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -43,12 +43,17 @@ typedef struct _GVariant GVariant;
 typedef struct _JSCValue JSCValue;
 #endif
 
+namespace WebCore {
+struct SerializedNode;
+}
+
 namespace API {
 class Object;
 }
 
 namespace WebKit {
 
+struct JSHandleInfo;
 struct JSObjectIDType;
 using JSObjectID = ObjectIdentifier<JSObjectIDType>;
 
@@ -64,7 +69,7 @@ public:
         Seconds,
         Vector<JSObjectID>,
         ObjectMap,
-        JSHandleInfo,
+        UniqueRef<JSHandleInfo>,
         UniqueRef<WebCore::SerializedNode>
     >;
     using Map = HashMap<JSObjectID, Value>;

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -80,8 +80,8 @@ RetainPtr<id> JavaScriptEvaluationResult::ObjCInserter::toID(Value&& root)
         RetainPtr dictionary = adoptNS([[NSMutableDictionary alloc] initWithCapacity:map.size()]);
         m_dictionaries.append({ WTFMove(map), dictionary });
         return dictionary;
-    }, [] (JSHandleInfo&& info) -> RetainPtr<id> {
-        return wrapper(API::JSHandle::create(WTFMove(info)));
+    }, [] (UniqueRef<JSHandleInfo>&& info) -> RetainPtr<id> {
+        return wrapper(API::JSHandle::create(WTFMove(info.get())));
     }, [] (UniqueRef<WebCore::SerializedNode>&& serializedNode) -> RetainPtr<id> {
         return wrapper(API::SerializedNode::create(WTFMove(serializedNode.get())).get());
     });
@@ -161,7 +161,7 @@ auto JavaScriptEvaluationResult::ObjCExtractor::toValue(id object) -> Value
         return makeUniqueRef<WebCore::SerializedNode>(((_WKSerializedNode *)object)->_node->coreSerializedNode());
 
     if ([object isKindOfClass:_WKJSHandle.class])
-        return JSHandleInfo { ((_WKJSHandle *)object)->_ref->info() };
+        return makeUniqueRef<JSHandleInfo>(((_WKJSHandle *)object)->_ref->info());
 
     // This object has been null checked and went through isSerializable which only supports these types.
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
@@ -22,12 +22,13 @@
 
 struct WebKit::JSHandleInfo {
     WebCore::JSHandleIdentifier identifier;
+    WebKit::FrameInfoData frameInfo;
     Markable<WebCore::FrameIdentifier> windowProxyFrameIdentifier;
 };
 
 class WebKit::JavaScriptEvaluationResult {
     WebKit::JSObjectID root()
-    HashMap<WebKit::JSObjectID, Variant<WebKit::JavaScriptEvaluationResult::EmptyType, bool, double, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>, WebKit::JSHandleInfo, UniqueRef<WebCore::SerializedNode>>> map()
+    HashMap<WebKit::JSObjectID, Variant<WebKit::JavaScriptEvaluationResult::EmptyType, bool, double, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>, UniqueRef<WebKit::JSHandleInfo>, UniqueRef<WebCore::SerializedNode>>> map()
 }
 
 [Nested] enum class WebKit::JavaScriptEvaluationResult::EmptyType : bool

--- a/Source/WebKit/Shared/NodeHitTestResult.h
+++ b/Source/WebKit/Shared/NodeHitTestResult.h
@@ -25,25 +25,18 @@
 
 #pragma once
 
-#include "FrameInfoData.h"
 #include "JSHandleInfo.h"
 #include <WebCore/FloatPoint.h>
-#include <WebCore/FrameIdentifier.h>
 #include <wtf/Variant.h>
 
 namespace WebKit {
-
-struct NodeAndFrameInfo {
-    WebKit::JSHandleInfo node;
-    WebKit::FrameInfoData frame;
-};
 
 struct NodeHitTestResult {
     struct RemoteFrameInfo {
         WebCore::FrameIdentifier remoteFrameIdentifier;
         WebCore::FloatPoint transformedPoint;
     };
-    Variant<std::monostate, RemoteFrameInfo, NodeAndFrameInfo> variant;
+    Variant<std::monostate, RemoteFrameInfo, JSHandleInfo> variant;
 };
 
 }

--- a/Source/WebKit/Shared/NodeHitTestResult.serialization.in
+++ b/Source/WebKit/Shared/NodeHitTestResult.serialization.in
@@ -20,16 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[Nested] struct WebKit::NodeAndFrameInfo {
-    WebKit::JSHandleInfo node;
-    WebKit::FrameInfoData frame;
-};
-
 [Nested] struct WebKit::NodeHitTestResult::RemoteFrameInfo {
     WebCore::FrameIdentifier remoteFrameIdentifier;
     WebCore::FloatPoint transformedPoint;
 };
 
 struct WebKit::NodeHitTestResult {
-    Variant<std::monostate, WebKit::NodeHitTestResult::RemoteFrameInfo, WebKit::NodeAndFrameInfo> variant;
+    Variant<std::monostate, WebKit::NodeHitTestResult::RemoteFrameInfo, WebKit::JSHandleInfo> variant;
 };

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -227,6 +227,7 @@ Shared/IPCStreamTester.cpp
 Shared/IPCTester.cpp
 Shared/IPCTesterReceiver.cpp
 Shared/JavaScriptEvaluationResult.cpp
+Shared/JSHandleInfo.cpp
 Shared/KeyEventInterpretationContext.cpp
 Shared/PersistencyUtils.cpp
 Shared/PrintInfo.cpp
@@ -530,6 +531,7 @@ UIProcess/API/C/WKHTTPCookieStoreRef.cpp
 UIProcess/API/C/WKHitTestResult.cpp
 UIProcess/API/C/WKIconDatabase.cpp
 UIProcess/API/C/WKInspector.cpp
+UIProcess/API/C/WKJSHandleRef.cpp
 UIProcess/API/C/WKKeyValueStorageManager.cpp
 UIProcess/API/C/WKMediaKeySystemPermissionCallback.cpp
 UIProcess/API/C/WKMessageListener.cpp

--- a/Source/WebKit/UIProcess/API/C/WKAPICast.h
+++ b/Source/WebKit/UIProcess/API/C/WKAPICast.h
@@ -57,6 +57,7 @@ class FrameHandle;
 class FrameInfo;
 class HTTPCookieStore;
 class HitTestResult;
+class JSHandle;
 class MessageListener;
 class Navigation;
 class NavigationAction;
@@ -137,6 +138,7 @@ WK_ADD_API_MAPPING(WKHTTPCookieStoreRef, API::HTTPCookieStore)
 WK_ADD_API_MAPPING(WKHitTestResultRef, API::HitTestResult)
 WK_ADD_API_MAPPING(WKIconDatabaseRef, WebIconDatabase)
 WK_ADD_API_MAPPING(WKInspectorRef, WebInspectorUIProxy)
+WK_ADD_API_MAPPING(WKJSHandleRef, API::JSHandle);
 WK_ADD_API_MAPPING(WKMediaKeySystemPermissionCallbackRef, MediaKeySystemPermissionCallback)
 WK_ADD_API_MAPPING(WKQueryPermissionResultCallbackRef, QueryPermissionResultCallback)
 WK_ADD_API_MAPPING(WKMessageListenerRef, API::MessageListener)

--- a/Source/WebKit/UIProcess/API/C/WKJSHandleRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKJSHandleRef.cpp
@@ -23,21 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKFoundation.h>
+#include "config.h"
+#include "WKJSHandleRef.h"
 
-@class WKFrameInfo;
+#include "APIFrameInfo.h"
+#include "APIJSHandle.h"
+#include "WKAPICast.h"
 
-NS_ASSUME_NONNULL_BEGIN
+WKTypeID WKJSHandleGetTypeID()
+{
+    return WebKit::toAPI(API::Object::Type::JSHandle);
+}
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-@interface _WKJSHandle : NSObject
-
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
-
-- (WKFrameInfo *)frame;
-- (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler;
-
-@end
-
-NS_ASSUME_NONNULL_END
+WKFrameInfoRef WKJSHandleCopyFrameInfo(WKJSHandleRef handle)
+{
+    return WebKit::toAPILeakingRef(API::FrameInfo::create(WebKit::FrameInfoData { WebKit::toProtectedImpl(handle)->info().frameInfo }));
+}

--- a/Source/WebKit/UIProcess/API/C/WKJSHandleRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKJSHandleRef.h
@@ -23,21 +23,18 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKFoundation.h>
+#pragma once
 
-@class WKFrameInfo;
+#include <WebKit/WKBase.h>
 
-NS_ASSUME_NONNULL_BEGIN
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-@interface _WKJSHandle : NSObject
+WK_EXPORT WKTypeID WKJSHandleGetTypeID();
 
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
+WK_EXPORT WKFrameInfoRef WKJSHandleCopyFrameInfo(WKJSHandleRef handle);
 
-- (WKFrameInfo *)frame;
-- (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler;
-
-@end
-
-NS_ASSUME_NONNULL_END
+#ifdef __cplusplus
+}
+#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4278,15 +4278,15 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
     });
 }
 
-- (void)_hitTestAtPoint:(CGPoint)point inFrameCoordinateSpace:(WKFrameInfo *)frame completionHandler:(void (^)(_WKJSHandle *, WKFrameInfo *, NSError *))completionHandler
+- (void)_hitTestAtPoint:(CGPoint)point inFrameCoordinateSpace:(WKFrameInfo *)frame completionHandler:(void (^)(_WKJSHandle *, NSError *))completionHandler
 {
     RefPtr mainFrame = _page->mainFrame();
     if (!frame && !mainFrame)
-        return completionHandler(nil, nil, unknownError().get());
+        return completionHandler(nil, unknownError().get());
     _page->hitTestAtPoint(frame ? frame->_frameInfo->frameInfoData().frameID : mainFrame->frameID(), point, [completionHandler = makeBlockPtr(completionHandler)] (auto&& result) mutable {
         if (!result)
-            return completionHandler(nil, nil, unknownError().get());
-        completionHandler(wrapper(API::JSHandle::create(WTFMove(result->node))).get(), wrapper(API::FrameInfo::create(WTFMove(result->frame))).get(), nil);
+            return completionHandler(nil, unknownError().get());
+        completionHandler(wrapper(API::JSHandle::create(WTFMove(*result))).get(), nil);
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -442,7 +442,7 @@ for this property.
 // If frame is non-nil, not only will frame's coordinate space be used, but frame's subtree will be searched,
 // so a node from a parent node won't be returned, even if point is outside frame's rect.
 // The result frame info is the frame that contains the hit node.
-- (void)_hitTestAtPoint:(CGPoint)point inFrameCoordinateSpace:(WKFrameInfo *)frame completionHandler:(void (^)(_WKJSHandle *, WKFrameInfo *, NSError *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_hitTestAtPoint:(CGPoint)point inFrameCoordinateSpace:(WKFrameInfo *)frame completionHandler:(void (^)(_WKJSHandle *, NSError *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 + (NSString *)_userVisibleStringForURL:(NSURL *)url WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm
@@ -42,6 +42,11 @@
     [super dealloc];
 }
 
+- (WKFrameInfo *)frame
+{
+    return wrapper(API::FrameInfo::create(WebKit::FrameInfoData { _ref->info().frameInfo })).autorelease();
+}
+
 - (void)windowFrameInfo:(void (^)(WKFrameInfo *))completionHandler
 {
     RefPtr webFrame = WebKit::WebFrameProxy::webFrame(_ref->info().windowProxyFrameIdentifier);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13191,7 +13191,7 @@ Awaitable<std::optional<WebCore::FloatRect>> WebPageProxy::convertRectToMainFram
     } };
 }
 
-void WebPageProxy::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, CompletionHandler<void(std::optional<NodeAndFrameInfo>&&)>&& completionHandler)
+void WebPageProxy::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoint point, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&& completionHandler)
 {
     sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::HitTestAtPoint(frameID, point), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (auto&& result) mutable {
         WTF::switchOn(WTFMove(result.variant), [&] (std::monostate) {
@@ -13201,7 +13201,7 @@ void WebPageProxy::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::Flo
             if (!protectedThis)
                 return completionHandler(std::nullopt);
             protectedThis->hitTestAtPoint(info.remoteFrameIdentifier, info.transformedPoint, WTFMove(completionHandler));
-        }, [&] (NodeAndFrameInfo&& nodeAndFrame) {
+        }, [&] (JSHandleInfo&& nodeAndFrame) {
             completionHandler(WTFMove(nodeAndFrame));
         });
     });

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -560,12 +560,12 @@ struct InputMethodState;
 struct InsertTextOptions;
 struct InteractionInformationAtPosition;
 struct InteractionInformationRequest;
+struct JSHandleInfo;
 struct KeyEventInterpretationContext;
 struct LoadParameters;
 struct ModelIdentifier;
 struct NavigationActionData;
 struct NetworkResourceLoadIdentifierType;
-struct NodeAndFrameInfo;
 struct PDFContextMenu;
 struct PDFPluginIdentifierType;
 struct PlatformPopupMenuData;
@@ -2705,7 +2705,7 @@ public:
     void convertPointToMainFrameCoordinates(WebCore::FloatPoint, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(std::optional<WebCore::FloatPoint>)>&&);
     void convertRectToMainFrameCoordinates(WebCore::FloatRect, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(std::optional<WebCore::FloatRect>)>&&);
     Awaitable<std::optional<WebCore::FloatRect>> convertRectToMainFrameCoordinates(WebCore::FloatRect, std::optional<WebCore::FrameIdentifier>);
-    void hitTestAtPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(std::optional<NodeAndFrameInfo>&&)>&&);
+    void hitTestAtPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setDefaultSpatialTrackingLabel(const String&);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2659,6 +2659,7 @@
 		FA580B4C2DA64B5F005E4965 /* UnifiedSource177.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA580B372DA64B5F005E4965 /* UnifiedSource177.cpp */; };
 		FA580B4D2DA64B5F005E4965 /* UnifiedSource179.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA580B392DA64B5F005E4965 /* UnifiedSource179.cpp */; };
 		FA580B4E2DA64B5F005E4965 /* UnifiedSource163.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA580B292DA64B5F005E4965 /* UnifiedSource163.cpp */; };
+		FA84D6692E579F38004BDAA4 /* WKJSHandleRef.h in Headers */ = {isa = PBXBuildFile; fileRef = FA84D6672E579EA4004BDAA4 /* WKJSHandleRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA8B4F6D2E46AFFC00E419CD /* WKScriptMessageRef.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8B4F6B2E46A93500E419CD /* WKScriptMessageRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA8B4F7C2E4A5F7C00E419CD /* _WKJSHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8B4F792E4A5F7300E419CD /* _WKJSHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAA4E3012A1575A5003F5E50 /* WebFrameLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA4E2FF2A1575A4003F5E50 /* WebFrameLoaderClient.h */; };
@@ -8711,6 +8712,9 @@
 		FA6DCE722BAAB3AB0043109B /* WebPagePreferencesLockdownModeObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPagePreferencesLockdownModeObserver.h; sourceTree = "<group>"; };
 		FA7036C32D72882A00083D04 /* RunJavaScriptParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RunJavaScriptParameters.h; sourceTree = "<group>"; };
 		FA8262722B2193EA00BB8236 /* APINumber.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = APINumber.serialization.in; sourceTree = "<group>"; };
+		FA84D6672E579EA4004BDAA4 /* WKJSHandleRef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKJSHandleRef.h; sourceTree = "<group>"; };
+		FA84D6682E579EA4004BDAA4 /* WKJSHandleRef.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WKJSHandleRef.cpp; sourceTree = "<group>"; };
+		FA84D66A2E57AE2F004BDAA4 /* JSHandleInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSHandleInfo.cpp; sourceTree = "<group>"; };
 		FA87D9B42D8BDC2B00B609D4 /* FrameInfoData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameInfoData.cpp; sourceTree = "<group>"; };
 		FA8B4F662E4674BC00E419CD /* APIScriptMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIScriptMessage.h; sourceTree = "<group>"; };
 		FA8B4F672E4674BC00E419CD /* APIScriptMessage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APIScriptMessage.cpp; sourceTree = "<group>"; };
@@ -9762,6 +9766,7 @@
 				FAC7C0AF2D70225500E7297E /* JavaScriptEvaluationResult.h */,
 				FAC7C0B22D7022AF00E7297E /* JavaScriptEvaluationResult.mm */,
 				FAC7C0B02D70228200E7297E /* JavaScriptEvaluationResult.serialization.in */,
+				FA84D66A2E57AE2F004BDAA4 /* JSHandleInfo.cpp */,
 				FA58F4562E1E030A0098E1C8 /* JSHandleInfo.h */,
 				074A6FC62D5F1DEA0027F958 /* KeyEventInterpretationContext.cpp */,
 				074A6FC52D5F1DEA0027F958 /* KeyEventInterpretationContext.h */,
@@ -15258,6 +15263,8 @@
 				5110AE0B133C16CB0072717A /* WKIconDatabase.h */,
 				1C8E293812761E5B00BC7BD0 /* WKInspector.cpp */,
 				1C8E293712761E5B00BC7BD0 /* WKInspector.h */,
+				FA84D6682E579EA4004BDAA4 /* WKJSHandleRef.cpp */,
+				FA84D6672E579EA4004BDAA4 /* WKJSHandleRef.h */,
 				51A9E1081315CD18009E7031 /* WKKeyValueStorageManager.cpp */,
 				51A9E1091315CD18009E7031 /* WKKeyValueStorageManager.h */,
 				2D790A9E1AD7164900AB90B3 /* WKLayoutMode.h */,
@@ -18426,6 +18433,7 @@
 				073A63CF2DC33DEC0057A3F5 /* WKIntelligenceSmartReplyTextEffectCoordinator.h in Headers */,
 				073A63CE2DC33DE30057A3F5 /* WKIntelligenceTextEffectCoordinator.h in Headers */,
 				E88885682DC914C400C572B8 /* WKISO18013Request.h in Headers */,
+				FA84D6692E579F38004BDAA4 /* WKJSHandleRef.h in Headers */,
 				2DD5E129210ADC7B00DB6012 /* WKKeyboardScrollingAnimator.h in Headers */,
 				51E8284E2B21395A009119F9 /* WKKeyedCoder.h in Headers */,
 				51A9E10B1315CD18009E7031 /* WKKeyValueStorageManager.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10186,7 +10186,7 @@ void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoi
         JSLockHolder locker(lexicalGlobalObject);
         return WebCore::WebKitJSHandle::create(document, WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
     }();
-    completionHandler({ NodeAndFrameInfo { { nodeHandle->identifier(), nodeHandle->windowFrameIdentifier() }, { nodeWebFrame->info() } } });
+    completionHandler({ JSHandleInfo { nodeHandle->identifier(), nodeWebFrame->info(), nodeHandle->windowFrameIdentifier() } });
 }
 
 void WebPage::adjustVisibilityForTargetedElements(Vector<TargetedElementAdjustment>&& adjustments, CompletionHandler<void(bool)>&& completion)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -803,16 +803,12 @@ private:
 
     class Callbacks {
     public:
-        void append(WKFrameInfoRef frame, WKTypeRef callbackHandle) { m_callbacks.append({ frame, callbackHandle }); }
+        void append(WKTypeRef);
         void clear() { m_callbacks.clear(); }
         void notifyListeners(WKStringRef);
         void notifyListeners();
     private:
-        struct Info {
-            WKRetainPtr<WKFrameInfoRef> frame;
-            WKRetainPtr<WKTypeRef> callbackHandle;
-        };
-        Vector<Info> m_callbacks;
+        Vector<WKRetainPtr<WKJSHandleRef>> m_callbacks;
     };
     Callbacks m_tooltipCallbacks;
     Callbacks m_beginSwipeCallbacks;


### PR DESCRIPTION
#### fccd92e3da0195681cd6f07e33366e1716e95fe2
<pre>
Add WKFrameInfo accessor to _WKJSHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=297745">https://bugs.webkit.org/show_bug.cgi?id=297745</a>
<a href="https://rdar.apple.com/158885679">rdar://158885679</a>

Reviewed by Ryosuke Niwa.

A _WKJSHandle can&apos;t be used for much without using a WKFrameInfo, and it has to be the correct
WKFrameInfo, so before this change we always needed to keep the pair of objects together.
This makes the API a little more ergonomic by adding a frame accessor so you only need to keep
one object in a container and can use it.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::frameID const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::frameID const):
* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Shared/API/c/WKBase.h:
* Source/WebKit/Shared/JSHandleInfo.cpp: Copied from Source/WebKit/Shared/JSHandleInfo.h.
* Source/WebKit/Shared/JSHandleInfo.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::APIInserter::toAPI):
(WebKit::JavaScriptEvaluationResult::APIExtractor::toValue):
(WebKit::JavaScriptEvaluationResult::JSExtractor::toValue):
(WebKit::JavaScriptEvaluationResult::JSInserter::toJS):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::ObjCInserter::toID):
(WebKit::JavaScriptEvaluationResult::ObjCExtractor::toValue):
* Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in:
* Source/WebKit/Shared/NodeHitTestResult.h:
* Source/WebKit/Shared/NodeHitTestResult.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/C/WKAPICast.h:
* Source/WebKit/UIProcess/API/C/WKJSHandleRef.cpp: Copied from Source/WebKit/Shared/JSHandleInfo.h.
(WKJSHandleGetTypeID):
(WKJSHandleCopyFrameInfo):
* Source/WebKit/UIProcess/API/C/WKJSHandleRef.h: Copied from Source/WebKit/Shared/JSHandleInfo.h.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _hitTestAtPoint:inFrameCoordinateSpace:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm:
(-[_WKJSHandle frame]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::hitTestAtPoint):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hitTestAtPoint):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, HitTesting)):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::Callbacks::append):
(WTR::TestController::Callbacks::notifyListeners):
(WTR::CompletionHandler&lt;void):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::Callbacks::append): Deleted.

Canonical link: <a href="https://commits.webkit.org/299058@main">https://commits.webkit.org/299058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6126bb2ef71ff2bdd18bb2538db17981a40a831b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69596 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8585fe96-6673-4b85-8a95-cf0d5cd26d4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89236 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/45046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ae142e2-7def-4836-a0de-2055c00262b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105429 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69738 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf76b22b-7b4c-4bdb-aedc-08a2c80a35eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23545 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67369 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126813 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97902 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97690 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40849 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18778 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44362 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50037 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43820 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->