### PR TITLE
[web-animations] `Animation.commitStyles()` does not commit custom properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
@@ -19,7 +19,7 @@ PASS Commit composites on top of the underlying value
 PASS Commits logical properties
 FAIL Commits logical properties as physical properties assert_equals: expected "20px" but got "10px"
 PASS Commits em units as pixel values
-FAIL Commits custom variables assert_approx_equals: expected 0.8 +/- 0.0001 but got 0.5
+PASS Commits custom variables
 PASS Commits variable references as their computed values
 PASS Commits relative line-height
 PASS Commits transforms

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1831,7 +1831,7 @@ ExceptionOr<void> WebAnimation::commitStyles()
                 return false;
             },
             [&](const AtomString& customProperty) {
-                auto string = computedStyleExtractor.customPropertyValueSerialization(customProperty, CSS::defaultSerializationContext());
+                auto string = computedStyleExtractor.customPropertyValueSerializationInStyle(*animatedStyle, customProperty, CSS::defaultSerializationContext());
                 if (!string.isEmpty())
                     return inlineStyle->setCustomProperty(customProperty, WTFMove(string), { styledElement->document() });
                 return false;

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -258,15 +258,16 @@ RefPtr<CSSValue> Extractor::customPropertyValue(const AtomString& propertyName) 
 String Extractor::customPropertyValueSerialization(const AtomString& propertyName, const CSS::SerializationContext& serializationContext) const
 {
     std::unique_ptr<RenderStyle> ownedStyle;
-    auto* style = computeStyleForCustomProperty(ownedStyle);
-    if (!style)
-        return emptyString();
+    if (auto* style = computeStyleForCustomProperty(ownedStyle))
+        return customPropertyValueSerializationInStyle(*style, propertyName, serializationContext);
+    return emptyString();
+}
 
-    RefPtr value = style->customPropertyValue(propertyName);
-    if (!value)
-        return emptyString();
-
-    return value->propertyValueSerialization(serializationContext, *style);
+String Extractor::customPropertyValueSerializationInStyle(const RenderStyle& style, const AtomString& propertyName, const CSS::SerializationContext& serializationContext) const
+{
+    if (RefPtr value = style.customPropertyValue(propertyName))
+        return value->propertyValueSerialization(serializationContext, style);
+    return emptyString();
 }
 
 static bool isLayoutDependent(CSSPropertyID propertyID, const RenderStyle* style, const RenderObject* renderer)

--- a/Source/WebCore/style/StyleExtractor.h
+++ b/Source/WebCore/style/StyleExtractor.h
@@ -80,6 +80,9 @@ public:
     // Extract a serialized value for the specified custom property.
     String customPropertyValueSerialization(const AtomString& propertyName, const CSS::SerializationContext&) const;
 
+    // Extract a serialized value for the specified custom property using the provided RenderStyle and RenderElement.
+    String customPropertyValueSerializationInStyle(const RenderStyle&, const AtomString& propertyName, const CSS::SerializationContext&) const;
+
     // Helper methods for HTML editing.
     Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>) const;
     Ref<MutableStyleProperties> copyProperties() const;


### PR DESCRIPTION
#### 67574dc9fe52eec1ba7626d6167d1067217ab57d
<pre>
[web-animations] `Animation.commitStyles()` does not commit custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=297764">https://bugs.webkit.org/show_bug.cgi?id=297764</a>
<a href="https://rdar.apple.com/158919736">rdar://158919736</a>

Reviewed by Tim Nguyen.

The `WebAnimation::commitStyles()` method applies effects in an effect stack on a `RenderStyle`
object that is never associated directly with the animation effect&apos;s target element. As such,
we must provide the `RenderStyle` object directly to the `Style::Extractor` object being used,
just like we do in the CSSPropertyID case.

We add a new `customPropertyValueSerializationInStyle()` method to `Style::Extractor` that we
call from `WebAnimation::commitStyles()` and refactor the existing `customPropertyValueSerialization()`
to use it as well.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::Extractor::customPropertyValueSerialization const):
(WebCore::Style::Extractor::customPropertyValueSerializationInStyle const):
* Source/WebCore/style/StyleExtractor.h:

Canonical link: <a href="https://commits.webkit.org/299045@main">https://commits.webkit.org/299045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d44a9322bcc3356bab6f5e5e902632ace77b65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69619 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ced0d34-0dc0-4226-b295-f88d3cbb27b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89250 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/45989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/751cd678-6718-47e2-a603-9c8cb1491825) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105450 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9191f24e-006b-4053-bf67-4aefc6decf5c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67397 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126836 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97915 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97703 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40872 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44385 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43843 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45535 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->