### PR TITLE
[JSC] Inline some of type displays into WebAssemblyGCStructure

### DIFF
--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
@@ -37,12 +37,15 @@ WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, JSGlobalObject* globalObj
     , m_rtt(WTFMove(rtt))
     , m_type(WTFMove(type))
 {
+    for (unsigned i = 0; i < std::min((m_rtt->displaySizeExcludingThis() + 1), inlinedTypeDisplaySize); ++i)
+        m_inlinedTypeDisplay[i] = m_rtt->displayEntry(i);
 }
 
 WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, WebAssemblyGCStructure* previous)
     : Structure(vm, StructureVariant::WebAssemblyGC, previous)
     , m_rtt(previous->m_rtt)
     , m_type(previous->m_type)
+    , m_inlinedTypeDisplay(previous->m_inlinedTypeDisplay)
 {
 }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
@@ -41,9 +41,11 @@ namespace JSC {
 // FIXME: It seems like almost all the fields of a Structure are useless to a wasm GC "object" since they can't have dynamic fields
 // e.g. PropertyTables, Transitions, SeenProperties, Prototype, etc.
 class WebAssemblyGCStructure final : public Structure {
-    typedef Structure Base;
+    using Base = Structure;
 public:
     friend class Structure;
+
+    static constexpr unsigned inlinedTypeDisplaySize = 6;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -57,6 +59,7 @@ public:
     static WebAssemblyGCStructure* create(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
 
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCStructure, m_rtt); }
+    static constexpr ptrdiff_t offsetOfInlinedTypeDisplay() { return OBJECT_OFFSETOF(WebAssemblyGCStructure, m_inlinedTypeDisplay); }
 
 private:
     WebAssemblyGCStructure(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
@@ -64,6 +67,7 @@ private:
 
     Ref<const Wasm::RTT> m_rtt;
     Ref<const Wasm::TypeDefinition> m_type;
+    std::array<const Wasm::RTT*, inlinedTypeDisplaySize> m_inlinedTypeDisplay { };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### dee2b5f11525509a493b72a694d567d915f880df
<pre>
[JSC] Inline some of type displays into WebAssemblyGCStructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=297769">https://bugs.webkit.org/show_bug.cgi?id=297769</a>
<a href="https://rdar.apple.com/158925602">rdar://158925602</a>

Reviewed by Yijia Huang.

This patch inlines up to 5 RTT into WebAssemblyGCStructure itself.
This allows us to super quick type check for Wasm GC objects in BBQ and
OMG. We fill this inlinedTypeDisplay with nullptr, and set partial ones
into them.

1. We do not need to check sourceRTT-&gt;displaySizeExcludingThis() &gt;= targetRTT-&gt;displaySizeExcludingThis.
   Even if sourceRTT-&gt;displaySizeExcludingThis() is smaller, up to 6 RTT
   entries can be safely accessed. Non set entries are nullptr so it
   never matches.
2. This makes comparison just loading a pointer from
   WebAssemblyGCStructure, regardless of whether signature is final type
   or not.

We pick inlined type display size &quot;6&quot; based on profiled numbers &amp;
sizeof(WebAssemblyGCStructure).

* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitRefTestOrCast):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp:
(JSC::WebAssemblyGCStructure::WebAssemblyGCStructure):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h:

Canonical link: <a href="https://commits.webkit.org/299056@main">https://commits.webkit.org/299056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e75132fa72aaa04d345b0e1537b41d63a98007e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69631 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/144c723f-cf2e-415c-8da0-14f1466e5f6a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89260 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/47264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84791e92-14f8-4e64-8785-d53d759a8a53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105463 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69757 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 49757") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b286528e-0f17-42b9-95bd-6cd088a81b6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23579 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67409 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109733 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99658 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126848 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116132 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97927 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97714 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21047 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40884 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50072 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144830 "Hash e75132fa for PR 49757 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43856 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/144830 "Hash e75132fa for PR 49757 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47203 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45547 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->