### PR TITLE
Revised Mixed Content rules to match LNA spec

### DIFF
--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalNetworkAccess.h"
+
+#include "IPAddressSpace.h"
+#include "PolicyContainer.h"
+#include "ResourceError.h"
+#include "ResourceRequest.h"
+#include "SecurityContext.h"
+#include "SecurityOrigin.h"
+#include <wtf/Assertions.h>
+#include <wtf/URL.h>
+#include <wtf/text/StringConcatenateNumbers.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+std::optional<WebCore::ResourceError> performLocalNetworkAccessCheckWithContext(const ResourceRequest& request, const IPAddressSpace& connectionSpace, const SecurityContext* securityContext)
+{
+    if (request.hasHTTPOrigin()) {
+        auto originString = request.httpOrigin();
+        if (!originString.isEmpty()) {
+            auto requestOrigin = WebCore::SecurityOrigin::createFromString(originString);
+            if (requestOrigin->isPotentiallyTrustworthy()) {
+                auto currentURLOrigin = WebCore::SecurityOrigin::create(request.url());
+                if (requestOrigin->isSameOriginAs(currentURLOrigin.get()))
+                    return std::nullopt;
+            }
+        }
+    }
+
+    if (!securityContext)
+        return std::nullopt;
+
+    auto policyContainer = securityContext->policyContainer();
+    WebCore::IPAddressSpace requestorIPAddressSpace = policyContainer.ipAddressSpace;
+
+    if (connectionSpace != request.targetAddressSpace()) {
+        return WebCore::ResourceError { "WebKitErrorDomain"_s,
+            0,
+            request.url(),
+            "Local Network Access: Connection IP address space does not match target IP address space"_s,
+            WebCore::ResourceError::Type::AccessControl };
+    }
+    // FIXME: When IPAddressSpace value is returned from connection and targetAddressSpace isn't a necessary field to fetch off local network
+    // Return null.
+    // return std::nullopt;
+
+    // Step 4: If connection's IP address space is less public than request's policy container's IP address space
+    bool connectionIsLessPublic = (connectionSpace == WebCore::IPAddressSpace::Local && requestorIPAddressSpace == WebCore::IPAddressSpace::Public);
+
+    if (connectionIsLessPublic) {
+        // Let error be a network error.
+        WebCore::ResourceError error("WebKitErrorDomain"_s, 0, request.url(), "Local Network Access: Connection to less public address space blocked"_s, WebCore::ResourceError::Type::AccessControl);
+
+        // FIXME: Set error's IP address space property to connection's IP address space.
+        if (!securityContext->isSecureContext())
+            return error;
+
+        // TODO: Permission check system (not fully implemented yet)
+        // If the initiating origin has been granted the local network access permission, return null.
+        // If the initiating origin has been denied the local network access permission, return error.
+        // Otherwise, prompt the user:
+        //   If the user grants permission, return null.
+        //   If the user denies the permission, return error.
+
+        // For now, log that permission prompt is needed and return error
+        LOG_ERROR("Local Network Access: Permission required but user prompt not implemented for request to %s", request.url().string().utf8().data());
+        return error;
+    }
+    return std::nullopt;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
+++ b/Source/WebCore/Modules/fetch/LocalNetworkAccess.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ResourceError.h"
+
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/RefPtr.h>
+
+
+namespace WebCore {
+
+enum class IPAddressSpace : bool;
+struct PolicyContainer;
+class ResourceRequest;
+class SecurityOrigin;
+class SecurityContext;
+
+std::optional<ResourceError> performLocalNetworkAccessCheckWithContext(const ResourceRequest&, const IPAddressSpace&, const SecurityContext*);
+
+} // namespace WebCore
+

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/ScriptWrappable.h>
+#include <WebCore/ScriptWrappableInlines.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -134,7 +134,9 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
     
     if (response.transports()) {
         auto transports = *response.transports();
-        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoTransportsKey), toArrayValue(transports.map(WebCore::toString)));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoTransportsKey), toArrayValue(WTF::map(transports, [](const auto& transport) {
+            return WebCore::toString(transport);
+        })));
     }
 
     if (response.remainingDiscoverableCredentials())

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -137,6 +137,7 @@ Modules/fetch/FetchRequest.cpp
 Modules/fetch/FetchResponse.cpp
 Modules/fetch/FormDataConsumer.cpp
 Modules/fetch/IPAddressSpace.cpp
+Modules/fetch/LocalNetworkAccess.cpp
 Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
 Modules/filesystem/FileSystemDirectoryHandle.cpp
 Modules/filesystem/FileSystemFileHandle.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1311,6 +1311,7 @@
 		3BB6B81122A7D313003A2A69 /* TabSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BB6B80F22A7D311003A2A69 /* TabSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C244FEAA375AC633F88BE6F /* RenderLayerModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C244FE4A375AC633F88BE6F /* RenderLayerModelObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3C8D24EE2E25CF1A00D2A929 /* IPAddressSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3CFA510B2E45669200AAAAC9 /* LocalNetworkAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CFA510A2E45668200AAAAC9 /* LocalNetworkAccess.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3DFAB6FE2BCDA7AB00EDC3C4 /* ImageBufferPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D0F80C52BCA014D006C8023 /* ImageBufferPixelFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F42B31D1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F42B31B1881191B00278AAC /* WebVideoFullscreenControllerAVKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F8020351E9E47BF00DEC61D /* CoreAudioCaptureDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F8020321E9E381D00DEC61D /* CoreAudioCaptureDevice.h */; };
@@ -10165,6 +10166,8 @@
 		3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPAddressSpace.cpp; sourceTree = "<group>"; };
 		3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPAddressSpace.h; sourceTree = "<group>"; };
 		3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPAddressSpace.idl; sourceTree = "<group>"; };
+		3CFA51092E45665D00AAAAC9 /* LocalNetworkAccess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LocalNetworkAccess.cpp; sourceTree = "<group>"; };
+		3CFA510A2E45668200AAAAC9 /* LocalNetworkAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalNetworkAccess.h; sourceTree = "<group>"; };
 		3D0F80C52BCA014D006C8023 /* ImageBufferPixelFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferPixelFormat.h; sourceTree = "<group>"; };
 		3F3BB5821E709EE400C701F2 /* CoreAudioCaptureSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CoreAudioCaptureSource.cpp; sourceTree = "<group>"; };
 		3F3BB5831E709EE400C701F2 /* CoreAudioCaptureSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreAudioCaptureSource.h; sourceTree = "<group>"; };
@@ -25989,6 +25992,8 @@
 				3C6A595F2E4E5D5300A908CC /* IPAddressSpace.cpp */,
 				3C8D24ED2E25CF1A00D2A929 /* IPAddressSpace.h */,
 				3CE7C6702E270278005CDFD8 /* IPAddressSpace.idl */,
+				3CFA51092E45665D00AAAAC9 /* LocalNetworkAccess.cpp */,
+				3CFA510A2E45668200AAAAC9 /* LocalNetworkAccess.h */,
 				44CF5098299B906F0038D284 /* RequestPriority.h */,
 				44CF5097299B90600038D284 /* RequestPriority.idl */,
 				7C2E0BD125106AC4005F3C87 /* WindowOrWorkerGlobalScope+Fetch.idl */,
@@ -44056,6 +44061,7 @@
 				113D0B521F9FDD2B00F611BB /* LocalFrameViewLayoutContext.h in Headers */,
 				E35B907F23F60A50000011FF /* LocalizedDeviceModel.h in Headers */,
 				935207BE09BD410A00F2038D /* LocalizedStrings.h in Headers */,
+				3CFA510B2E45669200AAAAC9 /* LocalNetworkAccess.h in Headers */,
 				41FCD6BB23CE027700C62567 /* LocalSampleBufferDisplayLayer.h in Headers */,
 				BCE1C41B0D982980003B02F2 /* Location.h in Headers */,
 				E3C788EE2D035C9500D6C13D /* LogClient.h in Headers */,

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -754,7 +754,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
         if (!parentFrame)
             return completionHandler(WTFMove(newRequest));
 
-        if (MixedContentChecker::shouldBlockRequest(*parentFrame, newRequest.url())) {
+        if (MixedContentChecker::shouldBlockRequestWithTarget(*parentFrame, newRequest.url(), newRequest.targetAddressSpace(), MixedContentChecker::IsUpgradable::No)) {
             cancelMainResourceLoad(protectedFrameLoader()->cancelledError(newRequest));
             return completionHandler(WTFMove(newRequest));
         }

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -612,8 +612,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     RefPtr frame = m_document->frame();
     if (!frame)
         return;
-
-    if (MixedContentChecker::shouldBlockRequest(*frame, requestURL))
+    if (MixedContentChecker::shouldBlockRequestWithTarget(*frame, requestURL, request.targetAddressSpace()))
         return;
 
     RefPtr<SharedBuffer> data;

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -31,6 +31,7 @@
 #include "MixedContentChecker.h"
 
 #include "Document.h"
+#include "IPAddressSpace.h"
 #include "LegacySchemeRegistry.h"
 #include "LocalFrame.h"
 #include "SecurityOrigin.h"
@@ -107,7 +108,7 @@ static bool destinationIsImageAndInitiatorIsImageset(FetchOptions::Destination d
     return destination == FetchOptions::Destination::Image && initiator == Initiator::Imageset;
 }
 
-bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Destination destination, Initiator initiator)
+bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Destination destination, Initiator initiator, IPAddressSpace targetAddressSpace)
 {
     RefPtr document = frame.document();
     if (!document || isUpgradable != IsUpgradable::Yes)
@@ -122,14 +123,14 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
     auto shouldUpgradeIPAddressAndLocalhostForTesting = document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled();
 
     // 4.1 The request's URL is not upgraded in the following cases.
-    if (!canModifyRequest(url, destination, initiator))
+    if (!canModifyRequest(url, destination, initiator, targetAddressSpace))
         return false;
 
     logConsoleWarning(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);
     return true;
 }
 
-bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator)
+bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator, IPAddressSpace targetAddressSpace)
 {
     // 4.1.1 request’s URL is a potentially trustworthy URL.
     if (url.protocolIs("https"_s))
@@ -143,6 +144,8 @@ bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destina
     // 4.1.5 request’s destination is "image" and request’s initiator is "imageset".
     auto schemeIsHandledBySchemeHandler = LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol());
     if (!schemeIsHandledBySchemeHandler && destinationIsImageAndInitiatorIsImageset(destination, initiator))
+        return false;
+    if (targetAddressSpace == IPAddressSpace::Local)
         return false;
     return true;
 }
@@ -158,6 +161,12 @@ bool MixedContentChecker::shouldBlockRequest(LocalFrame& frame, const URL& url, 
         return false;
     logConsoleWarning(frame, /* blocked */ true, url, document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled());
     return true;
+}
+bool MixedContentChecker::shouldBlockRequestWithTarget(LocalFrame& frame, const URL& url, IPAddressSpace targetAddressSpace, IsUpgradable isUpgradable)
+{
+    if (!SecurityOrigin::create(url)->isPotentiallyTrustworthy() && targetAddressSpace == IPAddressSpace::Local)
+        return false;
+    return shouldBlockRequest(frame, url, isUpgradable);
 }
 
 void MixedContentChecker::checkFormForMixedContent(LocalFrame& frame, const URL& url)

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -37,17 +37,19 @@ namespace WebCore {
 class LocalFrame;
 class SecurityOrigin;
 enum class Initiator : uint8_t;
+enum class IPAddressSpace : bool;
 
 namespace MixedContentChecker {
 
 enum class IsUpgradable : bool { No, Yes, };
 
-bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Destination, Initiator);
+bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Destination, Initiator, IPAddressSpace);
 
 bool shouldBlockRequest(LocalFrame&, const URL&, IsUpgradable = IsUpgradable::No);
+bool shouldBlockRequestWithTarget(LocalFrame&, const URL&, IPAddressSpace, IsUpgradable = IsUpgradable::No);
 void checkFormForMixedContent(LocalFrame&, const URL&);
 
-WEBCORE_EXPORT bool canModifyRequest(const URL&, FetchOptions::Destination, Initiator);
+WEBCORE_EXPORT bool canModifyRequest(const URL&, FetchOptions::Destination, Initiator, IPAddressSpace);
 
 } // namespace MixedContentChecker
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -64,6 +64,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
+#include "LocalNetworkAccess.h"
 #include "LocalizedStrings.h"
 #include "Logging.h"
 #include "MemoryCache.h"
@@ -268,11 +269,11 @@ ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::request
         if (frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None) {
             bool isRequestUpgradable { false };
             if (RefPtr document = frame->document()) {
-                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().destination, request.options().initiator);
+                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().destination, request.options().initiator, request.resourceRequest().targetAddressSpace());
                 request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
             }
             URL requestURL = request.resourceRequest().url();
-            if (requestURL.isValid() && canRequest(CachedResource::Type::ImageResource, requestURL, request.options(), ForPreload::No, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload()))
+            if (requestURL.isValid() && canRequest(CachedResource::Type::ImageResource, requestURL, request.options(), ForPreload::No, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload(), request.resourceRequest().targetAddressSpace()))
                 PingLoader::loadImage(*frame, WTFMove(requestURL));
             return CachedResourceHandle<CachedImage> { };
         }
@@ -441,7 +442,7 @@ static MixedContentChecker::IsUpgradable isUpgradableTypeFromResourceType(Cached
     return MixedContentChecker::IsUpgradable::No;
 }
 
-bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const URL& url, MixedContentChecker::IsUpgradable isRequestUpgradable) const
+bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const URL& url, MixedContentChecker::IsUpgradable isRequestUpgradable, IPAddressSpace targetAddressSpace) const
 {
     if (!canRequestInContentDispositionAttachmentSandbox(type, url))
         return false;
@@ -470,7 +471,7 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
     case CachedResource::Type::Ping:
     case CachedResource::Type::FontResource: {
         if (RefPtr frame = this->frame()) {
-            if (MixedContentChecker::shouldBlockRequest(*frame, url, isRequestUpgradable))
+            if (MixedContentChecker::shouldBlockRequestWithTarget(*frame, url, targetAddressSpace, isRequestUpgradable))
                 return false;
         }
         break;
@@ -579,7 +580,7 @@ RefPtr<LocalFrame> CachedResourceLoader::protectedFrame() const
 }
 
 // Security checks defined in https://fetch.spec.whatwg.org/#main-fetch.
-bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, ForPreload forPreload, MixedContentChecker::IsUpgradable isRequestUpgradable, bool isLinkPreload)
+bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, ForPreload forPreload, MixedContentChecker::IsUpgradable isRequestUpgradable, bool isLinkPreload, IPAddressSpace targetAddressSpace)
 {
     if (RefPtr document = m_document.get()) {
         if (!document->protectedSecurityOrigin()->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
@@ -623,14 +624,14 @@ bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url,
     // They'll still get a warning in the console about CSP blocking the load.
 
     // FIXME: Should we consider whether the request is for preload here?
-    if (!checkInsecureContent(type, url, isRequestUpgradable))
+    if (!checkInsecureContent(type, url, isRequestUpgradable, targetAddressSpace))
         return false;
 
     return true;
 }
 
 // FIXME: Should we find a way to know whether the redirection is for a preload request like we do for CachedResourceLoader::canRequest?
-bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, const URL& preRedirectURL) const
+bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, const URL& preRedirectURL, IPAddressSpace targetAddressSpace) const
 {
     if (RefPtr document = m_document.get()) {
         if (!document->protectedSecurityOrigin()->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
@@ -657,7 +658,7 @@ bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type,
 
     // Last of all, check for insecure content. We do this last so that when folks block insecure content with a CSP policy, they don't get a warning.
     // They'll still get a warning in the console about CSP blocking the load.
-    if (!checkInsecureContent(type, url, MixedContentChecker::IsUpgradable::No)) {
+    if (!checkInsecureContent(type, url, MixedContentChecker::IsUpgradable::No, targetAddressSpace)) {
         CACHEDRESOURCELOADER_RELEASE_LOG("canRequestAfterRedirection: URL was not allowed because content is insecure");
         return false;
     }
@@ -771,7 +772,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         return true;
 
     if (RefPtr document = m_documentLoader->cachedResourceLoader().document()) {
-        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(Ref { *document->frame() }, isUpgradableTypeFromResourceType(type), request.url(), options.destination, options.initiator) : false;
+        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(Ref { *document->frame() }, isUpgradableTypeFromResourceType(type), request.url(), options.destination, options.initiator, request.targetAddressSpace()) : false;
         upgradeInsecureResourceRequestIfNeeded(request, *document, alwaysUpgradeMixedContent ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
     }
 
@@ -810,7 +811,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         }
     }
 
-    return canRequestAfterRedirection(type, request.url(), options, preRedirectURL);
+    return canRequestAfterRedirection(type, request.url(), options, preRedirectURL, request.targetAddressSpace());
 }
 
 bool CachedResourceLoader::canRequestInContentDispositionAttachmentSandbox(CachedResource::Type type, const URL& url) const
@@ -1084,7 +1085,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     bool isRequestUpgradable { false };
     RefPtr document = m_document.get();
     if (document) {
-        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator);
+        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator, request.resourceRequest().targetAddressSpace());
         request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
         url = request.resourceRequest().url();
     }
@@ -1101,7 +1102,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     }
 
     // We are passing url as well as request, as request url may contain a fragment identifier.
-    if (!canRequest(type, url, request.options(), forPreload, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload())) {
+    if (!canRequest(type, url, request.options(), forPreload, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload(), request.resourceRequest().targetAddressSpace())) {
         CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Not allowed to request resource", frame.get());
         return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Not allowed to request resource"_s, ResourceError::Type::AccessControl });
     }
@@ -1297,6 +1298,39 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         break;
     }
     ASSERT(resource);
+
+    // Perform local network access check before setting original request
+    if (RefPtr document = m_document.get(); document && document->settings().localNetworkAccessEnabled()) {
+        if (originalRequest) {
+            const auto& localNetworkRequest = *originalRequest;
+            // FIXME: Pass address space from connection as second argument
+            auto targetAddressSpace = localNetworkRequest.targetAddressSpace();
+            if (auto localNetworkError = WebCore::performLocalNetworkAccessCheckWithContext(localNetworkRequest, targetAddressSpace, document.get())) {
+                CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Local network access check failed: %s", frame.get(), localNetworkError->localizedDescription().utf8().data());
+
+                // Only retry if we have an access control error and can modify the request
+                if (localNetworkError->type() == ResourceError::Type::AccessControl && !localNetworkError->isCancellation()) {
+                    // Create retry request with modified settings
+                    CachedResourceRequest retryRequest = request;
+
+                    // FIXME: Set target IP address space from response IP Address
+                    auto responseIPAddressSpace = localNetworkRequest.targetAddressSpace();
+                    retryRequest.resourceRequest().setTargetAddressSpace(responseIPAddressSpace);
+                    CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Set target IP address space to %d", frame.get(), static_cast<bool>(responseIPAddressSpace));
+
+                    // Disable service workers for retry
+                    auto retryOptions = retryRequest.options();
+                    retryOptions.serviceWorkersMode = ServiceWorkersMode::None;
+                    retryRequest.setOptions(retryOptions);
+
+                    CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Retrying with HTTP-no-service-worker fetch", frame.get());
+                    return requestResource(type, WTFMove(retryRequest), forPreload, imageLoading);
+                }
+                return makeUnexpected(WTFMove(*localNetworkError));
+            }
+        }
+    }
+
     resource->setOriginalRequest(WTFMove(originalRequest));
 
     if ((type == CachedResource::Type::Script || type == CachedResource::Type::JSON) && contentSecurityPolicy) {
@@ -1326,6 +1360,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             return makeUnexpected(resourceError);
         }
     }
+
+
 
     if (document && !document->loadEventFinished() && !resource->resourceRequest().url().protocolIsData())
         m_validatedURLs.add(resource->resourceRequest().url());

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -196,7 +196,7 @@ private:
     void prepareFetch(CachedResource::Type, CachedResourceRequest&);
     void updateHTTPRequestHeaders(FrameLoader&, CachedResource::Type, CachedResourceRequest&);
 
-    bool canRequest(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ForPreload, MixedContentChecker::IsUpgradable, bool isLinkPreload);
+    bool canRequest(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ForPreload, MixedContentChecker::IsUpgradable, bool isLinkPreload, IPAddressSpace = IPAddressSpace::Public);
 
     enum RevalidationPolicy { Use, Revalidate, Reload, Load };
     RevalidationPolicy determineRevalidationPolicy(CachedResource::Type, CachedResourceRequest&, CachedResource* existingResource, ForPreload, ImageLoading) const;
@@ -205,14 +205,14 @@ private:
     CachedResourceHandle<CachedResource> updateCachedResourceWithCurrentRequest(const CachedResource&, CachedResourceRequest&&, PAL::SessionID, const CookieJar&, const Settings&);
 
     bool shouldContinueAfterNotifyingLoadedFromMemoryCache(const CachedResourceRequest&, CachedResource&, ResourceError&);
-    bool checkInsecureContent(CachedResource::Type, const URL&, MixedContentChecker::IsUpgradable) const;
+    bool checkInsecureContent(CachedResource::Type, const URL&, MixedContentChecker::IsUpgradable, IPAddressSpace = IPAddressSpace::Public) const;
 
     void performPostLoadActions();
 
     ImageLoading clientDefersImage(const URL&) const;
     void reloadImagesIfNotDeferred();
 
-    bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL) const;
+    bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL, IPAddressSpace = IPAddressSpace::Public) const;
     bool canRequestInContentDispositionAttachmentSandbox(CachedResource::Type, const URL&) const;
 
     RefPtr<DocumentLoader> protectedDocumentLoader() const;

--- a/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
@@ -37,64 +37,74 @@ TEST(MixedContentChecker, CanModifyRequest)
     URL url { "http://example.com/cat.jpg"_s };
     FetchOptions::Destination destination = FetchOptions::Destination::Image;
     Initiator initiator = Initiator::EmptyString;
+    IPAddressSpace targetAddressSpace = IPAddressSpace::Public;
 
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         url,
         destination,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     // 4.1.1 request’s URL is a potentially trustworthy URL.
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         URL { "https://example.com/cat.jpg"_s },
         destination,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     // 4.1.2 request’s URL’s host is an IP address.
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         URL { "http://192.0.1.36"_s },
         destination,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     // Exception for 4.1.2 potentially truthworthy address
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "http://127.0.0.1"_s },
         destination,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "http://localhost"_s },
         destination,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     // 4.1.4 request’s destination is not "image", "audio", or "video".
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         url,
         FetchOptions::Destination::Audio,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         url,
         FetchOptions::Destination::Video,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         url,
         FetchOptions::Destination::Font,
-        initiator
+        initiator,
+        targetAddressSpace
     ));
 
     // 4.1.5 request’s destination is "image" and request’s initiator is "imageset".
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         url,
         destination,
-        Initiator::Imageset
+        Initiator::Imageset,
+        targetAddressSpace
     ));
 
     // But if the scheme is handled by the handler, it is modifiable even if the initiator is "imageset".
@@ -105,7 +115,8 @@ TEST(MixedContentChecker, CanModifyRequest)
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "custom://example.com/cat.jpg"_s },
         destination,
-        Initiator::Imageset
+        Initiator::Imageset,
+        targetAddressSpace
     ));
 
     // This exception won't apply if the cheme is not registered.
@@ -114,7 +125,15 @@ TEST(MixedContentChecker, CanModifyRequest)
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         URL { "custom2://example.com/cat.jpg"_s },
         destination,
-        Initiator::Imageset
+        Initiator::Imageset,
+        targetAddressSpace
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        url,
+        destination,
+        initiator,
+        IPAddressSpace::Local
     ));
 }
 


### PR DESCRIPTION
#### d34d367932a75bc25eb1eab4447de68a844547f8
<pre>
Revised Mixed Content rules to match LNA spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=297739">https://bugs.webkit.org/show_bug.cgi?id=297739</a>
<a href="https://rdar.apple.com/154439054">rdar://154439054</a>

Reviewed by NOBODY (OOPS!).

LNA integration with mixed content. This adds conditions to determining if a request should be blocked as mixedContent. If the origin is not potentially trustworthy and the targetAddressSpace is set to local, then the request will be allowed. When checking if a request can be upgraded, if the targetAddressSpace is set to local, then the request will not be upgraded.

* Source/WebCore/Modules/fetch/LocalNetworkAccess.cpp: Added.
(WebCore::performLocalNetworkAccessCheckWithContext):
* Source/WebCore/Modules/fetch/LocalNetworkAccess.h: Added.
* Source/WebCore/Modules/indexeddb/IDBKeyRange.h:
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::encodeAsCBOR):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
(WebCore::MixedContentChecker::canModifyRequest):
(WebCore::MixedContentChecker::shouldBlockRequestWithTarget):
* Source/WebCore/loader/MixedContentChecker.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestImage):
(WebCore::CachedResourceLoader::checkInsecureContent const):
(WebCore::CachedResourceLoader::canRequest):
(WebCore::CachedResourceLoader::canRequestAfterRedirection const):
(WebCore::CachedResourceLoader::updateRequestAfterRedirection):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp:
(TestWebKitAPI::TEST(MixedContentChecker, CanModifyRequest)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d34d367932a75bc25eb1eab4447de68a844547f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89315 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/51725 "Found 8 new test failures: storage/domstorage/localstorage/missing-arguments.html storage/indexeddb/delete-in-upgradeneeded-close-in-open-success-private.html storage/indexeddb/modern/index-cursor-2-private.html webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-r8ui-red_integer-unsigned_byte.html webgl/2.0.y/conformance/extensions/webgl-compressed-texture-size-limit.html webgl/2.0.y/conformance/glsl/bugs/global-invariant-does-not-leak-across-shaders.html webgl/2.0.y/conformance2/query/occlusion-query.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69806 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/117040 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67473 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109791 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126908 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97972 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97759 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21101 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40949 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44456 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50130 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->