### PR TITLE
Schedule task on buffered PerformanceObserver

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/buffered-does-not-sync-invoke-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/buffered-does-not-sync-invoke-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Buffered PerformanceObservers should not invoke callbacks synchronously.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/buffered-does-not-sync-invoke.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/buffered-does-not-sync-invoke.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+async_test(function(test) {
+    let first_callback_called = false
+    let callback_can_run_now = false
+
+    new Promise( (resolve) => {
+        new PerformanceObserver( (entries, observer) => {
+            first_callback_called = true
+            observer.disconnect()
+            resolve()
+        }).observe({ type: "mark", buffered: true })
+    })
+    .then( () => {
+        new PerformanceObserver ( (entries) => {
+            assert_true(callback_can_run_now, "Callback shouldn't be invoked inside the .observe() call")
+            test.done()
+        }).observe({ type: "mark", buffered: true })
+        callback_can_run_now = true
+    })
+    assert_false(first_callback_called)
+    performance.mark('mark')
+}, "Buffered PerformanceObservers should not invoke callbacks synchronously.");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/performance-api/performance-observer-no-duplicate-navigation-expected.txt
+++ b/LayoutTests/performance-api/performance-observer-no-duplicate-navigation-expected.txt
@@ -1,0 +1,10 @@
+PerformanceNavigationTiming entries should only be queued once per observer.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS navigation_callback_already_invoked is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/performance-api/performance-observer-no-duplicate-navigation.html
+++ b/LayoutTests/performance-api/performance-observer-no-duplicate-navigation.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+
+window.jsTestIsAsync = true;
+description("PerformanceNavigationTiming entries should only be queued once per observer.");
+let navigation_callback_already_invoked = false
+window.q = []
+
+new Promise( (resolve) => {
+    new PerformanceObserver(function (entryList) {
+        entryList.getEntries().forEach(function(entry) {
+            shouldBeFalse("navigation_callback_already_invoked")
+            navigation_callback_already_invoked = true
+            resolve()
+        })
+    }).observe({ type: "navigation", buffered: true })
+})
+.then( () => new Promise( (resolve) => {
+    // Produce another entry, completely unrelated to navigation:
+    new PerformanceObserver( (entryList, observer) => {
+        resolve()
+    }).observe({ type: "mark" })
+    performance.mark("New mark")
+}))
+.then( () => {
+    // Spin the event loop to make sure pending spurious callbacks can run
+    // before the test is over:
+    setTimeout(() => finishJSTest(), 5)
+})
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -450,7 +450,7 @@ void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadM
 
     if (RefPtr document = this->document()) {
         if (RefPtr window = document->window())
-            window->protectedPerformance()->navigationFinished(metrics);
+            window->protectedPerformance()->documentLoadFinished(metrics);
     }
 
     ASSERT_UNUSED(resource, m_mainResource == &resource);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2962,9 +2962,6 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
             }
         }
 
-        if (RefPtr window = m_frame->document() ? m_frame->document()->window() : nullptr)
-            window->protectedPerformance()->scheduleNavigationObservationTaskIfNeeded();
-
         auto& error = documentLoader->mainDocumentError();
 
         auto loadingEvent = AXLoadingEvent::Failed;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2353,8 +2353,7 @@ void LocalDOMWindow::dispatchLoadEvent()
     if (shouldMarkLoadEventTimes) {
         auto now = MonotonicTime::now();
         protectedLoader->timing().setLoadEventEnd(now);
-        if (RefPtr navigationTiming = performance().navigationTiming())
-            navigationTiming->documentLoadTiming().setLoadEventEnd(now);
+        performance().navigationFinished(now);
         WTFEmitSignpost(document.get(), NavigationAndPaintTiming, "loadEventEnd");
         WTFEndSignpost(document.get(), NavigationAndPaintTiming);
     }

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -42,6 +42,7 @@
 #include <memory>
 #include <wtf/ContinuousTime.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/MonotonicTime.h>
 
 namespace JSC {
 class JSGlobalObject;
@@ -108,7 +109,8 @@ public:
     void clearMeasures(const String& measureName);
 
     void addNavigationTiming(DocumentLoader&, Document&, CachedResource&, const DocumentLoadTiming&, const NetworkLoadMetrics&);
-    void navigationFinished(const NetworkLoadMetrics&);
+    void documentLoadFinished(const NetworkLoadMetrics&);
+    void navigationFinished(MonotonicTime loadEventEnd);
     void addResourceTiming(ResourceTiming&&);
 
     void reportFirstContentfulPaint();
@@ -130,7 +132,7 @@ public:
     using RefCounted::ref;
     using RefCounted::deref;
 
-    void scheduleNavigationObservationTaskIfNeeded();
+    void scheduleTaskIfNeeded();
 
     PerformanceNavigationTiming* navigationTiming() { return m_navigationTiming.get(); }
 
@@ -148,7 +150,6 @@ private:
     void resourceTimingBufferFullTimerFired();
 
     void queueEntry(PerformanceEntry&);
-    void scheduleTaskIfNeeded();
 
     const std::unique_ptr<EventCounts> m_eventCounts;
     mutable RefPtr<PerformanceNavigation> m_navigation;
@@ -170,7 +171,7 @@ private:
     // https://w3c.github.io/resource-timing/#dfn-resource-timing-buffer-full-flag
     bool m_resourceTimingBufferFullFlag { false };
     bool m_waitingForBackupBufferToBeProcessed { false };
-    bool m_hasScheduledTimingBufferDeliveryTask { false };
+    bool m_hasScheduledDeliveryTask { false };
 
     MonotonicTime m_timeOrigin;
     ContinuousTime m_continuousTimeOrigin;

--- a/Source/WebCore/page/PerformanceNavigationTiming.cpp
+++ b/Source/WebCore/page/PerformanceNavigationTiming.cpp
@@ -140,7 +140,7 @@ double PerformanceNavigationTiming::duration() const
     return loadEventEnd() - startTime();
 }
 
-void PerformanceNavigationTiming::navigationFinished(const NetworkLoadMetrics& metrics)
+void PerformanceNavigationTiming::documentLoadFinished(const NetworkLoadMetrics& metrics)
 {
     m_documentLoadTiming.markEndTime();
     m_resourceTiming.networkLoadMetrics().updateFromFinalMetrics(metrics);

--- a/Source/WebCore/page/PerformanceNavigationTiming.h
+++ b/Source/WebCore/page/PerformanceNavigationTiming.h
@@ -70,7 +70,7 @@ public:
 
     DocumentEventTiming& documentEventTiming() { return m_documentEventTiming; }
     DocumentLoadTiming& documentLoadTiming() { return m_documentLoadTiming; }
-    void navigationFinished(const NetworkLoadMetrics&);
+    void documentLoadFinished(const NetworkLoadMetrics&);
 
 private:
     PerformanceNavigationTiming(MonotonicTime timeOrigin, CachedResource&, const DocumentLoadTiming&, const NetworkLoadMetrics&, const DocumentEventTiming&, const SecurityOrigin&, WebCore::NavigationType);

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -110,8 +110,9 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
         protectedPerformance()->registerPerformanceObserver(*this);
         m_registered = true;
     }
-    if (isBuffered)
-        deliver();
+
+    if (isBuffered && m_entriesToDeliver.size())
+        protectedPerformance()->scheduleTaskIfNeeded();
 
     return { };
 }


### PR DESCRIPTION
#### fbf81e4f230b7c80faa2fe9d8103418154bac661
<pre>
Schedule task on buffered PerformanceObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=297765">https://bugs.webkit.org/show_bug.cgi?id=297765</a>
<a href="https://rdar.apple.com/158950657">rdar://158950657</a>

Reviewed by Chris Dumez and Ryan Reno.

PerformanceObserver::observe() with `buffered: true` now schedules a task to
run all callbacks instead of invoking the relevant callbacks directly. The
new behavior is more conformant; see
<a href="https://www.w3.org/TR/performance-timeline/#observe-method">https://www.w3.org/TR/performance-timeline/#observe-method</a>, step 7.5.3.

This change exposed some inconsistencies in the logic that sends navigation
entries to PerformanceObservers, so a minor rework was required. In the new
implementation, the navigation entry is only exposed to PerformanceObservers
after the load event is handled. This is done in
LocalDOMWindow::dispatchLoadEvent(). The previous implementation did this
in FrameLoader::checkLoadCompleteForThisFrame(), with less consistent behavior.
Notably, web-platform-tests/navigation-timing/po-navigation.html seems to
fail randomly if opened outside of testing.

The spec is unclear with regards to when a navigation performance entry
should be considered available. In this implementation, there is some span
of time before the onload event in which the navigation entry is available
through performance.getEntries() while not being observable through
PerformanceObservers. This inconsistency is reasonable: the navigation entry
contains timing information about the onload event itself, so can only be
considered complete after that. Considering PerformanceObservers were
introduced to reduce unnecessary processing, it makes sense for them to
only receive completed entries.

New tests added:
* LayoutTests/imported/w3c/web-platform-tests/performance-timeline/buffered-does-not-sync-invoke.html :
    verifies that calling observe() does not invoke the callbacks synchronously. This is a direct test
    of the bug that motivated the patch.
* LayoutTests/performance-api/performance-observer-no-duplicate-navigation.html : exercises a latent
    bug (now removed) in which navigation entries were queued twice

Canonical link: <a href="https://commits.webkit.org/299508@main">https://commits.webkit.org/299508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8346ac6842f68ee3fbdf9636f4190c7c75db8f21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90193 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59706 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24661 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68690 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98628 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25146 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22078 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42306 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45619 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51297 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->