### PR TITLE
[Navigation API] imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-detach-multiple.html is crashing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7091,7 +7091,6 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-e
 # -- Navigation API -- #
 
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html [ Timeout ]
-webkit.org/b/297414 [ Debug ] imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-detach-multiple.html [ Crash ]
 webkit.org/b/291451 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted.html [ Pass Crash ]
 webkit.org/b/297477 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html [ Timeout Pass Failure ]
 webkit.org/b/297793 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept.html [ Crash Pass ]


### PR DESCRIPTION
#### eaa78a5094ac76bd4e28fdc820a45fad6004ef3c
<pre>
[Navigation API] imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-detach-multiple.html is crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=297414">https://bugs.webkit.org/show_bug.cgi?id=297414</a>
<a href="https://rdar.apple.com/158349001">rdar://158349001</a>

Reviewed by Ben Nham.

The Navigation API spec in Step #7 here:
(<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries-for-the-navigation-api)">https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries-for-the-navigation-api)</a>
says that when getting the entries, we should start at index
(startingIndex - 1) and work backwards while prepending the
entries to our list. The code wasn&apos;t doing that. It was starting
at 0 and working up to (startingIndex - 1). Given that we break
if we see an entry with a different domain, that means that in
the scenario where the entries before (startingIndex - 1) are:

1. foo.com
2. foo.com#A
3. bar.com
4. foo.com#B
5. current entry (of foo.com origin)

And the origin we&apos;re filtering by is foo.com, the entries we&apos;ll
end up with are:

1. foo.com
2. foo.com#A

Whereas we should have ended up with:

1. foo.com#B

m_entries corresponds to the entries that this navigation object
can navigate the frame to. It cannot go from entry 5 to 2 because
that would have gone to 3 first and cross-origin navigation aren&apos;t
allowed by this API. So 2 should not be in the list at all.

That&apos;s what is happening in this test. The entries in the list
are incorrect and leading to an error down the line.

* LayoutTests/TestExpectations:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):

Canonical link: <a href="https://commits.webkit.org/299078@main">https://commits.webkit.org/299078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/237e3fd3a8357bf50a830dc613e184194d5c9a57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69620 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a973dd4e-a48b-4330-b58d-f3dd8c24221a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89251 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/45987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14f8f1f7-f905-4abd-b8e6-1ac97712acae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105452 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69838 "Found 14 new API test failures: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WPEPlatform/TestDisplayWayland:/wpe-platform/DisplayWayland/connect, /WPE/TestSSL:/webkit/WebKitWebView/ssl, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWTF:WTF_DateMath.calculateLocalTimeOffset, /WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/user-messages, /WPE/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors, /WPEPlatform/TestDisplayWayland:/wpe-platform/DisplayWayland/keymap, /WPEPlatform/TestDisplayWayland:/wpe-platform/DisplayWayland/screens, /WPEPlatform/TestDisplayWayland:/wpe-platform/DisplayWayland/create-view ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c902d92-cb3d-4c10-a4d7-b6cbac57146e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23569 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67398 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126837 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97916 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97704 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21037 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40873 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18791 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50061 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45536 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->