### PR TITLE
[Form Control Refresh] <progress> is missing window inactive state

### DIFF
--- a/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode-expected-mismatch.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="dark" />
+    </head>
+    <body>
+        <progress value=70 max=100></progress>
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="dark" />
+    </head>
+    <body>
+        <progress value=70 max=100></progress>
+    </body>
+    <script>
+        if (window.testRunner)
+            window.testRunner.setWindowIsKey(false);
+    </script>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-light-mode-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-light-mode-expected-mismatch.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="light" />
+    </head>
+    <body>
+        <progress value=70 max=100></progress>
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="light" />
+    </head>
+    <body>
+        <progress value=70 max=100></progress>
+    </body>
+    <script>
+        if (window.testRunner)
+            window.testRunner.setWindowIsKey(false);
+    </script>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7979,6 +7979,8 @@ imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.h
 # Window inactive appearance is only used on macOS.
 fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme.html [ Skip ]
 fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html [ Skip ]
+fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode.html [ Skip ]
+fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html [ Skip ]
 
 # rdar://155348715 (REGRESSION (Liquid Glass): [ iOS 26 ] 72 WPT/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-*.html tests are constantly failing (IMAGE).)
 # Explicit pass expectations for many of these tests are set above. Uncomment that block once this is resolved.

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -169,6 +169,8 @@ fast/forms/form-control-refresh [ Pass ]
 # Window inactive appearance is only used on macOS.
 fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-dark-bg-light-color-scheme.html [ Skip ]
 fast/forms/form-control-refresh/checkbox-radio-inactive-appearance-light-bg-dark-color-scheme.html [ Skip ]
+fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode.html [ Skip ]
+fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html [ Skip ]
 
 ### END OF Triaged failures
 ###################################################################################################

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2813,6 +2813,8 @@ bool RenderThemeCocoa::adjustProgressBarStyleForVectorBasedControls(RenderStyle&
     return false;
 }
 
+static constexpr auto cssValueForInactiveBarFill = CSSValueAppleSystemTertiaryLabel;
+
 bool RenderThemeCocoa::paintProgressBarForVectorBasedControls(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
 {
     if (!formControlRefreshEnabled(renderer))
@@ -2903,8 +2905,14 @@ bool RenderThemeCocoa::paintProgressBarForVectorBasedControls(const RenderObject
         }
     }
 
+    auto isWindowActive = true;
+#if PLATFORM(MAC)
+    isWindowActive = extractControlStyleStatesForRenderer(renderer).contains(ControlStyle::State::WindowActive);
+#endif
+    const auto fillColor = isWindowActive ? controlTintColorWithContrast(renderer.style(), styleColorOptions) : systemColor(cssValueForInactiveBarFill, styleColorOptions);
+
     FloatRect barRect(barInlineStart, barBlockStart, barInlineSize, barBlockSize);
-    context.fillRoundedRect(FloatRoundedRect(isHorizontalWritingMode ? barRect : barRect.transposedRect(), barCornerRadii), controlTintColorWithContrast(renderer.style(), styleColorOptions).colorWithAlphaMultipliedBy(alpha));
+    context.fillRoundedRect(FloatRoundedRect(isHorizontalWritingMode ? barRect : barRect.transposedRect(), barCornerRadii), fillColor.colorWithAlphaMultipliedBy(alpha));
 
     return true;
 }
@@ -3093,7 +3101,7 @@ bool RenderThemeCocoa::paintSliderTrackForVectorBasedControls(const RenderObject
 
 #if PLATFORM(MAC)
     const auto isWindowActive = states.contains(ControlStyle::State::WindowActive);
-    auto fillColor = isWindowActive ? controlTintColorWithContrast(box.style(), styleColorOptions) : systemColor(CSSValueAppleSystemTertiaryLabel, styleColorOptions);
+    auto fillColor = isWindowActive ? controlTintColorWithContrast(box.style(), styleColorOptions) : systemColor(cssValueForInactiveBarFill, styleColorOptions);
 #else
     auto fillColor = controlTintColorWithContrast(box.style(), styleColorOptions);
 #endif


### PR DESCRIPTION
#### 51786e15c354e214f638faf535767b21d509e5d2
<pre>
[Form Control Refresh] &lt;progress&gt; is missing window inactive state
<a href="https://bugs.webkit.org/show_bug.cgi?id=297746">https://bugs.webkit.org/show_bug.cgi?id=297746</a>
<a href="https://rdar.apple.com/158885234">rdar://158885234</a>

Reviewed by Aditya Keerthi.

When the window is inactive on macOS, use the tertiary label color for
the fill color.

* LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-dark-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-light-mode-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintProgressBarForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintSliderTrackForVectorBasedControls):

Canonical link: <a href="https://commits.webkit.org/299037@main">https://commits.webkit.org/299037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4cf9b5c85a385c1490517ac1311435c96edec74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69540 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dca9be2a-5062-4096-af7f-154f1c4d05e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45793 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89200 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/45020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1df84929-295f-401b-b0b4-0b404f4f945d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105389 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69708 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 40 api tests failed or timed out; re-run-api-tests (cancelled)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae297cdc-299f-45f6-a5c2-8f6036d6c40c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126758 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97871 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97659 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43032 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20976 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49982 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43764 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47113 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->