### PR TITLE
Adopt more smart pointers in Page, Quirks, and /page/csp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -80,7 +80,6 @@ page/EventHandler.h
 page/Page.h
 page/PageOverlayController.cpp
 page/WheelEventTestMonitor.h
-page/csp/ContentSecurityPolicy.h
 page/mac/ImageOverlayControllerMac.mm
 page/mac/ServicesOverlayController.mm
 page/scrolling/ScrollingStateNode.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -427,7 +427,6 @@ page/Location.cpp
 page/MemoryRelease.cpp
 page/NavigateEvent.cpp
 page/Navigator.cpp
-page/Page.cpp
 page/PageColorSampler.cpp
 page/PageOverlay.cpp
 page/PageOverlayController.cpp
@@ -437,7 +436,6 @@ page/PerformanceMonitor.cpp
 page/PointerCaptureController.cpp
 page/PointerLockController.cpp
 page/PrintContext.cpp
-page/Quirks.cpp
 page/RemoteFrame.cpp
 page/ResizeObservation.cpp
 page/ResizeObserver.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -277,7 +277,6 @@ page/LocalDOMWindow.cpp
 page/LocalFrame.cpp
 page/LocalFrameView.cpp
 page/LocalFrameViewLayoutContext.cpp
-page/Page.cpp
 page/PageColorSampler.cpp
 page/PageOverlay.cpp
 page/PageSerializer.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -593,7 +593,6 @@ page/NavigationDestination.cpp
 page/NavigationDestination.h
 page/Navigator.cpp
 page/NavigatorLoginStatus.cpp
-page/Page.cpp
 page/PageColorSampler.cpp
 page/PageOverlay.cpp
 page/PageOverlayController.cpp
@@ -606,7 +605,6 @@ page/PerformanceUserTiming.cpp
 page/PointerCaptureController.cpp
 page/PointerLockController.cpp
 page/PrintContext.cpp
-page/Quirks.cpp
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp
 page/RenderingUpdateScheduler.cpp
@@ -628,7 +626,6 @@ page/cocoa/PageCocoa.mm
 page/cocoa/ResourceUsageOverlayCocoa.mm
 page/cocoa/ResourceUsageThreadCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
-page/csp/ContentSecurityPolicy.cpp
 page/mac/DragControllerMac.mm
 page/mac/EventHandlerMac.mm
 page/mac/ImageOverlayControllerMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -46,7 +46,6 @@ page/IntelligenceTextEffectsSupport.cpp
 page/Navigator.cpp
 page/ShareDataReader.cpp
 page/cocoa/ResourceUsageOverlayCocoa.mm
-page/csp/ContentSecurityPolicy.cpp
 page/writing-tools/WritingToolsController.mm
 platform/ScrollableArea.cpp
 platform/cocoa/NetworkExtensionContentFilter.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -302,7 +302,6 @@ page/PerformanceTiming.cpp
 page/PerformanceUserTiming.cpp
 page/PointerCaptureController.cpp
 page/PrintContext.cpp
-page/Quirks.cpp
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp
 page/ResizeObservation.cpp

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -421,6 +421,7 @@ public:
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& mainFrameURL() const;
     SecurityOrigin& mainFrameOrigin() const;
+    Ref<SecurityOrigin> protectedMainFrameOrigin() const;
 
     WEBCORE_EXPORT void setMainFrameURLAndOrigin(const URL&, RefPtr<SecurityOrigin>&&);
 #if ENABLE(DOM_AUDIO_SESSION)
@@ -1356,6 +1357,7 @@ public:
     WEBCORE_EXPORT RefPtr<HTMLMediaElement> bestMediaElementForRemoteControls(PlatformMediaSessionPlaybackControlsPurpose, Document*);
 
     WEBCORE_EXPORT MediaSessionManagerInterface& mediaSessionManager();
+    WEBCORE_EXPORT Ref<MediaSessionManagerInterface> protectedMediaSessionManager();
     WEBCORE_EXPORT MediaSessionManagerInterface* mediaSessionManagerIfExists() const;
     WEBCORE_EXPORT static MediaSessionManagerInterface* mediaSessionManagerForPageIdentifier(PageIdentifier);
 
@@ -1426,6 +1428,7 @@ private:
     void prioritizeVisibleResources();
 
     RenderingUpdateScheduler& renderingUpdateScheduler();
+    CheckedRef<RenderingUpdateScheduler> checkedRenderingUpdateScheduler();
     RenderingUpdateScheduler* existingRenderingUpdateScheduler();
 
     WheelEventTestMonitor& ensureWheelEventTestMonitor();

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include <WebCore/ContentSecurityPolicyClient.h>
 #include <WebCore/ContentSecurityPolicyHash.h>
 #include <WebCore/ContentSecurityPolicyResponseHeaders.h>
+#include <WebCore/ReportingClient.h>
 #include <WebCore/SecurityContext.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginHash.h>
@@ -65,8 +67,6 @@ class LocalFrame;
 class ResourceRequest;
 class ScriptExecutionContext;
 class SecurityOrigin;
-struct ContentSecurityPolicyClient;
-struct ReportingClient;
 
 enum class ParserInserted : bool { No, Yes };
 static constexpr unsigned bitWidthOfParserInserted = 1;

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -856,6 +856,11 @@ RenderLayerCompositor& RenderView::compositor()
     return *m_compositor;
 }
 
+CheckedRef<RenderLayerCompositor> RenderView::checkedCompositor()
+{
+    return compositor();
+}
+
 void RenderView::setIsInWindow(bool isInWindow)
 {
     if (m_compositor)

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -138,6 +138,7 @@ public:
     void setIsInWindow(bool);
 
     WEBCORE_EXPORT RenderLayerCompositor& compositor();
+    WEBCORE_EXPORT CheckedRef<RenderLayerCompositor> checkedCompositor();
     WEBCORE_EXPORT bool usesCompositing() const;
 
     WEBCORE_EXPORT IntRect unscaledDocumentRect() const;


### PR DESCRIPTION
#### 0a03566a8de562433f5d5c56700dafecca3e5c64
<pre>
Adopt more smart pointers in Page, Quirks, and /page/csp
<a href="https://bugs.webkit.org/show_bug.cgi?id=297809">https://bugs.webkit.org/show_bug.cgi?id=297809</a>
<a href="https://rdar.apple.com/158978230">rdar://158978230</a>

Reviewed by Chris Dumez.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::protectedMainFrameOrigin const):
(WebCore::Page::logMediaDiagnosticMessage const):
(WebCore::Page::setPageScaleFactor):
(WebCore::Page::scheduleRenderingUpdateInternal):
(WebCore::Page::doAfterUpdateRendering):
(WebCore::Page::bestMediaElementForRemoteControls):
(WebCore::Page::setActivityState):
(WebCore::Page::setUnderPageBackgroundColorOverride):
(WebCore::Page::addRelevantRepaintedObject):
(WebCore::Page::addRelevantUnpaintedObject):
(WebCore::Page::logNavigation):
(WebCore::Page::checkedRenderingUpdateScheduler):
(WebCore::Page::recomputeTextAutoSizingInAllFrames):
(WebCore::Page::updateElementsWithTextRecognitionResults):
(WebCore::Page::deleteRemovedNodesAndDetachedRenderers):
(WebCore::Page::updateFixedContainerEdges):
(WebCore::Page::updateActiveNowPlayingSessionNow):
(WebCore::Page::requiresScriptTrackingPrivacyProtections const):
(WebCore::Page::requiresUserGestureForAudioPlayback const):
(WebCore::Page::requiresUserGestureForVideoPlayback const):
(WebCore::Page::protectedMediaSessionManager):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::allowedAutoplayQuirks):
(WebCore::Quirks::isEmbedDomain const):
(WebCore::Quirks::shouldBypassBackForwardCache const):
(WebCore::Quirks::triggerOptionalStorageAccessIframeQuirk const):
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::responseHeaders const):
(WebCore::ContentSecurityPolicy::applyPolicyToScriptExecutionContext):
(WebCore::ContentSecurityPolicy::allowJavaScriptURLs const):
(WebCore::ContentSecurityPolicy::allowInlineEventHandlers const):
(WebCore::ContentSecurityPolicy::allowNonParserInsertedScripts const):
(WebCore::ContentSecurityPolicy::allowInlineScript const):
(WebCore::ContentSecurityPolicy::allowInlineStyle const):
(WebCore::ContentSecurityPolicy::allowEval const):
(WebCore::ContentSecurityPolicy::allowFrameAncestors const):
(WebCore::ContentSecurityPolicy::allowPluginType const):
(WebCore::ContentSecurityPolicy::allowObjectFromSource const):
(WebCore::ContentSecurityPolicy::allowChildFrameFromSource const):
(WebCore::ContentSecurityPolicy::allowResourceFromSource const):
(WebCore::ContentSecurityPolicy::allowWorkerFromSource const):
(WebCore::ContentSecurityPolicy::allowScriptFromSource const):
(WebCore::ContentSecurityPolicy::allowStyleFromSource const):
(WebCore::ContentSecurityPolicy::allowConnectToSource const):
(WebCore::ContentSecurityPolicy::allowBaseURI const):
(WebCore::ContentSecurityPolicy::allowTrustedTypesPolicy const):
(WebCore::ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup const):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::checkedCompositor):
* Source/WebCore/rendering/RenderView.h:

Canonical link: <a href="https://commits.webkit.org/300009@main">https://commits.webkit.org/300009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cdf5274bb31c6c746f429ab809da461cfed3122

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72807 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d69f70ad-bd7c-4d03-9de6-145fd99ce604) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91702 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60948 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/584bc932-55ef-4f1c-ae0f-c082b2cf9c95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72250 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72db11ac-84c2-4e77-a0b0-6b869d73048e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26324 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70731 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129993 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100314 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25461 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44313 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53220 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48670 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->