### PR TITLE
[JSC] Fix exception scope handling in llint_check_stack_and_vm_traps

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -562,11 +562,12 @@ UGPRPair SYSV_ABI llint_check_stack_and_vm_traps(CallFrame* callFrame, const JSI
 
     if (vm.traps().handleTrapsIfNeeded()) {
         if (vm.hasPendingTerminationException()) {
+            throwScope.release();
             pc = returnToThrow(vm);
             LLINT_RETURN_TWO(pc, callFrame);
         }
-        ASSERT(!vm.exceptionForInspection());
     }
+    throwScope.assertNoException();
 
     // Redo stack check because we may really have gotten here due to an imminent StackOverflow.
     bool imminentOverflowDetected = false;


### PR DESCRIPTION
#### 0693d90fa79881a734fa412c7717f2575f398789
<pre>
[JSC] Fix exception scope handling in llint_check_stack_and_vm_traps
<a href="https://bugs.webkit.org/show_bug.cgi?id=297794">https://bugs.webkit.org/show_bug.cgi?id=297794</a>
<a href="https://rdar.apple.com/158958322">rdar://158958322</a>

Reviewed by Mark Lam.

The bug in timer-exception.js is an unchecked exception validation failure where
llint_check_stack_and_vm_traps calls handleTraps which can throw a termination
exception, but the exception is never checked before the ThrowScope destructor
runs, causing the assertion &quot;exception check validation failed&quot; when the watchdog
timer fires during JavaScript function prologue execution.

This patch fixes exception scope validation failures on throwScope in
llint_check_stack_and_vm_traps since handleTrapsIfNeeded can throw a
termination exception.

1. When a termination exception is pending after trap handling, we now
   properly release the throwScope before propagating the exception.

2. When no traps are handled, we assert that no exceptions should be
   present, updating m_needExceptionCheck to false.

The fix ensures proper exception scope lifecycle management while
maintaining the integrity of the exception handling system for both normal
execution and termination scenarios.

Canonical link: <a href="https://commits.webkit.org/299116@main">https://commits.webkit.org/299116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b5dc6d7b43c96eee26a98e2b420a0b1e7626ad3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28256 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/69978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/edc5e91e-4d69-462c-92ab-017da9ebde97) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46203 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/124090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/69978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca7d70b7-3a38-45ff-954b-6c5d5c1ad016) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120895 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/30512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98660d30-4244-4d4d-a10d-594684ee130a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/67753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110054 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/24054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127171 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116453 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/44846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45207 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/101984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/43354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18799 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/44718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50392 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/145151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/44178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/145151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/47523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/45867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->