### PR TITLE
[css-anchor-position-1] Only generate position options on base style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-animation-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Starts rendering with flip-block
+PASS No successful position, keep flip-block
+PASS Base position without fallback now successful
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-animation.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning: last successful position fallback with animation</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<meta name="description" content="Tests a bug in WebKit where the last-successful position fallback isn't remembered when the anchor-positioned element is animated">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#last-successful-position-fallback">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+<style>
+  #container {
+    position: relative;
+    width: 400px;
+    height: 400px;
+    background: teal;
+  }
+
+  #anchor {
+    position: relative;
+    top: 100px;
+    left: 100px;
+    width: 100px;
+    height: 100px;
+    background: red;
+    anchor-name: --a;
+  }
+
+  /* Dummy animation keyframe */
+  @keyframes anime {
+    from { background: #000000; }
+    to { background: #ffffff; }
+  }
+
+  #anchored {
+    position-anchor: --a;
+    position-try-fallbacks: flip-block;
+    position: absolute;
+    width: 100px;
+    height: 200px;
+    position-area: top center;
+    background: lime;
+    animation: anime 1s linear;
+  }
+</style>
+<div id="container">
+  <div id="anchor"></div>
+  <div id="anchored"></div>
+</div>
+<script>
+  promise_test(async () => {
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetTop, 200);
+  }, "Starts rendering with flip-block");
+
+  promise_test(async () => {
+    anchor.style.top = "150px";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetTop, 200);
+  }, "No successful position, keep flip-block");
+
+  promise_test(async () => {
+    anchor.style.top = "200px";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetTop, 0);
+  }, "Base position without fallback now successful");
+</script>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -217,11 +217,15 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
     // Preserve the last successful fallback by propagating it from the old to new style.
     style->setLastSuccessfulPositionTryFallbackIndex(lastSuccessfulPositionTryFallbackIndex(existingStyle, style.get()));
 
-    return {
+    ResolvedStyle resolvedStyle {
         .style = WTFMove(style),
         .relations = { },
         .matchResult = WTFMove(unadjustedStyle.matchResult)
     };
+
+    generatePositionOptionsIfNeeded(resolvedStyle, styleable, resolutionContext);
+
+    return resolvedStyle;
 }
 
 static void resetStyleForNonRenderedDescendants(Element& current)
@@ -315,7 +319,6 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
     Styleable styleable { element, { } };
     auto resolvedStyle = styleForStyleable(styleable, resolutionType, resolutionContext, existingStyle);
 
-    generatePositionOptionsIfNeeded(resolvedStyle, styleable, resolutionContext);
     updateForPositionVisibility(*resolvedStyle.style, styleable);
 
     auto update = createAnimatedElementUpdate(WTFMove(resolvedStyle), styleable, parent().changes, resolutionContext, parent().isInDisplayNoneTree);


### PR DESCRIPTION
#### 9ef775bd0681492912c644241d85c723e86cc0f8
<pre>
[css-anchor-position-1] Only generate position options on base style
<a href="https://rdar.apple.com/158900076">rdar://158900076</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297759">https://bugs.webkit.org/show_bug.cgi?id=297759</a>

Reviewed by Antti Koivisto.

TreeResolver::generatePositionOptionsIfNeeded expects the input style
(from TreeResolver::styleForStyleable) to be the &quot;base&quot; style i.e the
style before any position options are applied.
TreeResolver::styleForStyleable returns a base style except if
1) we&apos;re in the middle of trying options and 2) if resolution type
is animations only, it returns the last style change event style.
In case of 2), the returned style could be a style with position option
applied, if the element has both animations and position-try. Since
we&apos;re only updating style for animation, we should not try position options,
so don&apos;t generate position options for this case.
TreeResolver::tryChoosePositionOption will then not try anything, because no
position options are generated.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-animation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-animation.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):
(WebCore::Style::TreeResolver::resolveElement):

Canonical link: <a href="https://commits.webkit.org/299135@main">https://commits.webkit.org/299135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87e7b529ac299ab70b78ff4323b3ae7d8de54a96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69971 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16e5ca4f-0008-4ecf-857f-f46e21e6fd06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89499 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59114 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c31d480-1b37-44a2-8fcd-d83fc5c74f65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69994 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee68e6fc-4445-4bb0-a855-643d01ccf3fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67746 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127164 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98166 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97954 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24924 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21330 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41273 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50385 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44171 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47516 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->