### PR TITLE
WebPaymentCoordinatorProxy::ShowPaymentUI should be an asynchronous flow

### DIFF
--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
@@ -33,6 +33,7 @@
 #include "JSApplePayAMSUIRequest.h"
 #include "JSDOMConvert.h"
 #include "Page.h"
+#include <wtf/CompletionHandler.h>
 
 namespace WebCore {
 
@@ -129,15 +130,17 @@ ExceptionOr<void> ApplePayAMSUIPaymentHandler::convertData(Document& document, J
     return { };
 }
 
-ExceptionOr<void> ApplePayAMSUIPaymentHandler::show(Document&)
+void ApplePayAMSUIPaymentHandler::show(Document&, CompletionHandler<void(ExceptionOr<void>&&)>&& completionHandler)
 {
     ASSERT(m_applePayAMSUIRequest);
 
     Ref page = this->page();
-    if (!page->startApplePayAMSUISession(page->mainFrameURL(), *this, *m_applePayAMSUIRequest))
-        return Exception { ExceptionCode::AbortError };
+    if (!page->startApplePayAMSUISession(page->mainFrameURL(), *this, *m_applePayAMSUIRequest)) {
+        completionHandler(Exception { ExceptionCode::AbortError });
+        return;
+    }
 
-    return { };
+    completionHandler({ });
 }
 
 void ApplePayAMSUIPaymentHandler::hide()
@@ -169,9 +172,9 @@ ExceptionOr<void> ApplePayAMSUIPaymentHandler::complete(Document&, std::optional
     return { };
 }
 
-ExceptionOr<void> ApplePayAMSUIPaymentHandler::retry(PaymentValidationErrors&&)
+void ApplePayAMSUIPaymentHandler::retry(PaymentValidationErrors&&, CompletionHandler<void(ExceptionOr<void>&&)>&& completionHandler)
 {
-    return show(Ref { document() }.get());
+    return show(Ref { document() }.get(), WTFMove(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h
@@ -31,6 +31,7 @@
 #include "ContextDestructionObserver.h"
 #include "PaymentHandler.h"
 #include "PaymentRequest.h"
+#include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
@@ -70,14 +71,14 @@ private:
 
     // PaymentHandler
     ExceptionOr<void> convertData(Document&, JSC::JSValue) final;
-    ExceptionOr<void> show(Document&) final;
+    void show(Document&, CompletionHandler<void(ExceptionOr<void>&&)>&&) final;
     bool canAbortSession() final { return false; }
     void hide() final;
     void canMakePayment(Document&, Function<void(bool)>&& completionHandler) final;
     ExceptionOr<void> detailsUpdated(PaymentRequest::UpdateReason, String&& error, AddressErrors&&, PayerErrorFields&&, JSC::JSObject* paymentMethodErrors) final;
     ExceptionOr<void> merchantValidationCompleted(JSC::JSValue&&) final;
     ExceptionOr<void> complete(Document&, std::optional<PaymentComplete>&&, String&& serializedData) final;
-    ExceptionOr<void> retry(PaymentValidationErrors&&) final;
+    void retry(PaymentValidationErrors&&, CompletionHandler<void(ExceptionOr<void>&&)>&&) final;
 
     PaymentRequest::MethodIdentifier m_identifier;
     const Ref<PaymentRequest> m_paymentRequest;

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -611,8 +611,17 @@ ExceptionOr<void> ApplePaySession::begin(Document& document)
     Ref paymentCoordinator = this->paymentCoordinator();
     if (paymentCoordinator->hasActiveSession())
         return Exception { ExceptionCode::InvalidAccessError, "Page already has an active payment session."_s };
-    if (!paymentCoordinator->beginPaymentSession(document, *this, m_paymentRequest))
-        return Exception { ExceptionCode::InvalidAccessError, "There is already has an active payment session."_s };
+
+    paymentCoordinator->beginPaymentSession(document, *this, m_paymentRequest, [weakThis = WeakPtr { *this }](bool success) {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis)
+            return;
+
+        if (success)
+            strongThis->m_state = State::Active;
+        else
+            strongThis->protectedPaymentCoordinator()->didCancelPaymentSession({ });
+    });
 
     m_state = State::Active;
     return { };

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -41,11 +41,14 @@
 #include "Page.h"
 #include "PaymentCoordinatorClient.h"
 #include "PaymentSession.h"
+#include "PaymentSessionError.h"
 #include "UserContentProvider.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
+#include <wtf/Vector.h>
 
 #define PAYMENT_COORDINATOR_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ApplePay, "%p - PaymentCoordinator::" fmt, this, ##__VA_ARGS__)
 #define PAYMENT_COORDINATOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(ApplePay, "%p - PaymentCoordinator::" fmt, this, ##__VA_ARGS__)
@@ -105,29 +108,40 @@ void PaymentCoordinator::openPaymentSetup(Document& document, const String& merc
     m_client->openPaymentSetup(merchantIdentifier, document.domain(), WTFMove(completionHandler));
 }
 
-bool PaymentCoordinator::beginPaymentSession(Document& document, PaymentSession& paymentSession, const ApplePaySessionPaymentRequest& paymentRequest)
+static Vector<URL> linkIconURLs(Document& document)
+{
+    return LinkIconCollector { document }.iconsOfTypes({ LinkIconType::TouchIcon, LinkIconType::TouchPrecomposedIcon }).map([](auto& icon) {
+        return icon.url;
+    });
+}
+
+void PaymentCoordinator::beginPaymentSession(Document& document, PaymentSession& paymentSession, const ApplePaySessionPaymentRequest& paymentRequest, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(!m_activeSession);
 
     RefPtr page = document.page();
     if (!page)
-        return false;
+        return completionHandler(false);
 
-    auto linkIconURLs = LinkIconCollector { document }.iconsOfTypes({ LinkIconType::TouchIcon, LinkIconType::TouchPrecomposedIcon }).map([](auto& icon) {
-        return icon.url;
-    });
-    auto showPaymentUI = m_client->showPaymentUI(page->mainFrameURL(), WTFMove(linkIconURLs), paymentRequest);
-    PAYMENT_COORDINATOR_RELEASE_LOG("beginPaymentSession() -> %d", showPaymentUI);
-    if (!showPaymentUI)
-        return false;
+    m_client->showPaymentUI(page->mainFrameURL(), linkIconURLs(document), paymentRequest, [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler), paymentSession = Ref { paymentSession }, document = Ref { document }, &paymentRequest](bool success) mutable {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis)
+            return completionHandler(false);
 
 #if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)
-    if (paymentRequest.shippingContactEditingMode() == ApplePayShippingContactEditingMode::Enabled)
-        document.addConsoleMessage(MessageSource::PaymentRequest, MessageLevel::Warning, "`enabled` is a deprecated value for `shippingContactEditingMode`. Please use `available` instead."_s);
+        if (paymentRequest.shippingContactEditingMode() == ApplePayShippingContactEditingMode::Enabled)
+            document->addConsoleMessage(MessageSource::PaymentRequest, MessageLevel::Warning, "`enabled` is a deprecated value for `shippingContactEditingMode`. Please use `available` instead."_s);
 #endif
 
-    m_activeSession = paymentSession;
-    return true;
+        strongThis->m_activeSession = WTFMove(paymentSession);
+
+        if (!success) {
+            strongThis->didCancelPaymentSession({ });
+            return completionHandler(false);
+        }
+
+        completionHandler(true);
+    });
 }
 
 void PaymentCoordinator::completeMerchantValidation(const PaymentMerchantSession& paymentMerchantSession)

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.h
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.h
@@ -73,7 +73,7 @@ public:
 
     bool hasActiveSession() const { return m_activeSession; }
 
-    bool beginPaymentSession(Document&, PaymentSession&, const ApplePaySessionPaymentRequest&);
+    void beginPaymentSession(Document&, PaymentSession&, const ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&);
     void completeMerchantValidation(const PaymentMerchantSession&);
     void completeShippingMethodSelection(std::optional<ApplePayShippingMethodUpdate>&&);
     void completeShippingContactSelection(std::optional<ApplePayShippingContactUpdate>&&);

--- a/Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h
@@ -55,7 +55,7 @@ public:
     virtual void canMakePaymentsWithActiveCard(const String& merchantIdentifier, const String& domainName, CompletionHandler<void(bool)>&&) = 0;
     virtual void openPaymentSetup(const String& merchantIdentifier, const String& domainName, CompletionHandler<void(bool)>&&) = 0;
 
-    virtual bool showPaymentUI(const URL& originatingURL, const Vector<URL>& linkIconURLs, const ApplePaySessionPaymentRequest&) = 0;
+    virtual void showPaymentUI(const URL& originatingURL, Vector<URL>&& linkIconURLs, const ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&) = 0;
     virtual void completeMerchantValidation(const PaymentMerchantSession&) = 0;
     virtual void completeShippingMethodSelection(std::optional<ApplePayShippingMethodUpdate>&&) = 0;
     virtual void completeShippingContactSelection(std::optional<ApplePayShippingContactUpdate>&&) = 0;

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -72,6 +72,7 @@
 #include "PaymentValidationErrors.h"
 #include "Settings.h"
 #include <JavaScriptCore/JSONObject.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -250,12 +251,12 @@ static void mergePaymentOptions(const PaymentOptions& options, ApplePaySessionPa
         request.setShippingType(convert(options.shippingType));
 }
 
-ExceptionOr<void> ApplePayPaymentHandler::show(Document& document)
+void ApplePayPaymentHandler::show(Document& document,  CompletionHandler<void(ExceptionOr<void>&&)>&& completionHandler)
 {
     Ref paymentCoordinator = this->paymentCoordinator();
     auto validatedRequest = convertAndValidate(document, m_applePayRequest->version, *m_applePayRequest, paymentCoordinator.get());
     if (validatedRequest.hasException())
-        return validatedRequest.releaseException();
+        return completionHandler(validatedRequest.releaseException());
 
     ApplePaySessionPaymentRequest request = validatedRequest.releaseReturnValue();
     request.setRequester(ApplePaySessionPaymentRequest::Requester::PaymentRequest);
@@ -271,7 +272,7 @@ ExceptionOr<void> ApplePayPaymentHandler::show(Document& document)
 
     auto modifierException = firstApplicableModifier();
     if (modifierException.hasException())
-        return modifierException.releaseException();
+        return completionHandler(modifierException.releaseException());
     auto modifierData = modifierException.releaseReturnValue();
     std::optional<ApplePayModifier> applePayModifier;
     if (modifierData)
@@ -280,7 +281,7 @@ ExceptionOr<void> ApplePayPaymentHandler::show(Document& document)
     if (details.displayItems) {
         auto convertedLineItems = convertAndValidate(*details.displayItems, expectedCurrency);
         if (convertedLineItems.hasException())
-            return convertedLineItems.releaseException();
+            return completionHandler(convertedLineItems.releaseException());
         Vector<ApplePayLineItem>  lineItems = convertedLineItems.releaseReturnValue();
         if (applePayModifier)
             lineItems.appendVector(applePayModifier->additionalLineItems);
@@ -293,11 +294,11 @@ ExceptionOr<void> ApplePayPaymentHandler::show(Document& document)
 
     auto shippingMethods = computeShippingMethods();
     if (shippingMethods.hasException())
-        return shippingMethods.releaseException();
+        return completionHandler(shippingMethods.releaseException());
     request.setShippingMethods(shippingMethods.releaseReturnValue());
 
     if (modifierException.hasException())
-        return modifierException.releaseException();
+        return completionHandler(modifierException.releaseException());
     if (applePayModifier) {
 
 #if ENABLE(APPLE_PAY_RECURRING_PAYMENTS)
@@ -328,12 +329,13 @@ ExceptionOr<void> ApplePayPaymentHandler::show(Document& document)
     };
     auto exception = PaymentRequestValidator::validate(request, fieldsToValidate);
     if (exception.hasException())
-        return exception.releaseException();
+        return completionHandler(exception.releaseException());
 
-    if (!paymentCoordinator->beginPaymentSession(document, *this, request))
-        return Exception { ExceptionCode::AbortError };
-
-    return { };
+    paymentCoordinator->beginPaymentSession(document, *this, request, [completionHandler = WTFMove(completionHandler)](bool success) mutable {
+        if (!success)
+            return completionHandler(Exception { ExceptionCode::AbortError });
+        completionHandler({ });
+    });
 }
 
 void ApplePayPaymentHandler::hide()
@@ -958,7 +960,7 @@ ExceptionOr<void> ApplePayPaymentHandler::complete(Document& document, std::opti
     return { };
 }
 
-ExceptionOr<void> ApplePayPaymentHandler::retry(PaymentValidationErrors&& validationErrors)
+void ApplePayPaymentHandler::retry(PaymentValidationErrors&& validationErrors, CompletionHandler<void(ExceptionOr<void>&&)>&& completionHandler)
 {
     Vector<Ref<ApplePayError>> errors;
 
@@ -967,13 +969,13 @@ ExceptionOr<void> ApplePayPaymentHandler::retry(PaymentValidationErrors&& valida
 
     auto exception = computePaymentMethodErrors(validationErrors.paymentMethod.get(), errors);
     if (exception.hasException())
-        return exception.releaseException();
+        return completionHandler(exception.releaseException());
 
     // computePaymentMethodErrors() may run JS, which may abort the request so we need to
     // make sure we still have an active session.
     Ref paymentCoordinator = this->paymentCoordinator();
     if (!paymentCoordinator->hasActiveSession())
-        return Exception { ExceptionCode::AbortError };
+        return completionHandler(Exception { ExceptionCode::AbortError });
 
     // Ensure there is always at least one error to avoid having a final result.
     if (errors.isEmpty())
@@ -984,7 +986,7 @@ ExceptionOr<void> ApplePayPaymentHandler::retry(PaymentValidationErrors&& valida
     authorizationResult.errors = WTFMove(errors);
     ASSERT(!authorizationResult.isFinalState());
     paymentCoordinator->completePaymentSession(WTFMove(authorizationResult));
-    return { };
+    completionHandler({ });
 }
 
 unsigned ApplePayPaymentHandler::version() const

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
@@ -33,6 +33,7 @@
 #include "PaymentHandler.h"
 #include "PaymentRequest.h"
 #include "PaymentSession.h"
+#include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
@@ -74,14 +75,14 @@ private:
 
     // PaymentHandler
     ExceptionOr<void> convertData(Document&, JSC::JSValue) final;
-    ExceptionOr<void> show(Document&) final;
+    void show(Document&, CompletionHandler<void(ExceptionOr<void>&&)>&&) final;
     bool canAbortSession() final { return true; }
     void hide() final;
     void canMakePayment(Document&, Function<void(bool)>&& completionHandler) final;
     ExceptionOr<void> detailsUpdated(PaymentRequest::UpdateReason, String&& error, AddressErrors&&, PayerErrorFields&&, JSC::JSObject* paymentMethodErrors) final;
     ExceptionOr<void> merchantValidationCompleted(JSC::JSValue&&) final;
     ExceptionOr<void> complete(Document&, std::optional<PaymentComplete>&&, String&& serializedData) final;
-    ExceptionOr<void> retry(PaymentValidationErrors&&) final;
+    void retry(PaymentValidationErrors&&, CompletionHandler<void(ExceptionOr<void>&&)>&&) final;
 
     // PaymentSession
     unsigned version() const final;

--- a/Source/WebCore/Modules/paymentrequest/PaymentHandler.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentHandler.h
@@ -29,6 +29,7 @@
 
 #include "PaymentRequest.h"
 #include "PaymentSessionBase.h"
+#include <wtf/Forward.h>
 #include <wtf/Function.h>
 
 namespace JSC {
@@ -51,14 +52,14 @@ public:
     static bool hasActiveSession(Document&);
 
     virtual ExceptionOr<void> convertData(Document&, JSC::JSValue) = 0;
-    virtual ExceptionOr<void> show(Document&) = 0;
+    virtual void show(Document&, CompletionHandler<void(ExceptionOr<void>&&)>&&) = 0;
     virtual bool canAbortSession() = 0;
     virtual void hide() = 0;
     virtual void canMakePayment(Document&, Function<void(bool)>&& completionHandler) = 0;
     virtual ExceptionOr<void> detailsUpdated(PaymentRequest::UpdateReason, String&& error, AddressErrors&&, PayerErrorFields&&, JSC::JSObject* paymentMethodErrors) = 0;
     virtual ExceptionOr<void> merchantValidationCompleted(JSC::JSValue&&) = 0;
     virtual ExceptionOr<void> complete(Document&, std::optional<PaymentComplete>&&, String&& serializedData) = 0;
-    virtual ExceptionOr<void> retry(PaymentValidationErrors&&) = 0;
+    virtual void retry(PaymentValidationErrors&&, CompletionHandler<void(ExceptionOr<void>&&)>&&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -426,20 +426,25 @@ void PaymentRequest::show(Document& document, RefPtr<DOMPromise>&& detailsPromis
         return;
     }
 
-    auto exception = selectedPaymentHandler->show(document);
-    if (exception.hasException()) {
-        settleShowPromise(exception.releaseException());
-        return;
-    }
+    selectedPaymentHandler->show(document, [weakThis = WeakPtr { *this }, detailsPromise = WTFMove(detailsPromise), selectedPaymentHandler](ExceptionOr<void>&& exception) mutable {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis)
+            return;
 
-    ASSERT(!m_activePaymentHandler);
-    m_activePaymentHandler = PaymentHandlerWithPendingActivity { selectedPaymentHandler.releaseNonNull(), makePendingActivity(*this) };
+        if (exception.hasException()) {
+            strongThis->settleShowPromise(exception.releaseException());
+            return;
+        }
 
-    if (!detailsPromise)
-        return;
+        ASSERT(!strongThis->m_activePaymentHandler);
+        strongThis->m_activePaymentHandler = PaymentHandlerWithPendingActivity { selectedPaymentHandler.releaseNonNull(), strongThis->makePendingActivity(*strongThis) };
 
-    exception = updateWith(UpdateReason::ShowDetailsResolved, detailsPromise.releaseNonNull());
-    ASSERT(!exception.hasException());
+        if (!detailsPromise)
+            return;
+
+        exception = strongThis->updateWith(UpdateReason::ShowDetailsResolved, detailsPromise.releaseNonNull());
+        ASSERT(!exception.hasException());
+    });
 }
 
 void PaymentRequest::abortWithException(Exception&& exception)
@@ -817,16 +822,16 @@ ExceptionOr<void> PaymentRequest::complete(Document& document, std::optional<Pay
     return { };
 }
 
-ExceptionOr<void> PaymentRequest::retry(PaymentValidationErrors&& errors)
+void PaymentRequest::retry(PaymentValidationErrors&& errors, CompletionHandler<void(ExceptionOr<void>&&)>&& completionHandler)
 {
     ASSERT(m_state == State::Closed);
     if (!m_activePaymentHandler)
-        return Exception { ExceptionCode::AbortError };
+        return completionHandler(Exception { ExceptionCode::AbortError });
 
     m_state = State::Interactive;
 
     Ref activePaymentHandler = *this->activePaymentHandler();
-    return activePaymentHandler->retry(WTFMove(errors));
+    activePaymentHandler->retry(WTFMove(errors), WTFMove(completionHandler));
 }
 
 void PaymentRequest::cancel()

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -35,6 +35,7 @@
 #include "PaymentMethodChangeEvent.h"
 #include "PaymentOptions.h"
 #include "PaymentResponse.h"
+#include <wtf/Forward.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -102,7 +103,7 @@ public:
     void accept(const String& methodName, PaymentResponse::DetailsFunction&&, Ref<PaymentAddress>&& shippingAddress, const String& payerName, const String& payerEmail, const String& payerPhone);
     void reject(Exception&&);
     ExceptionOr<void> complete(Document&, std::optional<PaymentComplete>&&, String&& serializedData);
-    ExceptionOr<void> retry(PaymentValidationErrors&&);
+    void retry(PaymentValidationErrors&&, CompletionHandler<void(ExceptionOr<void>&&)>&&);
     void cancel();
 
     using MethodIdentifier = Variant<String, URL>;

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
@@ -130,13 +130,20 @@ void PaymentResponse::retry(PaymentValidationErrors&& errors, DOMPromiseDeferred
     ASSERT(hasPendingActivity());
     ASSERT(m_state == State::Created);
 
-    auto exception = request->retry(WTFMove(errors));
-    if (exception.hasException()) {
-        promise.reject(exception.releaseException());
-        return;
-    }
+    request->retry(WTFMove(errors), [weakThis = WeakPtr { * this }, promise = WTFMove(promise)](ExceptionOr<void>&& exception) mutable {
+        RefPtr strongThis = weakThis.get();
+        if (!strongThis) {
+            promise.reject(Exception { ExceptionCode::AbortError });
+            return;
+        }
 
-    m_retryPromise = makeUnique<DOMPromiseDeferred<void>>(WTFMove(promise));
+        if (exception.hasException()) {
+            promise.reject(exception.releaseException());
+            return;
+        }
+
+        strongThis->m_retryPromise = makeUnique<DOMPromiseDeferred<void>>(WTFMove(promise));
+    });
 }
 
 void PaymentResponse::abortWithException(Exception&& exception)

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -458,7 +458,7 @@ private:
     bool canMakePayments() final { return false; }
     void canMakePaymentsWithActiveCard(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler) final { callOnMainThread([completionHandler = WTFMove(completionHandler)]() mutable { completionHandler(false); }); }
     void openPaymentSetup(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler) final { callOnMainThread([completionHandler = WTFMove(completionHandler)]() mutable { completionHandler(false); }); }
-    bool showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest&) final { return false; }
+    void showPaymentUI(const URL&, Vector<URL>&&, const ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&& completionHandler) final { callOnMainThread([completionHandler = WTFMove(completionHandler)]() mutable { completionHandler(false); }); }
     void completeMerchantValidation(const PaymentMerchantSession&) final { }
     void completeShippingMethodSelection(std::optional<ApplePayShippingMethodUpdate>&&) final { }
     void completeShippingContactSelection(std::optional<ApplePayShippingContactUpdate>&&) final { }

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -116,7 +116,7 @@ void MockPaymentCoordinator::dispatchIfShowing(Function<void()>&& function)
     });
 }
 
-bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest& request)
+void MockPaymentCoordinator::showPaymentUI(const URL&, Vector<URL>&&, const ApplePaySessionPaymentRequest& request, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (request.shippingContact().pkContact().get())
         m_shippingAddress = request.shippingContact().toApplePayPaymentContact(request.version());
@@ -158,15 +158,17 @@ bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const
 #endif
 
     RefPtr page = m_page.get();
-    if (!page)
-        return false;
+    if (!page) {
+        completionHandler(false);
+        return;
+    }
 
     ASSERT(m_showCount == m_hideCount);
     ++m_showCount;
-    dispatchIfShowing([page = WTFMove(page)]() {
+    dispatchIfShowing([page = WTFMove(page)] {
         page->protectedPaymentCoordinator()->validateMerchant(URL { "https://webkit.org/"_str });
     });
-    return true;
+    completionHandler(true);
 }
 
 void MockPaymentCoordinator::completeMerchantValidation(const PaymentMerchantSession&)

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -130,7 +130,7 @@ private:
     bool canMakePayments() final;
     void canMakePaymentsWithActiveCard(const String&, const String&, CompletionHandler<void(bool)>&&) final;
     void openPaymentSetup(const String&, const String&, CompletionHandler<void(bool)>&&) final;
-    bool showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest&) final;
+    void showPaymentUI(const URL&, Vector<URL>&&, const ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&) final;
     void completeMerchantValidation(const PaymentMerchantSession&) final;
     void completeShippingMethodSelection(std::optional<ApplePayShippingMethodUpdate>&&) final;
     void completeShippingContactSelection(std::optional<ApplePayShippingContactUpdate>&&) final;

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
@@ -89,7 +89,7 @@ void WebPaymentCoordinatorProxy::openPaymentSetup(const String& merchantIdentifi
     platformOpenPaymentSetup(merchantIdentifier, domainName, WTFMove(completionHandler));
 }
 
-void WebPaymentCoordinatorProxy::showPaymentUI(WebCore::PageIdentifier destinationID, WebPageProxyIdentifier webPageProxyID, const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest, CompletionHandler<void(bool)>&& completionHandler)
+void WebPaymentCoordinatorProxy::showPaymentUI(WebCore::PageIdentifier destinationID, WebPageProxyIdentifier webPageProxyID, const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (auto& coordinator = activePaymentCoordinatorProxy())
         coordinator->didReachFinalState();
@@ -102,7 +102,7 @@ void WebPaymentCoordinatorProxy::showPaymentUI(WebCore::PageIdentifier destinati
     m_destinationID = destinationID;
     m_state = State::Activating;
 
-    platformShowPaymentUI(webPageProxyID, originatingURL, linkIconURLs, paymentRequest, [weakThis = WeakPtr { *this }](bool result) {
+    platformShowPaymentUI(webPageProxyID, originatingURL, WTFMove(linkIconURLs), paymentRequest, [weakThis = WeakPtr { *this }](bool result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -158,7 +158,7 @@ private:
     void canMakePayments(CompletionHandler<void(bool)>&&);
     void canMakePaymentsWithActiveCard(const String& merchantIdentifier, const String& domainName, CompletionHandler<void(bool)>&&);
     void openPaymentSetup(const String& merchantIdentifier, const String& domainName, CompletionHandler<void(bool)>&&);
-    void showPaymentUI(WebCore::PageIdentifier destinationID, WebPageProxyIdentifier, const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&);
+    void showPaymentUI(WebCore::PageIdentifier destinationID, WebPageProxyIdentifier, const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&);
     void completeMerchantValidation(const WebCore::PaymentMerchantSession&);
     void completeShippingMethodSelection(std::optional<WebCore::ApplePayShippingMethodUpdate>&&);
     void completeShippingContactSelection(std::optional<WebCore::ApplePayShippingContactUpdate>&&);
@@ -186,7 +186,7 @@ private:
     void platformCanMakePayments(CompletionHandler<void(bool)>&&);
     void platformCanMakePaymentsWithActiveCard(const String& merchantIdentifier, const String& domainName, WTF::Function<void(bool)>&& completionHandler);
     void platformOpenPaymentSetup(const String& merchantIdentifier, const String& domainName, WTF::Function<void(bool)>&& completionHandler);
-    void platformShowPaymentUI(WebPageProxyIdentifier, const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&);
+    void platformShowPaymentUI(WebPageProxyIdentifier, const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&);
     void platformCompleteMerchantValidation(const WebCore::PaymentMerchantSession&);
     void platformCompleteShippingMethodSelection(std::optional<WebCore::ApplePayShippingMethodUpdate>&&);
     void platformCompleteShippingContactSelection(std::optional<WebCore::ApplePayShippingContactUpdate>&&);
@@ -197,7 +197,7 @@ private:
     void platformCompletePaymentSession(WebCore::ApplePayPaymentAuthorizationResult&&);
     void platformHidePaymentUI();
 #if PLATFORM(COCOA)
-    RetainPtr<PKPaymentRequest> platformPaymentRequest(const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&);
+    RetainPtr<PKPaymentRequest> platformPaymentRequest(const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&);
     void platformSetPaymentRequestUserAgent(PKPaymentRequest *, const String& userAgent);
 #endif
 

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
@@ -36,7 +36,7 @@ messages -> WebPaymentCoordinatorProxy {
     CanMakePaymentsWithActiveCard(String merchantIdentifier, String domainName) -> (bool canMakePayments)
     OpenPaymentSetup(String merchantIdentifier, String domainName) -> (bool result)
 
-    ShowPaymentUI(WebCore::PageIdentifier destinationID, WebKit::WebPageProxyIdentifier webPageProxyIdentifier, URL originatingURL, Vector<URL> linkIconURLs, WebCore::ApplePaySessionPaymentRequest paymentRequest) -> (bool result) Synchronous
+    ShowPaymentUI(WebCore::PageIdentifier destinationID, WebKit::WebPageProxyIdentifier webPageProxyIdentifier, URL originatingURL, Vector<URL> linkIconURLs, WebCore::ApplePaySessionPaymentRequest paymentRequest) -> (bool result)
     CompleteMerchantValidation(WebCore::PaymentMerchantSession paymentMerchantSession)
     CompleteShippingMethodSelection(struct std::optional<WebCore::ApplePayShippingMethodUpdate> update)
     CompleteShippingContactSelection(struct std::optional<WebCore::ApplePayShippingContactUpdate> update)

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -296,7 +296,7 @@ static PKPaymentRequestAPIType toAPIType(WebCore::ApplePaySessionPaymentRequest:
     }
 }
 
-RetainPtr<PKPaymentRequest> WebPaymentCoordinatorProxy::platformPaymentRequest(const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest)
+RetainPtr<PKPaymentRequest> WebPaymentCoordinatorProxy::platformPaymentRequest(const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest)
 {
     auto result = adoptNS([PAL::allocPKPaymentRequestInstance() init]);
 

--- a/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
+++ b/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -45,7 +45,7 @@ void WebPaymentCoordinatorProxy::platformCanMakePayments(CompletionHandler<void(
     });
 }
 
-void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier webPageProxyID, const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& request, CompletionHandler<void(bool)>&& completionHandler)
+void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier webPageProxyID, const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& request, CompletionHandler<void(bool)>&& completionHandler)
 {
 
     RetainPtr<PKPaymentRequest> paymentRequest;
@@ -56,7 +56,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
         paymentRequest = RetainPtr<PKPaymentRequest>((PKPaymentRequest *)disbursementRequest.get());
     } else
 #endif
-        paymentRequest = platformPaymentRequest(originatingURL, linkIconURLs, request);
+        paymentRequest = platformPaymentRequest(originatingURL, WTFMove(linkIconURLs), request);
 
     checkedClient()->getPaymentCoordinatorEmbeddingUserAgent(webPageProxyID, [webPageProxyID, paymentRequest, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](const String& userAgent) mutable {
         auto paymentCoordinatorProxy = weakThis.get();

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -54,7 +54,7 @@ void WebPaymentCoordinatorProxy::platformCanMakePayments(CompletionHandler<void(
     });
 }
 
-void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier webPageProxyID, const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& request, CompletionHandler<void(bool)>&& completionHandler)
+void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier webPageProxyID, const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& request, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if HAVE(PASSKIT_MODULARIZATION) && HAVE(PASSKIT_MAC_HELPER_TEMP)
     if (!PAL::isPassKitMacHelperTempFrameworkAvailable())
@@ -73,7 +73,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
         paymentRequest = RetainPtr<PKPaymentRequest>((PKPaymentRequest *)disbursementRequest.get());
     } else
 #endif
-        paymentRequest = platformPaymentRequest(originatingURL, linkIconURLs, request);
+        paymentRequest = platformPaymentRequest(originatingURL, WTFMove(linkIconURLs), request);
 
     checkedClient()->getPaymentCoordinatorEmbeddingUserAgent(webPageProxyID, [weakThis = WeakPtr { *this }, paymentRequest, completionHandler = WTFMove(completionHandler)](const String& userAgent) mutable {
         RefPtr paymentCoordinatorProxy = weakThis.get();

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -108,15 +108,15 @@ void WebPaymentCoordinator::openPaymentSetup(const String& merchantIdentifier, c
     sendWithAsyncReply(Messages::WebPaymentCoordinatorProxy::OpenPaymentSetup(merchantIdentifier, domainName), WTFMove(completionHandler));
 }
 
-bool WebPaymentCoordinator::showPaymentUI(const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest)
+void WebPaymentCoordinator::showPaymentUI(const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest, CompletionHandler<void(bool)>&& completionHandler)
 {
     RefPtr webPage = m_webPage.get();
-    if (!webPage)
-        return false;
+    if (!webPage) {
+        completionHandler(false);
+        return;
+    }
 
-    auto sendResult = sendSync(Messages::WebPaymentCoordinatorProxy::ShowPaymentUI(webPage->identifier(), webPage->webPageProxyIdentifier(), originatingURL, linkIconURLs, paymentRequest));
-    auto [result] = sendResult.takeReplyOr(false);
-    return result;
+    sendWithAsyncReply(Messages::WebPaymentCoordinatorProxy::ShowPaymentUI(webPage->identifier(), webPage->webPageProxyIdentifier(), originatingURL, WTFMove(linkIconURLs), paymentRequest), WTFMove(completionHandler));
 }
 
 void WebPaymentCoordinator::completeMerchantValidation(const WebCore::PaymentMerchantSession& paymentMerchantSession)

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
@@ -70,7 +70,7 @@ private:
     bool canMakePayments() override;
     void canMakePaymentsWithActiveCard(const String& merchantIdentifier, const String& domainName, CompletionHandler<void(bool)>&&) override;
     void openPaymentSetup(const String& merchantIdentifier, const String& domainName, CompletionHandler<void(bool)>&&) override;
-    bool showPaymentUI(const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&) override;
+    void showPaymentUI(const URL& originatingURL, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&) override;
     void completeMerchantValidation(const WebCore::PaymentMerchantSession&) override;
     void completeShippingMethodSelection(std::optional<WebCore::ApplePayShippingMethodUpdate>&&) override;
     void completeShippingContactSelection(std::optional<WebCore::ApplePayShippingContactUpdate>&&) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.h
@@ -47,7 +47,7 @@ private:
     bool canMakePayments() override;
     void canMakePaymentsWithActiveCard(const String&, const String&, CompletionHandler<void(bool)>&&) override;
     void openPaymentSetup(const String& merchantIdentifier, const String& domainName, CompletionHandler<void(bool)>&&) override;
-    bool showPaymentUI(const URL&, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&) override;
+    void showPaymentUI(const URL&, Vector<URL>&& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&&) override;
     void completeMerchantValidation(const WebCore::PaymentMerchantSession&) override;
     void completeShippingMethodSelection(std::optional<WebCore::ApplePayShippingMethodUpdate>&&) override;
     void completeShippingContactSelection(std::optional<WebCore::ApplePayShippingContactUpdate>&&) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm
@@ -68,9 +68,11 @@ void WebPaymentCoordinatorClient::openPaymentSetup(const String&, const String&,
     });
 }
 
-bool WebPaymentCoordinatorClient::showPaymentUI(const URL&, const Vector<URL>&, const WebCore::ApplePaySessionPaymentRequest&)
+void WebPaymentCoordinatorClient::showPaymentUI(const URL&, Vector<URL>&&, const WebCore::ApplePaySessionPaymentRequest&, CompletionHandler<void(bool)>&& completionHandler)
 {
-    return false;
+    callOnMainThread([completionHandler = WTFMove(completionHandler)] mutable {
+        completionHandler(false);
+    });
 }
 
 void WebPaymentCoordinatorClient::completeMerchantValidation(const WebCore::PaymentMerchantSession&)


### PR DESCRIPTION
#### 4fee150e6dd9363385cc7aa9e25a98bcde9698a3
<pre>
WebPaymentCoordinatorProxy::ShowPaymentUI should be an asynchronous flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=297814">https://bugs.webkit.org/show_bug.cgi?id=297814</a>
<a href="https://rdar.apple.com/158983113">rdar://158983113</a>

Reviewed by NOBODY (OOPS!).

There is no strong reason for this to be sync IPC, so we make it
asynchronous in this patch.

The async flow would be instantly compatible with the PaymentRequest
API, which is promise-based. Moreover, the ApplePaySession API already
exposes event-based error propagation mechanisms, so an asynchronous
flow can be could be made to fit that API, too, as long as we are
dispatching the appropriate cancel events in failure cases.

A future improvement could be to make the failure cases more informative
by plumbing through some error reason `Expected&lt;Monostate, String&gt;` over
a simple boolean result.

As a drive-by fix, we also change linkIcons to be passed as r-value
references instead of const l-value references.

* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp:
(WebCore::ApplePayAMSUIPaymentHandler::show):
(WebCore::ApplePayAMSUIPaymentHandler::retry):
* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h:
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::ApplePaySession::begin):
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::linkIconURLs):
(WebCore::PaymentCoordinator::beginPaymentSession):
* Source/WebCore/Modules/applepay/PaymentCoordinator.h:
* Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::ApplePayPaymentHandler::show):
(WebCore::ApplePayPaymentHandler::retry):
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h:
* Source/WebCore/Modules/paymentrequest/PaymentHandler.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::show):
(WebCore::PaymentRequest::retry):
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp:
(WebCore::PaymentResponse::retry):
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::MockPaymentCoordinator::showPaymentUI):
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp:
(WebKit::WebPaymentCoordinatorProxy::showPaymentUI):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
(WebKit::WebPaymentCoordinator::showPaymentUI):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm:
(WebPaymentCoordinatorClient::showPaymentUI):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fee150e6dd9363385cc7aa9e25a98bcde9698a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69941 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff4ffb51-0910-41ae-bad1-a1926c9415aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89473 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59086 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d48b2406-b542-499d-86f9-5411d2433830) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69969 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42e48ba6-f407-46f2-aed7-05c7bebc6c73) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23839 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67716 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127204 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98196 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97984 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41239 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50356 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47487 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45831 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->