### PR TITLE
[SPI Checking] UITextEffectView swift SPI is different on debug/release configurations

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -752,17 +752,6 @@ symbols = [
     "_$s5UIKit28UIDirectionalLightEffectViewC13ConfigurationV9fillColorSo7UIColorCvg",
     "_$s5UIKit28UIDirectionalLightEffectViewC13ConfigurationV9ponderingAEvgZ",
     "_$s5UIKit28UIDirectionalLightEffectViewC13ConfigurationVMa",
-
-    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C5chunk4view8delegate9fromColorAeA0bcF5ChunkC_AcE8Delegate_pSo7UIColorCtcfC",
-    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTq",
-    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTq",
-    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaF",
-    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTu",
-    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaF",
-    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTu",
-    "_$s5UIKit16UITextEffectViewC09PonderingC0C5chunk4view18lightConfigurationAeA0bC9TextChunkC_AcA018UIDirectionalLightcD0C0I0VtcfC",
-    "_$s5UIKit16UITextEffectViewC6sourceAcA0bcD6Source_p_tcfC",
-
     "_APSEnvironmentProduction",
     "_ASCAuthorizationErrorDomain",
     "_BKSDisplayBrightnessGetCurrent",
@@ -950,6 +939,35 @@ symbols = [
     "_kAXSEnhanceTextLegibilityChangedNotification",
     "_kGSEventHardwareKeyboardAvailabilityChangedNotification",
 ]
+
+# Some of the TextEffectView SPI symbols WebKit uses change between Debug and Release builds. This appears to be an
+# implementation detail of Swift's ABI in different optimization modes. Perhaps
+# audit-spi should have a higher level way to declare usage of Swift types that
+# allows use of both kinds of symbols. (rdar://158963645)
+[[legacy]]
+symbols = [
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTq",
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTq",
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaF",
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTu",
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaF",
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTu",
+]
+[[legacy]]
+symbols = [
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C5chunk4view8delegate9fromColorAeA0bcF5ChunkC_AcE8Delegate_pSo7UIColorCtcfC",
+    "_$s5UIKit16UITextEffectViewC09PonderingC0C5chunk4view18lightConfigurationAeA0bC9TextChunkC_AcA018UIDirectionalLightcD0C0I0VtcfC",
+    "_$s5UIKit16UITextEffectViewC6sourceAcA0bcD6Source_p_tcfC",
+]
+requires = ["!NDEBUG"]
+[[legacy]]
+symbols = [
+    "_$s5UIKit16UITextEffectViewC015ReplacementTextC0C5chunk4view8delegate9fromColorAeA0bcF5ChunkC_AcE8Delegate_pSo7UIColorCtcfc",
+    "_$s5UIKit16UITextEffectViewC09PonderingC0C5chunk4view18lightConfigurationAeA0bC9TextChunkC_AcA018UIDirectionalLightcD0C0I0Vtcfc",
+    "_$s5UIKit16UITextEffectViewC0C2IDVSQAAMc",
+    "_$s5UIKit16UITextEffectViewC6sourceAcA0bcD6Source_p_tcfc",
+]
+requires = ["NDEBUG"]
 
 [[legacy]]
 selectors = [


### PR DESCRIPTION
#### 677fa6dd436b7e0cfadf8ee3c52d64abb5c369cd
<pre>
[SPI Checking] UITextEffectView swift SPI is different on debug/release configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=297800">https://bugs.webkit.org/show_bug.cgi?id=297800</a>
<a href="https://rdar.apple.com/158963964">rdar://158963964</a>

Reviewed by Richard Robinson.

This appears to be some detail of the Swift ABI that binds to different
symbols (such as a class&apos;s __allocation_init vs __init) at different
optimization levels. Reflect this in WebKit&apos;s allowlist.

* Source/WebKit/Configurations/AllowedSPI-legacy.toml:

Canonical link: <a href="https://commits.webkit.org/299169@main">https://commits.webkit.org/299169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea529cfd1e31bb76a6a1deefa88775e2d7884b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69899 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/813069f8-c395-4a7b-b2a3-15d152cea7c3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89330 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59062 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1721bc73-113c-4130-9f9c-92fa9833d9f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105528 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69821 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/520373b3-4fe8-4832-869e-30ee1d8742c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29370 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67495 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126930 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97987 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97774 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43156 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40971 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50152 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->