### PR TITLE
[JSC] IPInt SIMD entrypoint should throw error correctly

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -234,70 +234,6 @@ end
     addp gprStorageSize + fprStorageSize, sp
 end
 
-macro preserveCalleeSavesUsedByWasm()
-    # NOTE: We intentionally don't save memoryBase and boundsCheckingSize here. See the comment
-    # in restoreCalleeSavesUsedByWasm() below for why.
-    subp CalleeSaveSpaceStackAligned, sp
-    if ARM64 or ARM64E
-        storepairq wasmInstance, PB, -16[cfr]
-    elsif X86_64 or RISCV64
-        storep PB, -0x8[cfr]
-        storep wasmInstance, -0x10[cfr]
-    elsif ARMv7
-        storep PB, -4[cfr]
-        storep wasmInstance, -8[cfr]
-    else
-        error
-    end
-end
-
-macro restoreCalleeSavesUsedByWasm()
-    # NOTE: We intentionally don't restore memoryBase and boundsCheckingSize here. These are saved
-    # and restored when entering Wasm by the JSToWasm wrapper and changes to them are meant
-    # to be observable within the same Wasm module.
-    if ARM64 or ARM64E
-        loadpairq -16[cfr], wasmInstance, PB
-    elsif X86_64 or RISCV64
-        loadp -0x8[cfr], PB
-        loadp -0x10[cfr], wasmInstance
-    elsif ARMv7
-        loadp -4[cfr], PB
-        loadp -8[cfr], wasmInstance
-    else
-        error
-    end
-end
-
-macro preserveGPRsUsedByTailCall(gpr0, gpr1)
-    storep gpr0, ThisArgumentOffset[sp]
-    storep gpr1, ArgumentCountIncludingThis[sp]
-end
-
-macro restoreGPRsUsedByTailCall(gpr0, gpr1)
-    loadp ThisArgumentOffset[sp], gpr0
-    loadp ArgumentCountIncludingThis[sp], gpr1
-end
-
-macro preserveReturnAddress(scratch)
-if X86_64
-    loadp ReturnPC[cfr], scratch
-    storep scratch, ReturnPC[sp]
-elsif ARM64 or ARM64E or ARMv7 or RISCV64
-    loadp ReturnPC[cfr], lr
-end
-end
-
-macro usePreviousFrame()
-    if ARM64 or ARM64E
-        loadpairq -PtrSize[cfr], PB, cfr
-    elsif ARMv7 or X86_64 or RISCV64
-        loadp -PtrSize[cfr], PB
-        loadp [cfr], cfr
-    else
-        error
-    end
-end
-
 macro reloadMemoryRegistersFromInstance(instance, scratch1)
 if not ARMv7
     loadp JSWebAssemblyInstance::m_cachedMemory[instance], memoryBase
@@ -331,111 +267,6 @@ macro callWasmCallSlowPath(slowPath, action)
     action(r0, r1)
 end
 
-# Tier up immediately, while saving full vectors in argument FPRs
-macro wasmPrologueSIMD(slow_path)
-if (WEBASSEMBLY_BBQJIT or WEBASSEMBLY_OMGJIT) and not ARMv7
-    preserveCallerPCAndCFR()
-    preserveCalleeSavesUsedByWasm()
-    reloadMemoryRegistersFromInstance(wasmInstance, ws0)
-
-    storep wasmInstance, CodeBlock[cfr]
-    loadp Callee[cfr], ws0
-if JSVALUE64
-    andp ~(constexpr JSValue::NativeCalleeTag), ws0
-end
-    leap WTFConfig + constexpr WTF::offsetOfWTFConfigLowestAccessibleAddress, ws1
-    loadp [ws1], ws1
-    addp ws1, ws0
-    storep ws0, UnboxedWasmCalleeStackSlot[cfr]
-
-    # Get new sp in ws1 and check stack height.
-    # This should match the calculation of m_stackSize, but with double the size for fpr arg storage and no locals.
-    move 8 + 8 * 2 + constexpr CallFrame::headerSizeInRegisters + 1, ws1
-    lshiftp 3, ws1
-    addp maxFrameExtentForSlowPathCall, ws1
-    subp cfr, ws1, ws1
-
-if not JSVALUE64
-    subp 8, ws1 # align stack pointer
-end
-
-if not ADDRESS64
-    bpa ws1, cfr, .stackOverflow
-end
-    bpbeq JSWebAssemblyInstance::m_stackMirror + StackManager::Mirror::m_trapAwareSoftStackLimit[wasmInstance], ws1, .stackHeightOK
-
-.checkStack:
-    preserveVolatileRegistersForSIMD()
-
-    storei PC, CallSiteIndex[cfr]
-    move wasmInstance, a0
-    move ws1, a1
-    cCall2(_ipint_extern_check_stack_and_vm_traps)
-    bpneq r1, (constexpr JSC::IPInt::SlowPathExceptionTag), .stackHeightOKAfterRestoringRegisters
-
-    addq (NumberOfWasmArgumentGPRs * MachineRegisterSize + NumberOfWasmArgumentFPRs * VectorRegisterSize), sp
-.stackOverflow:
-    # It's safe to request a StackOverflow error even if a TerminationException has
-    # been thrown. The exception throwing code downstream will handle it correctly
-    # and only throw the StackOverflow if a TerminationException is not already present.
-    # See slow_path_wasm_throw_exception() and Wasm::throwWasmToJSException().
-    throwException(StackOverflow)
-
-.stackHeightOKAfterRestoringRegisters:
-    restoreVolatileRegistersForSIMD()
-
-.stackHeightOK:
-    move ws1, sp
-
-    forEachWasmArgumentGPR(macro (index, gpr1, gpr2)
-        const base = - CalleeSaveSpaceAsVirtualRegisters * MachineRegisterSize
-        if ARM64 or ARM64E
-            storepairq gpr2, gpr1, base - (index + 2) * MachineRegisterSize[cfr]
-        elsif JSVALUE64
-            storeq gpr2, base - (index + 2) * MachineRegisterSize[cfr]
-            storeq gpr1, base - (index + 1) * MachineRegisterSize[cfr]
-        else
-            store2ia gpr2, gpr1, base - (index + 2) * MachineRegisterSize[cfr]
-        end
-    end)
-    forEachWasmArgumentFPR(macro (index, fpr1, fpr2)
-        const base = -(NumberOfWasmArgumentGPRs + CalleeSaveSpaceAsVirtualRegisters + 2) * MachineRegisterSize
-        storev fpr1, base - (index + 0) * VectorRegisterSize[cfr]
-        storev fpr2, base - (index + 1) * VectorRegisterSize[cfr]
-    end)
-
-    slow_path()
-    move r0, ws0
-
-    forEachWasmArgumentGPR(macro (index, gpr1, gpr2)
-        const base = - CalleeSaveSpaceAsVirtualRegisters * MachineRegisterSize
-        if ARM64 or ARM64E
-            loadpairq base - (index + 2) * MachineRegisterSize[cfr], gpr2, gpr1
-        elsif JSVALUE64
-            loadq base - (index + 2) * MachineRegisterSize[cfr], gpr2
-            loadq base - (index + 1) * MachineRegisterSize[cfr], gpr1
-        else
-            load2ia base - (index + 2) * MachineRegisterSize[cfr], gpr2, gpr1
-        end
-    end)
-    forEachWasmArgumentFPR(macro (index, fpr1, fpr2)
-        const base = -(NumberOfWasmArgumentGPRs + CalleeSaveSpaceAsVirtualRegisters + 2) * MachineRegisterSize
-        loadv base - (index + 0) * VectorRegisterSize[cfr], fpr1
-        loadv base - (index + 1) * VectorRegisterSize[cfr], fpr2
-    end)
-
-    restoreCalleeSavesUsedByWasm()
-    restoreCallerPCAndCFR()
-    if ARM64E
-        leap _g_config, ws1
-        jmp JSCConfigGateMapOffset + (constexpr Gate::wasmOSREntry) * PtrSize[ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
-    else
-        jmp ws0, WasmEntryPtrTag
-    end
-end
-    break
-end
-
 if ARMv7
 macro branchIfWasmException(exceptionTarget)
     loadp CodeBlock[cfr], t3
@@ -444,20 +275,6 @@ macro branchIfWasmException(exceptionTarget)
     jmp exceptionTarget
 .noException:
 end
-end
-
-macro zeroExtend32ToWord(r)
-    if JSVALUE64
-        andq 0xffffffff, r
-    end
-end
-
-macro boxInt32(r, rTag)
-    if JSVALUE64
-        orq constexpr JSValue::NumberTag, r
-    else
-        move constexpr JSValue::Int32Tag, rTag
-    end
 end
 
 // If you change this, make sure to modify JSToWasm.cpp:createJSToWasmJITShared
@@ -994,24 +811,6 @@ macro commonWasmOp(opcodeName, opcodeStruct, prologue, fn)
 end
 
 # Entry point
-
-op(ipint_function_prologue_simd_trampoline, macro ()
-    tagReturnAddress sp
-    jmp _ipint_function_prologue_simd
-end)
-
-op(ipint_function_prologue_simd, macro ()
-    if not WEBASSEMBLY or C_LOOP
-        error
-    end
-
-    wasmPrologueSIMD(macro()
-        move wasmInstance, a0
-        move cfr, a1
-        cCall2(_ipint_extern_simd_go_straight_to_bbq)
-    end)
-    break
-end)
 
 macro jumpToException()
     if ARM64E

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -77,6 +77,8 @@ private:
         runCompletionTasks();
     }
 
+    void fail(String&& errorMessage, CompilationError);
+
     const Ref<CalleeGroup> m_calleeGroup;
     FunctionCodeIndex m_functionIndex;
     bool m_completed { false };

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -294,13 +294,13 @@ RegisterAtOffsetList* IPIntCallee::calleeSaveRegistersImpl()
         RegisterSet registers;
         registers.add(GPRInfo::regCS0, IgnoreVectors); // JSWebAssemblyInstance
 #if CPU(X86_64)
-        registers.add(GPRInfo::regCS1, IgnoreVectors); // PM (pointer to metadata)
+        registers.add(GPRInfo::regCS1, IgnoreVectors); // MC (pointer to metadata)
         registers.add(GPRInfo::regCS2, IgnoreVectors); // PB
 #elif CPU(ARM64) || CPU(RISCV64)
-        registers.add(GPRInfo::regCS6, IgnoreVectors); // PM
+        registers.add(GPRInfo::regCS6, IgnoreVectors); // MC
         registers.add(GPRInfo::regCS7, IgnoreVectors); // PB
 #elif CPU(ARM)
-        registers.add(GPRInfo::regCS0, IgnoreVectors); // PM
+        registers.add(GPRInfo::regCS0, IgnoreVectors); // MC
         registers.add(GPRInfo::regCS1, IgnoreVectors); // PB
 #else
 #error Unsupported architecture.

--- a/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
@@ -37,6 +37,12 @@ namespace JSC { namespace Wasm {
 
 using IPIntPC = uint32_t;
 
+enum class CompilationError : uint8_t {
+    Default = 0,
+    OutOfMemory,
+    Parse
+};
+
 class IPIntTierUpCounter : public BaselineExecutionCounter {
     WTF_MAKE_NONCOPYABLE(IPIntTierUpCounter);
 
@@ -45,6 +51,7 @@ public:
         NotCompiled = 0,
         Compiling,
         Compiled,
+        Failed,
     };
 
     struct OSREntryData {
@@ -59,6 +66,7 @@ public:
         optimizeAfterWarmUp();
         m_compilationStatus.fill(CompilationStatus::NotCompiled);
         m_loopCompilationStatus.fill(CompilationStatus::NotCompiled);
+        m_compilationErrors.fill(CompilationError::Default);
     }
 
     void optimizeAfterWarmUp()
@@ -90,12 +98,16 @@ public:
     ALWAYS_INLINE CompilationStatus loopCompilationStatus(MemoryMode mode) WTF_REQUIRES_LOCK(m_lock) { return m_loopCompilationStatus[static_cast<MemoryModeType>(mode)]; }
     ALWAYS_INLINE void setLoopCompilationStatus(MemoryMode mode, CompilationStatus status) WTF_REQUIRES_LOCK(m_lock) { m_loopCompilationStatus[static_cast<MemoryModeType>(mode)] = status; }
 
+    ALWAYS_INLINE CompilationError compilationError(MemoryMode mode) WTF_REQUIRES_LOCK(m_lock) { return m_compilationErrors[static_cast<MemoryModeType>(mode)]; }
+    ALWAYS_INLINE void setCompilationError(MemoryMode mode, CompilationError error) WTF_REQUIRES_LOCK(m_lock) { m_compilationErrors[static_cast<MemoryModeType>(mode)] = error; }
+
     void resetAndOptimizeSoon(MemoryMode mode)
     {
         {
             Locker locker { m_lock };
             m_compilationStatus[static_cast<MemoryModeType>(mode)] = CompilationStatus::NotCompiled;
             m_loopCompilationStatus[static_cast<MemoryModeType>(mode)] = CompilationStatus::NotCompiled;
+            m_compilationErrors[static_cast<MemoryModeType>(mode)] = CompilationError::Default;
         }
         optimizeSoon();
     }
@@ -104,6 +116,7 @@ public:
 private:
     std::array<CompilationStatus, numberOfMemoryModes> m_compilationStatus WTF_GUARDED_BY_LOCK(m_lock);
     std::array<CompilationStatus, numberOfMemoryModes> m_loopCompilationStatus WTF_GUARDED_BY_LOCK(m_lock);
+    std::array<CompilationError, numberOfMemoryModes> m_compilationErrors WTF_GUARDED_BY_LOCK(m_lock);
     const UncheckedKeyHashMap<IPIntPC, OSREntryData> m_osrEntryData;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -139,7 +139,7 @@ void OMGPlan::work()
 
     if (!parseAndCompileResult) [[unlikely]] {
         Locker locker { m_lock };
-        fail(makeString(parseAndCompileResult.error(), "when trying to tier up "_s, m_functionIndex.rawIndex()), Plan::Error::Parse);
+        fail(makeString(parseAndCompileResult.error(), "when trying to tier up "_s, m_functionIndex.rawIndex()), CompilationError::Parse);
         return;
     }
 
@@ -147,7 +147,7 @@ void OMGPlan::work()
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmOMG, JITCompilationCanFail);
     if (linkBuffer.didFailToAllocate()) [[unlikely]] {
         Locker locker { m_lock };
-        Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()), Plan::Error::OutOfMemory);
+        Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex.rawIndex()), CompilationError::OutOfMemory);
         return;
     }
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -116,7 +116,7 @@ bool Plan::tryRemoveContextAndCancelIfLast(VM& vm)
     return false;
 }
 
-void Plan::fail(String&& errorMessage, Error error)
+void Plan::fail(String&& errorMessage, CompilationError error)
 {
     if (failed())
         return;

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "CompilationResult.h"
+#include "WasmIPIntTierUpCounter.h"
 #include "WasmJS.h"
 #include "WasmModuleInformation.h"
 #include "WasmOMGIRGenerator.h"
@@ -66,12 +67,7 @@ public:
     ALWAYS_INLINE MemoryMode mode() const { return m_mode; }
 
     String errorMessage() const { return crossThreadCopy(m_errorMessage); }
-    enum class Error : uint8_t {
-        Default = 0,
-        OutOfMemory,
-        Parse
-    };
-    Error error() const { return m_error; }
+    CompilationError error() const { return m_error; }
 
     bool WARN_UNUSED_RETURN failed() const { return !m_errorMessage.isNull(); }
     virtual bool hasWork() const = 0;
@@ -84,7 +80,7 @@ public:
 
 protected:
     void runCompletionTasks() WTF_REQUIRES_LOCK(m_lock);
-    void fail(String&& errorMessage, Error = Error::Default) WTF_REQUIRES_LOCK(m_lock);
+    void fail(String&& errorMessage, CompilationError = CompilationError::Default) WTF_REQUIRES_LOCK(m_lock);
 
     virtual bool isComplete() const = 0;
     virtual void complete() WTF_REQUIRES_LOCK(m_lock) = 0;
@@ -104,7 +100,7 @@ protected:
     Vector<std::pair<VM*, CompletionTask>, 1> m_completionTasks;
 
     String m_errorMessage;
-    Error m_error { Error::Default };
+    CompilationError m_error { CompilationError::Default };
 };
 
 


### PR DESCRIPTION
#### ea8ba765cb6bd2bf4181c5990020862a4d9df6f1
<pre>
[JSC] IPInt SIMD entrypoint should throw error correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=297815">https://bugs.webkit.org/show_bug.cgi?id=297815</a>
<a href="https://rdar.apple.com/158957311">rdar://158957311</a>

Reviewed by Yijia Huang.

We found that IPInt SIMD prologue stub is not handling errors correctly.

1. BBQJIT plan should notify compilation failure to IPIntTierUpCounter.
   So IPInt side will find this. Avoiding dead lock.
2. IPInt SIMD prologue should throw an error when the error code is returned.
3. Move this prologue implementation to InPlaceInterpreter side as it is
   relying on InPlaceInterpreter.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
(JSC::Wasm::BBQPlan::fail):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::calleeSaveRegistersImpl):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::jitCompileSIMDFunction):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h:
(JSC::Wasm::IPIntTierUpCounter::IPIntTierUpCounter):
(JSC::Wasm::IPIntTierUpCounter::WTF_REQUIRES_LOCK):
(JSC::Wasm::IPIntTierUpCounter::resetAndOptimizeSoon):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmPlan.cpp:
(JSC::Wasm::Plan::fail):
* Source/JavaScriptCore/wasm/WasmPlan.h:
(JSC::Wasm::Plan::error const):

Canonical link: <a href="https://commits.webkit.org/299122@main">https://commits.webkit.org/299122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef2e3e90bed08fbadabcf07e9606ebbfa570f05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69769 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a780cf9d-3255-43e6-a60e-00b024ac546e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/57250 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec5672a8-be28-4f47-aa4b-a9026c70cf1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69863 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd4af93b-564e-4744-94d8-26731ce2818d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23699 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67548 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109866 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126982 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116264 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98025 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45016 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97813 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21164 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41023 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18802 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44530 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50204 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144962 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43988 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37300 "Found 1 new JSC binary failure: testapi, Found 20029 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->