### PR TITLE
[css-anchor-position-1] Last-successful position fallback doesn't apply on anchoreum.com

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-position-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-position-area-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Starts rendering with fallback
+PASS Both base and fallback works, position-try-fallbacks is set to the same value, keeps fallback
+PASS position-try-fallbacks is set to a different value, both base and fallback works, uses base because last successful position option is invalidated
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-position-area.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-position-area.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning: changing position-try-fallbacks to the same position-area value does not invalidate last successful position fallback</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position/#last-successful-position-fallback">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+<style>
+  #container {
+    position: relative;
+    width: 600px;
+    height: 300px;
+    background: teal;
+  }
+  #anchor {
+    position: relative;
+    top: 100px;
+    left: 100px;
+    width: 100px;
+    height: 100px;
+    background: red;
+    anchor-name: --a;
+  }
+  #anchored {
+    position-anchor: --a;
+    position-try-fallbacks: right center;
+    position: absolute;
+    width: 200px;
+    height: 100px;
+    position-area: left center;
+    background: lime;
+  }
+</style>
+<div id="container">
+  <div id="anchor"></div>
+  <div id="anchored"></div>
+</div>
+<script>
+  promise_test(async () => {
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 200);
+  }, "Starts rendering with fallback");
+
+  promise_test(async () => {
+    anchor.style.left = "300px";
+    anchored.style.positionTryFallbacks = "right center";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 400);
+  }, "Both base and fallback works, position-try-fallbacks is set to the same value, keeps fallback");
+
+  promise_test(async () => {
+    anchored.style.positionTryFallbacks = "right top";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetLeft, 100);
+  }, "position-try-fallbacks is set to a different value, both base and fallback works, uses base because last successful position option is invalidated");
+</script>

--- a/Source/WebCore/rendering/style/PositionTryFallback.h
+++ b/Source/WebCore/rendering/style/PositionTryFallback.h
@@ -36,6 +36,8 @@ class StyleProperties;
 namespace Style {
 
 struct PositionTryFallback {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(PositionTryFallback);
+
     std::optional<ScopedName> positionTryRuleName { };
 
     enum class Tactic : uint8_t {
@@ -46,12 +48,13 @@ struct PositionTryFallback {
     Vector<Tactic> tactics { };
 
     // A position-area fallback is mutually exclusive with the rest.
-    RefPtr<const StyleProperties> positionAreaProperties { };
+    const RefPtr<const StyleProperties> positionAreaProperties { };
 
     ~PositionTryFallback();
-    bool operator==(const PositionTryFallback&) const;
+    friend bool operator==(const PositionTryFallback&, const PositionTryFallback&);
 };
 
+TextStream& operator<<(TextStream&, const PositionTryFallback::Tactic&);
 TextStream& operator<<(TextStream&, const PositionTryFallback&);
 TextStream& operator<<(TextStream&, const Vector<PositionTryFallback>&);
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1772,7 +1772,7 @@ inline FixedVector<PositionTryFallback> BuilderConverter::convertPositionTryFall
             // Turn the inlined position-area fallback into properties object that can be applied similarly to @position-try declarations.
             auto property = CSSProperty { CSSPropertyPositionArea, Ref { const_cast<CSSValue&>(fallbackValue) } };
             return PositionTryFallback {
-                .positionAreaProperties = ImmutableStyleProperties::create(std::span { &property, 1 }, HTMLStandardMode)
+                .positionAreaProperties = ImmutableStyleProperties::createDeduplicating(std::span { &property, 1 }, HTMLStandardMode)
             };
         }
 


### PR DESCRIPTION
#### 9a79c5246dd6cb20a321af81ac1e2f2eb432a705
<pre>
[css-anchor-position-1] Last-successful position fallback doesn&apos;t apply on anchoreum.com
<a href="https://rdar.apple.com/158365856">rdar://158365856</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297438">https://bugs.webkit.org/show_bug.cgi?id=297438</a>

Reviewed by Antti Koivisto.

If a PositionTryFallback is a position-area option, the position-area is
stored in a RefPtr&lt;const StyleProperties&gt;. The current operator== for
PositionTryFallback is default, so it&apos;d only check whether the StyleProperties
pointers are the same. Fix it to look inside the StyleProperties and check
if the CSSValue of position-area are equal.

Also improve operator&lt;&lt; of PositionTryFallback to print out more debug
information.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-position-area-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks-position-area.html: Added.
* Source/WebCore/rendering/style/PositionTryFallback.cpp:
(WebCore::Style::operator==):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/rendering/style/PositionTryFallback.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertPositionTryFallbacks):
- Use ImmutableStyleProperties::createStyleDeduplicating to deduplicate the
  returning ImmutableStyleProperties, if an identical one was created before.

Canonical link: <a href="https://commits.webkit.org/299367@main">https://commits.webkit.org/299367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3edec53611c2c60cdcadef2750032b25305e854

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70817 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17d6a75e-9f81-4513-b7f1-e4ae1b82c529) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90131 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59642 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec8fd6c8-c320-49f3-b71b-00a66a10d534) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70637 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e4879f7-e617-481f-a01c-cfb7d0b5d8a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24583 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68601 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127996 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98779 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98561 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43999 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22005 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42187 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51212 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->