### PR TITLE
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 4)

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -913,7 +913,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/DOMPromiseProxy.h
     bindings/js/DOMWrapperWorld.h
     bindings/js/ExceptionDetails.h
-    bindings/js/GCController.h
+    bindings/js/GarbageCollectionController.h
     bindings/js/IDBBindingUtilities.h
     bindings/js/JSCSSRuleCustom.h
     bindings/js/JSCSSStyleDeclarationCustom.h

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -31,7 +31,7 @@ Modules/webdatabase/DatabaseManager.h
 Modules/webdatabase/DatabaseThread.h
 accessibility/AXTextMarker.cpp
 accessibility/AccessibilityObject.cpp
-bindings/js/GCController.cpp
+bindings/js/GarbageCollectionController.cpp
 bindings/js/JSDOMAsyncIterator.h
 bindings/js/JSDOMConvertBase.h
 bindings/js/JSLocationCustom.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -635,7 +635,7 @@ bindings/js/CachedScriptFetcher.cpp
 bindings/js/CommonVM.cpp
 bindings/js/DOMGCOutputConstraint.cpp
 bindings/js/DOMWrapperWorld.cpp
-bindings/js/GCController.cpp
+bindings/js/GarbageCollectionController.cpp
 bindings/js/IDBBindingUtilities.cpp
 bindings/js/InternalReadableStream.cpp
 bindings/js/InternalWritableStream.cpp

--- a/Source/WebCore/bindings/js/GarbageCollectionController.h
+++ b/Source/WebCore/bindings/js/GarbageCollectionController.h
@@ -37,12 +37,12 @@ class VM;
 
 namespace WebCore {
 
-class GCController {
-    WTF_MAKE_TZONE_ALLOCATED(GCController);
-    WTF_MAKE_NONCOPYABLE(GCController);
-    friend class WTF::NeverDestroyed<GCController>;
+class GarbageCollectionController {
+    WTF_MAKE_TZONE_ALLOCATED(GarbageCollectionController);
+    WTF_MAKE_NONCOPYABLE(GarbageCollectionController);
+    friend class WTF::NeverDestroyed<GarbageCollectionController>;
 public:
-    WEBCORE_EXPORT static GCController& singleton();
+    WEBCORE_EXPORT static GarbageCollectionController& singleton();
     WEBCORE_EXPORT static void dumpHeapForVM(JSC::VM&);
 
     // Do nothing since this is a singleton.
@@ -62,7 +62,7 @@ public:
     WEBCORE_EXPORT void dumpHeap();
 
 private:
-    GCController(); // Use singleton() instead.
+    GarbageCollectionController(); // Use singleton() instead.
 
     void gcTimerFired();
     Timer m_GCTimer;

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -33,7 +33,7 @@
 #include "Document.h"
 #include "Frame.h"
 #include "FrameLoaderTypes.h"
-#include "GCController.h"
+#include "GarbageCollectionController.h"
 #include "JSDOMWindow.h"
 #include "JSDOMWindowProperties.h"
 #include "JSEventTarget.h"
@@ -88,7 +88,7 @@ void JSWindowProxy::setWindow(VM& vm, JSDOMGlobalObject& window)
 {
     ASSERT(window.classInfo() == JSDOMWindow::info());
     setTarget(vm, &window);
-    GCController::singleton().garbageCollectSoon();
+    GarbageCollectionController::singleton().garbageCollectSoon();
 }
 
 void JSWindowProxy::setWindow(DOMWindow& domWindow)

--- a/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
+++ b/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
@@ -35,7 +35,7 @@
 #include "CommonVM.h"
 #include "Document.h"
 #include "FrameInlines.h"
-#include "GCController.h"
+#include "GarbageCollectionController.h"
 #include "JSDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
@@ -108,7 +108,7 @@ void ScriptCachedFrameData::clear()
 
     JSLockHolder lock(commonVM());
     m_windows.clear();
-    GCController::singleton().garbageCollectSoon();
+    GarbageCollectionController::singleton().garbageCollectSoon();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -24,7 +24,7 @@
 #include "CommonVM.h"
 #include "DOMWrapperWorld.h"
 #include "FrameInlines.h"
-#include "GCController.h"
+#include "GarbageCollectionController.h"
 #include "JSDOMWindowBase.h"
 #include "JSWindowProxy.h"
 #include "LocalFrame.h"
@@ -51,9 +51,9 @@ static void collectGarbageAfterWindowProxyDestruction()
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
         // NOTE: We do the collection on next runloop to ensure that there's no pointer
         //       to the window object on the stack.
-        GCController::singleton().garbageCollectOnNextRunLoop();
+        GarbageCollectionController::singleton().garbageCollectOnNextRunLoop();
     } else
-        GCController::singleton().garbageCollectSoon();
+        GarbageCollectionController::singleton().garbageCollectSoon();
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WindowProxy);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -71,7 +71,7 @@
 #include "FrameLoadRequest.h"
 #include "FrameNetworkingContext.h"
 #include "FrameTree.h"
-#include "GCController.h"
+#include "GarbageCollectionController.h"
 #include "HTMLAnchorElement.h"
 #include "HTMLFormElement.h"
 #include "HTMLIFrameElement.h"

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -38,7 +38,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "FontCache.h"
-#include "GCController.h"
+#include "GarbageCollectionController.h"
 #include "HRTFElevation.h"
 #include "HTMLMediaElement.h"
 #include "HTMLNameCache.h"
@@ -153,9 +153,9 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
     }
 
     if (synchronous == Synchronous::Yes)
-        GCController::singleton().deleteAllCode(JSC::PreventCollectionAndDeleteAllCode);
+        GarbageCollectionController::singleton().deleteAllCode(JSC::PreventCollectionAndDeleteAllCode);
     else
-        GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
+        GarbageCollectionController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
 
 #if ENABLE(VIDEO)
     for (auto& mediaElement : HTMLMediaElement::allMediaElements())
@@ -163,12 +163,12 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
 #endif
 
     if (synchronous == Synchronous::Yes) {
-        GCController::singleton().garbageCollectNow();
+        GarbageCollectionController::singleton().garbageCollectNow();
     } else {
 #if PLATFORM(IOS_FAMILY)
-        GCController::singleton().garbageCollectNowIfNotDoneRecently();
+        GarbageCollectionController::singleton().garbageCollectNowIfNotDoneRecently();
 #else
-        GCController::singleton().garbageCollectSoon();
+        GarbageCollectionController::singleton().garbageCollectSoon();
 #endif
     }
 
@@ -181,7 +181,7 @@ void releaseMemory(Critical critical, Synchronous synchronous, MaintainBackForwa
 
 #if PLATFORM(IOS_FAMILY)
     if (critical == Critical::No)
-        GCController::singleton().garbageCollectNowIfNotDoneRecently();
+        GarbageCollectionController::singleton().garbageCollectNowIfNotDoneRecently();
 #endif
 
     if (critical == Critical::Yes) {

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -28,7 +28,7 @@
 
 #include "CommonVM.h"
 #include "Document.h"
-#include "GCController.h"
+#include "GarbageCollectionController.h"
 #include "IdleCallbackController.h"
 #include "Page.h"
 #include "Settings.h"

--- a/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
@@ -28,7 +28,7 @@
 
 #import "CGSubimageCacheWithTimer.h"
 #import "FontCache.h"
-#import "GCController.h"
+#import "GarbageCollectionController.h"
 #import "HTMLNameCache.h"
 #import "IOSurfacePool.h"
 #import "LayerPool.h"
@@ -94,7 +94,7 @@ void jettisonExpensiveObjectsOnTopLevelNavigation()
 #if PLATFORM(IOS_FAMILY)
     // Throw away linked JS code. Linked code is tied to a global object and is not reusable.
     // The immediate memory savings outweigh the cost of recompilation in case we go back again.
-    GCController::singleton().deleteAllLinkedCode(JSC::DeleteAllCodeIfNotCollecting);
+    GarbageCollectionController::singleton().deleteAllLinkedCode(JSC::DeleteAllCodeIfNotCollecting);
 #endif
 
     HTMLNameCache::clear();
@@ -106,11 +106,11 @@ void registerMemoryReleaseNotifyCallbacks()
     std::call_once(onceFlag, [] {
         int dummy;
         notify_register_dispatch("com.apple.WebKit.fullGC", &dummy, dispatch_get_main_queue(), ^(int) {
-            GCController::singleton().garbageCollectNow();
+            GarbageCollectionController::singleton().garbageCollectNow();
         });
         notify_register_dispatch("com.apple.WebKit.deleteAllCode", &dummy, dispatch_get_main_queue(), ^(int) {
-            GCController::singleton().deleteAllCode(JSC::PreventCollectionAndDeleteAllCode);
-            GCController::singleton().garbageCollectNow();
+            GarbageCollectionController::singleton().deleteAllCode(JSC::PreventCollectionAndDeleteAllCode);
+            GarbageCollectionController::singleton().garbageCollectNow();
         });
     });
 }

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -40,7 +40,7 @@
 #include "DocumentInlines.h"
 #include "FontCustomPlatformData.h"
 #include "FontFaceSet.h"
-#include "GCController.h"
+#include "GarbageCollectionController.h"
 #include "IDBConnectionProxy.h"
 #include "ImageBitmapOptions.h"
 #include "InspectorInstrumentation.h"
@@ -686,7 +686,7 @@ void WorkerGlobalScope::dumpGCHeapForWorkers()
     Locker locker { allWorkerGlobalScopeIdentifiersLock };
     for (auto& globalScopeIdentifier : allWorkerGlobalScopeIdentifiers()) {
         postTaskTo(globalScopeIdentifier, [](auto& context) {
-            GCController::dumpHeapForVM(downcast<WorkerGlobalScope>(context).vm());
+            GarbageCollectionController::dumpHeapForVM(downcast<WorkerGlobalScope>(context).vm());
         });
     }
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
@@ -28,7 +28,7 @@
 #include "WebKitWebProcessExtensionPrivate.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
-#include <WebCore/GCController.h>
+#include <WebCore/GarbageCollectionController.h>
 #include <glib/gi18n-lib.h>
 #include <wtf/HashMap.h>
 #include <wtf/glib/GRefPtr.h>
@@ -194,7 +194,7 @@ private:
         m_extension->priv->pages.remove(&page);
 #if ENABLE(DEVELOPER_MODE)
         if (m_extension->priv->garbageCollectOnPageDestroy)
-            WebCore::GCController::singleton().garbageCollectNow();
+            WebCore::GarbageCollectionController::singleton().garbageCollectNow();
 #endif
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebProcessExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebProcessExtension.cpp
@@ -28,7 +28,7 @@
 #include "WebKitWebProcessExtensionPrivate.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
-#include <WebCore/GCController.h>
+#include <WebCore/GarbageCollectionController.h>
 #include <glib/gi18n-lib.h>
 #include <wtf/HashMap.h>
 #include <wtf/glib/GRefPtr.h>
@@ -198,7 +198,7 @@ private:
         m_extension->priv->pages.remove(&page);
 #if ENABLE(DEVELOPER_MODE)
         if (m_extension->priv->garbageCollectOnPageDestroy)
-            WebCore::GCController::singleton().garbageCollectNow();
+            WebCore::GarbageCollectionController::singleton().garbageCollectNow();
 #endif
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -55,7 +55,7 @@
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/Document.h>
 #include <WebCore/FrameLoader.h>
-#include <WebCore/GCController.h>
+#include <WebCore/GarbageCollectionController.h>
 #include <WebCore/GeolocationClient.h>
 #include <WebCore/GeolocationController.h>
 #include <WebCore/GeolocationPositionData.h>
@@ -221,12 +221,12 @@ bool InjectedBundle::isProcessingUserGesture()
 
 void InjectedBundle::garbageCollectJavaScriptObjects()
 {
-    GCController::singleton().garbageCollectNow();
+    GarbageCollectionController::singleton().garbageCollectNow();
 }
 
 void InjectedBundle::garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging(bool waitUntilDone)
 {
-    GCController::singleton().garbageCollectOnAlternateThreadForDebugging(waitUntilDone);
+    GarbageCollectionController::singleton().garbageCollectOnAlternateThreadForDebugging(waitUntilDone);
 }
 
 size_t InjectedBundle::javaScriptObjectsCount()

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -111,7 +111,7 @@
 #include <WebCore/FontCache.h>
 #include <WebCore/FontCascade.h>
 #include <WebCore/FrameLoader.h>
-#include <WebCore/GCController.h>
+#include <WebCore/GarbageCollectionController.h>
 #include <WebCore/GlyphPage.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/LegacySchemeRegistry.h>
@@ -470,7 +470,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
                 critical = Critical::Yes;
 
             if (Options::dumpHeapOnLowMemory()) [[unlikely]]
-                GCController::singleton().dumpHeap();
+                GarbageCollectionController::singleton().dumpHeap();
 
 #if PLATFORM(COCOA)
             // If this is a process we keep around for performance, kill it on memory pressure instead of trying to free up its memory.
@@ -1035,7 +1035,7 @@ void WebProcess::terminate()
 {
 #ifndef NDEBUG
     // These are done in an attempt to reduce LEAK output.
-    GCController::singleton().garbageCollectNow();
+    GarbageCollectionController::singleton().garbageCollectNow();
     FontCache::invalidateAllFontCaches();
     MemoryCache::singleton().setDisabled(true);
 #endif
@@ -1166,7 +1166,7 @@ void WebProcess::isJITEnabled(CompletionHandler<void(bool)>&& completionHandler)
 
 void WebProcess::garbageCollectJavaScriptObjects()
 {
-    GCController::singleton().garbageCollectNow();
+    GarbageCollectionController::singleton().garbageCollectNow();
 }
 
 void WebProcess::backgroundResponsivenessPing()
@@ -1228,7 +1228,7 @@ void WebProcess::gamepadDisconnected(unsigned index)
 
 void WebProcess::setJavaScriptGarbageCollectorTimerEnabled(bool flag)
 {
-    GCController::singleton().setJavaScriptGarbageCollectorTimerEnabled(flag);
+    GarbageCollectionController::singleton().setJavaScriptGarbageCollectorTimerEnabled(flag);
 }
 
 void WebProcess::handleInjectedBundleMessage(const String& messageName, const UserData& messageBody)

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -37,7 +37,7 @@
 #import <WebCore/BackForwardCache.h>
 #import <WebCore/CommonVM.h>
 #import <WebCore/FontCache.h>
-#import <WebCore/GCController.h>
+#import <WebCore/GarbageCollectionController.h>
 #import <WebCore/GlyphPage.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/LocalFrame.h>
@@ -105,17 +105,17 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (void)garbageCollectJavaScriptObjects
 {
-    GCController::singleton().garbageCollectNow();
+    GarbageCollectionController::singleton().garbageCollectNow();
 }
 
 + (void)garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging:(BOOL)waitUntilDone
 {
-    GCController::singleton().garbageCollectOnAlternateThreadForDebugging(waitUntilDone);
+    GarbageCollectionController::singleton().garbageCollectOnAlternateThreadForDebugging(waitUntilDone);
 }
 
 + (void)setJavaScriptGarbageCollectorTimerEnabled:(BOOL)enable
 {
-    GCController::singleton().setJavaScriptGarbageCollectorTimerEnabled(enable);
+    GarbageCollectionController::singleton().setJavaScriptGarbageCollectorTimerEnabled(enable);
 }
 
 + (size_t)iconPageURLMappingCount

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -171,8 +171,8 @@
 #import <WebCore/FrameLoader.h>
 #import <WebCore/FrameSelection.h>
 #import <WebCore/FrameTree.h>
-#import <WebCore/GCController.h>
 #import <WebCore/GameControllerGamepadProvider.h>
+#import <WebCore/GarbageCollectionController.h>
 #import <WebCore/GeolocationController.h>
 #import <WebCore/GeolocationError.h>
 #import <WebCore/HTMLNames.h>
@@ -2513,7 +2513,7 @@ static bool fastDocumentTeardownEnabled()
 #ifndef NDEBUG
     // Need this to make leak messages accurate.
     if (applicationIsTerminating) {
-        WebCore::GCController::singleton().garbageCollectNow();
+        WebCore::GarbageCollectionController::singleton().garbageCollectNow();
         [WebCache setDisabled:YES];
     }
 #endif


### PR DESCRIPTION
#### 8fac702b248b7583ccb2a2ab3860b8e90ce5a0b9
<pre>
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=297767">https://bugs.webkit.org/show_bug.cgi?id=297767</a>
<a href="https://rdar.apple.com/158921043">rdar://158921043</a>

Reviewed by Aditya Keerthi.

Rename GCController to GarbageCollectionController; this is necessary because otherwise the module verifier reports a violation
since GCController is the name of another symbol in the SDK that WebKit uses.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/GarbageCollectionController.cpp: Renamed from Source/WebCore/bindings/js/GCController.cpp.
(WebCore::collect):
(WebCore::GarbageCollectionController::singleton):
(WebCore::GarbageCollectionController::GarbageCollectionController):
(WebCore::GarbageCollectionController::garbageCollectSoon):
(WebCore::GarbageCollectionController::garbageCollectOnNextRunLoop):
(WebCore::GarbageCollectionController::gcTimerFired):
(WebCore::GarbageCollectionController::garbageCollectNow):
(WebCore::GarbageCollectionController::garbageCollectNowIfNotDoneRecently):
(WebCore::GarbageCollectionController::garbageCollectOnAlternateThreadForDebugging):
(WebCore::GarbageCollectionController::setJavaScriptGarbageCollectorTimerEnabled):
(WebCore::GarbageCollectionController::deleteAllCode):
(WebCore::GarbageCollectionController::deleteAllLinkedCode):
(WebCore::GarbageCollectionController::dumpHeapForVM):
(WebCore::GarbageCollectionController::dumpHeap):
* Source/WebCore/bindings/js/GarbageCollectionController.h: Renamed from Source/WebCore/bindings/js/GCController.h.
(WebCore::GarbageCollectionController::ref const):
(WebCore::GarbageCollectionController::deref const):
* Source/WebCore/bindings/js/JSWindowProxy.cpp:
* Source/WebCore/bindings/js/ScriptCachedFrameData.cpp:
* Source/WebCore/bindings/js/WindowProxy.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/page/MemoryRelease.cpp:
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
* Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::dumpGCHeapForWorkers):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::garbageCollectJavaScriptObjects):
(WebKit::InjectedBundle::garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
(WebKit::WebProcess::terminate):
(WebKit::WebProcess::garbageCollectJavaScriptObjects):
(WebKit::WebProcess::setJavaScriptGarbageCollectorTimerEnabled):
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(+[WebCoreStatistics garbageCollectJavaScriptObjects]):
(+[WebCoreStatistics garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging:]):
(+[WebCoreStatistics setJavaScriptGarbageCollectorTimerEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _close]):

Canonical link: <a href="https://commits.webkit.org/299059@main">https://commits.webkit.org/299059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5ba27b2cc82f3ecc2b9ab918c5f6b0d3cd963b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117668 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69679 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9e992d9-70ee-4ee8-8730-321c823d2122) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45928 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/49915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1964dd1f-130b-48be-98cb-33163f5a02c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1235416c-80a8-4443-ad47-1549d1f13dcb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23621 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67458 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126895 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97963 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40935 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50117 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144875 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43901 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/144875 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47248 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->