### PR TITLE
[PerformanceTests] Add a video-element-creation-with-controls performance test

### DIFF
--- a/PerformanceTests/Media/VideoElementWithControlsCreation.html
+++ b/PerformanceTests/Media/VideoElementWithControlsCreation.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<script>
+    window.addEventListener('load', event => {
+        const numberOfIterations = 20;
+        const numberOfItems = 100;
+
+        PerfTestRunner.prepareToMeasureValuesAsync({
+            customIterationCount: numberOfIterations,
+            unit: 'ms',
+            done: function () {
+                PerfTestRunner.gc();
+            }
+        });
+
+        function startIteration()
+        {
+            testGenerator = runIteration();
+            testGenerator.next();
+        }
+
+        function *runIteration()
+        {
+            let target = document.createElement('div');
+            document.body.appendChild(target);
+
+            var startTime = PerfTestRunner.now();
+
+            for (let i = 0; i < numberOfItems; ++i) {
+                let video = document.createElement('video');
+                video.controls = true;
+                target.appendChild(video);
+            }
+
+
+            if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime)) {
+                document.body.removeChild(target);
+                return;
+            }
+
+            document.body.removeChild(target);
+            PerfTestRunner.gc();
+            setTimeout(startIteration, 0);
+        }
+
+        startIteration();
+    })
+</script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
#### 3aa27dbca3d7004128a05516d687189a8b553a56
<pre>
[PerformanceTests] Add a video-element-creation-with-controls performance test
<a href="https://rdar.apple.com/158964685">rdar://158964685</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297804">https://bugs.webkit.org/show_bug.cgi?id=297804</a>

Reviewed by Eric Carlson.

* PerformanceTests/Media/VideoElementWithControlsCreation.html: Added.

Canonical link: <a href="https://commits.webkit.org/299216@main">https://commits.webkit.org/299216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad63de91eced1894042a40720acf3e718ebe0d2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69722 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d90af037-60cd-4e6a-8b29-989aafd01478) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89336 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/53215 "Too many flaky failures: css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dfg-inline-constructor-that-uses-arguments.html, js/dom/custom-getter-setter-exception-check.html, js/dom/random-array-gc-stress.html, js/instance-property-setter-other-instance.html, js/stack-overflow-regexp.html, storage/indexeddb/delete-in-upgradeneeded-close-in-open-success-private.html, storage/indexeddb/key-sort-order-date-private.html, storage/indexeddb/modern/request-dispatch-untrusted-event.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-3d-r16f-red-float.html, webgl/2.0.0/conformance2/textures/image/tex-2d-rgba32f-rgba-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgb565-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/misc/copy-texture-image-luma-format.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-3d-r8-red-unsigned_byte.html, webgl/2.0.y/conformance/extensions/ext-float-blend.html, webgl/2.0.y/conformance/glsl/bugs/temp-expressions-should-not-crash.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd7d768f-7137-4e85-acec-dc11a27c6b5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69829 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93865b44-b903-4cd9-be99-ecfcbcb8fc0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29380 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67501 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126936 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97991 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97778 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40977 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18844 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44484 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43942 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47289 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45633 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->