### PR TITLE
[GTK][WPE] Minor EventSenderProxy refactoring

### DIFF
--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -237,25 +237,26 @@ static int getGDKKeySymForKeyRef(WKStringRef keyRef, unsigned location, guint* m
     return gdk_unicode_to_keyval(static_cast<guint32>(buffer.get()[0]));
 }
 
-void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location)
+static inline void processKeyEvent(WebKitWebViewBase* webViewBase, WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location, KeyEventType type)
 {
     guint modifiers = webkitModifiersToGDKModifiers(wkModifiers);
     int gdkKeySym = getGDKKeySymForKeyRef(keyRef, location, &modifiers);
-    webkitWebViewBaseSynthesizeKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), KeyEventType::Insert, gdkKeySym, modifiers, ShouldTranslateKeyboardState::No);
+    webkitWebViewBaseSynthesizeKeyEvent(webViewBase, type, gdkKeySym, modifiers, ShouldTranslateKeyboardState::No);
+}
+
+void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location)
+{
+    processKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), keyRef, wkModifiers, location, KeyEventType::Insert);
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers wkModifiers, unsigned keyLocation)
 {
-    guint modifiers = webkitModifiersToGDKModifiers(wkModifiers);
-    int gdkKeySym = getGDKKeySymForKeyRef(key, keyLocation, &modifiers);
-    webkitWebViewBaseSynthesizeKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), KeyEventType::Press, gdkKeySym, modifiers, ShouldTranslateKeyboardState::No);
+    processKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), key, wkModifiers, keyLocation, KeyEventType::Press);
 }
 
 void EventSenderProxy::rawKeyUp(WKStringRef key, WKEventModifiers wkModifiers, unsigned keyLocation)
 {
-    guint modifiers = webkitModifiersToGDKModifiers(wkModifiers);
-    int gdkKeySym = getGDKKeySymForKeyRef(key, keyLocation, &modifiers);
-    webkitWebViewBaseSynthesizeKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), KeyEventType::Release, gdkKeySym, modifiers, ShouldTranslateKeyboardState::No);
+    processKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), key, wkModifiers, keyLocation, KeyEventType::Release);
 }
 
 void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType)

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
@@ -74,6 +74,33 @@ static unsigned wkEventModifiersToWPE(WKEventModifiers wkModifiers)
     return modifiers;
 }
 
+static unsigned applyKeyvalModifiers(unsigned keyval, unsigned modifiers)
+{
+    unsigned updatedModifiers = modifiers;
+    switch (keyval) {
+    case WPE_KEY_Control_L:
+    case WPE_KEY_Control_R:
+        updatedModifiers |= WPE_MODIFIER_KEYBOARD_CONTROL;
+        break;
+    case WPE_KEY_Shift_L:
+    case WPE_KEY_Shift_R:
+        updatedModifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
+        break;
+    case WPE_KEY_Alt_L:
+    case WPE_KEY_Alt_R:
+        updatedModifiers |= WPE_MODIFIER_KEYBOARD_ALT;
+        break;
+    case WPE_KEY_Meta_L:
+    case WPE_KEY_Meta_R:
+        updatedModifiers |= WPE_MODIFIER_KEYBOARD_META;
+        break;
+    case WPE_KEY_Caps_Lock:
+        updatedModifiers |= WPE_MODIFIER_KEYBOARD_CAPS_LOCK;
+        break;
+    }
+    return updatedModifiers;
+}
+
 static unsigned eventSenderButtonToWPEButton(unsigned button)
 {
     int mouseButton = 3;
@@ -264,28 +291,7 @@ void EventSenderProxyClientWPE::keyDown(WKStringRef keyRef, double time, WKEvent
 {
     unsigned modifiers = wkEventModifiersToWPE(wkModifiers);
     auto keyval = wpeKeyvalForKeyRef(keyRef, location, modifiers);
-    unsigned downModifiers = modifiers;
-    switch (keyval) {
-    case WPE_KEY_Control_L:
-    case WPE_KEY_Control_R:
-        downModifiers |= WPE_MODIFIER_KEYBOARD_CONTROL;
-        break;
-    case WPE_KEY_Shift_L:
-    case WPE_KEY_Shift_R:
-        downModifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
-        break;
-    case WPE_KEY_Alt_L:
-    case WPE_KEY_Alt_R:
-        downModifiers |= WPE_MODIFIER_KEYBOARD_ALT;
-        break;
-    case WPE_KEY_Meta_L:
-    case WPE_KEY_Meta_R:
-        downModifiers |= WPE_MODIFIER_KEYBOARD_META;
-        break;
-    case WPE_KEY_Caps_Lock:
-        downModifiers |= WPE_MODIFIER_KEYBOARD_CAPS_LOCK;
-        break;
-    }
+    unsigned downModifiers = applyKeyvalModifiers(keyval, modifiers);
 
     auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
     unsigned keycode = 0;
@@ -307,27 +313,7 @@ void EventSenderProxyClientWPE::rawKeyDown(WKStringRef keyRef, WKEventModifiers 
 {
     unsigned modifiers = wkEventModifiersToWPE(wkModifiers);
     auto keyval = wpeKeyvalForKeyRef(keyRef, location, modifiers);
-    switch (keyval) {
-    case WPE_KEY_Control_L:
-    case WPE_KEY_Control_R:
-        modifiers |= WPE_MODIFIER_KEYBOARD_CONTROL;
-        break;
-    case WPE_KEY_Shift_L:
-    case WPE_KEY_Shift_R:
-        modifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
-        break;
-    case WPE_KEY_Alt_L:
-    case WPE_KEY_Alt_R:
-        modifiers |= WPE_MODIFIER_KEYBOARD_ALT;
-        break;
-    case WPE_KEY_Meta_L:
-    case WPE_KEY_Meta_R:
-        modifiers |= WPE_MODIFIER_KEYBOARD_META;
-        break;
-    case WPE_KEY_Caps_Lock:
-        modifiers |= WPE_MODIFIER_KEYBOARD_CAPS_LOCK;
-        break;
-    }
+    modifiers = applyKeyvalModifiers(keyval, modifiers);
 
     auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
     unsigned keycode = 0;


### PR DESCRIPTION
#### a4f15a2dcb6026e5d20a185f1cc2c186729da425
<pre>
[GTK][WPE] Minor EventSenderProxy refactoring
<a href="https://bugs.webkit.org/show_bug.cgi?id=297774">https://bugs.webkit.org/show_bug.cgi?id=297774</a>

Reviewed by Adrian Perez de Castro.

Consolidate some of the EventSenderProxy repeated logic into helper
functions, including guarded code, for GTK, LibWPE and WPE.

* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp: created a helper
  function that abstracts the common key handling logic.
(WTR::processKeyEvent):
(WTR::EventSenderProxy::keyDown):
(WTR::EventSenderProxy::rawKeyDown):
(WTR::EventSenderProxy::rawKeyUp):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.cpp:
  created a helper class to abstract event creation and destruction of
  helper resources.
(WTR::KeyboardEvent::KeyboardEvent):
(WTR::KeyboardEvent::~KeyboardEvent):
(WTR::KeyboardEvent::createInputKeyboardEvent):
(WTR::EventSenderProxyClientLibWPE::keyDown):
(WTR::EventSenderProxyClientLibWPE::rawKeyDown):
(WTR::EventSenderProxyClientLibWPE::rawKeyUp):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::applyKeyvalModifiers): extracted additional changes to modifiers
into a separate method.
(WTR::EventSenderProxyClientWPE::keyDown):
(WTR::EventSenderProxyClientWPE::rawKeyDown):

Canonical link: <a href="https://commits.webkit.org/299549@main">https://commits.webkit.org/299549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22b17370d3f88bf1d6775fd3ddf3cd95630bedec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71301 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90588 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98927 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25181 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44392 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22402 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42722 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46014 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47171 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->