### PR TITLE
When evaluating JavaScript from the API in a target frame (via WKFrameInfo or similar), target only the specific Document that frame info represented

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -126,6 +126,7 @@ enum class SDKAlignedBehavior {
     SupportGameControllerEventInteractionAPI,
     DidFailProvisionalNavigationWithErrorForFileURLNavigation,
     CrashWhenPreconnectingFromBackgroundThread,
+    EvaluateJavaScriptFromWebKitAPITargetsSpecificDocument,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/bindings/js/RunJavaScriptParameters.h
+++ b/Source/WebCore/bindings/js/RunJavaScriptParameters.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/SourceProvider.h>
 
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -46,7 +47,7 @@ enum class RemoveTransientActivation : bool { No, Yes };
 using ArgumentMap = HashMap<String, Function<JSC::JSValue(JSC::JSGlobalObject&)>>;
 
 struct RunJavaScriptParameters {
-    RunJavaScriptParameters(String&& source, JSC::SourceTaintedOrigin taintedness, URL&& sourceURL, RunAsAsyncFunction runAsAsyncFunction, std::optional<ArgumentMap>&& arguments, ForceUserGesture forceUserGesture, RemoveTransientActivation removeTransientActivation)
+    RunJavaScriptParameters(String&& source, JSC::SourceTaintedOrigin taintedness, URL&& sourceURL, RunAsAsyncFunction runAsAsyncFunction, std::optional<ArgumentMap>&& arguments, std::optional<ScriptExecutionContextIdentifier>&& targetScriptExecutionContext, ForceUserGesture forceUserGesture, RemoveTransientActivation removeTransientActivation)
         : source(WTFMove(source))
         , taintedness(taintedness)
         , sourceURL(WTFMove(sourceURL))
@@ -54,10 +55,11 @@ struct RunJavaScriptParameters {
         , arguments(WTFMove(arguments))
         , forceUserGesture(forceUserGesture)
         , removeTransientActivation(removeTransientActivation)
+        , targetScriptExecutionContext(WTFMove(targetScriptExecutionContext))
     {
     }
 
-    RunJavaScriptParameters(const String& source, JSC::SourceTaintedOrigin taintedness, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentMap>&& arguments, bool forceUserGesture, RemoveTransientActivation removeTransientActivation)
+    RunJavaScriptParameters(const String& source, JSC::SourceTaintedOrigin taintedness, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentMap>&& arguments, std::optional<ScriptExecutionContextIdentifier>&& targetScriptExecutionContext, bool forceUserGesture, RemoveTransientActivation removeTransientActivation)
         : source(source)
         , taintedness(taintedness)
         , sourceURL(WTFMove(sourceURL))
@@ -65,10 +67,11 @@ struct RunJavaScriptParameters {
         , arguments(WTFMove(arguments))
         , forceUserGesture(forceUserGesture ? ForceUserGesture::Yes : ForceUserGesture::No)
         , removeTransientActivation(removeTransientActivation)
+        , targetScriptExecutionContext(WTFMove(targetScriptExecutionContext))
     {
     }
 
-    RunJavaScriptParameters(String&& source, JSC::SourceTaintedOrigin taintedness, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentMap>&& arguments, bool forceUserGesture, RemoveTransientActivation removeTransientActivation)
+    RunJavaScriptParameters(String&& source, JSC::SourceTaintedOrigin taintedness, URL&& sourceURL, bool runAsAsyncFunction, std::optional<ArgumentMap>&& arguments, std::optional<ScriptExecutionContextIdentifier>&& targetScriptExecutionContext, bool forceUserGesture, RemoveTransientActivation removeTransientActivation)
         : source(WTFMove(source))
         , taintedness(taintedness)
         , sourceURL(WTFMove(sourceURL))
@@ -76,6 +79,7 @@ struct RunJavaScriptParameters {
         , arguments(WTFMove(arguments))
         , forceUserGesture(forceUserGesture ? ForceUserGesture::Yes : ForceUserGesture::No)
         , removeTransientActivation(removeTransientActivation)
+        , targetScriptExecutionContext(WTFMove(targetScriptExecutionContext))
     {
     }
 
@@ -86,6 +90,7 @@ struct RunJavaScriptParameters {
     std::optional<ArgumentMap> arguments;
     ForceUserGesture forceUserGesture;
     RemoveTransientActivation removeTransientActivation;
+    std::optional<ScriptExecutionContextIdentifier> targetScriptExecutionContext;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -613,12 +613,22 @@ JSC::JSValue ScriptController::executeScriptIgnoringException(const String& scri
 
 JSC::JSValue ScriptController::executeScriptInWorldIgnoringException(DOMWrapperWorld& world, const String& script, JSC::SourceTaintedOrigin taintedness, bool forceUserGesture)
 {
-    auto result = executeScriptInWorld(world, { script, taintedness, URL { }, false, std::nullopt, forceUserGesture, RemoveTransientActivation::Yes });
+    auto result = executeScriptInWorld(world, { script, taintedness, URL { }, false, std::nullopt, std::nullopt, forceUserGesture, RemoveTransientActivation::Yes });
     return result ? result.value() : JSC::JSValue { };
 }
 
 ValueOrException ScriptController::executeScriptInWorld(DOMWrapperWorld& world, RunJavaScriptParameters&& parameters)
 {
+#if PLATFORM(COCOA)
+    if (parameters.targetScriptExecutionContext) {
+        if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::EvaluateJavaScriptFromWebKitAPITargetsSpecificDocument)) {
+            RefPtr document = m_frame->document();
+            if (!document || document->identifier() != *parameters.targetScriptExecutionContext)
+                return makeUnexpected(ExceptionDetails { "Attempting to execute JavaScript in a specific document, but this frame's document has changed"_s });
+        }
+    }
+#endif
+
 #if ENABLE(APP_BOUND_DOMAINS)
     if (m_frame->loader().client().shouldEnableInAppBrowserPrivacyProtections()) {
         if (RefPtr document = m_frame->document())
@@ -750,7 +760,7 @@ JSC::JSValue ScriptController::executeUserAgentScriptInWorldIgnoringException(DO
 }
 ValueOrException ScriptController::executeUserAgentScriptInWorld(DOMWrapperWorld& world, const String& script, bool forceUserGesture)
 {
-    return executeScriptInWorld(world, { script, JSC::SourceTaintedOrigin::Untainted, URL { }, false, std::nullopt, forceUserGesture, RemoveTransientActivation::No });
+    return executeScriptInWorld(world, { script, JSC::SourceTaintedOrigin::Untainted, URL { }, false, std::nullopt, std::nullopt, forceUserGesture, RemoveTransientActivation::No });
 }
 
 void ScriptController::executeAsynchronousUserAgentScriptInWorld(DOMWrapperWorld& world, RunJavaScriptParameters&& parameters, ResolveFunction&& resolveCompletionHandler)

--- a/Source/WebKit/Shared/RunJavaScriptParameters.h
+++ b/Source/WebKit/Shared/RunJavaScriptParameters.h
@@ -34,6 +34,8 @@ namespace WebCore {
 enum class RunAsAsyncFunction : bool;
 enum class ForceUserGesture : bool;
 enum class RemoveTransientActivation : bool;
+
+using ScriptExecutionContextIdentifier = ProcessQualified<WTF::UUID>;
 }
 
 namespace WebKit {
@@ -46,6 +48,7 @@ struct RunJavaScriptParameters {
     std::optional<Vector<std::pair<String, JavaScriptEvaluationResult>>> arguments;
     WebCore::ForceUserGesture forceUserGesture;
     WebCore::RemoveTransientActivation removeTransientActivation;
+    std::optional<WebCore::ScriptExecutionContextIdentifier> targetScriptExecutionContext;
 };
 
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4386,6 +4386,7 @@ struct WebKit::RunJavaScriptParameters {
     std::optional<Vector<std::pair<String, WebKit::JavaScriptEvaluationResult>>> arguments;
     WebCore::ForceUserGesture forceUserGesture;
     WebCore::RemoveTransientActivation removeTransientActivation;
+    std::optional<WebCore::ScriptExecutionContextIdentifier> targetScriptExecutionContext;
 }
 
 header: <WebCore/FontAttributes.h>

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2761,6 +2761,8 @@ void WKPageEvaluateJavaScriptInFrame(WKPageRef pageRef, WKFrameInfoRef frame, WK
     CRASH_IF_SUSPENDED;
 
     auto frameID = frame ? std::optional(toImpl(frame)->frameInfoData().frameID) : std::nullopt;
+    auto documentID = frame ? std::optional(toImpl(frame)->frameInfoData().documentID.value()) : std::nullopt;
+
     toProtectedImpl(pageRef)->runJavaScriptInFrameInScriptWorld(WebKit::RunJavaScriptParameters {
         toProtectedImpl(scriptRef)->string(),
         JSC::SourceTaintedOrigin::Untainted,
@@ -2768,7 +2770,8 @@ void WKPageEvaluateJavaScriptInFrame(WKPageRef pageRef, WKFrameInfoRef frame, WK
         WebCore::RunAsAsyncFunction::No,
         std::nullopt,
         WebCore::ForceUserGesture::Yes,
-        RemoveTransientActivation::Yes
+        RemoveTransientActivation::Yes,
+        documentID
     }, frameID, API::ContentWorld::pageContentWorldSingleton(), !!callback, [context, callback] (auto&& result) {
         if (!callback)
             return;
@@ -2794,6 +2797,8 @@ void WKPageCallAsyncJavaScript(WKPageRef page, WKStringRef script, WKDictionaryR
     };
 
     auto frameID = frame ? std::optional(toImpl(frame)->frameInfoData().frameID) : std::nullopt;
+    auto documentID = frame ? std::optional(toImpl(frame)->frameInfoData().documentID.value()) : std::nullopt;
+
     toProtectedImpl(page)->runJavaScriptInFrameInScriptWorld(WebKit::RunJavaScriptParameters {
         toProtectedImpl(script)->string(),
         JSC::SourceTaintedOrigin::Untainted,
@@ -2801,7 +2806,8 @@ void WKPageCallAsyncJavaScript(WKPageRef page, WKStringRef script, WKDictionaryR
         WebCore::RunAsAsyncFunction::Yes,
         extractArguments(toProtectedImpl(arguments).get()),
         WebCore::ForceUserGesture::Yes,
-        RemoveTransientActivation::Yes
+        RemoveTransientActivation::Yes,
+        documentID
     }, frameID, API::ContentWorld::pageContentWorldSingleton(), !!callback, [context, callback] (auto&& result) {
         if (!callback)
             return;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1469,10 +1469,16 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
 
         return;
     }
-    
+
     std::optional<WebCore::FrameIdentifier> frameID;
-    if (frame && frame._handle && frame._handle->_frameHandle->frameID())
-        frameID = frame._handle->_frameHandle->frameID();
+    std::optional<WebCore::ScriptExecutionContextIdentifier> documentID;
+    if (frame) {
+        if (frame._handle && frame._handle->_frameHandle->frameID())
+            frameID = frame._handle->_frameHandle->frameID();
+
+        if (frame->_frameInfo->frameInfoData().documentID)
+            documentID = frame->_frameInfo->frameInfoData().documentID.value();
+    }
 
     auto removeTransientActivation = !_dontResetTransientActivationAfterRunJavaScript && WebKit::shouldEvaluateJavaScriptWithoutTransientActivation() ? WebCore::RemoveTransientActivation::Yes : WebCore::RemoveTransientActivation::No;
     _page->runJavaScriptInFrameInScriptWorld(WebKit::RunJavaScriptParameters {
@@ -1482,7 +1488,8 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
         asAsyncFunction ? WebCore::RunAsAsyncFunction::Yes : WebCore::RunAsAsyncFunction::No,
         WTFMove(argumentsMap),
         forceUserGesture ? WebCore::ForceUserGesture::Yes : WebCore::ForceUserGesture::No,
-        removeTransientActivation
+        removeTransientActivation,
+        documentID
     }, frameID, Ref { *world->_contentWorld }, !!handler, [handler] (auto&& result) {
         if (!handler)
             return;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4300,7 +4300,8 @@ void webkitWebViewRunJavascriptWithoutForcedUserGestures(WebKitWebView* webView,
         RunAsAsyncFunction::No,
         std::nullopt,
         ForceUserGesture::No,
-        RemoveTransientActivation::Yes
+        RemoveTransientActivation::Yes,
+        std::nullopt
     };
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), nullptr, RunJavascriptReturnType::JSCValue, adoptGRef(g_task_new(webView, cancellable, callback, userData)));
 }
@@ -4318,7 +4319,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
         RunAsAsyncFunction::No,
         std::nullopt,
         ForceUserGesture::Yes,
-        RemoveTransientActivation::Yes
+        RemoveTransientActivation::Yes,
+        std::nullopt
     };
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), worldName, returnType, adoptGRef(g_task_new(webView, cancellable, callback, userData)));
@@ -4465,7 +4467,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
         RunAsAsyncFunction::Yes,
         WTFMove(argumentsVector),
         ForceUserGesture::Yes,
-        RemoveTransientActivation::Yes
+        RemoveTransientActivation::Yes,
+        std::nullopt
     };
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), worldName, returnType, adoptGRef(g_task_new(webView, cancellable, callback, userData)));
@@ -4735,7 +4738,8 @@ static void resourcesStreamReadCallback(GObject* object, GAsyncResult* result, g
         RunAsAsyncFunction::No,
         std::nullopt,
         ForceUserGesture::Yes,
-        RemoveTransientActivation::Yes
+        RemoveTransientActivation::Yes,
+        std::nullopt
     };
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), nullptr, RunJavascriptReturnType::WebKitJavascriptResult, WTFMove(task));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4489,6 +4489,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
         WTFMove(parameters.sourceURL),
         parameters.runAsAsyncFunction == WebCore::RunAsAsyncFunction::Yes,
         mapArguments(WTFMove(parameters.arguments)),
+        WTFMove(parameters.targetScriptExecutionContext),
         parameters.forceUserGesture == WebCore::ForceUserGesture::Yes,
         parameters.removeTransientActivation
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -379,6 +379,34 @@ TEST(WebKit, GetFrameInfo_detachedFrame)
     EXPECT_EQ(pid, [webView _webProcessIdentifier]);
 }
 
+TEST(WebKit, EvaluateInFrameAfterDocumentChange)
+{
+    auto webView = adoptNS([TestWKWebView new]);
+    [webView synchronouslyLoadHTMLString:@"Hello world!"];
+
+    __block bool done = false;
+    __block RetainPtr<_WKFrameTreeNode> mainFrame;
+    [webView _frames:^(_WKFrameTreeNode *mainFrameNode) {
+        EXPECT_NOT_NULL(mainFrameNode);
+        EXPECT_NOT_NULL(mainFrameNode.info);
+        mainFrame = mainFrameNode;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    // This WKFrameInfo references the document synchronously loaded above.
+    // Navigate to switch to a new document.
+    [webView synchronouslyLoadHTMLString:@"Goodbye friend!"];
+
+    done = false;
+    [webView callAsyncJavaScript:@"document.innerHTML" arguments:nil inFrame:mainFrame.get().info inContentWorld:WKContentWorld.defaultClientWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(result);
+        EXPECT_NOT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
 TEST(WebKit, EvaluateJavaScriptInAttachments)
 {
     // Attachments displayed inline are in sandboxed documents.


### PR DESCRIPTION
#### 3bfacacb80a0bfb671d21b4f5ba422d0fb8e78a3
<pre>
When evaluating JavaScript from the API in a target frame (via WKFrameInfo or similar), target only the specific Document that frame info represented
<a href="https://rdar.apple.com/158911444">rdar://158911444</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297762">https://bugs.webkit.org/show_bug.cgi?id=297762</a>

Reviewed by NOBODY (OOPS!).

Whenever evaluating JavaScript in a specific frame, the relevant WKFrameInfo was retrieved through an asynchronous operation.
Then, evaluating the JS is itself an asynchronous operation.

In that time gap, the frame might have navigated and represent a different (and unexpected!) Document.

This patch adds the behavior of verifying that the Document we&apos;re running JS in matches the one that was originally captured
in a WKFrameInfo object, and therefore doesn&apos;t lead to nasty surprises for the API client.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/bindings/js/RunJavaScriptParameters.h:
(WebCore::RunJavaScriptParameters::RunJavaScriptParameters):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeScriptInWorldIgnoringException):
(WebCore::ScriptController::executeScriptInWorld):
(WebCore::ScriptController::executeUserAgentScriptInWorld):
* Source/WebKit/Shared/RunJavaScriptParameters.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageEvaluateJavaScriptInFrame):
(WKPageCallAsyncJavaScript):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WebKit, EvaluateInFrameAfterDocumentChange)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bfacacb80a0bfb671d21b4f5ba422d0fb8e78a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123722 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69616 "Hash 3bfacacb for PR 49748 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89246 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/69616 "Hash 3bfacacb for PR 49748 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30228 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105447 "Found 4 new API test failures: TestWebKitAPI.WKNavigation.LoadRadarURLFromSandboxedFrameWithUserGesture, TestWebKitAPI.EvaluateJavaScript.JavaScriptInFramesFromNavigationDelegate, TestWebKitAPI.SiteIsolation.NavigateIframeSameOriginBackForward, TestWebKitAPI.SiteIsolation.NavigateIframeCrossOriginBackForward (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69746 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 49748") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29289 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67393 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109718 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99644 "Found 7 new API test failures: TestWebKitAPI.WKNavigation.LoadRadarURLFromSandboxedFrameWithUserGesture, TestWebKitAPI.EvaluateJavaScript.JavaScriptInFramesFromNavigationDelegate, TestWebKitAPI.InAppBrowserPrivacy.AboutBlankSubFrameMatchesTopFrameAppBound, TestWebKitAPI.SiteIsolation.NavigateIframeSameOriginBackForward, TestWebKitAPI.SiteIsolation.NavigateIframeCrossOriginBackForward, TestWebKitAPI.InAppBrowserPrivacy.JavaScriptInNonAppBoundFrameFails, TestWebKitAPI.WebKit.DeviceOrientationPermissionInIFrame (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126833 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116117 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97700 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40869 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50057 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43840 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37267 "Found 1 new JSC binary failure: testapi, Found 20017 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47188 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->