### PR TITLE
[WebGPU] webgpu:api,validation,createView:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc-expected.txt
@@ -169,12 +169,7 @@ FAIL :subresources,texture_view_usages:bindingType="sampled-texture";viewUsage=8
     expectValidationError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1201:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
  Reached unreachable code
-FAIL :subresources,texture_view_usages:bindingType="sampled-texture";viewUsage=16 assert_unreached:
-  - VALIDATION FAILED: Validation succeeded unexpectedly.
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectValidationError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1201:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
- Reached unreachable code
+PASS :subresources,texture_view_usages:bindingType="sampled-texture";viewUsage=16
 PASS :subresources,texture_view_usages:bindingType="writeonly-storage-texture";viewUsage=0
 FAIL :subresources,texture_view_usages:bindingType="writeonly-storage-texture";viewUsage=1 assert_unreached:
   - VALIDATION FAILED: Validation succeeded unexpectedly.
@@ -195,12 +190,7 @@ FAIL :subresources,texture_view_usages:bindingType="writeonly-storage-texture";v
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
  Reached unreachable code
 PASS :subresources,texture_view_usages:bindingType="writeonly-storage-texture";viewUsage=8
-FAIL :subresources,texture_view_usages:bindingType="writeonly-storage-texture";viewUsage=16 assert_unreached:
-  - VALIDATION FAILED: Validation succeeded unexpectedly.
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectValidationError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1201:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
- Reached unreachable code
+PASS :subresources,texture_view_usages:bindingType="writeonly-storage-texture";viewUsage=16
 PASS :subresources,texture_view_usages:bindingType="readonly-storage-texture";viewUsage=0
 FAIL :subresources,texture_view_usages:bindingType="readonly-storage-texture";viewUsage=1 assert_unreached:
   - VALIDATION FAILED: Validation succeeded unexpectedly.
@@ -221,12 +211,7 @@ FAIL :subresources,texture_view_usages:bindingType="readonly-storage-texture";vi
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
  Reached unreachable code
 PASS :subresources,texture_view_usages:bindingType="readonly-storage-texture";viewUsage=8
-FAIL :subresources,texture_view_usages:bindingType="readonly-storage-texture";viewUsage=16 assert_unreached:
-  - VALIDATION FAILED: Validation succeeded unexpectedly.
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectValidationError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1201:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
- Reached unreachable code
+PASS :subresources,texture_view_usages:bindingType="readonly-storage-texture";viewUsage=16
 PASS :subresources,texture_view_usages:bindingType="readwrite-storage-texture";viewUsage=0
 FAIL :subresources,texture_view_usages:bindingType="readwrite-storage-texture";viewUsage=1 assert_unreached:
   - VALIDATION FAILED: Validation succeeded unexpectedly.
@@ -247,10 +232,5 @@ FAIL :subresources,texture_view_usages:bindingType="readwrite-storage-texture";v
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
  Reached unreachable code
 PASS :subresources,texture_view_usages:bindingType="readwrite-storage-texture";viewUsage=8
-FAIL :subresources,texture_view_usages:bindingType="readwrite-storage-texture";viewUsage=16 assert_unreached:
-  - VALIDATION FAILED: Validation succeeded unexpectedly.
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectValidationError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1201:36
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.js:668:32
- Reached unreachable code
+PASS :subresources,texture_view_usages:bindingType="readwrite-storage-texture";viewUsage=16
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1626,7 +1626,6 @@ http/tests/webgpu/webgpu/api/operation/command_buffer/copyTextureToTexture.html 
 http/tests/webgpu/webgpu/api/operation/command_buffer/image_copy.html [ Skip ]
 http/tests/webgpu/webgpu/api/operation/resource_init/texture_zero.html [ Skip ]
 http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.html [ Skip ]
-http/tests/webgpu/webgpu/api/validation/createView.html [ Skip ]
 http/tests/webgpu/webgpu/api/validation/render_pipeline/vertex_state.html [ Slow ]
 http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/draw.html [ Skip ]
 http/tests/webgpu/webgpu/api/validation/createTexture.html [ Skip ]

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
@@ -83,18 +83,9 @@ void GPUTexture::setLabel(String&& label)
 
 static WebGPU::TextureViewDescriptor convertToBacking(const std::optional<GPUTextureViewDescriptor>& textureViewDescriptor)
 {
-    if (!textureViewDescriptor) {
-        return {
-            { },
-            std::nullopt,
-            std::nullopt,
-            WebGPU::TextureAspect::All,
-            0,
-            std::nullopt,
-            0,
-            std::nullopt
-        };
-    }
+    if (!textureViewDescriptor)
+        return WebGPU::TextureViewDescriptor { };
+
     return textureViewDescriptor->convertToBacking();
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.h
@@ -29,6 +29,7 @@
 #include "GPUObjectDescriptorBase.h"
 #include "GPUTextureAspect.h"
 #include "GPUTextureFormat.h"
+#include "GPUTextureUsage.h"
 #include "GPUTextureViewDimension.h"
 #include "WebGPUTextureViewDescriptor.h"
 #include <optional>
@@ -42,6 +43,7 @@ struct GPUTextureViewDescriptor : public GPUObjectDescriptorBase {
             { label },
             format ? std::optional { WebCore::convertToBacking(*format) } : std::nullopt,
             dimension ? std::optional { WebCore::convertToBacking(*dimension) } : std::nullopt,
+            convertTextureUsageFlagsToBacking(usage),
             WebCore::convertToBacking(aspect),
             baseMipLevel,
             mipLevelCount,
@@ -52,6 +54,7 @@ struct GPUTextureViewDescriptor : public GPUObjectDescriptorBase {
 
     std::optional<GPUTextureFormat> format;
     std::optional<GPUTextureViewDimension> dimension;
+    GPUTextureUsageFlags usage { 0 };
     GPUTextureAspect aspect { GPUTextureAspect::All };
     GPUIntegerCoordinate baseMipLevel { 0 };
     std::optional<GPUIntegerCoordinate> mipLevelCount;

--- a/Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.idl
@@ -27,6 +27,7 @@
 
 // https://bugs.webkit.org/show_bug.cgi?id=232548 This shouldn't need to be here.
 typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
+typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 
 [
     EnabledBySetting=WebGPUEnabled,
@@ -36,6 +37,7 @@ typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
+    GPUTextureUsageFlags usage = 0;
     GPUTextureAspect aspect = "all";
     GPUIntegerCoordinate baseMipLevel = 0;
     GPUIntegerCoordinate mipLevelCount;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -65,6 +65,7 @@ RefPtr<TextureView> TextureImpl::createView(const std::optional<TextureViewDescr
         .baseArrayLayer = descriptor ? descriptor->baseArrayLayer : 0,
         .arrayLayerCount = descriptor && descriptor->arrayLayerCount ? *descriptor->arrayLayerCount : static_cast<uint32_t>(WGPU_ARRAY_LAYER_COUNT_UNDEFINED),
         .aspect = descriptor ? convertToBackingContext->convertToBacking(descriptor->aspect) : WGPUTextureAspect_All,
+        .usage = descriptor ? convertToBackingContext->convertTextureUsageFlagsToBacking(descriptor->usage) : 0,
     };
 
     return TextureViewImpl::create(adoptWebGPU(wgpuTextureCreateView(m_backing.get(), &backingDescriptor)), convertToBackingContext);

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureViewDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureViewDescriptor.h
@@ -29,6 +29,7 @@
 #include <WebCore/WebGPUObjectDescriptorBase.h>
 #include <WebCore/WebGPUTextureAspect.h>
 #include <WebCore/WebGPUTextureFormat.h>
+#include <WebCore/WebGPUTextureUsage.h>
 #include <WebCore/WebGPUTextureViewDimension.h>
 #include <optional>
 
@@ -37,6 +38,7 @@ namespace WebCore::WebGPU {
 struct TextureViewDescriptor : public ObjectDescriptorBase {
     std::optional<TextureFormat> format;
     std::optional<TextureViewDimension> dimension;
+    TextureUsageFlags usage;
     TextureAspect aspect { TextureAspect::All };
     IntegerCoordinate baseMipLevel { 0 };
     std::optional<IntegerCoordinate> mipLevelCount;

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
@@ -111,15 +111,16 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
     auto texture = Texture::create(backingTexture, textureDescriptor, { format }, device);
 
     WGPUTextureViewDescriptor textureViewDescriptor {
-        nullptr,
-        label.data(),
-        format,
-        WGPUTextureViewDimension_2D,
-        0,
-        1,
-        0,
-        1,
-        WGPUTextureAspect_All,
+        .nextInChain = nullptr,
+        .label = label.data(),
+        .format = format,
+        .dimension = WGPUTextureViewDimension_2D,
+        .baseMipLevel = 0,
+        .mipLevelCount = 1,
+        .baseArrayLayer = 0,
+        .arrayLayerCount = 1,
+        .aspect = WGPUTextureAspect_All,
+        .usage = 0
     };
 
     auto textureView = TextureView::create(backingTexture, textureViewDescriptor, { { width, height, 1 } }, texture, device);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3271,6 +3271,11 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
         return TextureView::createInvalid(*this, device.get());
     }
 
+    if (inputDescriptor.usage && (~usage() & inputDescriptor.usage)) {
+        device->generateAValidationError([NSString stringWithFormat:@"GPUTexture.createView: when the view's usage(%u) is specified it must be a subset of the Texture's usage(%u)", inputDescriptor.usage, usage()]);
+        return TextureView::createInvalid(*this, device.get());
+    }
+
     MTLTextureType textureType;
     switch (descriptor->dimension) {
     case WGPUTextureViewDimension_Undefined:

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1185,6 +1185,7 @@ typedef struct WGPUTextureViewDescriptor {
     uint32_t baseArrayLayer;
     uint32_t arrayLayerCount;
     WGPUTextureAspect aspect;
+    WGPUTextureUsageFlags usage;
 } WGPUTextureViewDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexAttribute {

--- a/Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.cpp
@@ -40,7 +40,7 @@ std::optional<TextureViewDescriptor> ConvertToBackingContext::convertToBacking(c
     if (!base)
         return std::nullopt;
 
-    return { { WTFMove(*base), textureViewDescriptor.format, textureViewDescriptor.dimension, textureViewDescriptor.aspect, textureViewDescriptor.baseMipLevel, textureViewDescriptor.mipLevelCount, textureViewDescriptor.baseArrayLayer, textureViewDescriptor.arrayLayerCount } };
+    return { { WTFMove(*base), textureViewDescriptor.format, textureViewDescriptor.dimension, textureViewDescriptor.usage, textureViewDescriptor.aspect, textureViewDescriptor.baseMipLevel, textureViewDescriptor.mipLevelCount, textureViewDescriptor.baseArrayLayer, textureViewDescriptor.arrayLayerCount } };
 }
 
 std::optional<WebCore::WebGPU::TextureViewDescriptor> ConvertFromBackingContext::convertFromBacking(const TextureViewDescriptor& textureViewDescriptor)
@@ -49,7 +49,7 @@ std::optional<WebCore::WebGPU::TextureViewDescriptor> ConvertFromBackingContext:
     if (!base)
         return std::nullopt;
 
-    return { { WTFMove(*base), textureViewDescriptor.format, textureViewDescriptor.dimension, textureViewDescriptor.aspect, textureViewDescriptor.baseMipLevel, textureViewDescriptor.mipLevelCount, textureViewDescriptor.baseArrayLayer, textureViewDescriptor.arrayLayerCount } };
+    return { { WTFMove(*base), textureViewDescriptor.format, textureViewDescriptor.dimension, textureViewDescriptor.usage, textureViewDescriptor.aspect, textureViewDescriptor.baseMipLevel, textureViewDescriptor.mipLevelCount, textureViewDescriptor.baseArrayLayer, textureViewDescriptor.arrayLayerCount } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.h
@@ -31,6 +31,7 @@
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <WebCore/WebGPUTextureAspect.h>
 #include <WebCore/WebGPUTextureFormat.h>
+#include <WebCore/WebGPUTextureUsage.h>
 #include <WebCore/WebGPUTextureViewDimension.h>
 #include <optional>
 
@@ -39,6 +40,7 @@ namespace WebKit::WebGPU {
 struct TextureViewDescriptor : public ObjectDescriptorBase {
     std::optional<WebCore::WebGPU::TextureFormat> format;
     std::optional<WebCore::WebGPU::TextureViewDimension> dimension;
+    WebCore::WebGPU::TextureUsageFlags usage;
     WebCore::WebGPU::TextureAspect aspect { WebCore::WebGPU::TextureAspect::All };
     WebCore::WebGPU::IntegerCoordinate baseMipLevel { 0 };
     std::optional<WebCore::WebGPU::IntegerCoordinate> mipLevelCount;

--- a/Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.serialization.in
@@ -24,6 +24,7 @@
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::TextureViewDescriptor : WebKit::WebGPU::ObjectDescriptorBase {
     std::optional<WebCore::WebGPU::TextureFormat> format;
     std::optional<WebCore::WebGPU::TextureViewDimension> dimension;
+    WebCore::WebGPU::TextureUsageFlags usage;
     WebCore::WebGPU::TextureAspect aspect;
     WebCore::WebGPU::IntegerCoordinate baseMipLevel;
     std::optional<WebCore::WebGPU::IntegerCoordinate> mipLevelCount;


### PR DESCRIPTION
#### a52f380e134ee19c76e3714651bfd3b85649c417
<pre>
[WebGPU] webgpu:api,validation,createView:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=297801">https://bugs.webkit.org/show_bug.cgi?id=297801</a>
<a href="https://rdar.apple.com/158964197">rdar://158964197</a>

Reviewed by Tadeu Zagallo.

GPUTextureViewDescriptor has a usage but we didn&apos;t support it.

Add the usage paramater along with validation such that all test
cases under createView pass.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/createView-expected.txt:
Add passing expectations.

* LayoutTests/platform/mac-wk2/TestExpectations:
Stop skipping test.

* Source/WebCore/Modules/WebGPU/GPUTexture.cpp:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.h:
(WebCore::GPUTextureViewDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::createView):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureViewDescriptor.h:
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm:
(WebGPU::PresentationContextCoreAnimation::Configuration::generateCurrentFrameState):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::createView):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.h:
* Source/WebKit/Shared/WebGPU/WebGPUTextureViewDescriptor.serialization.in:

Canonical link: <a href="https://commits.webkit.org/299171@main">https://commits.webkit.org/299171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/927991e191afed577a407f177b728e0112f89669

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70110 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1bc6be2-cb37-417f-85c2-153488054940) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89603 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59210 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/405f03c4-9414-4f71-b154-14575e9331a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67d39fd1-d646-41bc-9165-019a72aa5e28) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23991 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67891 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127304 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98277 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41421 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50522 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44308 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47653 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->