### PR TITLE
Fix the warnings for extern-template in JSObject template classes

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -27,6 +27,9 @@
 #ifndef JSCallbackObject_h
 #define JSCallbackObject_h
 
+#if JSC_OBJC_API_ENABLED
+#include "JSAPIWrapperObject.h"
+#endif
 #include "JSObjectRef.h"
 #include "JSValueRef.h"
 #include "JSObject.h"
@@ -160,10 +163,7 @@ public:
     void setPrivate(void* data);
     void* getPrivate();
 
-    // FIXME: We should fix the warnings for extern-template in JSObject template classes: https://bugs.webkit.org/show_bug.cgi?id=161979
-    IGNORE_CLANG_WARNINGS_BEGIN("undefined-var-template")
     DECLARE_INFO;
-    IGNORE_CLANG_WARNINGS_END
 
     JSClassRef classRef() const { return m_callbackObjectData->jsClass; }
     bool inherits(JSClassRef) const;
@@ -248,6 +248,15 @@ void JSCallbackObject<Parent>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Parent::visitChildren(thisObject, visitor);
     thisObject->m_callbackObjectData->visitChildren(visitor);
 }
+
+// JSCallbackObject<T>::info()'s forward definition triggers an undefined template var warning
+// without these declarations in the same translation unit.
+template<> const ClassInfo JSCallbackObject<JSGlobalObject>::s_info;
+template<> const ClassInfo JSCallbackObject<JSNonFinalObject>::s_info;
+
+#if JSC_OBJC_API_ENABLED
+template<> const ClassInfo JSCallbackObject<JSAPIWrapperObject>::s_info;
+#endif
 
 } // namespace JSC
 


### PR DESCRIPTION
#### 93d1c5aab08094e0b241f15389a7c00e341c5604
<pre>
Fix the warnings for extern-template in JSObject template classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=161979">https://bugs.webkit.org/show_bug.cgi?id=161979</a>
<a href="https://rdar.apple.com/problem/158907443">rdar://problem/158907443</a>

Reviewed by Keith Miller.

* Source/JavaScriptCore/API/JSAPIWrapperObject.mm:
* Source/JavaScriptCore/API/JSCallbackObject.cpp:
(JSC::JSCallbackObject&lt;JSGlobalObject&gt;::visitChildren):
(JSC::JSCallbackObject&lt;JSNonFinalObject&gt;::visitChildren):
(JSC::JSCallbackObject&lt;JSAPIWrapperObject&gt;::visitChildren):
* Source/JavaScriptCore/API/JSCallbackObject.h:
* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
(JSC::JSCallbackObject&lt;Parent&gt;::finishCreation):

Canonical link: <a href="https://commits.webkit.org/299144@main">https://commits.webkit.org/299144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5d4ec9f8b445642624f8d5b00073418ab8616f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70044 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46269 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70043 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23936 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67821 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127240 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116519 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33841 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98009 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24930 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21398 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44784 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50458 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145217 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44244 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->