### PR TITLE
Fix spill / fill order of vector registers in wasmPrologueSIMD.

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -400,8 +400,8 @@ end
     end)
     forEachWasmArgumentFPR(macro (index, fpr1, fpr2)
         const base = -(NumberOfWasmArgumentGPRs + CalleeSaveSpaceAsVirtualRegisters + 2) * MachineRegisterSize
-        storev fpr2, base - (index + 1) * VectorRegisterSize[cfr]
         storev fpr1, base - (index + 0) * VectorRegisterSize[cfr]
+        storev fpr2, base - (index + 1) * VectorRegisterSize[cfr]
     end)
 
     slow_path()
@@ -420,8 +420,8 @@ end
     end)
     forEachWasmArgumentFPR(macro (index, fpr1, fpr2)
         const base = -(NumberOfWasmArgumentGPRs + CalleeSaveSpaceAsVirtualRegisters + 2) * MachineRegisterSize
-        loadv base - (index + 1) * VectorRegisterSize[cfr], fpr2
         loadv base - (index + 0) * VectorRegisterSize[cfr], fpr1
+        loadv base - (index + 1) * VectorRegisterSize[cfr], fpr2
     end)
 
     restoreCalleeSavesUsedByWasm()


### PR DESCRIPTION
#### 625cd2a4fe22843f4adf1af263160ead36597d2e
<pre>
Fix spill / fill order of vector registers in wasmPrologueSIMD.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297753">https://bugs.webkit.org/show_bug.cgi?id=297753</a>
<a href="https://rdar.apple.com/158708738">rdar://158708738</a>

Reviewed by Yijia Huang.

This is a speculative fix for a performance regression after 298634@main.

Looking at the generated LLIntAssembly.h code that spill vector registers, ...

Before 298634@main, the spill looks like:
    &quot;str q0, [x29, #-112] \n&quot;            // WebAssembly.asm:283
    &quot;str q1, [x29, #-128] \n&quot;
    &quot;str q2, [x29, #-144] \n&quot;
    &quot;str q3, [x29, #-160] \n&quot;
    &quot;str q4, [x29, #-176] \n&quot;
    &quot;str q5, [x29, #-192] \n&quot;
    &quot;str q6, [x29, #-208] \n&quot;
    &quot;str q7, [x29, #-224] \n&quot;

After 298634@main, the spill looks like:
    &quot;str q1, [x29, #-128] \n&quot;            // WebAssembly.asm:328
    &quot;str q0, [x29, #-112] \n&quot;            // WebAssembly.asm:329
    &quot;str q3, [x29, #-160] \n&quot;            // WebAssembly.asm:328
    &quot;str q2, [x29, #-144] \n&quot;            // WebAssembly.asm:329
    &quot;str q5, [x29, #-192] \n&quot;            // WebAssembly.asm:328
    &quot;str q4, [x29, #-176] \n&quot;            // WebAssembly.asm:329
    &quot;str q7, [x29, #-224] \n&quot;            // WebAssembly.asm:328
    &quot;str q6, [x29, #-208] \n&quot;            // WebAssembly.asm:329

We can see that the 298634@main unexpectedly scrambled the spill order so that it is no longer
storing consecutively in memory.  This patch restores the original order.  This is done both
for the spill and the matching fill.

* Source/JavaScriptCore/llint/WebAssembly.asm:

Canonical link: <a href="https://commits.webkit.org/299054@main">https://commits.webkit.org/299054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50d02e7c3f05ef631f94b2068d38592e47c75086

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123678 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69573 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cc18c1c-337f-4eb3-9264-661d63f44397) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89219 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/45030 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; 10 flakes 15 failures; Running compile-webkit-without-change") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e1a4f62-7fa3-4a95-ad24-fe4cd6ddb993) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105411 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69721 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ea1ee1e-be64-49b0-8c24-cb9a0bb0ab11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67347 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109676 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126791 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116075 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44469 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33457 "Found 1 new test failure: ipc/send-ignored-network-message.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97886 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97674 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40827 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50015 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43797 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37256 "Found 1 new JSC binary failure: testapi, Found 20052 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/EH/try2.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->