### PR TITLE
CSP: Link header with rel=preload does not recognize nonces

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Report should not be sent for an allowed link preload
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A Report-Only policy with a nonce does not send a report for an allowed link preload</title>
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script nonce="abc">
+var testName = "Report should not be sent for an allowed link preload";
+addEventListener("load", () => {
+    const script = document.createElement("script");
+    script.nonce = "abc";
+    script.src = `../support/checkReport.sub.js?reportExists=false&testName=${encodeURIComponent(testName)}`;
+
+    document.body.appendChild(script);
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html.sub.headers
@@ -1,0 +1,4 @@
+Set-Cookie: link-preload-report-only-nonce={{$id:uuid()}}; Path=/content-security-policy/reporting
+Content-Security-Policy: script-src 'self' 'unsafe-inline'
+Content-Security-Policy-Report-Only: script-src 'nonce-abc'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}
+Link: </content-security-policy/support/pass.js>;rel=preload;as=script;nonce=abc

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Report should not be sent for an allowed link preload
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A Report-Only policy with a nonce does not send a report for an allowed link preload</title>
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+<link nonce="abc" rel="preload" as="script" href="../support/pass.js">
+</head>
+<body>
+<script nonce="abc">
+var testName = "Report should not be sent for an allowed link preload";
+addEventListener("load", () => {
+    const script = document.createElement("script");
+    script.nonce = "abc";
+    script.src = `../support/checkReport.sub.js?reportExists=false&testName=${encodeURIComponent(testName)}`;
+
+    document.body.appendChild(script);
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub.html.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub.html.sub.headers
@@ -1,0 +1,3 @@
+Set-Cookie: link-preload-report-only-nonce={{$id:uuid()}}; Path=/content-security-policy/reporting
+Content-Security-Policy: script-src 'self' 'unsafe-inline'
+Content-Security-Policy-Report-Only: script-src 'nonce-abc'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/pass.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/pass.js
@@ -1,0 +1,1 @@
+// intentionally left blank.

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -69,6 +69,7 @@ CachedResourceRequest PreloadRequest::resourceRequest(Document& document)
     if (m_resourceType == CachedResource::Type::Script || m_resourceType == CachedResource::Type::JSON || m_resourceType == CachedResource::Type::ImageResource)
         options.referrerPolicy = m_referrerPolicy;
     options.fetchPriority = m_fetchPriority;
+    options.nonce = m_nonceAttribute;
     auto request = createPotentialAccessControlRequest(completeURL(document), WTFMove(options), document, crossOriginMode);
     request.setInitiatorType(m_initiatorType);
 


### PR DESCRIPTION
#### 2a8526c8f62291c1aad56394bd815d3504f02b03
<pre>
CSP: Link header with rel=preload does not recognize nonces
<a href="https://bugs.webkit.org/show_bug.cgi?id=222484">https://bugs.webkit.org/show_bug.cgi?id=222484</a>
<a href="https://rdar.apple.com/75060055">rdar://75060055</a>

Reviewed by Ryosuke Niwa.

Erroneous CSP violations can happen if a CSP report-only header has a nonce and we attempt a preload
that contains the nonce.

When building a preload request we aren&apos;t copying the nonce from the link header or element&apos;s
nonce attribute into the fetch options we use when creating the resource request. So later when
the loader tries to validate we&apos;re allowed to do the load there&apos;s no nonce to check against and we
can trip over a Content-Security-Policy-Report-Only header and generate an erroneous violation report.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-from-header-report-only-nonce.sub.html.sub.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/link-preload-report-only-nonce.sub.html.sub.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/pass.js: Added.
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::PreloadRequest::resourceRequest):

Canonical link: <a href="https://commits.webkit.org/299070@main">https://commits.webkit.org/299070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f7dbf7e8a994fbc51ae9ad100f336c0eb9c92a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69681 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d58fe54-6898-4d6a-b19e-e783487c26be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89309 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/50347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94c71d16-513c-4d71-9a4a-d831c6a4e53d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69800 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/009d5dd2-6a36-4a6f-af8b-3b4e7e514911) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67460 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126897 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97965 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97752 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24881 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43126 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21091 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40937 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43903 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47250 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->