### PR TITLE
Add id and lang attributes to WebVTT root node and add layout tests for lang selectors

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Reference for WebVTT rendering, ::cue([lang=]</title>
+<style>
+html { overflow:hidden }
+body { margin:0 }
+.video {
+    display: inline-block;
+    width: 320px;
+    height: 180px;
+    position: relative;
+    font-size: 9px;
+}
+.cue {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-family: sans-serif;
+    color: #00ff00;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
+}
+.cue > span > span {
+    color: #0000ff;
+}
+</style>
+<div class="video"><span class="cue"><span>Deutsch<span>English</span></span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>WebVTT rendering, ::cue([lang=])</title>
+<link rel="match" href="voice_color-ref.html">
+<style>
+html { overflow:hidden }
+body { margin:0 }
+::cue([lang="en"]) {
+    font-family: sans-serif;
+    color: #0000ff;
+}
+::cue([lang="de"]) {
+    font-family: sans-serif;
+    color: #00ff00;
+}
+</style>
+<script src="/common/reftest-wait.js"></script>
+<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+    <source src="/media/white.webm" type="video/webm">
+    <source src="/media/white.mp4" type="video/mp4">
+    <track src="../../../support/test_lang_object.vtt" srclang="de" default>
+    <script>
+    document.getElementsByTagName('track')[0].track.mode = 'showing';
+    </script>
+</video>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Reference for WebVTT rendering, ::cue(lang), color: #0000ff</title>
+<style>
+html { overflow:hidden }
+body { margin:0 }
+.video {
+    display: inline-block;
+    width: 320px;
+    height: 180px;
+    position: relative;
+    font-size: 9px;
+}
+.cue {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-family: sans-serif;
+    color: white;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
+}
+.cue > span > span {
+    color: #0000ff;
+}
+</style>
+<div class="video"><span class="cue"><span>Deutsch<span>English</span></span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>WebVTT rendering, ::cue(lang), color: #0000ff</title>
+<link rel="match" href="voice_color-ref.html">
+<style>
+html { overflow:hidden }
+body { margin:0 }
+::cue(lang) {
+    font-family: sans-serif;
+    color: #0000ff;
+}
+</style>
+<script src="/common/reftest-wait.js"></script>
+<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
+    <source src="/media/white.webm" type="video/webm">
+    <source src="/media/white.mp4" type="video/mp4">
+    <track src="../../../support/test_lang_object.vtt">
+    <script>
+    document.getElementsByTagName('track')[0].track.mode = 'showing';
+    </script>
+</video>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/test_lang_object.vtt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/test_lang_object.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000
+Deutsch<lang en>English</lang>

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -951,6 +951,13 @@ void VTTCue::obtainCSSBoxes()
 
     // Note: This is contained by default in m_cueHighlightBox.
     displayTree->setUserAgentPart(UserAgentParts::cue());
+
+    if (!id().isEmpty())
+        displayTree->setAttributeWithoutSynchronization(HTMLNames::idAttr, id());
+
+    if (!track()->language().isEmpty())
+        displayTree->setAttributeWithoutSynchronization(HTMLNames::langAttr, track()->language());
+
     m_cueHighlightBox->setUserAgentPart(UserAgentParts::internalCueBackground());
 
     m_cueBackdropBox->setUserAgentPart(UserAgentParts::webkitMediaTextTrackDisplayBackdrop());


### PR DESCRIPTION
#### 9a19a4c1d52631669a0e93575af4d967d97a1d0e
<pre>
Add id and lang attributes to WebVTT root node and add layout tests for lang selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=297796">https://bugs.webkit.org/show_bug.cgi?id=297796</a>
<a href="https://rdar.apple.com/158961777">rdar://158961777</a>

Reviewed by Jer Noble.

This patch adds a lang attribute to the webvtt root node matching the track&apos;s srclang attribute,
if it has one. This is a step towards implementing the behavior that a cue should be matched by
::cue([lang=xy]), where xy is the track srclang.

This patch also adds an id attribute to the webvtt root node if the node is given one in the .vtt.
This is a step towards implementing the ::cue(#id) selector.

Lastly this patch adds missing tests for ::cue([lang=xy]) and ::cue(lang). As of now,
lang_color.html (which tests ::cue(lang)) passes but lang_attribute.html (tests ::cue([lang=xy]))
does not, due to work that still needs to be done to make ::cue(selector) match the root webvtt node.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_attribute.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/lang_object/lang_color.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/test_lang_object.vtt: Added.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::obtainCSSBoxes):

Canonical link: <a href="https://commits.webkit.org/299115@main">https://commits.webkit.org/299115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01283ea9a674a71d54466cb1a1d0816639e92a12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69710 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/adacd0ff-8b2a-44ee-a7a9-ac9f3d2aeda6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89323 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/52503 "Found 1 new test failure: webgl/2.0.y/conformance2/query/occlusion-query.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21c4dc90-0fc3-47b2-a438-c4a9a2adb324) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69814 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bca8bc0e-8fe3-4c51-86c8-ece42843701e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67489 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126924 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97981 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97768 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40965 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50146 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43930 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47277 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->