### PR TITLE
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 5)

### DIFF
--- a/Source/JavaScriptCore/runtime/MemoryMode.h
+++ b/Source/JavaScriptCore/runtime/MemoryMode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSExportMacros.h>
+
 namespace JSC {
 
 // FIXME: We should support other modes. see: https://bugs.webkit.org/show_bug.cgi?id=162693

--- a/Source/WebCore/Modules/encryptedmedia/CDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.h
@@ -27,12 +27,12 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include <WebCore/CDMPrivate.h>
-#include <WebCore/ContextDestructionObserver.h>
 #include "MediaKeySessionType.h"
 #include "MediaKeySystemConfiguration.h"
 #include "MediaKeySystemMediaCapability.h"
 #include "MediaKeysRestrictions.h"
+#include <WebCore/CDMPrivate.h>
+#include <WebCore/ContextDestructionObserver.h>
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyEncryptionScheme.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyEncryptionScheme.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include "CDMEncryptionScheme.h"
+#include <WebCore/CDMEncryptionScheme.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySessionType.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySessionType.h
@@ -30,7 +30,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include "CDMSessionType.h"
+#include <WebCore/CDMSessionType.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.h
@@ -30,7 +30,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include "CDMKeySystemConfiguration.h"
+#include <WebCore/CDMKeySystemConfiguration.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemMediaCapability.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemMediaCapability.h
@@ -30,8 +30,8 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include "CDMMediaCapability.h"
 #include "MediaKeyEncryptionScheme.h"
+#include <WebCore/CDMMediaCapability.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeysRestrictions.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeysRestrictions.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include "CDMRestrictions.h"
+#include <WebCore/CDMRestrictions.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <WebCore/FetchBodySource.h>
+#include "FetchBodySource.h"
 #include "FormDataConsumer.h"
 #include <WebCore/JSDOMPromiseDeferredForward.h>
 #include <WebCore/ReadableStreamSink.h>

--- a/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -26,8 +26,8 @@
 
 #pragma once
 
+#include "ReadableStreamSource.h"
 #include <WebCore/ActiveDOMObject.h>
-#include <WebCore/ReadableStreamSource.h>
 
 namespace JSC {
 class ArrayBuffer;

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "ScriptExecutionContextIdentifier.h"
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <span>
 #include <wtf/Function.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/IDBCursor.h>
+#include "IDBCursor.h"
 #include <WebCore/IDBIndexInfo.h>
 #include <WebCore/IDBRequest.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -28,8 +28,8 @@
 
 #pragma once
 
+#include "ReadableStreamDefaultController.h"
 #include <WebCore/JSDOMPromiseDeferredForward.h>
-#include <WebCore/ReadableStreamDefaultController.h>
 #include <wtf/AbstractRefCounted.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(SYSTEM_PREVIEW)
 
 #include <WebCore/Image.h>

--- a/Source/WebCore/PAL/pal/cocoa/DataDetectorsCoreSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/DataDetectorsCoreSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(DATA_DETECTION)
 
 #include <pal/spi/cocoa/DataDetectorsCoreSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.h
+++ b/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(LOCKDOWN_MODE_API)
 
 namespace PAL {

--- a/Source/WebCore/accessibility/AXObjectRareData.h
+++ b/Source/WebCore/accessibility/AXObjectRareData.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "AXCoreObject.h"
-#include "AccessibilityObject.h"
+#include <WebCore/AXCoreObject.h>
+#include <WebCore/AccessibilityObject.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/accessibility/AXTreeStoreInlines.h
+++ b/Source/WebCore/accessibility/AXTreeStoreInlines.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "AXIsolatedTree.h"
+#include <WebCore/AXIsolatedTree.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -116,11 +116,11 @@ protected:
 
     JSC::EncodedJSValue fulfill(JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES onPromiseFulFilled(JSC::JSGlobalObject*, JSC::CallFrame*);
-    JSBoundFunction* createOnFulfilledFunction(JSC::JSGlobalObject*);
+    JSC::JSBoundFunction* createOnFulfilledFunction(JSC::JSGlobalObject*);
 
     JSC::EncodedJSValue reject(JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES onPromiseRejected(JSC::JSGlobalObject*, JSC::CallFrame*);
-    JSBoundFunction* createOnRejectedFunction(JSC::JSGlobalObject*);
+    JSC::JSBoundFunction* createOnRejectedFunction(JSC::JSGlobalObject*);
 
     static void destroy(JSC::JSCell*);
 
@@ -274,7 +274,7 @@ JSC::EncodedJSValue JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::settle(JS
 }
 
 template<typename JSWrapper, typename IteratorTraits>
-JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::onPromiseSettled(JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
+JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::onPromiseSettled(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -286,10 +286,10 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, I
 }
 
 template<typename JSWrapper, typename IteratorTraits>
-JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnSettledFunction(JSC::JSGlobalObject* globalObject)
+JSC::JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnSettledFunction(JSC::JSGlobalObject* globalObject)
 {
     JSC::VM& vm = globalObject->vm();
-    auto onSettled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseSettled, ImplementationVisibility::Public);
+    auto onSettled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseSettled, JSC::ImplementationVisibility::Public);
     return JSC::JSBoundFunction::create(vm, globalObject, onSettled, this, { }, 1, jsEmptyString(vm), JSC::makeSource("createOnSettledFunction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted));
 }
 
@@ -306,7 +306,7 @@ JSC::EncodedJSValue JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::fulfill(J
 }
 
 template<typename JSWrapper, typename IteratorTraits>
-JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::onPromiseFulFilled(JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
+JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::onPromiseFulFilled(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -318,10 +318,10 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, I
 }
 
 template<typename JSWrapper, typename IteratorTraits>
-JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnFulfilledFunction(JSC::JSGlobalObject* globalObject)
+JSC::JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnFulfilledFunction(JSC::JSGlobalObject* globalObject)
 {
     JSC::VM& vm = globalObject->vm();
-    auto onFulFilled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseFulFilled, ImplementationVisibility::Public);
+    auto onFulFilled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseFulFilled, JSC::ImplementationVisibility::Public);
     return JSC::JSBoundFunction::create(vm, globalObject, onFulFilled, this, { }, 1, jsEmptyString(vm), JSC::makeSource("createOnFulfilledFunction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted));
 }
 
@@ -349,10 +349,10 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, I
 }
 
 template<typename JSWrapper, typename IteratorTraits>
-JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnRejectedFunction(JSC::JSGlobalObject* globalObject)
+JSC::JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnRejectedFunction(JSC::JSGlobalObject* globalObject)
 {
     JSC::VM& vm = globalObject->vm();
-    auto onRejected = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseRejected, ImplementationVisibility::Public);
+    auto onRejected = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseRejected, JSC::ImplementationVisibility::Public);
     return JSC::JSBoundFunction::create(vm, globalObject, onRejected, this, { }, 1, jsEmptyString(vm), JSC::makeSource("createOnRejectedFunction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted));
 }
 

--- a/Source/WebCore/bindings/js/ReadableStreamDefaultController.h
+++ b/Source/WebCore/bindings/js/ReadableStreamDefaultController.h
@@ -29,11 +29,11 @@
 
 #pragma once
 
+#include "JSReadableStreamDefaultController.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/TypedArrays.h>
 #include <WebCore/JSDOMConvertBufferSource.h>
-#include <WebCore/JSReadableStreamDefaultController.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -20,10 +20,10 @@
 
 #pragma once
 
+#include "StyleExtractor.h"
 #include <WebCore/CSSStyleProperties.h>
 #include <WebCore/PseudoElementIdentifier.h>
 #include <WebCore/RenderStyleConstants.h>
-#include "StyleExtractor.h"
 #include <wtf/FixedVector.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "CSSURL.h"
-#include "CSSValue.h"
-#include "CachedResourceHandle.h"
-#include "ResourceLoaderOptions.h"
+#include <WebCore/CSSURL.h>
+#include <WebCore/CSSValue.h>
+#include <WebCore/CachedResourceHandle.h>
+#include <WebCore/ResourceLoaderOptions.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -30,10 +30,11 @@
 
 #pragma once
 
+#include "CSSFontFaceSrcValue.h"
+#include "StyleBuilderState.h"
 #include <WebCore/AnchorPositionEvaluator.h>
 #include <WebCore/CSSCalcSymbolTable.h>
 #include <WebCore/CSSCalcValue.h>
-#include "CSSFontFaceSrcValue.h"
 #include <WebCore/CSSPrimitiveValue.h>
 #include <WebCore/CSSToLengthConversionData.h>
 #include <WebCore/CSSValueKeywords.h>
@@ -45,7 +46,6 @@
 #include <WebCore/SVGRenderStyleDefs.h>
 #include <WebCore/ScrollAxis.h>
 #include <WebCore/ScrollTypes.h>
-#include "StyleBuilderState.h"
 #include <WebCore/StyleScrollBehavior.h>
 #include <WebCore/StyleWebKitOverflowScrolling.h>
 #include <WebCore/StyleWebKitTouchCallout.h>

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -27,12 +27,12 @@
 
 #pragma once
 
-#include "CSSSelector.h"
-#include "Element.h"
 #include "SelectorMatchingState.h"
 #include "StyleRelations.h"
-#include "StyleScopeOrdinal.h"
 #include "StyleScrollbarState.h"
+#include <WebCore/CSSSelector.h>
+#include <WebCore/Element.h>
+#include <WebCore/StyleScopeOrdinal.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/query/MediaQueryParser.h
+++ b/Source/WebCore/css/query/MediaQueryParser.h
@@ -25,11 +25,12 @@
 #pragma once
 
 #include "GenericMediaQueryParser.h"
-#include "MediaQuery.h"
 #include "MediaQueryParserContext.h"
 
 namespace WebCore {
 namespace MQ {
+
+struct MediaQuery;
 
 struct MediaQueryParser : public GenericMediaQueryParser<MediaQueryParser>  {
     static MediaQueryList parse(const String&, const CSSParserContext&);

--- a/Source/WebCore/editing/cocoa/DataDetection.h
+++ b/Source/WebCore/editing/cocoa/DataDetection.h
@@ -29,9 +29,9 @@
 
 #if ENABLE(DATA_DETECTION)
 
-#import "DataDetectorType.h"
-#import "FloatRect.h"
-#import "SimpleRange.h"
+#import <WebCore/DataDetectorType.h>
+#import <WebCore/FloatRect.h>
+#import <WebCore/SimpleRange.h>
 #import <wtf/OptionSet.h>
 
 #import <wtf/RetainPtr.h>

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "AttributedString.h"
-#import "SimpleRange.h"
+#import <WebCore/AttributedString.h>
+#import <WebCore/SimpleRange.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/floats/FloatAvoider.h
+++ b/Source/WebCore/layout/floats/FloatAvoider.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <WebCore/LayoutBox.h>
-#include "LayoutBoxGeometry.h"
+#include <WebCore/LayoutBoxGeometry.h>
 #include <WebCore/LayoutPoint.h>
 #include <WebCore/LayoutUnits.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <WebCore/FormattingContext.h>
-#include "LayoutBoxGeometry.h"
+#include <WebCore/LayoutBoxGeometry.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include <WebCore/FormattingConstraints.h>
-#include <WebCore/InlineFormattingContext.h>
-#include <WebCore/InlineFormattingUtils.h>
-#include <WebCore/InlineItem.h>
+#include "InlineFormattingContext.h"
+#include "InlineFormattingUtils.h"
 #include "InlineLineBuilder.h"
+#include <WebCore/FormattingConstraints.h>
+#include <WebCore/InlineItem.h>
 #include <WebCore/InlineLineTypes.h>
 #include <WebCore/InlineTextItem.h>
 #include <optional>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "InlineFormattingUtils.h"
 #include <WebCore/InlineDisplayContent.h>
 #include <WebCore/InlineFormattingConstraints.h>
-#include <WebCore/InlineFormattingUtils.h>
 #include <WebCore/InlineLayoutState.h>
 #include <WebCore/InlineQuirks.h>
 #include <WebCore/IntrinsicWidthHandler.h>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/InlineFormattingContext.h>
+#include "InlineFormattingContext.h"
 #include <WebCore/InlineLayoutState.h>
 #include "InlineLineBuilder.h"
 #include <WebCore/TextUtil.h>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
@@ -26,8 +26,8 @@
 
 #pragma once
 
-#include <WebCore/InlineFormattingContext.h>
-#include <WebCore/InlineFormattingUtils.h>
+#include "InlineFormattingContext.h"
+#include "InlineFormattingUtils.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/InlineFormattingContext.h>
+#include "InlineFormattingContext.h"
 #include "InlineLineBuilder.h"
 #include <WebCore/LayoutUnits.h>
 #include <wtf/Range.h>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/InlineDisplayLine.h>
-#include <WebCore/InlineFormattingContext.h>
+#include "InlineFormattingContext.h"
 #include "InlineLineBuilder.h"
+#include <WebCore/InlineDisplayLine.h>
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/InlineDamage.h>
+#include "InlineDamage.h"
 #include <WebCore/InlineDisplayContent.h>
 #include <optional>
 #include <wtf/Forward.h>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include "InlineFormattingContext.h"
 #include <WebCore/InlineDisplayContent.h>
-#include <WebCore/InlineFormattingContext.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include <WebCore/FloatRect.h>
-#include <WebCore/InlineDamage.h>
-#include <WebCore/InlineFormattingConstraints.h>
-#include <WebCore/InlineFormattingContext.h>
+#include "InlineDamage.h"
+#include "InlineFormattingContext.h"
 #include "InlineIteratorInlineBox.h"
+#include <WebCore/FloatRect.h>
+#include <WebCore/InlineFormattingConstraints.h>
 #include <WebCore/InlineIteratorLineBox.h>
 #include <WebCore/InlineIteratorTextBox.h>
 #include <WebCore/LayoutIntegrationBoxGeometryUpdater.h>

--- a/Source/WebCore/page/PerformanceEventTimingCandidate.h
+++ b/Source/WebCore/page/PerformanceEventTimingCandidate.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "EventTarget.h"
-#include "EventTimingInteractionID.h"
+#include <WebCore/EventTarget.h>
+#include <WebCore/EventTimingInteractionID.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/WebKitJSHandle.h
+++ b/Source/WebCore/page/WebKitJSHandle.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "FrameIdentifier.h"
-#include "ProcessQualified.h"
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/ProcessQualified.h>
 #include <wtf/Markable.h>
 #include <wtf/ObjectIdentifier.h>
 

--- a/Source/WebCore/page/mac/CorrectionIndicator.h
+++ b/Source/WebCore/page/mac/CorrectionIndicator.h
@@ -25,8 +25,12 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
 #include <wtf/Platform.h>
+
 #if PLATFORM(MAC)
+
+#import <AppKit/NSSpellChecker.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/cocoa/CocoaWritingToolsTypes.h
+++ b/Source/WebCore/platform/cocoa/CocoaWritingToolsTypes.h
@@ -47,6 +47,8 @@ constexpr auto CocoaWritingToolsResultTable = UIWritingToolsResultTable;
 
 #else
 
+#import <AppKit/NSTextCheckingClient.h>
+
 using CocoaWritingToolsBehavior = NSWritingToolsBehavior;
 
 constexpr auto CocoaWritingToolsBehaviorNone = NSWritingToolsBehaviorNone;

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
@@ -28,7 +28,7 @@
 #import <wtf/Platform.h>
 #if ENABLE(GAMEPAD) && PLATFORM(COCOA)
 
-#import "GameControllerSPI.h"
+#import <WebCore/GameControllerSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 

--- a/Source/WebCore/platform/graphics/ColorSpace.h
+++ b/Source/WebCore/platform/graphics/ColorSpace.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/ColorTypes.h>
+#include <WebCore/PlatformExportMacros.h>
 #include <functional>
 #include <wtf/Forward.h>
 

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include <WebCore/PlatformColorSpace.h>
+#include <WebCore/PlatformExportMacros.h>
 #include <optional>
 #include <wtf/Forward.h>
+#include <wtf/Platform.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/angle/ANGLEHeaders.h
+++ b/Source/WebCore/platform/graphics/angle/ANGLEHeaders.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(WEBGL)
 
 #ifndef EGL_EGLEXT_PROTOTYPES

--- a/Source/WebCore/platform/graphics/ca/cocoa/ContentsFormatCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/ContentsFormatCocoa.h
@@ -28,9 +28,9 @@
 #import <wtf/Platform.h>
 #if PLATFORM(COCOA)
 
-#import "ContentsFormat.h"
+#import <WebCore/ContentsFormat.h>
 #if HAVE(IOSURFACE)
-#import "IOSurface.h"
+#import <WebCore/IOSurface.h>
 #endif
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 

--- a/Source/WebCore/platform/graphics/cocoa/ColorCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/ColorCocoa.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#import "Color.h"
+#import <WebCore/Color.h>
 #import <wtf/Platform.h>
 
 #if USE(APPKIT)

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -29,10 +29,10 @@
 
 #if ENABLE(DATA_DETECTION) && PLATFORM(MAC)
 
-#import "GraphicsLayer.h"
-#import "GraphicsLayerClient.h"
-#import "SimpleRange.h"
-#import "Timer.h"
+#import <WebCore/GraphicsLayer.h>
+#import <WebCore/GraphicsLayerClient.h>
+#import <WebCore/SimpleRange.h>
+#import <WebCore/Timer.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>

--- a/Source/WebCore/platform/network/mac/AuthenticationMac.h
+++ b/Source/WebCore/platform/network/mac/AuthenticationMac.h
@@ -25,7 +25,7 @@
 #ifndef AuthenticationMac_h
 #define AuthenticationMac_h
 
-#import "PlatformExportMacros.h"
+#import <WebCore/PlatformExportMacros.h>
 
 @class NSURLAuthenticationChallenge;
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -38,7 +38,7 @@
 #include <WebCore/StyleSVGBaselineShift.h>
 #include <WebCore/StyleSVGCenterCoordinateComponent.h>
 #include <WebCore/StyleSVGCoordinateComponent.h>
-#include "StyleSVGPaint.h"
+#include <WebCore/StyleSVGPaint.h>
 #include <WebCore/StyleSVGRadius.h>
 #include <WebCore/StyleSVGRadiusComponent.h>
 #include <WebCore/StyleSVGStrokeDasharray.h>

--- a/Source/WebCore/style/SelectorMatchingState.h
+++ b/Source/WebCore/style/SelectorMatchingState.h
@@ -24,10 +24,10 @@
 
 #pragma once
 
-#include "ContainerQuery.h"
 #include "ContainerQueryEvaluator.h"
 #include "HasSelectorFilter.h"
 #include "SelectorFilter.h"
+#include <WebCore/ContainerQuery.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore::Style {

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -25,19 +25,19 @@
 
 #pragma once
 
-#include "CSSToLengthConversionData.h"
 #include "CSSToStyleMap.h"
 #include "CascadeLevel.h"
-#include "Document.h"
-#include "FontTaggedSettings.h"
-#include "PositionArea.h"
-#include "PositionTryFallback.h"
 #include "PropertyCascade.h"
 #include "RuleSet.h"
 #include "SelectorChecker.h"
-#include "StyleForVisitedLink.h"
 #include "TreeResolutionState.h"
-#include "platform/text/TextFlags.h"
+#include <WebCore/CSSToLengthConversionData.h>
+#include <WebCore/Document.h>
+#include <WebCore/FontTaggedSettings.h>
+#include <WebCore/PositionArea.h>
+#include <WebCore/PositionTryFallback.h>
+#include <WebCore/StyleForVisitedLink.h>
+#include <WebCore/TextFlags.h>
 #include <wtf/BitSet.h>
 #include <wtf/RefCountedFixedVector.h>
 

--- a/Source/WebCore/style/StyleExtractor.h
+++ b/Source/WebCore/style/StyleExtractor.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "PseudoElementIdentifier.h"
 #include "StyleExtractorState.h"
+#include <WebCore/PseudoElementIdentifier.h>
 #include <span>
 #include <wtf/RefPtr.h>
 

--- a/Source/WebCore/style/StyleExtractorState.h
+++ b/Source/WebCore/style/StyleExtractorState.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/PseudoElementIdentifier.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/TreeResolutionState.h
+++ b/Source/WebCore/style/TreeResolutionState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "AnchorPositionEvaluator.h"
+#include <WebCore/AnchorPositionEvaluator.h>
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeyword+Serialization.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeyword+Serialization.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/CSSPrimitiveValueMappings.h>
+#include "CSSPrimitiveValueMappings.h"
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.h
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.h
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include "StyleColor.h"
-#include "StyleURL.h"
+#include <WebCore/StyleColor.h>
+#include <WebCore/StyleURL.h>
 
 namespace WebCore {
 namespace Style {


### PR DESCRIPTION
#### 75fea81f40dbd830d8af1e3f6534b3cadd8b9917
<pre>
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=297810">https://bugs.webkit.org/show_bug.cgi?id=297810</a>
<a href="https://rdar.apple.com/158978764">rdar://158978764</a>

Reviewed by Aditya Keerthi.

Fix some more module verification violations:

* Add some missing includes
* Add some missing header files to the Xcode project
* Make some private headers project, and vice versa

* Source/JavaScriptCore/runtime/MemoryMode.h:
* Source/WebCore/Modules/encryptedmedia/CDM.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeyEncryptionScheme.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySessionType.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemMediaCapability.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeysRestrictions.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/fetch/FetchBodySource.h:
* Source/WebCore/Modules/fetch/FormDataConsumer.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/streams/ReadableStreamSource.h:
* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h:
* Source/WebCore/PAL/pal/cocoa/DataDetectorsCoreSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectRareData.h:
* Source/WebCore/accessibility/AXTreeStoreInlines.h:
* Source/WebCore/bindings/js/JSDOMAsyncIterator.h:
(WebCore::IteratorTraits&gt;::onPromiseSettled):
(WebCore::IteratorTraits&gt;::createOnSettledFunction):
(WebCore::IteratorTraits&gt;::onPromiseFulFilled):
(WebCore::IteratorTraits&gt;::createOnFulfilledFunction):
(WebCore::IteratorTraits&gt;::createOnRejectedFunction):
* Source/WebCore/bindings/js/ReadableStreamDefaultController.h:
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/query/MediaQueryParser.h:
* Source/WebCore/editing/cocoa/DataDetection.h:
* Source/WebCore/editing/cocoa/EditingHTMLConverter.h:
* Source/WebCore/layout/floats/FloatAvoider.h:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/page/PerformanceEventTimingCandidate.h:
* Source/WebCore/page/WebKitJSHandle.h:
* Source/WebCore/page/mac/CorrectionIndicator.h:
* Source/WebCore/platform/cocoa/CocoaWritingToolsTypes.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h:
* Source/WebCore/platform/graphics/ColorSpace.h:
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
* Source/WebCore/platform/graphics/angle/ANGLEHeaders.h:
* Source/WebCore/platform/graphics/ca/cocoa/ContentsFormatCocoa.h:
* Source/WebCore/platform/graphics/cocoa/ColorCocoa.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/platform/network/mac/AuthenticationMac.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/style/SelectorMatchingState.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleExtractor.h:
* Source/WebCore/style/TreeResolutionState.h:
* Source/WebCore/style/values/svg/StyleSVGPaint.h:

Canonical link: <a href="https://commits.webkit.org/299086@main">https://commits.webkit.org/299086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9d5739707af8f863f7420011eeda82195a73e01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69792 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5759cd5-1680-49f8-b361-f2ec1acc0d74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89381 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/58572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08a7eefa-458f-44fa-a973-b50569aa2762) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69874 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17e42fe7-b44a-40b8-809c-6aaf65d39096) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67569 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109883 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126999 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116281 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98036 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97824 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41041 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50221 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144979 "Hash b9d57397 for PR 49799 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44005 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/144979 "Hash b9d57397 for PR 49799 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->