### PR TITLE
[WebCore] kMRMediaRemoteCommandInfoPreferredIntervalsKey macro gets the wrong symbol

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -131,7 +131,6 @@ symbols = [
     "_kCAFilterLuminosityBlendMode",
     "_kCAFilterSaturationBlendMode",
     "_kCVPixelBufferPreferRealTimeCacheModeIfEveryoneDoesKey",
-    "_kMRMediaRemoteCommandInfoPreferredIntervalsKey",
 ]
 
 [[legacy]]

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
@@ -123,7 +123,7 @@ void RemoteCommandListenerCocoa::updateSupportedCommands()
         MRMediaRemoteCommandInfoSetCommand(commandInfo.get(), command.value());
         MRMediaRemoteCommandInfoSetEnabled(commandInfo.get(), true);
         if (platformCommand == PlatformMediaSession::RemoteControlCommandType::SkipForwardCommand || platformCommand == PlatformMediaSession::RemoteControlCommandType::SkipBackwardCommand)
-            MRMediaRemoteCommandInfoSetOptions(commandInfo.get(), (__bridge CFDictionaryRef)(@{(__bridge NSString *)kMRMediaRemoteCommandInfoPreferredIntervalsKey : @[@(15.0)]}));
+            MRMediaRemoteCommandInfoSetOptions(commandInfo.get(), (__bridge CFDictionaryRef)(@{ (__bridge NSString *)kMRMediaRemoteOptionSkipInterval : @[@(15.0)] }));
         CFArrayAppendValue(commandInfoArray.get(), commandInfo.get());
     }
 

--- a/Source/WebCore/platform/mac/MediaRemoteSoftLink.h
+++ b/Source/WebCore/platform/mac/MediaRemoteSoftLink.h
@@ -86,8 +86,6 @@ SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, MediaRemote, kMRMediaRemoteNowPlayingInfo
 #define kMRMediaRemoteNowPlayingInfoUniqueIdentifier get_MediaRemote_kMRMediaRemoteNowPlayingInfoUniqueIdentifier()
 SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, MediaRemote, kMRMediaRemoteOptionSkipInterval, CFStringRef);
 #define kMRMediaRemoteOptionSkipInterval get_MediaRemote_kMRMediaRemoteOptionSkipInterval()
-SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, MediaRemote, kMRMediaRemoteCommandInfoPreferredIntervalsKey, CFStringRef);
-#define kMRMediaRemoteCommandInfoPreferredIntervalsKey get_MediaRemote_kMRMediaRemoteOptionSkipInterval()
 
 #if PLATFORM(IOS_FAMILY)
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, MediaRemote, MRMediaRemoteCopyPickableRoutes, CFArrayRef, (), ())

--- a/Source/WebCore/platform/mac/MediaRemoteSoftLink.mm
+++ b/Source/WebCore/platform/mac/MediaRemoteSoftLink.mm
@@ -58,7 +58,6 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, MediaRemote, kMRMediaRemoteNowPlayingInfo
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, MediaRemote, kMRMediaRemoteOptionPlaybackPosition, CFStringRef);
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, MediaRemote, kMRMediaRemoteNowPlayingInfoUniqueIdentifier, CFStringRef);
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, MediaRemote, kMRMediaRemoteOptionSkipInterval, CFStringRef);
-SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, MediaRemote, kMRMediaRemoteCommandInfoPreferredIntervalsKey, CFStringRef);
 
 #if PLATFORM(IOS_FAMILY)
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, MediaRemote, MRMediaRemoteCopyPickableRoutes, CFArrayRef, (), ());


### PR DESCRIPTION
#### 2d26a621c91c7305c8e005842a69a0ab1a0bb07c
<pre>
[WebCore] kMRMediaRemoteCommandInfoPreferredIntervalsKey macro gets the wrong symbol
<a href="https://bugs.webkit.org/show_bug.cgi?id=297802">https://bugs.webkit.org/show_bug.cgi?id=297802</a>

Reviewed by Eric Carlson.

The macro for accessing kMRMediaRemoteCommandInfoPreferredIntervalsKey
via soft-linking was defined as the wrong getter function. However the
behavior at its use site in RemoteCommandListenerCocoa appears to be
what we intend: We want to specify a default seek amount that gets
passed back to the page via MediaSessionActionDetails, but we do *not*
want to show a label in Now Playing indicating the seek amount, because
the page can override the requested amount.

So, fix the typo but keep using the same key. Now, the code never uses
kMRMediaRemoteCommandInfoPreferredIntervalsKey, so remove its soft-link
entirely.

* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm:
(WebCore::RemoteCommandListenerCocoa::updateSupportedCommands):
* Source/WebCore/platform/mac/MediaRemoteSoftLink.h:
* Source/WebCore/platform/mac/MediaRemoteSoftLink.mm:

Canonical link: <a href="https://commits.webkit.org/299232@main">https://commits.webkit.org/299232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a24aecd67d2620d0aa8b794f4f0ad37cc7ba371

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c6c44a6-1bae-40cb-a73c-e24f846cf47a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89787 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5bd26f3-ed62-400a-8d3a-eaeb2599d48b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70276 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bebf993-adb4-459c-bf93-478697b1bf1a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68139 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127548 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98462 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24975 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21635 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41695 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45089 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50765 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46239 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->