### PR TITLE
[css-anchor-position-1] PositionOptions::currentOption should always set lastSuccessfulPositionTryFallbackIndex

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-fallback-to-base-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-fallback-to-base-style-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Starts rendering with flip-inline fallback
+PASS Base position without fallback now successful
+PASS Both base position and flip-inline works, keep base position since it's the last successful option
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-fallback-to-base-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-fallback-to-base-style.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning: switch from using fallback style to base style</title>
+<meta name="description" content="Tests a bug in WebKit where if a fallback is initially used, then the base style is used, WebKit will remember the fallback to be the last successful position fallback instead of the base style.">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#last-successful-position-fallback">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+<style>
+  #container {
+    position: relative;
+    width: 600px;
+    height: 300px;
+    background: teal;
+  }
+  #anchor {
+    position: relative;
+    top: 100px;
+    left: 100px;
+    width: 100px;
+    height: 100px;
+    background: red;
+    anchor-name: --a;
+  }
+  #anchored {
+    position-anchor: --a;
+    position-try-fallbacks: flip-inline;
+    position: absolute;
+    width: 200px;
+    height: 100px;
+    position-area: left center;
+    background: lime;
+  }
+</style>
+<div id="container">
+  <div id="anchor"></div>
+  <div id="anchored"></div>
+</div>
+<script>
+  promise_test(async () => {
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 200);
+  }, "Starts rendering with flip-inline fallback");
+
+  promise_test(async () => {
+    anchor.style.left = "350px";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 150);
+  }, "Base position without fallback now successful");
+
+  promise_test(async () => {
+    anchor.style.left = "300px";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 100);
+  }, "Both base position and flip-inline works, keep base position since it's the last successful option");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Starts rendering with flip-block
-PASS No successful position (with intermediate successful), keep flip-block
+FAIL No successful position (with intermediate successful), keep flip-block assert_equals: expected 200 but got 0
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3721,7 +3721,7 @@ std::optional<size_t> RenderStyle::lastSuccessfulPositionTryFallbackIndex() cons
     return m_nonInheritedData->rareData->lastSuccessfulPositionTryFallbackIndex;
 }
 
-void RenderStyle::setLastSuccessfulPositionTryFallbackIndex(std::optional<size_t>&& index)
+void RenderStyle::setLastSuccessfulPositionTryFallbackIndex(std::optional<size_t> index)
 {
     SET_NESTED_VAR(m_nonInheritedData, rareData, lastSuccessfulPositionTryFallbackIndex, WTFMove(index));
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2371,7 +2371,7 @@ public:
     void setPositionTryFallbacks(FixedVector<Style::PositionTryFallback>&&);
 
     std::optional<size_t> lastSuccessfulPositionTryFallbackIndex() const;
-    void setLastSuccessfulPositionTryFallbackIndex(std::optional<size_t>&&);
+    void setLastSuccessfulPositionTryFallbackIndex(std::optional<size_t>);
 
     static constexpr OptionSet<PositionVisibility> initialPositionVisibility();
     inline OptionSet<PositionVisibility> positionVisibility() const;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1569,8 +1569,7 @@ std::unique_ptr<RenderStyle> TreeResolver::PositionOptions::currentOption() cons
     ASSERT(optionStyles[index].style);
 
     auto newStyle = RenderStyle::clonePtr(*optionStyles[index].style);
-    if (optionStyles[index].fallbackIndex)
-        newStyle->setLastSuccessfulPositionTryFallbackIndex(*optionStyles[index].fallbackIndex);
+    newStyle->setLastSuccessfulPositionTryFallbackIndex(optionStyles[index].fallbackIndex);
 
     return newStyle;
 }


### PR DESCRIPTION
#### eb8b277b0314108e5cb2886e39dfc52d98fc845a
<pre>
[css-anchor-position-1] PositionOptions::currentOption should always set lastSuccessfulPositionTryFallbackIndex
<a href="https://rdar.apple.com/158894957">rdar://158894957</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297754">https://bugs.webkit.org/show_bug.cgi?id=297754</a>

Reviewed by Antti Koivisto.

TreeResolver::PositionOptions::currentOption() sets
lastSuccessfulPositionTryFallbackIndex of the cloned style to be the index
of the current option, except when the current option doesn&apos;t have an index
(the index is nullopt.) The except part is wrong, because a nullopt current
option index means it&apos;s the base style, so lastSuccessfulPositionTryFallbackIndex
should also be set to nullopt, to indicate the last-successful position option
is the base style.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-fallback-to-base-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-fallback-to-base-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt:
    - Rebaseline test that incidentally passes because of the bug.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setLastSuccessfulPositionTryFallbackIndex):
* Source/WebCore/rendering/style/RenderStyle.h:
    - Pass index by value to RenderStyle::setLastSuccessfulPositionTryFallbackIndex.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::PositionOptions::currentOption const):

Canonical link: <a href="https://commits.webkit.org/299350@main">https://commits.webkit.org/299350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4325b74f107e3f96c9a0ae76f216a15a208fb9a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70535 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb663b8c-fc0c-457a-9611-ff071babf781) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89925 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59502 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91905306-72cc-4db7-9341-abdc0103bd0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106230 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70405 "1 api test failed or timed out") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/316f6195-d4be-4949-8d5f-63496e60a88c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30013 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68307 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127714 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98585 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25047 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43786 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21778 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41881 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50931 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48063 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46403 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->