### PR TITLE
[ews] Remove Workers.showWorkerBuilders

### DIFF
--- a/Tools/CISupport/ews-build-webserver/master.cfg
+++ b/Tools/CISupport/ews-build-webserver/master.cfg
@@ -45,7 +45,6 @@ c['www']['custom_templates_dir'] = 'templates'
 c['www']['ui_default_config'] = {
     'Builders.show_workers_name': True,
     'Builders.buildFetchLimit': 1000,
-    'Workers.showWorkerBuilders': True,
 }
 
 if not is_test_mode_enabled:

--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -47,7 +47,6 @@ if is_test_mode_enabled:
     c['www']['ui_default_config'] = {
         'Builders.show_workers_name': True,
         'Builders.buildFetchLimit': 1000,
-        'Workers.showWorkerBuilders': True,
     }
 
 c['protocols'] = {'pb': {'port': 17000}}


### PR DESCRIPTION
#### 96cf86e615dddb9e0f6c85a1efebb02b1c94391a
<pre>
[ews] Remove Workers.showWorkerBuilders
<a href="https://bugs.webkit.org/show_bug.cgi?id=297775">https://bugs.webkit.org/show_bug.cgi?id=297775</a>
<a href="https://rdar.apple.com/158937459">rdar://158937459</a>

Reviewed by Brianna Fan.

This setting doesn&apos;t work in buildbot version 4.0 onwards.
Specifying this causes buildbot webpages to be completely
blank, with an exception in the browser console:
`bad setting name Workers.showWorkerBuilders: setting does not exist`

See <a href="https://github.com/buildbot/buildbot/issues/8369">https://github.com/buildbot/buildbot/issues/8369</a>

* Tools/CISupport/ews-build-webserver/master.cfg:
* Tools/CISupport/ews-build/master.cfg:

Canonical link: <a href="https://commits.webkit.org/299062@main">https://commits.webkit.org/299062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/995e22132c5aa7cff09167f1af4e05519c9f7075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69650 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d155201-0185-47cc-af27-cb7596996ea0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89275 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/48131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f61371a6-a75c-4cd3-9457-2fb1fbce1c4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105483 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69767 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9096063-adae-4064-8636-1319341d3018) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67430 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99671 "Found 1 new API test failure: TestIPC.ConnectionTest/ConnectionRunLoopTest.SendAndInvalidate/ServerIsA (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97941 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/117061 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97728 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40908 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18781 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44415 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43874 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47221 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45565 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->