### PR TITLE
PIDToInheritApplicationStateFrom should be set by information already present in the GPU process

### DIFF
--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -143,9 +143,6 @@ void UserMediaRequest::start()
         break;
     }
 
-    ASSERT(document.page());
-    if (RefPtr page = document.page())
-        page->mediaSessionManager().prepareToSendUserMediaPermissionRequestForPage(*page);
     controller->requestUserMediaAccess(*this);
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -721,24 +721,6 @@ void AudioContext::isActiveNowPlayingSessionChanged()
     }
 }
 
-std::optional<ProcessID> AudioContext::mediaSessionPresentingApplicationPID() const
-{
-    RefPtr document = this->document();
-    if (!document)
-        return std::nullopt;
-
-    RefPtr page = document->page();
-    if (!page)
-        return std::nullopt;
-
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (page->settings().mediaCapabilityGrantsEnabled())
-        return std::nullopt;
-#endif
-
-    return page->presentingApplicationPID();
-}
-
 #if !RELEASE_LOG_DISABLED
 const Logger& AudioContext::logger() const
 {

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -145,7 +145,6 @@ private:
     bool canProduceAudio() const final { return true; }
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final;
     void isActiveNowPlayingSessionChanged() final;
-    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final;
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const final;
     bool isSuspended() const final;
     bool isPlaying() const final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9961,20 +9961,6 @@ void HTMLMediaElement::isActiveNowPlayingSessionChanged()
         page->hasActiveNowPlayingSessionChanged();
 }
 
-std::optional<ProcessID> HTMLMediaElement::mediaSessionPresentingApplicationPID() const
-{
-    RefPtr page = protectedDocument()->page();
-    if (!page)
-        return std::nullopt;
-
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (page->settings().mediaCapabilityGrantsEnabled())
-        return std::nullopt;
-#endif
-
-    return page->presentingApplicationPID();
-}
-
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void HTMLMediaElement::updateSpatialTrackingLabel()
 {

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -260,7 +260,6 @@ public:
 
     WEBCORE_EXPORT bool isActiveNowPlayingSession() const;
     void isActiveNowPlayingSessionChanged() final;
-    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final;
 
 // DOM API
 // error state

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5872,14 +5872,6 @@ const std::optional<audit_token_t>& Page::presentingApplicationAuditToken() cons
 void Page::setPresentingApplicationAuditToken(std::optional<audit_token_t> presentingApplicationAuditToken)
 {
     m_presentingApplicationAuditToken = WTFMove(presentingApplicationAuditToken);
-
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (settings().mediaCapabilityGrantsEnabled())
-        return;
-#endif
-
-    if (RefPtr mediaSessionManager = mediaSessionManagerIfExists())
-        mediaSessionManager->updatePresentingApplicationPIDIfNecessary(presentingApplicationPID());
 }
 #endif
 

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -89,8 +89,6 @@ public:
     virtual bool haveEverRegisteredAsNowPlayingApplication() const { return false; }
     virtual void resetHaveEverRegisteredAsNowPlayingApplicationForTesting() { };
 
-    virtual void prepareToSendUserMediaPermissionRequestForPage(Page&) { }
-
     virtual bool willIgnoreSystemInterruptions() const = 0;
     virtual void setWillIgnoreSystemInterruptions(bool) = 0;
     virtual void beginInterruption(PlatformMediaSessionInterruptionType) = 0;
@@ -159,8 +157,6 @@ public:
     virtual void resetSessionState() { };
 
     virtual WeakPtr<PlatformMediaSessionInterface> bestEligibleSessionForRemoteControls(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&, PlatformMediaSessionPlaybackControlsPurpose) = 0;
-
-    virtual void updatePresentingApplicationPIDIfNecessary(ProcessID) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
@@ -45,7 +45,6 @@ public:
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSessionInterruptionType) const final { return false; }
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final { return std::nullopt; }
     void isActiveNowPlayingSessionChanged() final { }
-    std::optional<ProcessID> mediaSessionPresentingApplicationPID() const final { return std::nullopt; }
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const { return emptyLogger(); }

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -107,8 +107,6 @@ public:
 
     virtual void isActiveNowPlayingSessionChanged() = 0;
 
-    virtual std::optional<ProcessID> mediaSessionPresentingApplicationPID() const = 0;
-
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
     Ref<const Logger> protectedLogger() const { return logger(); }
@@ -231,8 +229,6 @@ public:
 
     virtual bool isActiveNowPlayingSession() const = 0;
     virtual void setActiveNowPlayingSession(bool) = 0;
-
-    virtual std::optional<ProcessID> presentingApplicationPID() const { return client().mediaSessionPresentingApplicationPID(); }
 
     virtual void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy) { }
 

--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
@@ -32,8 +32,13 @@
 #import "NotImplemented.h"
 #import <AVFoundation/AVAudioSession.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WorkQueue.h>
+
+#if PLATFORM(IOS_FAMILY)
+#import "MediaSessionHelperIOS.h"
+#endif
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
@@ -100,6 +105,10 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
     // means that AVAudioSession may synchronously unduck previously ducked clients. Activation needs to complete before this method
     // returns, so do it synchronously on the same serial queue.
     if (active) {
+#if PLATFORM(IOS_FAMILY)
+        ASSERT(!isInAuxiliaryProcess() || MediaSessionHelper::sharedHelper().presentedApplicationPID());
+#endif
+
         bool success = false;
         setEligibleForSmartRouting(true);
         m_workQueue->dispatchSync([&success] {

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -61,8 +61,6 @@ public:
     bool registeredAsNowPlayingApplication() const final { return m_registeredAsNowPlayingApplication; }
     bool haveEverRegisteredAsNowPlayingApplication() const final { return m_haveEverRegisteredAsNowPlayingApplication; }
 
-    void prepareToSendUserMediaPermissionRequestForPage(Page&) final;
-
     std::optional<NowPlayingInfo> nowPlayingInfo() const final { return m_nowPlayingInfo; }
     static WEBCORE_EXPORT void clearNowPlayingInfo();
     static WEBCORE_EXPORT void setNowPlayingInfo(bool setAsNowPlayingApplication, bool shouldUpdateNowPlayingSuppression, const NowPlayingInfo&);
@@ -86,8 +84,6 @@ protected:
     void sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&) final;
     void clientCharacteristicsChanged(PlatformMediaSessionInterface&, bool) final;
     void sessionCanProduceAudioChanged() final;
-
-    virtual void providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>&) { }
 
     WeakPtr<PlatformMediaSessionInterface> nowPlayingEligibleSession();
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -229,15 +229,6 @@ void MediaSessionManagerCocoa::beginInterruption(PlatformMediaSession::Interrupt
     PlatformMediaSessionManager::beginInterruption(type);
 }
 
-void MediaSessionManagerCocoa::prepareToSendUserMediaPermissionRequestForPage(Page& page)
-{
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (page.settings().mediaCapabilityGrantsEnabled())
-        return;
-#endif
-    providePresentingApplicationPIDIfNecessary(page.presentingApplicationPID());
-}
-
 String MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool preservesPitch, double rate)
 {
     if (!preservesPitch || !rate || rate == 1.)
@@ -520,10 +511,8 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
 #endif
         ALWAYS_LOG(LOGIDENTIFIER, "title = \"", title, "\", isPlaying = ", nowPlayingInfo->isPlaying, ", duration = ", nowPlayingInfo->duration, ", now = ", nowPlayingInfo->currentTime, ", id = ", (nowPlayingInfo->uniqueIdentifier ? nowPlayingInfo->uniqueIdentifier->toUInt64() : 0), ", registered = ", m_registeredAsNowPlayingApplication, ", src = \"", src, "\"");
     }
-    if (!m_registeredAsNowPlayingApplication) {
+    if (!m_registeredAsNowPlayingApplication)
         m_registeredAsNowPlayingApplication = true;
-        providePresentingApplicationPIDIfNecessary(session->presentingApplicationPID());
-    }
 
     updateActiveNowPlayingSession(session);
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #include <WebCore/MediaPlaybackTarget.h>
+#include <wtf/ProcessID.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -91,9 +92,8 @@ public:
     void startMonitoringWirelessRoutes();
     void stopMonitoringWirelessRoutes();
 
-    enum class ShouldOverride : bool { No, Yes };
-    void providePresentingApplicationPID(int pid) { providePresentingApplicationPID(pid, ShouldOverride::No); }
-    virtual void providePresentingApplicationPID(int, ShouldOverride) = 0;
+    virtual std::optional<ProcessID> presentedApplicationPID() const;
+    virtual void providePresentingApplicationPID(ProcessID);
 
     void setIsExternalOutputDeviceAvailable(bool);
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -65,8 +65,6 @@ private:
 #endif
 
     void configureWirelessTargetMonitoring() final;
-    void providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>&) final;
-    void updatePresentingApplicationPIDIfNecessary(ProcessID) final;
     bool sessionWillBeginPlayback(PlatformMediaSessionInterface&) final;
     void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) final;
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -117,28 +117,6 @@ void MediaSessionManageriOS::configureWirelessTargetMonitoring()
 #endif
 }
 
-void MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary(const std::optional<ProcessID>& pid)
-{
-#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
-    if (m_havePresentedApplicationPID || !pid)
-        return;
-    m_havePresentedApplicationPID = true;
-    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(*pid);
-#else
-    UNUSED_PARAM(pid);
-#endif
-}
-
-void MediaSessionManageriOS::updatePresentingApplicationPIDIfNecessary(ProcessID pid)
-{
-#if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
-    if (m_havePresentedApplicationPID)
-        MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid, MediaSessionHelper::ShouldOverride::Yes);
-#else
-    UNUSED_PARAM(pid);
-#endif
-}
-
 bool MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSessionInterface& session)
 {
     if (!MediaSessionManagerCocoa::sessionWillBeginPlayback(session))
@@ -151,8 +129,6 @@ bool MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSessionInterf
         session.setPlaybackTarget(*target);
     session.setShouldPlayToPlaybackTarget(playbackTargetSupportsAirPlayVideo);
 #endif
-
-    providePresentingApplicationPIDIfNecessary(session.presentingApplicationPID());
 
     return true;
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -260,10 +260,6 @@ public:
     void performWithMediaPlayerOnMainThread(WebCore::MediaPlayerIdentifier, Function<void(WebCore::MediaPlayer&)>&&);
 #endif
 
-#if PLATFORM(IOS_FAMILY)
-    void overridePresentingApplicationPIDIfNeeded();
-#endif
-
 #if ENABLE(EXTENSION_CAPABILITIES)
     String mediaEnvironment(WebCore::PageIdentifier);
     void setMediaEnvironment(WebCore::PageIdentifier, const String&);

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -79,18 +79,6 @@ void RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes()
     MediaSessionHelper::sharedHelper().stopMonitoringWirelessRoutes();
 }
 
-void RemoteMediaSessionHelperProxy::providePresentingApplicationPID(int pid, MediaSessionHelper::ShouldOverride shouldOverride)
-{
-    m_presentingApplicationPID = pid;
-    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid, shouldOverride);
-}
-
-void RemoteMediaSessionHelperProxy::overridePresentingApplicationPIDIfNeeded()
-{
-    if (m_presentingApplicationPID)
-        MediaSessionHelper::sharedHelper().providePresentingApplicationPID(*m_presentingApplicationPID, MediaSessionHelper::ShouldOverride::Yes);
-}
-
 void RemoteMediaSessionHelperProxy::uiApplicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)
 {
     if (auto connection = m_gpuConnection.get())

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -48,7 +48,6 @@ public:
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
 
-    void overridePresentingApplicationPIDIfNeeded();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     void ref() const final;
@@ -61,7 +60,6 @@ private:
     // Messages
     void startMonitoringWirelessRoutes();
     void stopMonitoringWirelessRoutes();
-    void providePresentingApplicationPID(int, WebCore::MediaSessionHelper::ShouldOverride);
 
     // MediaSessionHelperClient
     void uiApplicationWillEnterForeground(SuspendedUnderLock) final;
@@ -76,7 +74,6 @@ private:
 
     bool m_isMonitoringWirelessRoutes { false };
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;
-    std::optional<int> m_presentingApplicationPID;
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
@@ -31,7 +31,6 @@
 messages -> RemoteMediaSessionHelperProxy {
     StartMonitoringWirelessRoutes()
     StopMonitoringWirelessRoutes()
-    ProvidePresentingApplicationPID(int pid, WebCore::MediaSessionHelper::ShouldOverride shouldOverride)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -642,7 +642,7 @@ void UserMediaCaptureManagerProxy::startProducingData(RealtimeMediaSourceIdentif
         return;
     }
 #endif // ENABLE(EXTENSION_CAPABILITIES) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-    m_connectionProxy->startProducingData(source->deviceType());
+    m_connectionProxy->startProducingData(source->deviceType(), pageIdentifier);
     proxy->start();
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
@@ -77,7 +77,7 @@ public:
 #if ENABLE(EXTENSION_CAPABILITIES)
         virtual bool setCurrentMediaEnvironment(WebCore::PageIdentifier) { return false; };
 #endif
-        virtual void startProducingData(WebCore::CaptureDevice::DeviceType) { }
+        virtual void startProducingData(WebCore::CaptureDevice::DeviceType, WebCore::PageIdentifier) { }
         virtual RemoteVideoFrameObjectHeap* remoteVideoFrameObjectHeap() { return nullptr; }
 
         virtual void startMonitoringCaptureDeviceRotation(WebCore::PageIdentifier, const String&) { }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1120,7 +1120,6 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::MediaProducerMutedState': ['<WebCore/MediaProducer.h>'],
         'WebCore::MediaPromise::Result': ['<WebCore/MediaPromiseTypes.h>'],
         'WebCore::MediaSamplesBlock::MediaSampleItem': ['<WebCore/MediaSample.h>'],
-        'WebCore::MediaSessionHelper::ShouldOverride': ['<WebCore/MediaSessionHelperIOS.h>'],
         'WebCore::MediaSettingsRange': ['<WebCore/MediaSettingsRange.h>'],
         'WebCore::MediaSourcePrivateAddStatus': ['<WebCore/MediaSourcePrivate.h>'],
         'WebCore::MediaSourcePrivateEndOfStreamStatus': ['<WebCore/MediaSourcePrivate.h>'],

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -528,7 +528,3 @@ using WebCore::WritingTools::Session::ID = WTF::UUID
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 using WebCore::MediaControlsContextMenuItem::ID = uint64_t;
 #endif
-
-#if PLATFORM(IOS_FAMILY)
-[Nested] enum class WebCore::MediaSessionHelper::ShouldOverride : bool
-#endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -741,7 +741,7 @@ bool PageClientImpl::handleRunOpenPanel(const WebPageProxy& page, const WebFrame
 #if ENABLE(MEDIA_CAPTURE)
     if (parameters.mediaCaptureType() != WebCore::MediaCaptureType::MediaCaptureTypeNone) {
         if (auto pid = page.configuration().processPool().configuration().presentingApplicationPID())
-            WebCore::MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid, WebCore::MediaSessionHelper::ShouldOverride::Yes);
+            WebCore::MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid);
     }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
@@ -71,11 +71,6 @@ void RemoteMediaSessionHelper::stopMonitoringWirelessRoutesInternal()
     ensureConnection().send(Messages::RemoteMediaSessionHelperProxy::StopMonitoringWirelessRoutes(), { });
 }
 
-void RemoteMediaSessionHelper::providePresentingApplicationPID(int pid, ShouldOverride shouldOverride)
-{
-    ensureConnection().send(Messages::RemoteMediaSessionHelperProxy::ProvidePresentingApplicationPID(pid, shouldOverride), { });
-}
-
 void RemoteMediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo supportsAirPlayVideo, MediaPlaybackTargetContextSerialized&& targetContext)
 {
     WTF::switchOn(targetContext.platformContext(), [](WebCore::MediaPlaybackTargetContextMock&&) {

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -65,7 +65,6 @@ private:
     // MediaSessionHelper
     void startMonitoringWirelessRoutesInternal() final;
     void stopMonitoringWirelessRoutesInternal() final;
-    void providePresentingApplicationPID(int, ShouldOverride) final;
 
     // Messages
     void activeVideoRouteDidChange(SupportsAirPlayVideo, MediaPlaybackTargetContextSerialized&&);


### PR DESCRIPTION
#### 8b5a389b1c1c52b00da0cf8ea2f42f13e66f5274
<pre>
PIDToInheritApplicationStateFrom should be set by information already present in the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=297789">https://bugs.webkit.org/show_bug.cgi?id=297789</a>
<a href="https://rdar.apple.com/156277603">rdar://156277603</a>

Reviewed by Youenn Fablet and Jer Noble.

PIDToInheritApplicationStateFrom can be set by information already present in the GPU process
-- notably the UI process&apos; and per-page presenting application&apos;s PID. Removed code from the
WebContent process that would send a presenting application PID to the GPU process when an audio or
camera session will start and instead provided the presenting application PID to AVSystemController
at the time an AVAudioSession or AVCaptureSession starts in the GPU process.

For activating AVAudioSession on tvOS, the GPU process&apos; parent PID is used instead of the
presenting application PID to account for that platform&apos;s unique process model.

* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::start):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::mediaSessionPresentingApplicationPID const): Deleted.
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaSessionPresentingApplicationPID const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setPresentingApplicationAuditToken):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
(WebCore::MediaSessionManagerInterface::prepareToSendUserMediaPermissionRequestForPage): Deleted.
(WebCore::MediaSessionManagerInterface::updatePresentingApplicationPIDIfNecessary): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp:
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
(WebCore::PlatformMediaSessionInterface::presentingApplicationPID const): Deleted.
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::tryToSetActiveInternal):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
(WebCore::MediaSessionManagerCocoa::providePresentingApplicationPIDIfNecessary): Deleted.
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):
(WebCore::MediaSessionManagerCocoa::prepareToSendUserMediaPermissionRequestForPage): Deleted.
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelperIOS::presentedApplicationPID const):
(MediaSessionHelperIOS::providePresentingApplicationPID):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::sessionWillBeginPlayback):
(WebCore::MediaSessionManageriOS::providePresentingApplicationPIDIfNecessary): Deleted.
(WebCore::MediaSessionManageriOS::updatePresentingApplicationPIDIfNecessary): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::ensureMediaSessionHelper):
(WebKit::GPUConnectionToWebProcess::overridePresentingApplicationPIDIfNeeded): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::tryToSetActiveForProcess):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::startProducingData):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h:
(WebKit::UserMediaCaptureManagerProxy::ConnectionProxy::startProducingData):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::handleRunOpenPanel):
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp:
(WebKit::RemoteMediaSessionHelper::providePresentingApplicationPID): Deleted.
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h:

Canonical link: <a href="https://commits.webkit.org/299129@main">https://commits.webkit.org/299129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5c5889bf24bf971b1e82ebda9bd77467a501247

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69976 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3092c39-f117-487e-96e4-83d286828542) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89502 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59113 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3646d6ea-3c2c-4068-bf9b-5ed077e835bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69996 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bcfbd259-5697-47ab-8ae0-9837a3ff6481) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/117301 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23871 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127169 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98171 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97959 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21335 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41278 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50390 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44176 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47521 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45865 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->