### PR TITLE
Remove unused SPI associated with @"WKCaptivePortalModeContainerConfigurationChanged"

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
@@ -55,7 +55,6 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
 {
     CFPreferencesSetValue(WKLockdownModeEnabledKeyCFString, enabled ? kCFBooleanTrue : kCFBooleanFalse, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
     CFPreferencesSynchronize(kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
 }
 
 + (BOOL)isCaptivePortalModeIgnored:(NSString *)containerPath
@@ -88,8 +87,6 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
         [[NSFileManager defaultManager] createFileAtPath:cpmconfigIgnoreFilePath contents:NULL attributes:NULL];
     else
         [[NSFileManager defaultManager] removeItemAtPath:cpmconfigIgnoreFilePath error:NULL];
-
-    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
@@ -33,6 +33,3 @@ const auto LDMEnabledKey = CFSTR("LDMGlobalEnabled");
 constexpr auto WKLockdownModeEnabledKey = WTF_CONCAT(STRINGIZE_VALUE_OF(WK_LOCKDOWN_MODE_ENABLED_KEY_MACRO), _s);
 // CFSTR("WKLockdownModeEnabled")
 const auto WKLockdownModeEnabledKeyCFString = CFSTR(STRINGIZE_VALUE_OF(WK_LOCKDOWN_MODE_ENABLED_KEY_MACRO));
-
-// This string must remain consistent with the lockdown mode notification name in privacy settings.
-constexpr auto WKLockdownModeContainerConfigurationChangedNotification = @"WKCaptivePortalModeContainerConfigurationChanged";

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -93,7 +93,6 @@
 #import <wtf/text/MakeString.h>
 
 #if ENABLE(LOCKDOWN_MODE_API)
-#import "_WKSystemPreferencesInternal.h"
 #import <WebCore/LocalizedStrings.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -960,10 +960,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             webProcessPool->sendToAllProcesses(Messages::WebProcess::PowerSourceDidChange(hasAC));
     });
 
-#if PLATFORM(COCOA)
-    addCFNotificationObserver(lockdownModeConfigurationUpdateCallback, (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
-#endif
-
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
     addCFNotificationObserver(accessibilityPreferencesChangedCallback, kAXSReduceMotionChangedNotification);
     addCFNotificationObserver(accessibilityPreferencesChangedCallback, kAXSIncreaseButtonLegibilityNotification);
@@ -1038,10 +1034,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     m_powerSourceNotifier = nullptr;
 
     [[NSNotificationCenter defaultCenter] removeObserver:m_finishedMobileAssetFontDownloadObserver.get()];
-
-#if PLATFORM(COCOA)
-    removeCFNotificationObserver((__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
-#endif
 
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
     removeCFNotificationObserver(kAXSReduceMotionChangedNotification);


### PR DESCRIPTION
#### b557f4328d1303896c41d5ab9304a79d43800131
<pre>
Remove unused SPI associated with @&quot;WKCaptivePortalModeContainerConfigurationChanged&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=297805">https://bugs.webkit.org/show_bug.cgi?id=297805</a>
<a href="https://rdar.apple.com/158981431">rdar://158981431</a>

Reviewed by NOBODY (OOPS!).

@&quot;WKCaptivePortalModeContainerConfigurationChanged&quot; is a legacy key that is no longer used for notifications. Yet we still have code in Webkit observing it. We should remove it.

* Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm:
(+[_WKSystemPreferences setCaptivePortalModeEnabled:]):
(+[_WKSystemPreferences setCaptivePortalModeIgnored:ignore:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b557f4328d1303896c41d5ab9304a79d43800131

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69765 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/704d569f-706a-4749-b219-f189efaf5bb4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89367 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/57904 "Too many flaky failures: css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/structuredClone/structured-clone-of-CachedString-in-map.html, js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html, storage/indexeddb/modern/deletedatabase-request-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, webgl/2.0.0/conformance2/textures/image_data/tex-2d-rgba8-rgba-unsigned_byte.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-rg32f-rg-float.html, webgl/2.0.y/conformance/buffers/index-validation-copies-indices.html, webgl/2.0.y/conformance/canvas/drawingbuffer-hd-dpi-test.html, webgl/2.0.y/conformance/context/context-creation-and-destruction.html, webgl/2.0.y/conformance2/query/occlusion-query.html, webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89c1cc33-0a42-4f1e-8101-6c512f2a2fca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69860 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59b593ac-c0b7-4aa1-a784-364409a3f7ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29407 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67544 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126978 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98022 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97810 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41019 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50200 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47331 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->