### PR TITLE
[macOS] Several API tests interacting with the PDF HUD are failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -341,10 +341,14 @@ UNIFIED_PDF_TEST(PrintSize)
     TestWebKitAPI::Util::run(&receivedSize);
 }
 
-// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
-UNIFIED_PDF_TEST(DISABLED_SetPageZoomFactorDoesNotBailIncorrectly)
+#endif // PLATFORM(MAC)
+
+#if ENABLE(PDF_HUD)
+
+UNIFIED_PDF_TEST(SetPageZoomFactorDoesNotBailIncorrectly)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF(true).get()]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
     [webView loadData:testPDFData().get() MIMEType:@"application/pdf" characterEncodingName:@"" baseURL:[NSURL URLWithString:@"https://www.apple.com/testPath"]];
     [webView _test_waitForDidFinishNavigation];
 
@@ -373,10 +377,10 @@ static void checkFrame(NSRect frame, CGFloat x, CGFloat y, CGFloat width, CGFloa
     EXPECT_EQ(frame.size.height, height);
 }
 
-// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
-UNIFIED_PDF_TEST(DISABLED_PDFHUDMainResourcePDF)
+UNIFIED_PDF_TEST(PDFHUDMainResourcePDF)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF(true).get()]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
     [webView loadData:testPDFData().get() MIMEType:@"application/pdf" characterEncodingName:@"" baseURL:[NSURL URLWithString:@"https://www.apple.com/testPath"]];
     EXPECT_EQ([webView _pdfHUDs].count, 0u);
     [webView _test_waitForDidFinishNavigation];
@@ -402,8 +406,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDMainResourcePDF)
         TestWebKitAPI::Util::spinRunLoop();
 }
 
-// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
-UNIFIED_PDF_TEST(DISABLED_PDFHUDMoveIFrame)
+UNIFIED_PDF_TEST(PDFHUDMoveIFrame)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -426,6 +429,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDMoveIFrame)
     RetainPtr configuration = configurationForWebViewTestingUnifiedPDF(true);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///main.html"]]];
     EXPECT_EQ([webView _pdfHUDs].count, 0u);
     [webView _test_waitForDidFinishNavigation];
@@ -462,8 +466,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDMoveIFrame)
     checkFrame([webView _pdfHUDs].anyObject.frame, 14, 40, 560, 210);
 }
 
-// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
-UNIFIED_PDF_TEST(DISABLED_PDFHUDNestedIFrames)
+UNIFIED_PDF_TEST(PDFHUDNestedIFrames)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -491,6 +494,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDNestedIFrames)
     RetainPtr configuration = configurationForWebViewTestingUnifiedPDF(true);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///main.html"]]];
     EXPECT_EQ([webView _pdfHUDs].count, 0u);
     [webView _test_waitForDidFinishNavigation];
@@ -502,8 +506,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDNestedIFrames)
         TestWebKitAPI::Util::spinRunLoop();
 }
 
-// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
-UNIFIED_PDF_TEST(DISABLED_PDFHUDIFrame3DTransform)
+UNIFIED_PDF_TEST(PDFHUDIFrame3DTransform)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -526,6 +529,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDIFrame3DTransform)
     RetainPtr configuration = configurationForWebViewTestingUnifiedPDF(true);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///main.html"]]];
     EXPECT_EQ([webView _pdfHUDs].count, 0u);
     [webView _test_waitForDidFinishNavigation];
@@ -533,8 +537,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDIFrame3DTransform)
     checkFrame([webView _pdfHUDs].anyObject.frame, 403, 10, 500, 500);
 }
 
-// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
-UNIFIED_PDF_TEST(DISABLED_PDFHUDMultipleIFrames)
+UNIFIED_PDF_TEST(PDFHUDMultipleIFrames)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -558,6 +561,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDMultipleIFrames)
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///main.html"]]];
+    [webView _setWindowOcclusionDetectionEnabled:NO];
     EXPECT_EQ([webView _pdfHUDs].count, 0u);
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ([webView _pdfHUDs].count, 2u);
@@ -576,12 +580,12 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDMultipleIFrames)
     EXPECT_TRUE(hadRightFrame);
 }
 
-// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
-UNIFIED_PDF_TEST(DISABLED_PDFHUDLoadPDFTypeWithPluginsBlocked)
+UNIFIED_PDF_TEST(PDFHUDLoadPDFTypeWithPluginsBlocked)
 {
     RetainPtr configuration = configurationForWebViewTestingUnifiedPDF(true);
     [configuration _setOverrideContentSecurityPolicy:@"object-src 'none'"];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
     [webView loadData:testPDFData().get() MIMEType:@"application/pdf" characterEncodingName:@"" baseURL:[NSURL URLWithString:@"https://www.apple.com/testPath"]];
     EXPECT_EQ([webView _pdfHUDs].count, 0u);
     [webView _test_waitForDidFinishNavigation];
@@ -589,7 +593,7 @@ UNIFIED_PDF_TEST(DISABLED_PDFHUDLoadPDFTypeWithPluginsBlocked)
     checkFrame([webView _pdfHUDs].anyObject.frame, 0, 0, 800, 600);
 }
 
-#endif // PLATFORM(MAC)
+#endif // ENABLE(PDF_HUD)
 
 UNIFIED_PDF_TEST(SnapshotsPaintPageContent)
 {


### PR DESCRIPTION
#### 4d1de07e2a0b99fc6b8324fdadd0a957bee7ab78
<pre>
[macOS] Several API tests interacting with the PDF HUD are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=296970">https://bugs.webkit.org/show_bug.cgi?id=296970</a>
<a href="https://rdar.apple.com/157605203">rdar://157605203</a>

Reviewed by Wenson Hsieh.

The PDF HUD was not being displayed because we were failing occlusion
checks, expectedly so given TestWebKitAPI. To workaround this, we follow
suit from PlatformWKWebView and  -_setWindowOcclusionDetectionEnabled:NO
on the relevant web views.

As a drive-by, I also wrapped all the HUD tests behind an ENABLE_PDF_HUD
conditional, assuming we will get this test coverage for free if we ever
bring ENABLE_PDF_HUD to other platforms.

Canonical link: <a href="https://commits.webkit.org/299080@main">https://commits.webkit.org/299080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1d3efa9e75d262bdfdf8cd53893084350ed6dd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69744 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a580150d-8ad1-499e-8d11-1ab8e5cf1005) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89351 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/55037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89ac20e6-b47b-43b7-9ac5-83a15550ecd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69845 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fba60bee-f2e8-41a1-b5d0-2274f225c24b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67523 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126957 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98007 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97794 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43174 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40998 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18793 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44505 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43963 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->