### PR TITLE
[WIP] GRA: IntervalSet testing

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -41,6 +41,7 @@
 #include "AirTmpMap.h"
 #include "AirTmpWidthInlines.h"
 #include "AirUseCounts.h"
+#include <wtf/IntervalSet.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/ListDump.h>
 #include <wtf/PriorityQueue.h>
@@ -378,11 +379,19 @@ private:
 
 class RegisterRange {
 public:
+    static constexpr unsigned cacheLinesPerNode = 3;
+    using AllocatedIntervalSet = IntervalSet<Point, Tmp, cacheLinesPerNode>;
+
     RegisterRange() = default;
 
     struct AllocatedInterval {
-        Tmp tmp;
         Interval interval;
+        Tmp tmp;
+
+        AllocatedInterval(const std::pair<Interval, Tmp>& pair)
+            : interval(pair.first)
+            , tmp(pair.second)
+        { }
 
         bool operator<(const AllocatedInterval& other) const
         {
@@ -395,39 +404,40 @@ public:
         }
     };
 
-    using AllocatedIntervalSet = StdSet<AllocatedInterval>;
-
     void add(Tmp tmp, LiveRange& range)
     {
         ASSERT(!hasConflict(range, Width64)); // Can't add overlapping LiveRanges
         for (auto& interval : range.intervals()) {
             ASSERT(interval != Interval()); // Strict ordering requires no empty intervals.
-            m_allocations.insert({ tmp, interval });
+            m_allocations.insert(interval, tmp);
         }
     }
 
     void addClobberHigh64(Reg reg, Point point)
     {
         ASSERT(reg.isFPR());
-        m_allocationsHigh64.insert({ Tmp(reg), Interval(point) });
+        m_allocationsHigh64.insert(Interval(point), Tmp(reg));
     }
 
-    void evict(Tmp tmp, LiveRange& range)
+    void evict(LiveRange& range)
     {
-        for (auto& interval : range.intervals()) {
-            auto r = m_allocations.erase({ tmp, interval });
-            ASSERT_UNUSED(r, r == 1);
-        }
+        for (auto& interval : range.intervals())
+            m_allocations.erase(interval);
     }
 
     bool hasConflict(LiveRange& range, Width width)
     {
-        bool hasConflict = false;
-        forEachConflict(range, width, [&](auto&) -> IterationStatus {
-            hasConflict = true;
-            return IterationStatus::Done;
-        });
-        return hasConflict;
+        for (auto interval : range.intervals()) {
+            if (m_allocations.hasOverlap(interval))
+                return true;
+        }
+        if (width <= Width64)
+            return false;
+        for (auto interval : range.intervals()) {
+            if (m_allocationsHigh64.hasOverlap(interval))
+                return true;
+        }
+        return false;
     }
 
     // func is called with each (Tmp, Interval) pair (i.e. AllocatedInterval) of this
@@ -447,7 +457,7 @@ public:
 
     bool isEmpty() const
     {
-        return m_allocations.empty() && m_allocationsHigh64.empty();
+        return m_allocations.isEmpty() && m_allocationsHigh64.isEmpty();
     }
 
     void dump(PrintStream& out) const
@@ -455,15 +465,15 @@ public:
         auto dumpSet = [&out](const AllocatedIntervalSet& allocationSet) {
             CommaPrinter comma;
             out.print("[");
-            for (auto& alloc : allocationSet) {
+            for (auto alloc : allocationSet) {
                 out.print(comma);
-                out.print(alloc);
+                out.print(AllocatedInterval(alloc));
             }
             out.print("]");
         };
 
         dumpSet(m_allocations);
-        if (!m_allocationsHigh64.empty()) {
+        if (!m_allocationsHigh64.isEmpty()) {
             out.print(", ↑");
             dumpSet(m_allocationsHigh64);
         }
@@ -473,47 +483,21 @@ private:
     template<typename Func>
     static IterationStatus forEachConflictImpl(AllocatedIntervalSet& allocatedSet, const LiveRange& range, const Func& func)
     {
-        auto rangeIter = range.intervals().begin();
-        auto rangeEnd = range.intervals().end();
-
-        if (rangeIter == rangeEnd)
-            return IterationStatus::Continue;
-        Point nextSearch = rangeIter->begin();
-
-        while (true) {
-            AllocatedInterval conflict;
-            {
-                auto conflictIter = findFirstIntervalEndingAfter(allocatedSet, nextSearch);
-                if (conflictIter == allocatedSet.end())
-                    return IterationStatus::Continue; // End of 'm_allocations', so no more potential conflicts
-                if (rangeIter->end() <= conflictIter->interval.begin()) {
-                    // No more conflicts with this 'range' interval. Move on to the next interval in 'range'.
-                    if (++rangeIter == rangeEnd)
-                        return IterationStatus::Continue; // End of 'range', so no more potential conflicts
-                    // Start searching for conflicts of the next 'range' interval.
-                    nextSearch = rangeIter->begin();
-                    continue;
-                }
-                // Found a conflict. There may be additional conflicts of this 'range' interval, so advance
-                // the search position beyond this conflict but don't advance the 'range' interval.
-                conflict = *conflictIter;
-                nextSearch = conflictIter->interval.end();
+        for (auto interval : range.intervals()) {
+            while (true) {
+                auto intervalAndTmp = allocatedSet.find(interval);
+                if (!intervalAndTmp)
+                    break;
+                AllocatedInterval conflict = { *intervalAndTmp };
+                if (func(conflict) == IterationStatus::Done)
+                    return IterationStatus::Done;
+                if (interval.end() <= conflict.interval.end())
+                    break; // There can't exist other conflicts with interval
+                // Search for remaining conflicts with 'interval'
+                interval = { conflict.interval.end(), interval.end() };
             }
-            // 'func' can invalidate iterators of 'm_allocations'.
-            if (func(conflict) == IterationStatus::Done)
-                return IterationStatus::Done;
         }
-    }
-
-    static AllocatedIntervalSet::iterator findFirstIntervalEndingAfter(AllocatedIntervalSet& allocatedSet, Point point)
-    {
-        Interval query(point);
-        // pos can be 0, yet we can't express a non-empty interval with end==0, so instead of looking
-        // for the first interval ending after pos we find the first interval ending at or after pos+1.
-        ASSERT(query.end() == point + 1);
-        auto iter = allocatedSet.lower_bound({ Tmp(), query });
-        ASSERT(iter == allocatedSet.end() || iter->interval.end() > point);
-        return iter;
+        return IterationStatus::Continue;
     }
 
     AllocatedIntervalSet m_allocations;
@@ -1616,7 +1600,7 @@ private:
         ASSERT(tmpData.stage == Stage::Assigned);
         ASSERT(tmpData.spillCost() != unspillableCost);
         ASSERT(tmpData.assigned == reg);
-        m_regRanges[reg].evict(tmp, tmpData.liveRange);
+        m_regRanges[reg].evict(tmpData.liveRange);
         tmpData.stage = Stage::New;
         tmpData.assigned = Reg();
         dataLogLnIf(verbose(), "Evicted ", tmp, " from ", reg);

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		A3E4DD931F3A803400DED0B4 /* TextStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3E4DD911F3A803400DED0B4 /* TextStream.cpp */; };
 		A3EE5C3A21FFAC5F00FABD61 /* OSAllocatorPOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3EE5C3921FFAC5E00FABD61 /* OSAllocatorPOSIX.cpp */; };
 		A3EE5C3D21FFAC7D00FABD61 /* SchedulePairCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3EE5C3B21FFAC7C00FABD61 /* SchedulePairCF.cpp */; };
+		A4F0F47D2E3056A3001BF35C /* IntervalSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A4F0F47C2E3056A3001BF35C /* IntervalSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5BA15F3182433A900A82E69 /* StringCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F2182433A900A82E69 /* StringCocoa.mm */; };
 		A5BA15F51824348000A82E69 /* StringImplCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F41824348000A82E69 /* StringImplCocoa.mm */; };
 		A5BA15FA182435A600A82E69 /* AtomStringImplCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F7182435A600A82E69 /* AtomStringImplCF.cpp */; };
@@ -1483,6 +1484,7 @@
 		A3E4DD921F3A803400DED0B4 /* TextStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextStream.h; sourceTree = "<group>"; };
 		A3EE5C3921FFAC5E00FABD61 /* OSAllocatorPOSIX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OSAllocatorPOSIX.cpp; sourceTree = "<group>"; };
 		A3EE5C3B21FFAC7C00FABD61 /* SchedulePairCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SchedulePairCF.cpp; sourceTree = "<group>"; };
+		A4F0F47C2E3056A3001BF35C /* IntervalSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntervalSet.h; sourceTree = "<group>"; };
 		A5BA15F2182433A900A82E69 /* StringCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StringCocoa.mm; sourceTree = "<group>"; };
 		A5BA15F41824348000A82E69 /* StringImplCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StringImplCocoa.mm; sourceTree = "<group>"; };
 		A5BA15F7182435A600A82E69 /* AtomStringImplCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AtomStringImplCF.cpp; sourceTree = "<group>"; };
@@ -2425,6 +2427,7 @@
 				E33667492722550900259122 /* Int128.cpp */,
 				F6D67D3226F90142006E0349 /* Int128.h */,
 				33FD4811265CB38000ABE4F4 /* InterferenceGraph.h */,
+				A4F0F47C2E3056A3001BF35C /* IntervalSet.h */,
 				0F7EB85B1FA8FF4100F1ABCB /* IsoMalloc.h */,
 				0F7EB85C1FA8FF4200F1ABCB /* IsoMallocInlines.h */,
 				5295B00427920C54006D746A /* IterationStatus.h */,
@@ -3557,6 +3560,7 @@
 				DD3DC86227A4BF8E007E5B61 /* Int128.h in Headers */,
 				DDF307E627C086DF006A526F /* IntegerToStringConversion.h in Headers */,
 				DD3DC86E27A4BF8E007E5B61 /* InterferenceGraph.h in Headers */,
+				A4F0F47D2E3056A3001BF35C /* IntervalSet.h in Headers */,
 				1C08E3682985D8F300CAE594 /* IOReturnSPI.h in Headers */,
 				1C97FF7A297CD119006422AA /* IOSurfaceSPI.h in Headers */,
 				1C08E3692985D8F800CAE594 /* IOTypesSPI.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -137,6 +137,7 @@ set(WTF_PUBLIC_HEADERS
     InstanceCounted.h
     Int128.h
     InterferenceGraph.h
+    IntervalSet.h
     IsoMalloc.h
     IsoMallocInlines.h
     IterationStatus.h

--- a/Source/WTF/wtf/IntervalSet.h
+++ b/Source/WTF/wtf/IntervalSet.h
@@ -1,0 +1,926 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CommaPrinter.h>
+#include <wtf/DataLog.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/MathExtras.h>
+#include <wtf/Range.h>
+#include <wtf/Vector.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace WTF {
+
+// IntervalSet: A specialized B+ tree for storing non-overlapping intervals with efficient overlap queries.
+// Uses WTF::Range<T> for interval representation and supports gap-based load balancing.
+
+template<typename T, typename Value, size_t cacheLinesPerNode = 1>
+    requires std::is_trivially_destructible_v<T> && std::is_trivially_destructible_v<Value>
+class IntervalSet {
+public:
+    using Interval = Range<T>;
+
+    static constexpr size_t cpuCacheLineSize = 64;
+    static constexpr size_t targetNodeSize = cacheLinesPerNode * cpuCacheLineSize;
+
+    // Calculate optimal order for each node type based on target cache line usage
+    static constexpr size_t calculateLeafOrder()
+    {
+        constexpr size_t sizePerOrder = sizeof(Interval) + sizeof(Value);
+        return targetNodeSize / sizePerOrder;
+    }
+
+    static constexpr size_t calculateInnerOrder()
+    {
+        constexpr size_t sizePerOrder = sizeof(Interval) + sizeof(uintptr_t);
+        return targetNodeSize / sizePerOrder;
+    }
+
+    static constexpr size_t leafOrder = calculateLeafOrder();
+    static constexpr size_t innerOrder = calculateInnerOrder();
+
+    // Ensure cacheLinesPerNode parameter is large enough for valid B+ tree orders
+    static_assert(leafOrder >= 2, "cacheLinesPerNode parameter too small: LeafNode order must be at least 2 for a valid B+ tree");
+    static_assert(innerOrder >= 2, "cacheLinesPerNode parameter too small: InnerNode order must be at least 2 for a valid B+ tree");
+
+    IntervalSet() = default;
+
+    ~IntervalSet()
+    {
+        freeAllNodes();
+        ASSERT(!assertOnlyNumNodes);
+    }
+
+    bool isEmpty() const { return !m_rootInterval; }
+
+    // Insert an interval-value pair. interval must not overlap with an existing interval.
+    // Invalidates all iterators.
+    void insert(const Interval& interval, const Value& value)
+    {
+        if (!m_root) [[unlikely]] {
+            LeafNode* leaf = allocNode<LeafNode>();
+            m_root = NodeRef(leaf, 0);
+            m_height = 0;
+        }
+
+        Path path;
+        NodeRef* nodeRef = &m_root;
+
+        // Descend down the tree, recording the path taken.
+        for (unsigned depth = 0; depth < m_height; depth++) {
+            InnerNode* inner = nodeRef->asInner();
+            size_t index = inner->subtreeForInsert(nodeRef->size(), interval.end());
+            path.append({ nodeRef, index });
+            nodeRef = &inner->child(index);
+        }
+        // Found the correct leaf for the insert, now determine the index within that leaf.
+        size_t insertionIndex = nodeRef->asLeaf()->firstIntervalEndAfter(nodeRef->size(), interval.end());
+        path.append({ nodeRef, insertionIndex });
+        ASSERT(path.size() == m_height + 1);
+
+        auto [newNode, newNodeCoverage] = insertInNodeSplitIfNeeded<LeafNode>(path, m_height, interval, value);
+
+        // Ascend back up along the same path, inserting any new children and splitting inner nodes as needed.
+        for (int depth = m_height - 1; depth >= 0; depth--) {
+            if (!newNode) [[likely]]
+                return;
+            PathEntry& entry = path[depth];
+
+            ASSERT(entry.nodeRef->asInner()->child(entry.index).size() + newNode.size() == (static_cast<unsigned>(depth + 1) == m_height ? leafOrder : innerOrder) + 1);
+            ASSERT(newNodeCoverage);
+            entry.index++; // Insert new parent immediately after the existing parent
+            std::tie(newNode, newNodeCoverage) = insertInNodeSplitIfNeeded<InnerNode>(path, depth, newNodeCoverage, newNode);
+        }
+
+        // If there's a new node at depth 0 then a new level is required.
+        if (newNode) [[unlikely]] {
+            ASSERT(m_root.size() + newNode.size() == (m_height ? innerOrder : leafOrder) + 1);
+            // Need to add another level to the tree.
+            InnerNode* newRoot = allocNode<InnerNode>();
+            newRoot->interval(0) = m_rootInterval;
+            newRoot->child(0) = m_root;
+            newRoot->interval(1) = newNodeCoverage;
+            newRoot->child(1) = newNode;
+            m_height++;
+            m_root = NodeRef(newRoot, 2);
+            m_rootInterval = newRoot->coverage(2);
+        }
+    }
+
+    // Remove the given interval from the IntervalSet. The interval must be present.
+    // Invalidates all iterators.
+    void erase(const Interval& interval)
+    {
+        Path path;
+        ASSERT(interval.overlaps(m_rootInterval));
+        ASSERT(m_root);
+        NodeRef* nodeRef = &m_root;
+
+        for (unsigned depth = 0; depth < m_height; ++depth) {
+            InnerNode* inner = nodeRef->asInner();
+            size_t index = inner->firstIntervalEndAfter(nodeRef->size(), interval.begin());
+            ASSERT(index < nodeRef->size());
+            ASSERT(inner->interval(index).begin() < interval.end());
+            path.append({ nodeRef, index });
+            nodeRef = &inner->child(index);
+        }
+        LeafNode* leaf = nodeRef->asLeaf();
+        size_t eraseIndex = leaf->firstIntervalEndAfter(nodeRef->size(), interval.begin());
+        ASSERT(leaf->interval(eraseIndex).begin() == interval.begin() && leaf->interval(eraseIndex).end() == interval.end());
+        path.append({ nodeRef, eraseIndex });
+
+        bool removedNode = eraseFromNode<LeafNode>(path, m_height);
+
+        // Ascend removing references to any child that was removed, which may in turn cause the parent to become empty.
+        for (int depth = m_height - 1; depth >= 0; depth--) {
+            if (!removedNode) [[likely]]
+                return;
+            removedNode = eraseFromNode<InnerNode>(path, depth);
+        }
+
+        // If removedNode was true at every depth, the tree is now empty.
+        if (removedNode) [[unlikely]] {
+            ASSERT(!assertOnlyNumNodes);
+            ASSERT(!m_root);
+            m_rootInterval = Interval();
+            m_height = 0;
+        }
+    }
+
+    // Returns the Interval and Value for the first interval, if any, that overlaps with the query interval
+    std::optional<std::pair<Interval, Value>> find(const Interval& query) const
+    {
+        if (!query.overlaps(m_rootInterval))
+            return std::nullopt;
+
+        ASSERT(m_root);
+        NodeRef nodeRef = m_root;
+        for (unsigned depth = 0; depth < m_height; ++depth) {
+            InnerNode* inner = nodeRef.asInner();
+            size_t index = inner->firstIntervalEndAfter(nodeRef.size(), query.begin());
+            if (index == nodeRef.size())
+                return std::nullopt; // query is entirely after this subtree
+            if (query.end() <= inner->interval(index).begin())
+                return std::nullopt; // query is entirely before this subtree
+            nodeRef = inner->child(index);
+        }
+        LeafNode* leaf = nodeRef.asLeaf();
+        size_t index = leaf->firstIntervalEndAfter(nodeRef.size(), query.begin());
+        ASSERT(index < nodeRef.size()); // coverage check at parent level ensures this
+        ASSERT(query.begin() < leaf->interval(index).end());
+        if (query.end() <= leaf->interval(index).begin())
+            return std::nullopt;
+        return std::make_pair(leaf->interval(index), leaf->value(index));
+    }
+
+    // Returns true iff any interval overlaps with the query interval. Similar to find() but can sometimes
+    // terminate before descending the full depth since the value is not needed.
+    bool hasOverlap(const Interval& query) const
+    {
+        if (!query.overlaps(m_rootInterval))
+            return false;
+
+        ASSERT(m_root);
+        NodeRef nodeRef = m_root;
+        for (unsigned depth = 0; depth < m_height; ++depth) {
+            InnerNode* inner = nodeRef.asInner();
+            size_t index = inner->firstIntervalEndAfter(nodeRef.size(), query.begin());
+            if (index == nodeRef.size())
+                return false; // query starts after all intervals
+            // query start lands either within the subtree or the gap immediately preceding that subtree
+            ASSERT(query.begin() < inner->interval(index).end());
+            if (query.end() <= inner->interval(index).begin())
+                return false; // query is entirely in the gap before this subtree
+            if (inner->interval(index).end() <= query.end())
+                return true; // query spans subtree end point so it must overlap the last interval
+            if (query.begin() <= inner->interval(index).begin())
+                return true; // query spans subtree start point so it must overlap the first interval
+            // Otherwise, subtree encompasses query so need to search subtree
+            ASSERT(inner->interval(index).begin() < query.begin() && query.end() < inner->interval(index).end());
+            nodeRef = inner->child(index);
+        }
+
+        LeafNode* leaf = nodeRef.asLeaf();
+        size_t index = leaf->firstIntervalEndAfter(nodeRef.size(), query.begin());
+        ASSERT(query.begin() < leaf->interval(index).end());
+        return leaf->interval(index).begin() < query.end();
+    }
+
+    // Pretty print the tree structure for debugging
+    void dump(PrintStream& out) const
+    {
+        out.print("IntervalSet(height=", m_height, ", leafOrder=", leafOrder, ", innerOrder=", innerOrder, ")");
+        if (!m_root) {
+            out.print(" <empty>");
+            return;
+        }
+        out.println(" coverage=", m_rootInterval);
+        dumpSubtree(out, m_root, m_height, 0);
+    }
+
+    // Height indicates the number of edges to reach the leaf level in a non-empty tree.
+    unsigned height() const { return m_height; }
+
+private:
+    struct LeafNode;
+    struct InnerNode;
+
+    // Common base class for all nodes - provides type identity for NodeRef
+    struct Node { };
+
+    template<typename Payload, size_t order>
+    struct NodeImpl : public Node {
+        using PayloadType = Payload;
+        static constexpr size_t capacity = order;
+
+        Interval& interval(size_t index)
+        {
+            ASSERT(index < capacity);
+            return intervals[index];
+        }
+
+        const Interval coverage(size_t size) const
+        {
+            RELEASE_ASSERT(size);
+            return { intervals[0].begin(), intervals[size - 1].end() };
+        }
+
+        // Transfer count intervals and values from the rightNode to this node, where the rightNode
+        // is the immediate right cousin of this.
+        void shiftLeftFrom(size_t& size, NodeImpl* rightNode, size_t& rightSize, size_t count)
+        {
+            ASSERT(size + count <= capacity);
+            ASSERT(count <= rightSize);
+            for (size_t i = 0; i < count; i++) {
+                intervals[i + size] = rightNode->intervals[i];
+                payloads[i + size] = rightNode->payloads[i];
+            }
+            for (size_t i = 0; i < rightSize - count; i++) {
+                rightNode->intervals[i] = rightNode->intervals[i + count];
+                rightNode->payloads[i] = rightNode->payloads[i + count];
+            }
+            size += count;
+            rightSize -= count;
+        }
+
+        // Transfer count intervals and values from this node to the rightNode, where the rightNode
+        // is the immediate right cousin of this.
+        void shiftRightTo(size_t& size, NodeImpl* rightNode, size_t& rightSize, size_t count)
+        {
+            ASSERT(rightSize + count <= capacity);
+            ASSERT(count <= size);
+            for (size_t i = rightSize + count - 1; i >= count; i--) {
+                rightNode->intervals[i] = rightNode->intervals[i - count];
+                rightNode->payloads[i] = rightNode->payloads[i - count];
+            }
+            for (size_t i = 0; i < count; i++) {
+                rightNode->intervals[i] = intervals[size - count + i];
+                rightNode->payloads[i] = payloads[size - count + i];
+            }
+            size -= count;
+            rightSize += count;
+        }
+
+        void insertAt(size_t& size, size_t index, const Interval& interval, const Payload& value)
+        {
+            ASSERT(size < capacity);
+            ASSERT(index <= size);
+            for (size_t i = size; i > index; --i) {
+                intervals[i] = intervals[i - 1];
+                payloads[i] = payloads[i - 1];
+            }
+            intervals[index] = interval;
+            payloads[index] = value;
+            size++;
+        }
+
+        void removeAt(size_t& size, size_t index)
+        {
+            ASSERT(size <= capacity);
+            ASSERT(index < size);
+            for (size_t i = index; i < size - 1; ++i) {
+                intervals[i] = intervals[i + 1];
+                payloads[i] = payloads[i + 1];
+            }
+            size--;
+        }
+
+        // Find the least interval with end greater than the given point, and return the index, if exists.
+        // Otherwise, returns size if no such interval exists.
+        size_t firstIntervalEndAfter(size_t size, T point) const
+        {
+            ASSERT(size <= capacity);
+            for (size_t i = 0; i < size; i++) {
+                if (point < intervals[i].end())
+                    return i;
+            }
+            return size;
+        }
+
+        // Intervals and payloads are stored separately for better cache access patterns in the case
+        // that cacheLinesPerNode > 1.
+        std::array<Interval, order> intervals;
+        std::array<Payload, order> payloads; // Either the NodeRefs to children (InnerNode) or the values (LeafNode)
+    };
+
+    // NodeRef is used to hold links from parent to children. The size of the child is packed into
+    // the lower bits. So, the NodeRef contains both the pointer to the child node (which may be either
+    // another InnerNode or a LeafNode) and the number of elements stored in that pointed to node.
+    // This is more space and cache efficient than storing the size in each node because it uses less
+    // storage and the size of a child node can be determined without accessing the child node's cacheline.
+    class NodeRef {
+    public:
+        static_assert(isPowerOfTwo(cpuCacheLineSize));
+
+        static constexpr uintptr_t sizeMask = cpuCacheLineSize - 1;
+        static_assert(leafOrder <= sizeMask && innerOrder <= sizeMask);
+
+        NodeRef()
+            : m_bits(0) { }
+
+        NodeRef(Node* ptr, size_t size)
+            : m_bits(reinterpret_cast<uintptr_t>(ptr) | size)
+        {
+            ASSERT(!(reinterpret_cast<uintptr_t>(ptr) & sizeMask));
+            ASSERT(size <= sizeMask);
+        }
+
+        Node* node() const
+        {
+            return reinterpret_cast<Node*>(m_bits & ~sizeMask);
+        }
+
+        size_t size() const
+        {
+            return m_bits & sizeMask;
+        }
+
+        void setSize(size_t newSize)
+        {
+            ASSERT(newSize <= sizeMask);
+            m_bits = (m_bits & ~sizeMask) | newSize;
+        }
+
+        explicit operator bool() const { return m_bits; }
+
+        template<typename NodeType> requires std::is_base_of_v<Node, NodeType>
+        NodeType* as() const
+        {
+            return static_cast<NodeType*>(node());
+        }
+
+        LeafNode* asLeaf() const
+        {
+            return as<LeafNode>();
+        }
+
+        InnerNode* asInner() const
+        {
+            return as<InnerNode>();
+        }
+
+    private:
+        uintptr_t m_bits;
+    };
+
+    struct LeafNode : public NodeImpl<Value, leafOrder> {
+        Value& value(size_t index)
+        {
+            ASSERT(index < leafOrder);
+            return this->payloads[index];
+        }
+    };
+
+    struct InnerNode : public NodeImpl<NodeRef, innerOrder> {
+        NodeRef& child(size_t index)
+        {
+            ASSERT(index < innerOrder);
+            return this->payloads[index];
+        }
+
+        size_t subtreeForInsert(size_t size, T endPoint) const
+        {
+            ASSERT(size);
+            ASSERT(size <= innerOrder);
+            for (size_t i = 0; i < size - 1; i++) {
+                if (endPoint <= this->intervals[i + 1].begin())
+                    return i;
+            }
+            return size - 1;
+        }
+    };
+
+private:
+    struct PathEntry {
+        NodeRef* nodeRef; // Indirection allows insert/erase to perform tree modifications
+        size_t index;
+
+        bool operator==(const PathEntry& other) const
+        {
+            return nodeRef->node() == other.nodeRef->node() && index == other.index;
+        }
+    };
+
+    // Path specifies which NodeRef and index were traversed at each depth to reach a particular payload within the tree.
+    class Path : public Vector<PathEntry, 8> {
+        using Base = Vector<PathEntry, 8>;
+
+    public:
+        Path() = default;
+
+        Path(const Path& from, unsigned depth)
+            : Base(from)
+        {
+            ASSERT(this->size() > depth);
+            this->shrink(depth + 1);
+        }
+
+        // Advances to the next index of the leaf node, if exists. If the current leaf node is exhausted,
+        // advance to the next leaf node and set index to 0.
+        void nextIndexInLeaf()
+        {
+            ASSERT(this->size());
+            PathEntry& leafEntry = this->last();
+            if (++leafEntry.index < leafEntry.nodeRef->size()) [[likely]]
+                return;
+            // Move on to the next leaf node, if exists.
+            toRightCousin();
+            ASSERT(!this->size() || !this->last().index);
+        }
+
+        // Cousin means node at the same depth (includes siblings, aka 0th cousin). The immediate
+        // left and right cousins may be in different subtrees, i.e. not necessarily siblings.
+        void toLeftCousin() { toCousin<TraverseLeft>(); }
+        void toRightCousin() { toCousin<TraverseRight>(); }
+
+    private:
+        struct TraverseLeft {
+            static bool hasMoreChildren(const PathEntry& entry)
+            {
+                // If index != 0, then we can traverse left at this level.
+                return !!entry.index;
+            }
+
+            static size_t nextSubtreeIndex(const PathEntry& entry)
+            {
+                ASSERT(entry.index);
+                // Left sibling is in the previous subtree.
+                return entry.index - 1;
+            }
+
+            static size_t descendIndex(const NodeRef nodeRef)
+            {
+                ASSERT(nodeRef.size());
+                // Descend down the right subtrees.
+                return nodeRef.size() - 1;
+            }
+        };
+
+        struct TraverseRight {
+            static bool hasMoreChildren(const PathEntry& entry)
+            {
+                // If index != size() - 1, then we can traverse right at this level.
+                return entry.index < entry.nodeRef->size() - 1;
+            }
+
+            static size_t nextSubtreeIndex(const PathEntry& entry)
+            {
+                ASSERT(entry.index < entry.nodeRef->size() - 1);
+                return entry.index + 1;
+            }
+
+            static size_t descendIndex(const NodeRef nodeRef)
+            {
+                ASSERT_UNUSED(nodeRef, nodeRef.size());
+                // Descend down the left subtrees.
+                return 0;
+            }
+        };
+
+        // Modifies the path so that it specifies the path to the immediate left or right cousin.
+        template<typename Traverser>
+        void toCousin()
+        {
+            int initialDepth = this->size() - 1;
+            if (!initialDepth) {
+                this->clear(); // Root has no cousins
+                return;
+            }
+            // Ascend up until we find a node with indicies to the left.
+            int depth = initialDepth - 1;
+            for (; depth >= 0; depth--) {
+                PathEntry& innerEntry = this->at(depth);
+                if (Traverser::hasMoreChildren(innerEntry))
+                    break;
+            }
+            if (depth < 0) {
+                // Exhausted all indicies of the root node.
+                this->clear();
+                return;
+            }
+            // Descend down the right-most edge of the left subtree.
+            PathEntry& innerEntry = this->at(depth);
+            innerEntry.index = Traverser::nextSubtreeIndex(innerEntry);
+            depth++;
+            NodeRef* childRef = &innerEntry.nodeRef->asInner()->child(innerEntry.index);
+            for (; depth < initialDepth; depth++) {
+                ASSERT(childRef->size());
+                size_t childIndex = Traverser::descendIndex(*childRef);
+                this->at(depth).nodeRef = childRef;
+                this->at(depth).index = childIndex;
+                childRef = &childRef->asInner()->child(childIndex);
+            }
+            ASSERT(childRef->size());
+            this->at(depth).nodeRef = childRef;
+            this->at(depth).index = Traverser::descendIndex(*childRef);
+        }
+    };
+
+public:
+    class iterator {
+    public:
+        iterator() = default;
+
+        iterator(Path&& path)
+            : m_path(WTFMove(path)) { }
+
+        const Interval& interval() const
+        {
+            auto [leaf, index] = leafAndIndex();
+            return leaf->interval(index);
+        }
+
+        const Value& value() const
+        {
+            auto [leaf, index] = leafAndIndex();
+            return leaf->value(index);
+        }
+
+        const std::pair<Interval, Value> operator*() const
+        {
+            return { interval(), value() };
+        }
+
+        iterator& operator++()
+        {
+            m_path.nextIndexInLeaf();
+            return *this;
+        }
+
+        bool operator==(const iterator& other) const
+        {
+            return m_path == other.m_path;
+        }
+
+        bool operator!=(const iterator& other) const
+        {
+            return !(*this == other);
+        }
+
+    private:
+        const std::pair<LeafNode*, unsigned> leafAndIndex() const
+        {
+            const PathEntry& entry = m_path.last();
+            return { entry.nodeRef->asLeaf(), entry.index };
+        }
+
+        Path m_path;
+    };
+
+    // returns an iterator with the path to the left-most leaf node and index 0
+    iterator begin() const
+    {
+        if (!m_root)
+            return end();
+        Path path;
+        NodeRef* nodeRef = const_cast<NodeRef*>(&m_root);
+        // Generate path to the left-most leaf node.
+        for (unsigned depth = 0; depth < m_height; depth++) {
+            ASSERT(nodeRef->size());
+            path.append({ nodeRef, 0 });
+            nodeRef = &nodeRef->asInner()->child(0);
+        }
+        // Leaf node
+        ASSERT(nodeRef->size());
+        path.append({ nodeRef, 0 });
+        ASSERT(path.size() == m_height + 1);
+        return iterator(WTFMove(path));
+    }
+
+    iterator end() const
+    {
+        return iterator();
+    }
+
+private:
+    bool isFirstOrLastIndex(NodeRef nodeRef, size_t index)
+    {
+        ASSERT(index < nodeRef.size());
+        return !index || index == nodeRef.size() - 1;
+    }
+
+    // After an interval within a node, give by path and depth, is modified, propagate the new interval
+    // information upwards, as necessary, in order to keep inner nodes' "coverage" intervals consistent.
+    void updateCoverage(const Path& path, int depth, Interval coverage)
+    {
+        ASSERT(depth >= 0);
+        depth--; // So that depth is at the parent of the node with 'coverage'.
+        while (depth >= 0) {
+            const PathEntry& entry = path[depth];
+            InnerNode* inner = entry.nodeRef->asInner();
+            inner->interval(entry.index) = coverage;
+
+            if (!isFirstOrLastIndex(*entry.nodeRef, entry.index)) {
+                // Since first/last of this node was not modified, its coverage hasn't changed - no need to continue upward.
+                verifyCoverageConsistency(path, depth, inner->coverage(entry.nodeRef->size()));
+                return;
+            }
+            coverage = inner->coverage(entry.nodeRef->size());
+            depth--;
+        }
+        m_rootInterval = coverage;
+    }
+
+    void verifyCoverageConsistency(const Path& path, int depth, Interval coverage)
+    {
+#ifdef ASSERT_ENABLED
+        ASSERT(depth >= 0);
+        depth--;
+        while (depth >= 0) {
+            const PathEntry& entry = path[depth];
+            InnerNode* inner = entry.nodeRef->asInner();
+            ASSERT(inner->interval(entry.index) == coverage);
+            coverage = inner->coverage(entry.nodeRef->size());
+            depth--;
+        }
+        if (m_rootInterval != coverage)
+            dataLogLn("FAIL: m_rootInterval=", m_rootInterval, " coverage=", coverage, " Tree=", *this);
+        ASSERT(m_rootInterval == coverage);
+#endif
+    }
+
+    // Inserts interval and value into the node referred to by path at the given depth. Updates affected NodePtr
+    // sizes and coverages for the affected subtree. If the node needed to be split then returns the NodePtr and
+    // coverage interval for the new node so that the caller can insert the new node into the parent.
+    template<typename NodeType>
+    std::pair<NodeRef, Interval> insertInNodeSplitIfNeeded(const Path& path, int depth, const Interval& interval, const typename NodeType::PayloadType& value)
+    {
+        NodeRef* nodeRef = path[depth].nodeRef;
+        size_t nodeSize = nodeRef->size();
+        ASSERT(nodeSize <= NodeType::capacity);
+
+        if (nodeSize < NodeType::capacity) [[likely]] {
+            auto insertionIndex = path[depth].index;
+            auto node = nodeRef->template as<NodeType>();
+            node->insertAt(nodeSize, insertionIndex, interval, value);
+            nodeRef->setSize(nodeSize);
+            if (isFirstOrLastIndex(*nodeRef, insertionIndex))
+                updateCoverage(path, depth, node->coverage(nodeSize));
+            return { NodeRef(), Interval() };
+        }
+        if (tryRedistributeLeftAndInsert<NodeType>(path, depth, interval, value))
+            return { NodeRef(), Interval() };
+        if (tryRedistributeRightAndInsert<NodeType>(path, depth, interval, value))
+            return { NodeRef(), Interval() };
+        return splitNodeAndInsert<NodeType>(path, depth, interval, value);
+    }
+
+    template<typename NodeType>
+    bool tryRedistributeLeftAndInsert(const Path& path, int depth, const Interval& interval, const typename NodeType::PayloadType& value)
+    {
+        NodeRef* nodeRef = path[depth].nodeRef;
+        auto insertionIndex = path[depth].index;
+        auto node = nodeRef->template as<NodeType>();
+        size_t nodeSize = nodeRef->size();
+
+        Path leftPath(path, depth);
+        leftPath.toLeftCousin();
+        if (leftPath.isEmpty())
+            return false;
+
+        // Note that since interval begin is used as the boundary between nodes and intervals are not allowed to
+        // overlap, insertionIndex will never be 0 if there is a left node -- the left node would have been chosen instead.
+        // Therefore if there is only one empty slot, the empty slot can be put into the right node without danger of
+        // shifting the insertionIndex into the left node.
+        ASSERT(0 < insertionIndex && insertionIndex <= nodeSize);
+
+        NodeRef* leftNodeRef = leftPath[depth].nodeRef;
+        size_t leftNodeSize = leftNodeRef->size();
+        if (leftNodeSize == NodeType::capacity)
+            return false;
+
+        auto leftNode = leftNodeRef->template as<NodeType>();
+        size_t newSize = (leftNodeSize + nodeSize) / 2;
+        ASSERT(newSize < NodeType::capacity);
+        size_t numToMove = nodeSize - newSize;
+        leftNode->shiftLeftFrom(leftNodeSize, node, nodeSize, numToMove);
+        ASSERT(nodeSize == newSize);
+        if (insertionIndex < numToMove)
+            leftNode->insertAt(leftNodeSize, leftNodeSize + insertionIndex - numToMove, interval, value);
+        else
+            node->insertAt(nodeSize, insertionIndex - numToMove, interval, value);
+        leftNodeRef->setSize(leftNodeSize);
+        updateCoverage(leftPath, depth, leftNode->coverage(leftNodeSize));
+        nodeRef->setSize(nodeSize);
+        updateCoverage(path, depth, node->coverage(nodeSize));
+        return true;
+    }
+
+    template<typename NodeType>
+    bool tryRedistributeRightAndInsert(const Path& path, int depth, const Interval& interval, const typename NodeType::PayloadType& value)
+    {
+        NodeRef* nodeRef = path[depth].nodeRef;
+        auto insertionIndex = path[depth].index;
+        auto node = nodeRef->template as<NodeType>();
+        size_t nodeSize = nodeRef->size();
+
+        Path rightPath(path, depth);
+        rightPath.toRightCousin();
+        if (rightPath.isEmpty())
+            return false;
+
+        NodeRef* rightNodeRef = rightPath[depth].nodeRef;
+        size_t rightNodeSize = rightNodeRef->size();
+        if (rightNodeSize == NodeType::capacity)
+            return false;
+
+        auto rightNode = rightNodeRef->template as<NodeType>();
+        // If the insertion index is after all items of the left node and we only have one empty slot
+        // we need to insert into the head of the right node.
+        if (insertionIndex == NodeType::capacity) {
+            rightNode->insertAt(rightNodeSize, 0, interval, value);
+            rightNodeRef->setSize(rightNodeSize);
+            updateCoverage(rightPath, depth, rightNode->coverage(rightNodeSize));
+            return true;
+        }
+        // Now, we know that insertionINdex < capacity, so if there's only one empty slot between both nodes,
+        // we should put it in the left node and the insertion point will still always be in the left node.
+        size_t newSize = (rightNodeSize + nodeSize) / 2;
+        ASSERT(newSize < NodeType::capacity);
+        size_t numToMove = nodeSize - newSize;
+        node->shiftRightTo(nodeSize, rightNode, rightNodeSize, numToMove);
+        ASSERT(nodeSize == newSize);
+        if (insertionIndex <= nodeSize)
+            node->insertAt(nodeSize, insertionIndex, interval, value);
+        else
+            rightNode->insertAt(rightNodeSize, insertionIndex - nodeSize, interval, value);
+        nodeRef->setSize(nodeSize);
+        updateCoverage(path, depth, node->coverage(nodeSize));
+        rightNodeRef->setSize(rightNodeSize);
+        updateCoverage(rightPath, depth, rightNode->coverage(rightNodeSize));
+        return true;
+    }
+
+    template<typename NodeType>
+    std::pair<NodeRef, Interval> splitNodeAndInsert(const Path& path, int depth, const Interval& interval, const typename NodeType::PayloadType& value)
+    {
+        NodeRef* nodeRef = path[depth].nodeRef;
+        auto insertionIndex = path[depth].index;
+        auto node = nodeRef->template as<NodeType>();
+        size_t nodeSize = nodeRef->size();
+        constexpr size_t splitPoint = NodeType::capacity / 2;
+        auto newNode = allocNode<NodeType>();
+
+        ASSERT(nodeSize == NodeType::capacity);
+
+        for (size_t i = splitPoint; i < nodeSize; ++i) {
+            newNode->intervals[i - splitPoint] = node->intervals[i];
+            newNode->payloads[i - splitPoint] = node->payloads[i];
+        }
+        size_t newNodeSize = nodeSize - splitPoint;
+        nodeSize = splitPoint;
+
+        if (insertionIndex < nodeSize)
+            node->insertAt(nodeSize, insertionIndex, interval, value);
+        else
+            newNode->insertAt(newNodeSize, insertionIndex - nodeSize, interval, value);
+        nodeRef->setSize(nodeSize);
+        updateCoverage(path, depth, node->coverage(nodeSize));
+        return { NodeRef(newNode, newNodeSize), newNode->coverage(newNodeSize) };
+    }
+
+    template<typename NodeType>
+    bool eraseFromNode(const Path& path, int depth)
+    {
+        NodeRef* nodeRef = path[depth].nodeRef;
+        auto eraseIndex = path[depth].index;
+        auto node = nodeRef->template as<NodeType>();
+        size_t nodeSize = nodeRef->size();
+        ASSERT(nodeSize <= NodeType::capacity);
+
+        if (nodeSize == 1) [[unlikely]] {
+            ASSERT(!eraseIndex);
+            freeNode(node);
+            *nodeRef = NodeRef();
+            return true;
+        }
+        node->removeAt(nodeSize, eraseIndex);
+        if (isFirstOrLastIndex(*nodeRef, eraseIndex))
+            updateCoverage(path, depth, node->coverage(nodeSize));
+        nodeRef->setSize(nodeSize);
+        return false;
+    }
+
+    template<typename NodeType>
+    NodeType* allocNode()
+    {
+        ASSERT(++assertOnlyNumNodes);
+        return static_cast<NodeType*>(fastAlignedMalloc(cpuCacheLineSize, sizeof(NodeType)));
+    }
+
+    template<typename NodeType>
+    void freeNode(NodeType* node)
+    {
+        ASSERT(assertOnlyNumNodes--);
+        fastAlignedFree(node);
+    }
+
+    void freeAllNodes()
+    {
+        if (!m_root)
+            return;
+
+        Vector<std::pair<NodeRef, unsigned>, 16> stack;
+        stack.append({ m_root, m_height });
+
+        while (!stack.isEmpty()) {
+            auto [node, distanceToLeaf] = stack.takeLast();
+
+            if (!distanceToLeaf) {
+                freeNode(node.asLeaf());
+                continue;
+            }
+            InnerNode* inner = node.asInner();
+            for (size_t i = 0; i < node.size(); ++i)
+                stack.append({ inner->child(i), distanceToLeaf - 1 });
+            freeNode(inner);
+        }
+    }
+
+    void dumpSubtree(PrintStream& out, NodeRef nodeRef, unsigned distanceToLeaf, unsigned indent) const
+    {
+        auto printIndent = [&] {
+            for (unsigned i = 0; i < indent; ++i)
+                out.print("  ");
+        };
+
+        if (distanceToLeaf) {
+            InnerNode* inner = nodeRef.asInner();
+            printIndent();
+            out.println("Inner(size=", nodeRef.size(), ", coverage=", inner->coverage(nodeRef.size()), "):");
+
+            for (size_t i = 0; i < nodeRef.size(); ++i) {
+                printIndent();
+                out.println("  [", i, "] ", inner->interval(i));
+                dumpSubtree(out, inner->child(i), distanceToLeaf - 1, indent + 2);
+            }
+        } else {
+            CommaPrinter comma;
+            LeafNode* leaf = nodeRef.asLeaf();
+            printIndent();
+            out.print("Leaf(size=", nodeRef.size(), "): ");
+            for (size_t i = 0; i < nodeRef.size(); ++i)
+                out.print(comma, leaf->interval(i), "=", leaf->value(i));
+            out.println();
+        }
+    }
+
+    NodeRef m_root { };
+    Interval m_rootInterval { };
+    unsigned m_height { 0 };
+
+#if ASSERT_ENABLED
+    unsigned assertOnlyNumNodes { 0 };
+#endif
+};
+
+} // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+using WTF::IntervalSet;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TestWTF_SOURCES
     Tests/WTF/IndexSparseSet.cpp
     Tests/WTF/Int128.cpp
     Tests/WTF/IntegerToStringConversion.cpp
+    Tests/WTF/IntervalSet.cpp
     Tests/WTF/IteratorRange.cpp
     Tests/WTF/JSONValue.cpp
     Tests/WTF/LEBDecoder.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1266,6 +1266,7 @@
 		A1EC11881F42541200D0146E /* PreviewConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1EC11871F42541200D0146E /* PreviewConverter.cpp */; };
 		A1FCFF2D2C292D0D0014463B /* NowPlayingSession.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1FCFF2C2C292A600014463B /* NowPlayingSession.mm */; };
 		A310827221F296FF00C28B97 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A310827121F296EC00C28B97 /* FileSystem.cpp */; };
+		A4EC3A792E305163002E3744 /* IntervalSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A4EC3A782E305163002E3744 /* IntervalSet.cpp */; };
 		A57D54F31F338C3600A97AA7 /* NeverDestroyed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F21F338C3600A97AA7 /* NeverDestroyed.cpp */; };
 		A57D54F61F3395D000A97AA7 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F41F3395D000A97AA7 /* Logger.cpp */; };
 		A57D54F91F3397B400A97AA7 /* LifecycleLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F71F3397B400A97AA7 /* LifecycleLogger.cpp */; };
@@ -3728,6 +3729,7 @@
 		A1FCFF2C2C292A600014463B /* NowPlayingSession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NowPlayingSession.mm; sourceTree = "<group>"; };
 		A1FDFD2E19C288BB005148A4 /* WKImageCreateCGImageCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKImageCreateCGImageCrash.cpp; sourceTree = "<group>"; };
 		A310827121F296EC00C28B97 /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystem.cpp; sourceTree = "<group>"; };
+		A4EC3A782E305163002E3744 /* IntervalSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntervalSet.cpp; sourceTree = "<group>"; };
 		A57A34EF16AF677200C2501F /* PageVisibilityStateWithWindowChanges.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PageVisibilityStateWithWindowChanges.mm; sourceTree = "<group>"; };
 		A57A34F116AF69E200C2501F /* PageVisibilityStateWithWindowChanges.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = PageVisibilityStateWithWindowChanges.html; sourceTree = "<group>"; };
 		A57D54F21F338C3600A97AA7 /* NeverDestroyed.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NeverDestroyed.cpp; sourceTree = "<group>"; };
@@ -6290,6 +6292,7 @@
 				33976D8224DC479B00812304 /* IndexSparseSet.cpp */,
 				F6D67D3626F90206006E0349 /* Int128.cpp */,
 				266FAFD215E5775200F61D5B /* IntegerToStringConversion.cpp */,
+				A4EC3A782E305163002E3744 /* IntervalSet.cpp */,
 				7CEB62A92236086C0069CBB0 /* IteratorRange.cpp */,
 				7A0509401FB9F04400B33FB8 /* JSONValue.cpp */,
 				E376DF942B5D0A2900DBF31F /* LazyRef.cpp */,
@@ -7466,6 +7469,7 @@
 				33976D8324DC479B00812304 /* IndexSparseSet.cpp in Sources */,
 				F6D67D3826F90206006E0349 /* Int128.cpp in Sources */,
 				7C83DEE01D0A590C00FEBCF3 /* IntegerToStringConversion.cpp in Sources */,
+				A4EC3A792E305163002E3744 /* IntervalSet.cpp in Sources */,
 				53FCDE6B229EFFB900598ECF /* IsoHeap.cpp in Sources */,
 				7CEB62AB223609DE0069CBB0 /* IteratorRange.cpp in Sources */,
 				7A0509411FB9F06400B33FB8 /* JSONValue.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/IntervalSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/IntervalSet.cpp
@@ -1,0 +1,546 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Test.h"
+
+#include <algorithm>
+#include <random>
+#include <wtf/DataLog.h>
+#include <wtf/IntervalSet.h>
+#include <wtf/ListDump.h>
+#include <wtf/StringPrintStream.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+struct IntervalSetTest {
+    static constexpr bool verbose = false;
+};
+
+using Point = uint32_t;
+using Value = int;
+using Interval = Range<Point>;
+
+TEST(WTF_IntervalSet, Basic)
+{
+    IntervalSet<Point, Value> intervalSet;
+
+    EXPECT_TRUE(intervalSet.isEmpty());
+    EXPECT_FALSE(intervalSet.hasOverlap({ 0, 10 }));
+    EXPECT_FALSE(intervalSet.find({ 0, 10 }));
+
+    EXPECT_EQ(intervalSet.begin(), intervalSet.end());
+}
+
+TEST(WTF_IntervalSet, SingleInterval)
+{
+    IntervalSet<Point, Value> intervalSet;
+
+    // Insert a single interval [10, 20) with value 42
+    intervalSet.insert({ 10, 20 }, 42);
+
+    EXPECT_FALSE(intervalSet.isEmpty());
+
+    EXPECT_NE(intervalSet.begin(), intervalSet.end());
+    auto it = intervalSet.begin();
+    EXPECT_EQ(it.interval(), Interval(10, 20));
+    EXPECT_EQ(it.value(), 42);
+    ++it;
+    EXPECT_EQ(it, intervalSet.end());
+
+    // Test overlap detection
+    EXPECT_TRUE(intervalSet.hasOverlap({ 15, 25 })); // Overlaps
+    EXPECT_TRUE(intervalSet.hasOverlap({ 5, 15 })); // Overlaps
+    EXPECT_TRUE(intervalSet.hasOverlap({ 10, 20 })); // Exact match
+    EXPECT_FALSE(intervalSet.hasOverlap({ 0, 10 })); // No overlap (adjacent)
+    EXPECT_FALSE(intervalSet.hasOverlap({ 20, 30 })); // No overlap (adjacent)
+    EXPECT_FALSE(intervalSet.hasOverlap({ 0, 5 })); // No overlap (before)
+    EXPECT_FALSE(intervalSet.hasOverlap({ 25, 30 })); // No overlap (after)
+
+    // Test find
+    auto result = intervalSet.find({ 15, 16 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(10, 20));
+    EXPECT_EQ(result->second, 42);
+
+    // Test find with non-overlapping interval
+    EXPECT_FALSE(intervalSet.find({ 0, 5 }));
+
+    // Test erase functionality
+    intervalSet.erase({ 10, 20 });
+
+    EXPECT_EQ(intervalSet.begin(), intervalSet.end());
+
+    // After erase, all overlap checks should return false
+    EXPECT_FALSE(intervalSet.hasOverlap({ 15, 25 })); // No longer overlaps
+    EXPECT_FALSE(intervalSet.hasOverlap({ 5, 15 })); // No longer overlaps
+    EXPECT_FALSE(intervalSet.hasOverlap({ 10, 20 })); // No longer overlaps
+    EXPECT_FALSE(intervalSet.hasOverlap({ 0, 10 })); // Still no overlap
+    EXPECT_FALSE(intervalSet.hasOverlap({ 20, 30 })); // Still no overlap
+    EXPECT_FALSE(intervalSet.hasOverlap({ 0, 5 })); // Still no overlap
+    EXPECT_FALSE(intervalSet.hasOverlap({ 25, 30 })); // Still no overlap
+
+    // After erase, all find operations should return nullopt
+    EXPECT_FALSE(intervalSet.find({ 15, 16 }));
+    EXPECT_FALSE(intervalSet.find({ 10, 20 }));
+    EXPECT_FALSE(intervalSet.find({ 0, 5 }));
+}
+
+TEST(WTF_IntervalSet, EraseTests)
+{
+    IntervalSet<Point, Value> intervalSet;
+
+    // Test basic erase functionality
+    intervalSet.insert({ 10, 20 }, 100);
+    intervalSet.insert({ 30, 40 }, 200);
+    intervalSet.insert({ 50, 60 }, 300);
+
+    // Verify iterator traverses all three intervals
+    size_t count = 0;
+    for (auto it = intervalSet.begin(); it != intervalSet.end(); ++it)
+        count++;
+    EXPECT_EQ(count, 3u);
+
+    // Verify all intervals are present
+    EXPECT_FALSE(intervalSet.isEmpty());
+    EXPECT_TRUE(intervalSet.hasOverlap({ 10, 20 }));
+    EXPECT_TRUE(intervalSet.hasOverlap({ 30, 40 }));
+    EXPECT_TRUE(intervalSet.hasOverlap({ 50, 60 }));
+
+    // Erase middle interval
+    intervalSet.erase({ 30, 40 });
+
+    // Verify iterator now traverses only two intervals
+    count = 0;
+    for (auto it = intervalSet.begin(); it != intervalSet.end(); ++it)
+        count++;
+    EXPECT_EQ(count, 2u);
+
+    // Verify middle interval is gone, others remain
+    EXPECT_FALSE(intervalSet.isEmpty());
+    EXPECT_TRUE(intervalSet.hasOverlap({ 10, 20 }));
+    EXPECT_FALSE(intervalSet.hasOverlap({ 30, 40 }));
+    EXPECT_TRUE(intervalSet.hasOverlap({ 50, 60 }));
+
+    // Verify find operations
+    auto result = intervalSet.find({ 15, 16 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(10, 20));
+    EXPECT_EQ(result->second, 100);
+
+    EXPECT_FALSE(intervalSet.find({ 35, 36 }));
+
+    result = intervalSet.find({ 55, 56 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(50, 60));
+    EXPECT_EQ(result->second, 300);
+
+    // Erase first interval
+    intervalSet.erase({ 10, 20 });
+
+    // Verify iterator now traverses only one interval
+    count = 0;
+    for (auto it = intervalSet.begin(); it != intervalSet.end(); ++it)
+        count++;
+    EXPECT_EQ(count, 1u);
+
+    EXPECT_FALSE(intervalSet.isEmpty());
+    EXPECT_FALSE(intervalSet.hasOverlap({ 10, 20 }));
+    EXPECT_FALSE(intervalSet.hasOverlap({ 30, 40 }));
+    EXPECT_TRUE(intervalSet.hasOverlap({ 50, 60 }));
+
+    // Erase last interval (should make set empty)
+    intervalSet.erase({ 50, 60 });
+
+    // Verify iterator shows empty set
+    EXPECT_EQ(intervalSet.begin(), intervalSet.end());
+
+    EXPECT_TRUE(intervalSet.isEmpty());
+    EXPECT_FALSE(intervalSet.hasOverlap({ 10, 20 }));
+    EXPECT_FALSE(intervalSet.hasOverlap({ 30, 40 }));
+    EXPECT_FALSE(intervalSet.hasOverlap({ 50, 60 }));
+
+    // Verify all finds return nullopt on empty set
+    EXPECT_FALSE(intervalSet.find({ 15, 16 }));
+    EXPECT_FALSE(intervalSet.find({ 35, 36 }));
+    EXPECT_FALSE(intervalSet.find({ 55, 56 }));
+}
+
+TEST(WTF_IntervalSet, EdgeCases)
+{
+    IntervalSet<Point, Value> intervalSet;
+
+    // Insert interval [0, 1) - single unit interval
+    intervalSet.insert({ 0, 1 }, 100);
+
+    EXPECT_TRUE(intervalSet.hasOverlap({ 0, 1 }));
+    EXPECT_FALSE(intervalSet.hasOverlap({ 1, 2 }));
+
+    auto result = intervalSet.find({ 0, 1 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(0, 1));
+    EXPECT_EQ(result->second, 100);
+
+    // Test with larger intervals that span the small one
+    EXPECT_TRUE(intervalSet.hasOverlap({ 0, 10 }));
+    result = intervalSet.find({ 0, 10 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(0, 1));
+    EXPECT_EQ(result->second, 100);
+}
+
+enum class IntervalOrdering {
+    Ascending,
+    Descending,
+    Random,
+};
+
+template<unsigned numCacheLines>
+static void stressTest(IntervalOrdering ordering)
+{
+    constexpr size_t numberTestIntervals = 10000;
+    constexpr size_t maxGap = 1000;
+    constexpr size_t maxSize = 1000;
+    constexpr size_t maxPoint = numberTestIntervals * (maxGap + maxSize);
+
+    struct TestCase : public std::pair<Interval, Value> {
+        TestCase() = default;
+        TestCase(const Interval& interval, const Value& value)
+            : std::pair<Interval, Value>(interval, value) { }
+
+        void dump(PrintStream& out) const
+        {
+            out.print("{ ", first, ", ", second, " }");
+        }
+    };
+
+    using TestIntervalSet = IntervalSet<Point, Value, numCacheLines>;
+    TestIntervalSet intervalSet;
+
+    std::mt19937 gen(testing::UnitTest::GetInstance()->random_seed());
+    std::uniform_int_distribution<size_t> gapDist(0, maxGap);
+    std::uniform_int_distribution<size_t> sizeDist(1, maxSize);
+    std::uniform_int_distribution<Value> valueDist(0, 10000);
+
+    // Generate non-overlapping intervals by sorting start points
+    Vector<TestCase> testData;
+    Point end = 0;
+    for (unsigned i = 0; i < numberTestIntervals; ++i) {
+        Point start = end + gapDist(gen);
+        end = start + sizeDist(gen);
+        Value value = valueDist(gen);
+        testData.append(TestCase({ start, end }, value));
+    }
+    dataLogLnIf(IntervalSetTest::verbose, "Test data: ", WTF::listDump(testData));
+
+    auto shuffledTestData = testData;
+
+    switch (ordering) {
+    case IntervalOrdering::Ascending:
+        break;
+    case IntervalOrdering::Descending:
+        std::reverse(shuffledTestData.begin(), shuffledTestData.end());
+        break;
+    case IntervalOrdering::Random:
+        // Shuffle the intervals to insert them in random order
+        std::shuffle(shuffledTestData.begin(), shuffledTestData.end(), gen);
+        break;
+    }
+    dataLogLnIf(IntervalSetTest::verbose, "After shuffle: ", WTF::listDump(shuffledTestData));
+
+    // Track which intervals are currently in the set for erase operations
+    Vector<TestCase> currentlyInserted;
+    std::uniform_int_distribution<int> eraseDist(1, 4); // 1 in 4 chance to erase
+
+    auto maybeEraseInterval = [&]() {
+        if (currentlyInserted.size() > 1 && eraseDist(gen) == 1) {
+            std::uniform_int_distribution<size_t> eraseIndexDist(0, currentlyInserted.size() - 1);
+            size_t eraseIndex = eraseIndexDist(gen);
+            TestCase toErase = currentlyInserted[eraseIndex];
+
+            intervalSet.erase(toErase.first);
+            currentlyInserted.removeAt(eraseIndex);
+            dataLogLnIf(IntervalSetTest::verbose, "Erased ", toErase.first, "=", toErase.second, ": ", intervalSet);
+        }
+    };
+
+    for (const auto& entry : shuffledTestData) {
+        intervalSet.insert(entry.first, entry.second);
+        currentlyInserted.append(entry);
+        dataLogLnIf(IntervalSetTest::verbose, "Added ", entry.first, "=", entry.second, ": ", intervalSet);
+
+        maybeEraseInterval();
+    }
+
+    // Validate that nodes are densely populated.
+    size_t capacity = TestIntervalSet::leafOrder;
+    unsigned expectedHeight = 0;
+    while (capacity < currentlyInserted.size()) {
+        capacity *= TestIntervalSet::innerOrder;
+        expectedHeight++;
+    }
+    EXPECT_EQ(intervalSet.height(), expectedHeight);
+
+    // Validate iterator traversal: count and ordering
+    size_t iteratorCount = 0;
+    Point lastEnd = 0;
+    for (auto it = intervalSet.begin(); it != intervalSet.end(); ++it) {
+        iteratorCount++;
+        auto interval = (*it).first;
+        // Verify intervals are in sorted order (non-overlapping by construction)
+        EXPECT_GE(interval.begin(), lastEnd);
+        lastEnd = interval.end();
+    }
+    EXPECT_EQ(iteratorCount, currentlyInserted.size());
+
+    // Test that all currently inserted intervals can be found with correct values
+    std::shuffle(currentlyInserted.begin(), currentlyInserted.end(), gen);
+    for (const auto& data : currentlyInserted) {
+        dataLogLnIf(IntervalSetTest::verbose, "Testing: interval=", data.first, " value=", data.second);
+        EXPECT_TRUE(intervalSet.hasOverlap(data.first));
+        auto found = intervalSet.find(data.first);
+        EXPECT_TRUE(found);
+        EXPECT_EQ(found->first, data.first);
+        EXPECT_EQ(found->second, data.second);
+    }
+
+    // Sort currentlyInserted by interval start for correct expected value calculation
+    std::sort(currentlyInserted.begin(), currentlyInserted.end(), [](const TestCase& a, const TestCase& b) {
+        return a.first.begin() < b.first.begin();
+    });
+
+    std::uniform_int_distribution<size_t> pointDist(0, maxPoint);
+    // Test random queries with occasional erase operations
+    for (unsigned i = 0; i < 500; ++i) {
+        Point start = pointDist(gen);
+        Point end = start + sizeDist(gen);
+        Interval query = { start, end };
+
+        std::optional<std::pair<Interval, Value>> expected;
+        for (const auto& data : currentlyInserted) {
+            if (query.overlaps(data.first)) {
+                expected = std::make_pair(data.first, data.second);
+                break;
+            }
+        }
+        dataLogLnIf(IntervalSetTest::verbose, "Testing: random interval=", query);
+
+        EXPECT_EQ(expected.has_value(), intervalSet.hasOverlap(query));
+        auto found = intervalSet.find(query);
+        if (expected) {
+            EXPECT_TRUE(found);
+            EXPECT_EQ(found->first, expected->first);
+            EXPECT_EQ(found->second, expected->second);
+        } else
+            EXPECT_FALSE(found);
+
+        // Occasionally erase an interval during query phase (reduced frequency)
+        if (i % 2)
+            maybeEraseInterval();
+    }
+}
+
+static constexpr unsigned stressNumCacheLines = 2;
+
+TEST(WTF_IntervalSet, AscendingStressTest)
+{
+    stressTest<stressNumCacheLines>(IntervalOrdering::Ascending);
+}
+
+TEST(WTF_IntervalSet, DescendingStressTest)
+{
+    stressTest<stressNumCacheLines>(IntervalOrdering::Descending);
+}
+
+TEST(WTF_IntervalSet, RandomStressTest)
+{
+    stressTest<stressNumCacheLines>(IntervalOrdering::Random);
+}
+
+TEST(WTF_IntervalSet, Dump)
+{
+    IntervalSet<int, const char*> intervalSet;
+
+    // Test empty tree
+    StringPrintStream emptyOutput;
+    intervalSet.dump(emptyOutput);
+    String emptyResult = emptyOutput.toString();
+    EXPECT_EQ(emptyResult, String("IntervalSet(height=0, leafOrder=4, innerOrder=4) <empty>"_s));
+
+    // Add some intervals
+    intervalSet.insert({ 10, 20 }, "first");
+    intervalSet.insert({ 30, 40 }, "second");
+    intervalSet.insert({ 50, 60 }, "third");
+
+    StringPrintStream basicOutput;
+    intervalSet.dump(basicOutput);
+    String basicResult = basicOutput.toString();
+    String expectedBasic = "IntervalSet(height=0, leafOrder=4, innerOrder=4) coverage=10...60\n"
+        "Leaf(size=3): 10...20=first, 30...40=second, 50...60=third\n"_s;
+
+    EXPECT_EQ(basicResult, expectedBasic);
+
+    // Add more intervals to potentially cause splits
+    intervalSet.insert({ 5, 8 }, "before");
+    intervalSet.insert({ 25, 28 }, "middle");
+    intervalSet.insert({ 65, 70 }, "after");
+
+    StringPrintStream fullOutput;
+    intervalSet.dump(fullOutput);
+    String fullResult = fullOutput.toString();
+    String expectedFull = "IntervalSet(height=1, leafOrder=4, innerOrder=4) coverage=5...70\n"
+        "Inner(size=2, coverage=5...70):\n"
+        "  [0] 5...20\n"
+        "    Leaf(size=2): 5...8=before, 10...20=first\n"
+        "  [1] 25...70\n"
+        "    Leaf(size=4): 25...28=middle, 30...40=second, 50...60=third, 65...70=after\n"_s;
+
+    EXPECT_EQ(fullResult, expectedFull);
+}
+
+TEST(WTF_IntervalSet, DestructorMemoryManagement)
+{
+    // Test destructor with single leaf node
+    {
+        IntervalSet<Point, Value> intervalSet;
+        intervalSet.insert({ 10, 20 }, 42);
+        intervalSet.insert({ 30, 40 }, 84);
+    }
+
+    // Test destructor with multi-level tree (force tree growth)
+    {
+        IntervalSet<Point, Value> intervalSet;
+
+        // Insert enough intervals to force tree growth beyond single leaf
+        for (Point i = 0; i < 100; ++i) {
+            Point start = i * 10;
+            Point end = start + 5;
+            intervalSet.insert({ start, end }, static_cast<Value>(i));
+        }
+    }
+
+    // Test destructor with empty tree
+    {
+        IntervalSet<Point, Value> intervalSet;
+    }
+}
+
+TEST(WTF_IntervalSet, EraseLastItemSingleLeaf)
+{
+    IntervalSet<Point, Value> intervalSet;
+
+    // Test case: Tree with only a single leaf node, erase the last (and only) item
+    intervalSet.insert({ 10, 20 }, 42);
+
+    // Verify the interval is present
+    EXPECT_TRUE(intervalSet.hasOverlap({ 10, 20 }));
+    auto result = intervalSet.find({ 15, 16 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(10, 20));
+    EXPECT_EQ(result->second, 42);
+
+    // Erase the only interval - this should make the tree empty
+    intervalSet.erase({ 10, 20 });
+
+    // Verify the tree is now empty
+    EXPECT_FALSE(intervalSet.hasOverlap({ 10, 20 }));
+    EXPECT_FALSE(intervalSet.find({ 15, 16 }));
+    EXPECT_FALSE(intervalSet.find({ 0, 100 })); // Any query should return nullopt
+
+    // Test that we can still insert after emptying the tree
+    intervalSet.insert({ 30, 40 }, 100);
+    EXPECT_TRUE(intervalSet.hasOverlap({ 30, 40 }));
+    result = intervalSet.find({ 35, 36 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(30, 40));
+    EXPECT_EQ(result->second, 100);
+}
+
+TEST(WTF_IntervalSet, EraseLastItemWithInnerNodes)
+{
+    IntervalSet<Point, Value> intervalSet;
+
+    // Build a tree with inner nodes by inserting many intervals
+    Vector<Interval> intervals;
+    for (Point i = 0; i < 50; ++i) {
+        Point start = i * 10;
+        Point end = start + 5;
+        Interval interval = { start, end };
+        intervals.append(interval);
+        intervalSet.insert(interval, static_cast<Value>(i));
+    }
+
+    // Verify we have a multi-level tree by checking all intervals are present
+    for (size_t i = 0; i < intervals.size(); ++i) {
+        EXPECT_TRUE(intervalSet.hasOverlap(intervals[i]));
+        auto result = intervalSet.find(intervals[i]);
+        EXPECT_TRUE(result);
+        EXPECT_EQ(result->first, intervals[i]);
+        EXPECT_EQ(result->second, static_cast<Value>(i));
+    }
+
+    // Erase all intervals one by one until only one remains
+    for (size_t i = 0; i < intervals.size() - 1; ++i) {
+        intervalSet.erase(intervals[i]);
+
+        // Verify the erased interval is gone
+        EXPECT_FALSE(intervalSet.hasOverlap(intervals[i]));
+        EXPECT_FALSE(intervalSet.find(intervals[i]));
+
+        // Verify remaining intervals are still present
+        for (size_t j = i + 1; j < intervals.size(); ++j)
+            EXPECT_TRUE(intervalSet.hasOverlap(intervals[j]));
+    }
+
+    // Now erase the very last interval - this should collapse the tree to empty
+    Interval lastInterval = intervals.last();
+    Value lastValue = static_cast<Value>(intervals.size() - 1);
+
+    // Verify the last interval is still present
+    EXPECT_TRUE(intervalSet.hasOverlap(lastInterval));
+    auto result = intervalSet.find(lastInterval);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, lastInterval);
+    EXPECT_EQ(result->second, lastValue);
+
+    intervalSet.erase(lastInterval);
+
+    EXPECT_FALSE(intervalSet.hasOverlap(lastInterval));
+    EXPECT_FALSE(intervalSet.find(lastInterval));
+
+    EXPECT_FALSE(intervalSet.hasOverlap({ 0, 1000 }));
+    EXPECT_FALSE(intervalSet.find({ 0, 1000 }));
+
+    // Verify we can still insert after completely emptying a complex tree
+    intervalSet.insert({ 1000, 2000 }, 999);
+    EXPECT_TRUE(intervalSet.hasOverlap({ 1000, 2000 }));
+    result = intervalSet.find({ 1500, 1600 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(1000, 2000));
+    EXPECT_EQ(result->second, 999);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### b66c0e306316751cb8783f9f2024a678802d22ad
<pre>
[WIP] GRA: IntervalSet testing
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::RegisterRange::AllocatedInterval::AllocatedInterval):
(JSC::B3::Air::Greedy::RegisterRange::add):
(JSC::B3::Air::Greedy::RegisterRange::addClobberHigh64):
(JSC::B3::Air::Greedy::RegisterRange::evict):
(JSC::B3::Air::Greedy::RegisterRange::hasConflict):
(JSC::B3::Air::Greedy::RegisterRange::isEmpty const):
(JSC::B3::Air::Greedy::RegisterRange::dump const):
(JSC::B3::Air::Greedy::RegisterRange::forEachConflictImpl):
(JSC::B3::Air::Greedy::GreedyAllocator::evict):
(JSC::B3::Air::Greedy::RegisterRange::findFirstIntervalEndingAfter): Deleted.
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/IntervalSet.h: Added.
(WTF::IntervalSet::calculateLeafOrder):
(WTF::IntervalSet::calculateInnerOrder):
(WTF::IntervalSet::~IntervalSet):
(WTF::IntervalSet::isEmpty const):
(WTF::IntervalSet::insert):
(WTF::IntervalSet::erase):
(WTF::IntervalSet::find const):
(WTF::IntervalSet::hasOverlap const):
(WTF::IntervalSet::dump const):
(WTF::IntervalSet::height const):
(WTF::IntervalSet::NodeImpl::interval):
(WTF::IntervalSet::NodeImpl::coverage const):
(WTF::IntervalSet::NodeImpl::shiftLeftFrom):
(WTF::IntervalSet::NodeImpl::shiftRightTo):
(WTF::IntervalSet::NodeImpl::insertAt):
(WTF::IntervalSet::NodeImpl::removeAt):
(WTF::IntervalSet::NodeImpl::firstIntervalEndAfter const):
(WTF::IntervalSet::NodeRef::NodeRef):
(WTF::IntervalSet::NodeRef::node const):
(WTF::IntervalSet::NodeRef::size const):
(WTF::IntervalSet::NodeRef::setSize):
(WTF::IntervalSet::NodeRef::operator bool const):
(WTF::IntervalSet::NodeRef::as const):
(WTF::IntervalSet::NodeRef::asLeaf const):
(WTF::IntervalSet::NodeRef::asInner const):
(WTF::IntervalSet::LeafNode::value):
(WTF::IntervalSet::InnerNode::child):
(WTF::IntervalSet::InnerNode::subtreeForInsert const):
(WTF::IntervalSet::PathEntry::operator== const):
(WTF::IntervalSet::Path::Path):
(WTF::IntervalSet::Path::nextIndexInLeaf):
(WTF::IntervalSet::Path::toLeftCousin):
(WTF::IntervalSet::Path::toRightCousin):
(WTF::IntervalSet::Path::TraverseLeft::hasMoreChildren):
(WTF::IntervalSet::Path::TraverseLeft::nextSubtreeIndex):
(WTF::IntervalSet::Path::TraverseLeft::descendIndex):
(WTF::IntervalSet::Path::TraverseRight::hasMoreChildren):
(WTF::IntervalSet::Path::TraverseRight::nextSubtreeIndex):
(WTF::IntervalSet::Path::TraverseRight::descendIndex):
(WTF::IntervalSet::Path::toCousin):
(WTF::IntervalSet::iterator::iterator):
(WTF::IntervalSet::iterator::interval const):
(WTF::IntervalSet::iterator::value const):
(WTF::IntervalSet::iterator::operator* const):
(WTF::IntervalSet::iterator::operator++):
(WTF::IntervalSet::iterator::operator== const):
(WTF::IntervalSet::iterator::operator!= const):
(WTF::IntervalSet::iterator::leafAndIndex const):
(WTF::IntervalSet::begin const):
(WTF::IntervalSet::end const):
(WTF::IntervalSet::isFirstOrLastIndex):
(WTF::IntervalSet::updateCoverage):
(WTF::IntervalSet::verifyCoverageConsistency):
(WTF::IntervalSet::insertInNodeSplitIfNeeded):
(WTF::IntervalSet::tryRedistributeLeftAndInsert):
(WTF::IntervalSet::tryRedistributeRightAndInsert):
(WTF::IntervalSet::splitNodeAndInsert):
(WTF::IntervalSet::eraseFromNode):
(WTF::IntervalSet::allocNode):
(WTF::IntervalSet::freeNode):
(WTF::IntervalSet::freeAllNodes):
(WTF::IntervalSet::dumpSubtree const):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/IntervalSet.cpp: Added.
(TestWebKitAPI::TEST(WTF_IntervalSet, Basic)):
(TestWebKitAPI::TEST(WTF_IntervalSet, SingleInterval)):
(TestWebKitAPI::TEST(WTF_IntervalSet, EraseTests)):
(TestWebKitAPI::TEST(WTF_IntervalSet, EdgeCases)):
(TestWebKitAPI::stressTest):
(TestWebKitAPI::TEST(WTF_IntervalSet, AscendingStressTest)):
(TestWebKitAPI::TEST(WTF_IntervalSet, DescendingStressTest)):
(TestWebKitAPI::TEST(WTF_IntervalSet, RandomStressTest)):
(TestWebKitAPI::TEST(WTF_IntervalSet, Dump)):
(TestWebKitAPI::TEST(WTF_IntervalSet, DestructorMemoryManagement)):
(TestWebKitAPI::TEST(WTF_IntervalSet, EraseLastItemSingleLeaf)):
(TestWebKitAPI::TEST(WTF_IntervalSet, EraseLastItemWithInnerNodes)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b66c0e306316751cb8783f9f2024a678802d22ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117732 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69746 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f61f612-ce95-49ac-84bf-f1be1f55b716) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89352 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/55148 "Too many flaky failures: css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, ietestcenter/Javascript/15.4.4.15-8-10.html, ietestcenter/Javascript/15.4.4.15-8-11.html, ietestcenter/Javascript/15.4.4.15-8-9.html, ietestcenter/Javascript/15.4.4.15-8-a-1.html, ietestcenter/Javascript/15.4.4.15-8-a-2.html, ietestcenter/Javascript/15.4.4.15-8-a-3.html, imported/w3c/web-platform-tests/css/CSS2/tables/table-header-group-001.xht, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, imported/w3c/web-platform-tests/wasm/core/conversions.wast.js.html, js/Array-isArray.html, js/dom/Promise-simple-in-workers.html, js/dom/array-with-double-assign.html, js/dom/array-with-double-push.html, js/structuredClone/structured-clone-of-CachedString-in-map.html, storage/indexeddb/cursor-advance-private.html, storage/indexeddb/cursor-leak.html, storage/indexeddb/modern/idbindex-getall-1.html, storage/indexeddb/modern/idbindex-getallkeys-1-private.html, storage/indexeddb/mozilla/cursor-mutation-objectstore-only-private.html, storage/indexeddb/mozilla/cursor-mutation-objectstore-only.html, storage/indexeddb/mozilla/key-requirements.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-rgb565-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-rgb565-rgb-unsigned_short_5_6_5.html, webgl/2.0.y/conformance/extensions/webgl-compressed-texture-size-limit.html, webgl/2.0.y/conformance/glsl/bugs/vector-scalar-arithmetic-inside-loop-complex.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/603fec0d-65b4-4d70-b78e-fa755249630f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69846 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f0f4565-da0c-46e4-972f-2c5f5a7bfafc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67525 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109843 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126959 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116241 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98009 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97796 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43177 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41000 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50181 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144939 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43965 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37295 "Found 1 new JSC binary failure: testapi, Found 20047 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47312 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->