### PR TITLE
[SPI Checking] Promote audit-spi warnings to errors on iOS

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -74,9 +74,7 @@ OTHER_LDFLAGS = $(inherited) $(WK_COMMON_OTHER_LDFLAGS);
 WK_COMMON_OTHER_TAPI_FLAGS = -x objective-c++ -std=c++2b -fno-rtti $(WK_SANITIZER_OTHER_TAPI_FLAGS);
 OTHER_TAPI_FLAGS = $(inherited) $(WK_COMMON_OTHER_TAPI_FLAGS);
 
-// SPI auditing is only enabled on public iOS SDK builds. Set WK_AUDIT_SPI to
-// YES in local overrides to enable checking.
-WK_DEFAULT_WK_AUDIT_SPI[sdk=iphoneos*] = $(WK_NOT_$(USE_INTERNAL_SDK));
+WK_DEFAULT_WK_AUDIT_SPI[sdk=iphoneos*] = YES;
 WK_AUDIT_SPI = $(WK_DEFAULT_WK_AUDIT_SPI);
 WK_OTHER_AUDIT_SPI_FLAGS = -DSDKDB_HAS_148943382 $(WK_OTHER_AUDIT_SPI_FLAGS_$(CONFIGURATION));
 WK_OTHER_AUDIT_SPI_FLAGS[sdk=iphoneos18*] = $(WK_OTHER_AUDIT_SPI_FLAGS_$(CONFIGURATION));

--- a/Source/WTF/Scripts/audit-spi-if-needed.sh
+++ b/Source/WTF/Scripts/audit-spi-if-needed.sh
@@ -10,6 +10,9 @@ depfile="${SCRIPT_OUTPUT_FILE_0/%.timestamp/.d}"
 
 eval allowlists=(${WK_AUDIT_SPI_ALLOWLISTS})
 
+# For compatibility with offline build environments.
+export DISABLE_WEBKITCOREPY_AUTOINSTALLER=1
+
 if [[ "${WK_AUDIT_SPI}" == YES && -f "${program}" ]]; then
     mkdir -p "${OBJROOT}/WebKitSDKDBs"
 
@@ -24,7 +27,6 @@ if [[ "${WK_AUDIT_SPI}" == YES && -f "${program}" ]]; then
     done
 
     for arch in ${ARCHS}; do
-         # FIXME: Remove --no-errors to enforce no new SPI in the build.
         (set -x && "${program}" \
          --sdkdb-dir "${versioned_sdkdb_dir}" \
          --sdkdb-cache "${OBJROOT}/WebKitSDKDBs/${SDK_NAME}.sqlite3" \
@@ -35,7 +37,6 @@ if [[ "${WK_AUDIT_SPI}" == YES && -f "${program}" ]]; then
          ${allowlists[@]/#/--allowlist } \
          ${WK_OTHER_AUDIT_SPI_FLAGS} \
          @"${BUILT_PRODUCTS_DIR}/DerivedSources/${PROJECT_NAME}/platform-enabled-swift-args.${arch}.resp" \
-         --no-errors \
          $@)
      done
 else

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
@@ -120,7 +120,7 @@ class SDKDB:
         while user_version != VERSION:
             self.con = sqlite3.connect(db_file, isolation_level='IMMEDIATE',
                                        detect_types=sqlite3.PARSE_DECLTYPES)
-            self.con.execute('PRAGMA busy_timeout = 60000')
+            self.con.execute('PRAGMA busy_timeout = 300000')
             self.con.execute('PRAGMA foreign_keys = ON')
             user_version, = self.con.execute('PRAGMA user_version').fetchone()
             if user_version == 0:


### PR DESCRIPTION
#### 2483129e9349295165c29ec2a4cedf7f4021dc3d
<pre>
[SPI Checking] Promote audit-spi warnings to errors on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=297757">https://bugs.webkit.org/show_bug.cgi?id=297757</a>
<a href="https://rdar.apple.com/158898790">rdar://158898790</a>

Reviewed by Ryan Haddad and Brianna Fan.

Now that internal and public builds of iOS are running audit-spi without
detecting any unattributed SPI, flip the switch to emit errors. This
enables automated enforcement of WebKit&apos;s SPI policy on iOS.

* Configurations/CommonBase.xcconfig:
* Source/WTF/Scripts/audit-spi-if-needed.sh: Disable the autoinstaller
  to support internal builds in offline build environments.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB.__init__): Increase the busy_timeout to survive some slow
  internal systems. Now set at 10x the expected ~30 sec initialization
  time on modern hardware.

Canonical link: <a href="https://commits.webkit.org/299570@main">https://commits.webkit.org/299570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/406d3da28479630c1c023729d581b501e452d032

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71392 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/300455a3-5ad0-45bd-835a-e9421a124e91) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90667 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59999 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e1a7edd-9ff7-4eb3-949e-e03c79049f7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71098 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/727e6b49-b71f-4b7e-b7d3-699ce31d15fd) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/118681 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25089 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69217 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111443 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128566 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117837 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99231 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42806 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51802 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146537 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45567 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37675 "Found 1 new JSC binary failure: testapi, Found 18618 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48917 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47254 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->