### PR TITLE
[WPE][GTK] API test runner: allow to pass a list of tests and subtests to run.

### DIFF
--- a/Tools/Scripts/run-gtk-tests
+++ b/Tools/Scripts/run-gtk-tests
@@ -20,7 +20,6 @@
 import logging
 import os
 import sys
-import optparse
 
 top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "flatpak"))
@@ -29,7 +28,7 @@ sys.path.insert(0, os.path.join(top_level_directory, "Tools", "glib"))
 import common
 import jhbuildutils
 import flatpakutils
-from api_test_runner import TestRunner, add_options, get_runner_args
+from api_test_runner import TestRunner, create_option_parser, get_runner_args
 
 
 try:
@@ -101,8 +100,7 @@ if __name__ == "__main__":
         print('*** Run update-webkitgtk-libs or update-webkit-flatpak before build-webkit to ensure proper testing..')
         print('***')
 
-    option_parser = optparse.OptionParser(usage='usage: %prog [options] [test...]')
-    add_options(option_parser)
+    option_parser = create_option_parser()
     option_parser.add_option('--display-server', choices=['xvfb', 'xorg', 'weston', 'wayland'], default='xvfb',
                              help='"xvfb": Use a virtualized X11 server. "xorg": Use the current X11 session. '
                                   '"weston": Use a virtualized Weston server. "wayland": Use the current wayland session.'),

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -20,7 +20,6 @@
 import logging
 import os
 import sys
-import optparse
 
 top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(top_level_directory, "Tools", "jhbuild"))
@@ -29,7 +28,7 @@ sys.path.insert(0, os.path.join(top_level_directory, "Tools", "glib"))
 import common
 import jhbuildutils
 import flatpakutils
-from api_test_runner import TestRunner, add_options, get_runner_args
+from api_test_runner import TestRunner, create_option_parser, get_runner_args
 
 class WPETestRunner(TestRunner):
     TestRunner.TEST_TARGETS = [ "WPE", "WPEPlatform", "WPEQt", "TestWebKit", "TestJSC", "TestWTF", "TestWebCore" ]
@@ -61,8 +60,7 @@ if __name__ == "__main__":
         print('*** Run update-webkitwpe-libs or update-webkit-flatpak before build-webkit to ensure proper testing..')
         print('***')
 
-    option_parser = optparse.OptionParser(usage='usage: %prog [options] [test...]')
-    add_options(option_parser);
+    option_parser = create_option_parser()
     option_parser.add_option('--display-server', choices=['headless', 'wayland'], default='headless',
                              help='"headless": Use headless view backend. "wayland": Use the current wayland session.')
     option_parser.add_option('--wpe-legacy-api', action="store_true", default=False,


### PR DESCRIPTION
#### c0eac65a07336e0e1e958e7b31d000ce9a602dd5
<pre>
[WPE][GTK] API test runner: allow to pass a list of tests and subtests to run.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297751">https://bugs.webkit.org/show_bug.cgi?id=297751</a>

Reviewed by Carlos Garcia Campos.

The API-Tests EWS bots have been not working properly for GTK and WPE since 288955@main
which introduced an optimization to run only the subtests that failed with the patch
on the retry step that runs without the patch.

The problem is that the API test runner script for GTK and WPE is not understanding the
syntax. So it is not running anything when the list of tests and subtests to run is passed.

This patch modifies it to support receiving a list of tests and subtests to run (previously
it could receive a list of tests, but it only allowed to specify the list of subtests when
running one test alone). The format used is MainTestName:subtest-name.

This also improves the behaviour around some corner cases, like when there is an exception
running the binary test, then the python runner generates a fake subtest with names like
&apos;afterAll&apos; or &apos;beforeAll&apos; that the binary runner won&apos;t understand if passed to it as a subtest
name. This patch modifies the python runner to detects that and in that case opt to run all
the subtests for that given test.

* Tools/glib/api_test_runner.py:
(TestRunner.__init__):
(TestRunner._get_tests):
(TestRunner._get_test_short_name):
(TestRunner):
(TestRunner._getsubtests_to_run_for_test):
(TestRunner.run_tests):
(TestRunner.run_tests.generate_test_list_for_json_output):
* Tools/glib/glib_test_runner.py:
(GLibTestRunner.run):

Canonical link: <a href="https://commits.webkit.org/299049@main">https://commits.webkit.org/299049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72497b55786c6c868e0070495a9cded475d04348

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45893 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/47774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30250 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29313 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99667 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126859 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33513 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44894 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/101704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97721 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43100 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40898 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18772 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44407 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43866 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->