### PR TITLE
WebGPU] beginningOfPassWriteIndex and endOfPassWriteIndex default to 0 and 1, leading to CTS failures

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginComputePass-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginComputePass-expected.txt
@@ -1,49 +1,8 @@
 
 PASS :timestampWrites,query_set_type:queryType="occlusion"
 PASS :timestampWrites,query_set_type:queryType="timestamp"
-FAIL :timestampWrites,invalid_query_set:querySetState="valid" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(1) || endOfPassWriteIndex(1) >= querySetCount(1) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(1)
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :timestampWrites,invalid_query_set:querySetState="valid"
 PASS :timestampWrites,invalid_query_set:querySetState="invalid"
-FAIL :timestampWrites,query_index: assert_unreached:
-  - (in subcase: beginningOfPassWriteIndex="_undef_";endOfPassWriteIndex="_undef_") VALIDATION FAILED: Validation succeeded unexpectedly.
-      at (elided: below max severity)
-  - (in subcase: beginningOfPassWriteIndex="_undef_";endOfPassWriteIndex="_undef_") INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex="_undef_";endOfPassWriteIndex=0) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex="_undef_";endOfPassWriteIndex=1) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex="_undef_";endOfPassWriteIndex=2) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex="_undef_";endOfPassWriteIndex=3) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=0;endOfPassWriteIndex="_undef_") INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=0;endOfPassWriteIndex=0) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=0;endOfPassWriteIndex=1) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=0;endOfPassWriteIndex=2) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=0;endOfPassWriteIndex=3) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=1;endOfPassWriteIndex="_undef_") INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=1;endOfPassWriteIndex=0) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=1;endOfPassWriteIndex=1) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=1;endOfPassWriteIndex=2) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=1;endOfPassWriteIndex=3) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=2;endOfPassWriteIndex="_undef_") INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=2;endOfPassWriteIndex=0) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=2;endOfPassWriteIndex=1) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=2;endOfPassWriteIndex=2) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=2;endOfPassWriteIndex=3) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=3;endOfPassWriteIndex="_undef_") INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=3;endOfPassWriteIndex=0) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=3;endOfPassWriteIndex=1) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=3;endOfPassWriteIndex=2) INFO: subcase ran
-  - (in subcase: beginningOfPassWriteIndex=3;endOfPassWriteIndex=3) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(2) || endOfPassWriteIndex(0) >= querySetCount(2) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(0)
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :timestamp_query_set,device_mismatch: assert_unreached:
-  - (in subcase: mismatched=true) INFO: subcase ran
-  - (in subcase: mismatched=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(1) || endOfPassWriteIndex(1) >= querySetCount(1) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(1)
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :timestampWrites,query_index:
+PASS :timestamp_query_set,device_mismatch:
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass-expected.txt
@@ -2,11 +2,5 @@
 PASS :color_attachments,device_mismatch:
 PASS :depth_stencil_attachment,device_mismatch:
 PASS :occlusion_query_set,device_mismatch:
-FAIL :timestamp_query_set,device_mismatch: assert_unreached:
-  - (in subcase: mismatched=true) INFO: subcase ran
-  - (in subcase: mismatched=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(1) || endOfPassWriteIndex(1) >= querySetCount(1) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(1)
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :timestamp_query_set,device_mismatch:
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat-expected.txt
@@ -12,97 +12,65 @@ PASS :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20pass";call=
 PASS :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=true
 PASS :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=false
 FAIL :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20bundle";call="draw";callWithZero=true assert_unreached:
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:509:12
-  - EXPECTATION FAILED: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:509:12
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false
-    Expected validation error
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:510:12
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:510:12
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true
-    Expected validation error
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false
-    Expected validation error
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true
-    OK
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true
-    OK
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true
-    Expected validation error
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true
-    OK
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true) INFO: subcase ran
  Reached unreachable code
 PASS :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20bundle";call="draw";callWithZero=false
 FAIL :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=true assert_unreached:
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:509:12
-  - EXPECTATION FAILED: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:509:12
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false
-    Expected validation error
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=true;setUnusedBindGroup2=false;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:510:12
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:510:12
+  - (in subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true
-    Expected validation error
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=true;setBindGroup1=false;setUnusedBindGroup2=true;useU32Array=true
-    OK
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false
-    Expected validation error
+  - (in subcase: setBindGroup0=false;setBindGroup1=true;setUnusedBindGroup2=true;useU32Array=true) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true
-    Expected validation error
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false) INFO: subcase ran
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=false
-    OK
-  - INFO: subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true
-    OK
+  - (in subcase: setBindGroup0=false;setBindGroup1=false;setUnusedBindGroup2=false;useU32Array=true) INFO: subcase ran
  Reached unreachable code
 PASS :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=false
 PASS :bind_groups_and_pipeline_layout_mismatch:encoderType="render%20bundle";call="drawIndirect";callWithZero=true
@@ -134,105 +102,69 @@ PASS :bgl_binding_mismatch:encoderType="render%20pass";call="drawIndirect";callW
 PASS :bgl_binding_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=true
 PASS :bgl_binding_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=false
 FAIL :bgl_binding_mismatch:encoderType="render%20bundle";call="draw";callWithZero=true assert_unreached:
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=true
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=true
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:695:12
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:695:12
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false
-    Expected validation error
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:696:12
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:696:12
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true
-    Expected validation error
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false
-    Expected validation error
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true
-    Expected validation error
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true
-    OK
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true) INFO: subcase ran
  Reached unreachable code
 PASS :bgl_binding_mismatch:encoderType="render%20bundle";call="draw";callWithZero=false
 FAIL :bgl_binding_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=true assert_unreached:
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=true
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=true
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:695:12
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:695:12
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false
-    Expected validation error
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,2];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:696:12
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:696:12
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[0,2];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,2];plBindings=[2,0];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1,3];useU32Array=true
-    OK
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true
-    Expected validation error
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false
-    Expected validation error
+  - (in subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true
-    Expected validation error
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false) INFO: subcase ran
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgBindings=[0,1,2];plBindings=[0,1];useU32Array=true
-    OK
-  - INFO: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=false
-    OK
-  - INFO: subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true
-    OK
+  - (in subcase: bgBindings=[0,1];plBindings=[0,1,2];useU32Array=true) INFO: subcase ran
  Reached unreachable code
 PASS :bgl_binding_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=false
 PASS :bgl_binding_mismatch:encoderType="render%20bundle";call="drawIndirect";callWithZero=true
@@ -252,465 +184,285 @@ PASS :bgl_visibility_mismatch:encoderType="render%20pass";call="drawIndirect";ca
 PASS :bgl_visibility_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=true
 PASS :bgl_visibility_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=false
 FAIL :bgl_visibility_mismatch:encoderType="render%20bundle";call="draw";callWithZero=true assert_unreached:
-  - INFO: subcase: bgVisibility=1;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=3;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=1;useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:747:12
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=1;useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:747:12
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:748:12
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:748:12
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=0;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=2;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=1;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=2;useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=3;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=1;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=5;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=1;useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=7;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=3;useU32Array=true
-    OK
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=true) INFO: subcase ran
  Reached unreachable code
 PASS :bgl_visibility_mismatch:encoderType="render%20bundle";call="draw";callWithZero=false
 FAIL :bgl_visibility_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=true assert_unreached:
-  - INFO: subcase: bgVisibility=1;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=3;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=1;useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:747:12
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=1;useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:747:12
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:748:12
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:748:12
+  - (in subcase: bgVisibility=0;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=0;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=0;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=0;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=0;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=2;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=1;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=1;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=2;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=2;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=1;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=1;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=2;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=1;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=3;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=3;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=3;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=4;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=3;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=3;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=4;plVisibility=3;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=4;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=5;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=5;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=5;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=2;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=5;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=2;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=6;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=1;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=6;plVisibility=3;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=1;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=2;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=1;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=2;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=6;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=6;plVisibility=3;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=1;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=1;useU32Array=true
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=2;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=2;useU32Array=true
-    OK
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=3;useU32Array=false
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=2;useU32Array=true) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgVisibility=7;plVisibility=3;useU32Array=true
-    Expected validation error
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=false) INFO: subcase ran
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgVisibility=7;plVisibility=3;useU32Array=false
-    OK
-  - INFO: subcase: bgVisibility=7;plVisibility=3;useU32Array=true
-    OK
+  - (in subcase: bgVisibility=7;plVisibility=3;useU32Array=true) INFO: subcase ran
  Reached unreachable code
 PASS :bgl_visibility_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=false
 PASS :bgl_visibility_mismatch:encoderType="render%20bundle";call="drawIndirect";callWithZero=true
@@ -730,399 +482,245 @@ PASS :bgl_resource_type_mismatch:encoderType="render%20pass";call="drawIndirect"
 PASS :bgl_resource_type_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=true
 PASS :bgl_resource_type_mismatch:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=false
 FAIL :bgl_resource_type_mismatch:encoderType="render%20bundle";call="draw";callWithZero=true assert_unreached:
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:821:12
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:821:12
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:822:12
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:822:12
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
  Reached unreachable code
 PASS :bgl_resource_type_mismatch:encoderType="render%20bundle";call="draw";callWithZero=false
 FAIL :bgl_resource_type_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=true assert_unreached:
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:821:12
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1252:34
-    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:295:19
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:821:12
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:822:12
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
+    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
+    runTest@http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:296:19
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.js:822:12
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true) INFO: subcase ran
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=true
-    OK
-  - INFO: subcase: bgResourceType="uniformBuf";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="filtSamp";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="sampledTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="writeonlyStorageTex";plResourceType="readwriteStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="uniformBuf";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="filtSamp";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false
-    OK
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="sampledTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - EXPECTATION FAILED: subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    Expected validation error
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) EXPECTATION FAILED: Expected validation error
       at (elided: only 2 shown)
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="readonlyStorageTex";useU32Array=false
-    OK
-  - INFO: subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false
-    OK
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="writeonlyStorageTex";useU32Array=false) INFO: subcase ran
+  - (in subcase: bgResourceType="readwriteStorageTex";plResourceType="readwriteStorageTex";useU32Array=false) INFO: subcase ran
  Reached unreachable code
 PASS :bgl_resource_type_mismatch:encoderType="render%20bundle";call="drawIndexed";callWithZero=false
 PASS :bgl_resource_type_mismatch:encoderType="render%20bundle";call="drawIndirect";callWithZero=true
@@ -1132,58 +730,58 @@ PASS :bgl_resource_type_mismatch:encoderType="render%20bundle";call="drawIndexed
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;computeCommand="dispatchIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;computeCommand="dispatch" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;computeCommand="dispatchIndirect"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;computeCommand="dispatch"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;computeCommand="dispatchIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;computeCommand="dispatch" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;computeCommand="dispatchIndirect"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;computeCommand="dispatch"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;computeCommand="dispatchIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;computeCommand="dispatch" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=4;computeCommand="dispatchIndirect"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=4;computeCommand="dispatch"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="draw" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="drawIndexed" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="drawIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="drawIndexedIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;renderCommand="draw"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;renderCommand="drawIndexed"
@@ -1192,22 +790,22 @@ PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:empt
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="draw" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="drawIndexed" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="drawIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="drawIndexedIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;renderCommand="draw"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;renderCommand="drawIndexed"
@@ -1216,22 +814,22 @@ PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:empt
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="draw" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="drawIndexed" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="drawIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="drawIndexedIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
     TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=4;renderCommand="draw"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=4;renderCommand="drawIndexed"

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1568,7 +1568,6 @@ webkit.org/b/263396 css3/color/text.html [ Skip ]
 
 # WebGPU
 fast/webgpu/nocrash/fuzz-275294.html [ Pass ]
-[ Release ] http/tests/webgpu/webgpu/api/validation/encoding/cmds/copyTextureToTexture.html
 
 # skipped due to infinite loop compute shaders normally not terminating on macOS, test must be run locally for now
 fast/webgpu/nocrash/fuzz-286820.html [ Skip ]
@@ -1723,7 +1722,6 @@ http/tests/webgpu/webgpu/shader/validation/shader_io/group_and_binding.html [ Sk
 http/tests/webgpu/webgpu/shader/validation/uniformity/uniformity.html [ Skip ]
 http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/multiple_buffers.html  [ Skip ]
 http/tests/webgpu/webgpu/api/operation/rendering/depth_clip_clamp.html  [ Skip ]
-http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.html  [ Skip ]
 http/tests/webgpu/webgpu/api/validation/getBindGroupLayout.html  [ Skip ]
 http/tests/webgpu/webgpu/shader/execution/expression/precedence.html  [ Skip ]
 http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/barriers.html  [ Skip ]
@@ -2254,10 +2252,6 @@ webkit.org/b/296209 http/tests/workers/service/basic-timeout.https.html [ Pass F
 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInFragmentStage.html [ Failure ]
 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInVertexStage.html [ Failure ]
 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/api/validation/createPipelineLayout.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/api/validation/encoding/beginComputePass.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/api/validation/encoding/cmds/index_access.html [ Failure ]
-[ Sequoia Release arm64 ] http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state.html [ Failure ]
 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift.html [ Failure ]
 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/execution/flow_control/eval_order.html [ Failure ]
 [ Sequoia Release arm64 ] http/tests/webgpu/webgpu/shader/validation/decl/var.html [ Failure ]

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h
@@ -44,8 +44,8 @@ struct GPUComputePassTimestampWrites {
     }
 
     WeakPtr<GPUQuerySet> querySet;
-    GPUSize32 beginningOfPassWriteIndex { 0 };
-    GPUSize32 endOfPassWriteIndex { 1 };
+    GPUSize32 beginningOfPassWriteIndex { WebGPU::kQuerySetIndexUndefined };
+    GPUSize32 endOfPassWriteIndex { WebGPU::kQuerySetIndexUndefined };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h
@@ -44,8 +44,8 @@ struct GPURenderPassTimestampWrites {
     }
 
     WeakPtr<GPUQuerySet> querySet;
-    GPUSize32 beginningOfPassWriteIndex { 0 };
-    GPUSize32 endOfPassWriteIndex { 1 };
+    GPUSize32 beginningOfPassWriteIndex { WebGPU::kQuerySetIndexUndefined };
+    GPUSize32 endOfPassWriteIndex { WebGPU::kQuerySetIndexUndefined };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
@@ -36,8 +36,8 @@ class QuerySet;
 
 struct ComputePassTimestampWrites {
     WeakPtr<QuerySet> querySet;
-    Size32 beginningOfPassWriteIndex { 0 };
-    Size32 endOfPassWriteIndex { 1 };
+    Size32 beginningOfPassWriteIndex { kQuerySetIndexUndefined };
+    Size32 endOfPassWriteIndex { kQuerySetIndexUndefined };
 
     RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUIntegralTypes.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUIntegralTypes.h
@@ -42,4 +42,6 @@ using SignedOffset32 = int32_t;
 
 using FlagsConstant = uint32_t;
 
+constexpr uint32_t kQuerySetIndexUndefined = 0xffffffffUL;
+
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
@@ -37,8 +37,8 @@ class QuerySet;
 
 struct RenderPassTimestampWrites {
     WeakPtr<QuerySet> querySet;
-    Size32 beginningOfPassWriteIndex { 0 };
-    Size32 endOfPassWriteIndex { 1 };
+    Size32 beginningOfPassWriteIndex { kQuerySetIndexUndefined };
+    Size32 endOfPassWriteIndex { kQuerySetIndexUndefined };
 
     RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };

--- a/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.h
@@ -37,8 +37,8 @@ namespace WebKit::WebGPU {
 
 struct ComputePassTimestampWrites {
     WebGPUIdentifier querySet;
-    WebCore::WebGPU::Size32 beginningOfPassWriteIndex { 0 };
-    WebCore::WebGPU::Size32 endOfPassWriteIndex { 1 };
+    WebCore::WebGPU::Size32 beginningOfPassWriteIndex { WebCore::WebGPU::kQuerySetIndexUndefined };
+    WebCore::WebGPU::Size32 endOfPassWriteIndex { WebCore::WebGPU::kQuerySetIndexUndefined };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.h
@@ -37,8 +37,8 @@ namespace WebKit::WebGPU {
 
 struct RenderPassTimestampWrites {
     WebGPUIdentifier querySet;
-    WebCore::WebGPU::Size32 beginningOfPassWriteIndex { 0 };
-    WebCore::WebGPU::Size32 endOfPassWriteIndex { 1 };
+    WebCore::WebGPU::Size32 beginningOfPassWriteIndex { WebCore::WebGPU::kQuerySetIndexUndefined };
+    WebCore::WebGPU::Size32 endOfPassWriteIndex { WebCore::WebGPU::kQuerySetIndexUndefined };
 };
 
 } // namespace WebKit::WebGPU


### PR DESCRIPTION
#### 11388c6920cd0868d470f47e077349fa758256cd
<pre>
WebGPU] beginningOfPassWriteIndex and endOfPassWriteIndex default to 0 and 1, leading to CTS failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=297808">https://bugs.webkit.org/show_bug.cgi?id=297808</a>
<a href="https://rdar.apple.com/158977287">rdar://158977287</a>

Reviewed by Tadeu Zagallo.

A QuerySet with 1 element is allowed, it will only write to either the start or end of the render
or compute pass. This was previously rejected in WebKit as we defaulted begin and end to 0 and 1.

Fixing this results in several more query timestamps tests passing.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginComputePass-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/copyTextureToTexture-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.js:
(F.prototype.TestCopyTextureToTexture): Deleted.
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/index_access-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/createRenderBundleEncoder-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/encoder_open_state-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/encoder_state-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/queries/general-expected.txt:
Add updated expectations

* LayoutTests/platform/mac-wk2/TestExpectations:
Stop skipping tests which are now passing.

* Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h:
* Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.h:
* Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.h:
Default to undefined query index instead of zero and one.

Canonical link: <a href="https://commits.webkit.org/299163@main">https://commits.webkit.org/299163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad657f30eab6f76ca39a3b936120ec40e26ea3e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70113 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ae5fde8-90af-4df3-9c8c-c6e2e51490a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46335 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89605 "Found 1 new test failure: fullscreen/fullscreen-zero-height-element-with-non-zero-children.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59211 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7baa1d7b-30b7-450c-864f-770be1d4f94b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70098 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33346e9d-d439-483f-a22b-73313ea9f75a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67894 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127306 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98280 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41423 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50524 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47655 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45999 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->