### PR TITLE
[WebGPU] https://gpuweb.github.io/cts/standalone/?debug=1&q=webgpu:api,operation,labels:* does not pass

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/labels-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/labels-expected.txt
@@ -14,86 +14,8 @@ PASS :object_has_descriptor_label:name="createRenderPipelineAsync"
 PASS :object_has_descriptor_label:name="createCommandEncoder"
 PASS :object_has_descriptor_label:name="createRenderBundleEncoder"
 PASS :object_has_descriptor_label:name="createQuerySet"
-FAIL :object_has_descriptor_label:name="beginRenderPass" assert_unreached:
-  - EXPECTATION FAILED: subcase: label="label"
-
-    expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    beginRenderPass@http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:206:13
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:263:38
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:261:11
-  - EXPECTATION FAILED: subcase: label="label"
-
-    expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    beginRenderPass@http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:208:13
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:263:38
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:261:11
-  - EXPECTATION FAILED: subcase: label="\u0000"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="\u0000"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="null\u0000in\u0000label"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="null\u0000in\u0000label"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="🌞👆"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="🌞👆"
-
-      at (elided: only 2 shown)
-  - INFO: subcase: label="label"
-    OK
-  - INFO: subcase: label="\u0000"
-    OK
-  - INFO: subcase: label="null\u0000in\u0000label"
-    OK
-  - INFO: subcase: label="🌞👆"
-    OK
- Reached unreachable code
-FAIL :object_has_descriptor_label:name="beginComputePass" assert_unreached:
-  - EXPECTATION FAILED: subcase: label="label"
-
-    expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    beginComputePass@http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:220:13
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:263:38
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:261:11
-  - EXPECTATION FAILED: subcase: label="label"
-
-    expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    beginComputePass@http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:222:13
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:263:38
-    @http://127.0.0.1:8000/webgpu/webgpu/api/operation/labels.spec.js:261:11
-  - EXPECTATION FAILED: subcase: label="\u0000"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="\u0000"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="null\u0000in\u0000label"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="null\u0000in\u0000label"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="🌞👆"
-
-      at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: label="🌞👆"
-
-      at (elided: only 2 shown)
-  - INFO: subcase: label="label"
-    OK
-  - INFO: subcase: label="\u0000"
-    OK
-  - INFO: subcase: label="null\u0000in\u0000label"
-    OK
-  - INFO: subcase: label="🌞👆"
-    OK
- Reached unreachable code
+PASS :object_has_descriptor_label:name="beginRenderPass"
+PASS :object_has_descriptor_label:name="beginComputePass"
 PASS :object_has_descriptor_label:name="finish"
 PASS :object_has_descriptor_label:name="createView"
 PASS :wrappers_do_not_share_labels:

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp
@@ -30,12 +30,17 @@ namespace WebCore {
 
 String GPUCommandBuffer::label() const
 {
-    return m_backing->label();
+    return m_overrideLabel ? *m_overrideLabel : m_backing->label();
 }
 
 void GPUCommandBuffer::setLabel(String&& label)
 {
     Ref { m_backing }->setLabel(WTFMove(label));
+}
+
+void GPUCommandBuffer::setOverrideLabel(String&& label)
+{
+    m_overrideLabel = WTFMove(label);
 }
 
 void GPUCommandBuffer::setBacking(WebGPU::CommandEncoder& commandEncoder, WebGPU::CommandBuffer& commandBuffer)

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.h
@@ -46,6 +46,7 @@ public:
 
     String label() const;
     void setLabel(String&&);
+    void setOverrideLabel(String&&);
 
     WebGPU::CommandBuffer& backing() { return m_backing; }
     const WebGPU::CommandBuffer& backing() const { return m_backing; }
@@ -60,6 +61,7 @@ private:
 
     Ref<WebGPU::CommandBuffer> m_backing;
     const Ref<GPUCommandEncoder> m_encoder;
+    std::optional<String> m_overrideLabel;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
@@ -121,6 +121,7 @@ private:
 
     Ref<WebGPU::CommandEncoder> m_backing;
     WeakPtr<WebGPU::Device> m_device;
+    std::optional<String> m_overrideLabel;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
@@ -42,7 +42,7 @@ GPUComputePassEncoder::GPUComputePassEncoder(Ref<WebGPU::ComputePassEncoder>&& b
 
 String GPUComputePassEncoder::label() const
 {
-    return m_backing->label();
+    return m_overrideLabel ? *m_overrideLabel : m_backing->label();
 }
 
 void GPUComputePassEncoder::setLabel(String&& label)
@@ -70,8 +70,10 @@ void GPUComputePassEncoder::dispatchWorkgroupsIndirect(const GPUBuffer& indirect
 void GPUComputePassEncoder::end()
 {
     protectedBacking()->end();
-    if (RefPtr device = m_device.get())
+    if (RefPtr device = m_device.get()) {
+        m_overrideLabel = label();
         m_backing = device->invalidComputePassEncoder();
+    }
 }
 
 void GPUComputePassEncoder::setBindGroup(GPUIndex32 index, const GPUBindGroup* bindGroup,

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
@@ -84,6 +84,7 @@ private:
 
     Ref<WebGPU::ComputePassEncoder> m_backing;
     WeakPtr<WebGPU::Device> m_device;
+    std::optional<String> m_overrideLabel;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -81,8 +81,10 @@ void GPUQueue::submit(Vector<Ref<GPUCommandBuffer>>&& commandBuffers)
     m_backing->submit(WTFMove(result));
 
     if (RefPtr device = m_device.get()) {
-        for (Ref commandBuffer : commandBuffers)
+        for (Ref commandBuffer : commandBuffers) {
+            commandBuffer->setOverrideLabel(commandBuffer->label());
             commandBuffer->setBacking(device->invalidCommandEncoder(), device->invalidCommandBuffer());
+        }
     }
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -43,7 +43,7 @@ GPURenderPassEncoder::GPURenderPassEncoder(Ref<WebGPU::RenderPassEncoder>&& back
 
 String GPURenderPassEncoder::label() const
 {
-    return m_backing->label();
+    return m_overrideLabel ? *m_overrideLabel : m_backing->label();
 }
 
 void GPURenderPassEncoder::setLabel(String&& label)
@@ -168,8 +168,10 @@ void GPURenderPassEncoder::executeBundles(Vector<Ref<GPURenderBundle>>&& bundles
 void GPURenderPassEncoder::end()
 {
     protectedBacking()->end();
-    if (RefPtr device = m_device.get())
+    if (RefPtr device = m_device.get()) {
+        m_overrideLabel = label();
         m_backing = device->invalidRenderPassEncoder();
+    }
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
@@ -113,6 +113,7 @@ private:
 
     Ref<WebGPU::RenderPassEncoder> m_backing;
     WeakPtr<WebGPU::Device> m_device;
+    std::optional<String> m_overrideLabel;
 };
 
 }


### PR DESCRIPTION
#### d9712c222d72b032bdba60bfb05cc29bf26d1c60
<pre>
[WebGPU] <a href="https://gpuweb.github.io/cts/standalone/?debug=1&amp">https://gpuweb.github.io/cts/standalone/?debug=1&amp</a>;q=webgpu:api,operation,labels:* does not pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=297611">https://bugs.webkit.org/show_bug.cgi?id=297611</a>
<a href="https://rdar.apple.com/158705661">rdar://158705661</a>

Reviewed by Tadeu Zagallo.

When transient objects can no longer be used in any valid ways, e.g.,
once a ComputePassEncoder calls end() all calls except label() will result
in validation errors.

To avoid keeping larger, underlying objects alive until the next JS GC, we
set these transient objects to invalid objects.

However, a call to label() is expected to return the previously set value.
Achieve this by caching the label prior to setting the object to an invalid one.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/labels-expected.txt:
Update expectations, now all passing.

* Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp:
(WebCore::GPUCommandBuffer::label const):
(WebCore::GPUCommandBuffer::setOverrideLabel):
* Source/WebCore/Modules/WebGPU/GPUCommandBuffer.h:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp:
(WebCore::GPUCommandEncoder::label const):
(WebCore::GPUCommandEncoder::finish):
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h:
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp:
(WebCore::GPUComputePassEncoder::label const):
(WebCore::GPUComputePassEncoder::end):
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h:
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::submit):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::label const):
(WebCore::GPURenderPassEncoder::end):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h:

Canonical link: <a href="https://commits.webkit.org/299124@main">https://commits.webkit.org/299124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5de410714e2d5e3648af33eb7196e9ec173db666

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69534 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5b26d7f-d22b-4034-abd6-4e023e26e9d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45787 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89197 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/45016 "Found 17 new test failures: css3/filters/drop-shadow-current-color.html fast/canvas/offscreen-no-script-context-crash.html http/tests/permissions/storage-access-permissions-query.html http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html imported/w3c/web-platform-tests/event-timing/contextmenu.html imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html js/stringimpl-to-jsstring-on-large-strings-2.html performance-api/performance-observer-exception.html storage/indexeddb/cursor-properties-private.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56418f08-f85f-4c9c-ab07-aaa95a2dad53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105385 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69705 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 40 api tests failed or timed out; 40 api tests failed or timed out; Compiled WebKit (cancelled)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02309172-d811-444f-9ef7-64d3d5b96752) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67304 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126752 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97868 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24917 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20972 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40788 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49976 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47107 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->