### PR TITLE
[JSC] Error subclass stack traces should skip constructor frames

### DIFF
--- a/JSTests/stress/stack-trace-error-subclasses.js
+++ b/JSTests/stress/stack-trace-error-subclasses.js
@@ -1,0 +1,104 @@
+function shouldThrow(fn, error, message, stackFunctions) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+
+        const stackLines = e.stack.split('\n').filter(line => line.trim());
+        if (stackLines.length !== stackFunctions.length) {
+            throw new Error(
+                `\nActual stack trace:\n${e.stack}\n`
+            );
+        }
+        for (let i = 0; i < stackFunctions.length; i++) {
+            const expectedFunction = stackFunctions[i];
+            const stackLine = stackLines[i];
+            let found = false;
+            if (stackLine.startsWith(`${expectedFunction}@`))
+                found = true;
+            if (!found) {
+                throw new Error(`Actual stack trace:\n${e.stack}`);
+            }
+        }
+    }
+}
+
+{
+    class MyError extends Error {}
+    function throwMyError () {
+        throw new MyError("my error");
+    }
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrow(() => {
+            throwMyError();
+        }, MyError, "my error", [
+            "throwMyError",
+            "",
+            "shouldThrow",
+            "global code"
+        ]);
+    }
+}
+
+{
+    class MyError1 extends Error {}
+    class MyError2 extends MyError1 {}
+    function throwMyError () {
+        throw new MyError2("my error 2");
+    }
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrow(() => {
+            throwMyError();
+        }, MyError2, "my error 2", [
+            "throwMyError",
+            "",
+            "shouldThrow",
+            "global code"
+        ]);
+    }
+}
+
+{
+    class MyError extends Error {
+        constructor(...args) { super(...args); }
+    }
+    function throwMyError () {
+        throw new MyError("my error");
+    }
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrow(() => {
+            throwMyError();
+        }, MyError, "my error", [
+            "throwMyError",
+            "",
+            "shouldThrow",
+            "global code"
+        ]);
+    }
+}
+
+{
+    class MyError1 extends Error {
+        constructor(...args) { super(...args); }
+    }
+    class MyError2 extends MyError1 {
+        constructor(...args) { super(...args); }
+    }
+    function throwMyError () {
+        throw new MyError2("my error 2");
+    }
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrow(() => {
+            throwMyError();
+        }, MyError2, "my error 2", [
+            "throwMyError",
+            "",
+            "shouldThrow",
+            "global code"
+        ]);
+    }
+}

--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
@@ -19,7 +19,6 @@ PASS :only_original_device_is_event_target:
 PASS :uncapturederror_from_non_originating_thread:
 FAIL :onuncapturederror_order_wrt_addEventListener: assert_unreached:
   - EXCEPTION: Error: timeout1
-    PromiseTimeoutError@
     @http://127.0.0.1:8000/webgpu/common/util/util.js:141:37
     @http://127.0.0.1:8000/resources/testharness.js:983:20
  Reached unreachable code

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/createPipelineLayout-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/createPipelineLayout-expected.txt
@@ -38,7 +38,6 @@ FAIL :bind_group_layouts,set_pipeline_with_null_bind_group_layouts: assert_unrea
   - (in subcase: pipelineType="Compute";emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=3;setBindGroupOnEmptyBindGroupLayoutIndex=true) INFO: subcase ran
   - (in subcase: pipelineType="Compute";emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=3;setBindGroupOnEmptyBindGroupLayoutIndex=false) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state-expected.txt
@@ -4,7 +4,6 @@ FAIL :setViewport,exceeds_attachment_size: assert_unreached:
   - (in subcase: attachmentWidth=3;attachmentHeight=3) INFO: subcase ran
   - (in subcase: attachmentWidth=1024;attachmentHeight=1024) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.finish: encoder state is 'Locked', expected 'Open'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :setViewport,xy_rect_contained_in_bounds: assert_unreached:
@@ -35,7 +34,6 @@ FAIL :setViewport,xy_rect_contained_in_bounds: assert_unreached:
   - (in subcase: dimension=1;om=0;od=0;sd=1) INFO: subcase ran
   - (in subcase: dimension=1;om=0;od=0;sd="positive") INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.finish: encoder state is 'Locked', expected 'Open'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :setViewport,depth_rangeAndOrder:

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat-expected.txt
@@ -729,58 +729,48 @@ PASS :bgl_resource_type_mismatch:encoderType="render%20bundle";call="drawIndexed
 PASS :bgl_resource_type_mismatch:encoderType="render%20bundle";call="drawIndexedIndirect";callWithZero=false
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;computeCommand="dispatchIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;computeCommand="dispatch" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;computeCommand="dispatchIndirect"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;computeCommand="dispatch"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;computeCommand="dispatchIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;computeCommand="dispatch" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;computeCommand="dispatchIndirect"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;computeCommand="dispatch"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;computeCommand="dispatchIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;computeCommand="dispatch" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=4;computeCommand="dispatchIndirect"
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,compute_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=4;computeCommand="dispatch"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="draw" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="drawIndexed" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="drawIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=3;renderCommand="drawIndexedIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;renderCommand="draw"
@@ -789,22 +779,18 @@ PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:empt
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Null";bindGroupLayoutEntryCount=4;renderCommand="drawIndexedIndirect"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="draw" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="drawIndexed" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="drawIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=3;renderCommand="drawIndexedIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;renderCommand="draw"
@@ -813,22 +799,18 @@ PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:empt
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Undefined";bindGroupLayoutEntryCount=4;renderCommand="drawIndexedIndirect"
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="draw" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="drawIndexed" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="drawIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=3;renderCommand="drawIndexedIndirect" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: number of bind groups set(3) is less than the pipeline uses(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :empty_bind_group_layouts_never_requires_empty_bind_groups,render_pass:emptyBindGroupLayoutType="Empty";bindGroupLayoutEntryCount=4;renderCommand="draw"

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/image_copy/buffer_related-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/image_copy/buffer_related-expected.txt
@@ -385,7 +385,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc1-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc1-rgba-unorm-srgb";dimension="2d"
@@ -409,7 +408,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc1-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc2-rgba-unorm";dimension="2d"
@@ -433,7 +431,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc2-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc2-rgba-unorm-srgb";dimension="2d"
@@ -457,7 +454,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc2-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc3-rgba-unorm";dimension="2d"
@@ -481,7 +477,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc3-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc3-rgba-unorm-srgb";dimension="2d"
@@ -505,7 +500,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc3-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc4-r-unorm";dimension="2d"
@@ -529,7 +523,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc4-r-unorm";dimension="3
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc4-r-snorm";dimension="2d"
@@ -553,7 +546,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc4-r-snorm";dimension="3
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc5-rg-unorm";dimension="2d"
@@ -577,7 +569,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc5-rg-unorm";dimension="
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc5-rg-snorm";dimension="2d"
@@ -601,7 +592,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc5-rg-snorm";dimension="
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc6h-rgb-ufloat";dimension="2d"
@@ -625,7 +615,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc6h-rgb-ufloat";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc6h-rgb-float";dimension="2d"
@@ -649,7 +638,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc6h-rgb-float";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc7-rgba-unorm";dimension="2d"
@@ -673,7 +661,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc7-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="bc7-rgba-unorm-srgb";dimension="2d"
@@ -697,7 +684,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="bc7-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="etc2-rgb8unorm";dimension="2d"
@@ -731,7 +717,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-4x4-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-4x4-unorm-srgb";dimension="2d"
@@ -755,7 +740,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-4x4-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-5x4-unorm";dimension="2d"
@@ -779,7 +763,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-5x4-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-5x4-unorm-srgb";dimension="2d"
@@ -803,7 +786,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-5x4-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-5x5-unorm";dimension="2d"
@@ -827,7 +809,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-5x5-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-5x5-unorm-srgb";dimension="2d"
@@ -851,7 +832,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-5x5-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-6x5-unorm";dimension="2d"
@@ -875,7 +855,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-6x5-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-6x5-unorm-srgb";dimension="2d"
@@ -899,7 +878,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-6x5-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-6x6-unorm";dimension="2d"
@@ -923,7 +901,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-6x6-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-6x6-unorm-srgb";dimension="2d"
@@ -947,7 +924,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-6x6-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-8x5-unorm";dimension="2d"
@@ -971,7 +947,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-8x5-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-8x5-unorm-srgb";dimension="2d"
@@ -995,7 +970,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-8x5-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-8x6-unorm";dimension="2d"
@@ -1019,7 +993,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-8x6-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-8x6-unorm-srgb";dimension="2d"
@@ -1043,7 +1016,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-8x6-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-8x8-unorm";dimension="2d"
@@ -1067,7 +1039,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-8x8-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-8x8-unorm-srgb";dimension="2d"
@@ -1091,7 +1062,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-8x8-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x5-unorm";dimension="2d"
@@ -1115,7 +1085,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x5-unorm";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x5-unorm-srgb";dimension="2d"
@@ -1139,7 +1108,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x5-unorm-srgb";dim
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x6-unorm";dimension="2d"
@@ -1163,7 +1131,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x6-unorm";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x6-unorm-srgb";dimension="2d"
@@ -1187,7 +1154,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x6-unorm-srgb";dim
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x8-unorm";dimension="2d"
@@ -1211,7 +1177,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x8-unorm";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x8-unorm-srgb";dimension="2d"
@@ -1235,7 +1200,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x8-unorm-srgb";dim
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x10-unorm";dimension="2d"
@@ -1259,7 +1223,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x10-unorm";dimensi
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-10x10-unorm-srgb";dimension="2d"
@@ -1283,7 +1246,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-10x10-unorm-srgb";di
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-12x10-unorm";dimension="2d"
@@ -1307,7 +1269,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-12x10-unorm";dimensi
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-12x10-unorm-srgb";dimension="2d"
@@ -1331,7 +1292,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-12x10-unorm-srgb";di
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-12x12-unorm";dimension="2d"
@@ -1355,7 +1315,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-12x12-unorm";dimensi
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(12)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyB2T";format="astc-12x12-unorm-srgb";dimension="2d"
@@ -1379,7 +1338,6 @@ FAIL :bytes_per_row_alignment:method="CopyB2T";format="astc-12x12-unorm-srgb";di
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyBufferToTexture: copySize.height(1) is not divisible by blockHeight(12)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="r8unorm";dimension="1d"
@@ -1535,7 +1493,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc1-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc1-rgba-unorm-srgb";dimension="2d"
@@ -1559,7 +1516,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc1-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc2-rgba-unorm";dimension="2d"
@@ -1583,7 +1539,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc2-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc2-rgba-unorm-srgb";dimension="2d"
@@ -1607,7 +1562,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc2-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc3-rgba-unorm";dimension="2d"
@@ -1631,7 +1585,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc3-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc3-rgba-unorm-srgb";dimension="2d"
@@ -1655,7 +1608,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc3-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc4-r-unorm";dimension="2d"
@@ -1679,7 +1631,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc4-r-unorm";dimension="3
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc4-r-snorm";dimension="2d"
@@ -1703,7 +1654,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc4-r-snorm";dimension="3
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc5-rg-unorm";dimension="2d"
@@ -1727,7 +1677,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc5-rg-unorm";dimension="
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc5-rg-snorm";dimension="2d"
@@ -1751,7 +1700,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc5-rg-snorm";dimension="
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc6h-rgb-ufloat";dimension="2d"
@@ -1775,7 +1723,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc6h-rgb-ufloat";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc6h-rgb-float";dimension="2d"
@@ -1799,7 +1746,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc6h-rgb-float";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc7-rgba-unorm";dimension="2d"
@@ -1823,7 +1769,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc7-rgba-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="bc7-rgba-unorm-srgb";dimension="2d"
@@ -1847,7 +1792,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="bc7-rgba-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="etc2-rgb8unorm";dimension="2d"
@@ -1881,7 +1825,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-4x4-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-4x4-unorm-srgb";dimension="2d"
@@ -1905,7 +1848,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-4x4-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-5x4-unorm";dimension="2d"
@@ -1929,7 +1871,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-5x4-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-5x4-unorm-srgb";dimension="2d"
@@ -1953,7 +1894,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-5x4-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(4)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-5x5-unorm";dimension="2d"
@@ -1977,7 +1917,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-5x5-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-5x5-unorm-srgb";dimension="2d"
@@ -2001,7 +1940,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-5x5-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-6x5-unorm";dimension="2d"
@@ -2025,7 +1963,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-6x5-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-6x5-unorm-srgb";dimension="2d"
@@ -2049,7 +1986,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-6x5-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-6x6-unorm";dimension="2d"
@@ -2073,7 +2009,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-6x6-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-6x6-unorm-srgb";dimension="2d"
@@ -2097,7 +2032,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-6x6-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-8x5-unorm";dimension="2d"
@@ -2121,7 +2055,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-8x5-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-8x5-unorm-srgb";dimension="2d"
@@ -2145,7 +2078,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-8x5-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-8x6-unorm";dimension="2d"
@@ -2169,7 +2101,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-8x6-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-8x6-unorm-srgb";dimension="2d"
@@ -2193,7 +2124,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-8x6-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-8x8-unorm";dimension="2d"
@@ -2217,7 +2147,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-8x8-unorm";dimension
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-8x8-unorm-srgb";dimension="2d"
@@ -2241,7 +2170,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-8x8-unorm-srgb";dime
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x5-unorm";dimension="2d"
@@ -2265,7 +2193,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x5-unorm";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x5-unorm-srgb";dimension="2d"
@@ -2289,7 +2216,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x5-unorm-srgb";dim
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(5)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x6-unorm";dimension="2d"
@@ -2313,7 +2239,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x6-unorm";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x6-unorm-srgb";dimension="2d"
@@ -2337,7 +2262,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x6-unorm-srgb";dim
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(6)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x8-unorm";dimension="2d"
@@ -2361,7 +2285,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x8-unorm";dimensio
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x8-unorm-srgb";dimension="2d"
@@ -2385,7 +2308,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x8-unorm-srgb";dim
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(8)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x10-unorm";dimension="2d"
@@ -2409,7 +2331,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x10-unorm";dimensi
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-10x10-unorm-srgb";dimension="2d"
@@ -2433,7 +2354,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-10x10-unorm-srgb";di
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-12x10-unorm";dimension="2d"
@@ -2457,7 +2377,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-12x10-unorm";dimensi
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-12x10-unorm-srgb";dimension="2d"
@@ -2481,7 +2400,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-12x10-unorm-srgb";di
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(10)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-12x12-unorm";dimension="2d"
@@ -2505,7 +2423,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-12x12-unorm";dimensi
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(12)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bytes_per_row_alignment:method="CopyT2B";format="astc-12x12-unorm-srgb";dimension="2d"
@@ -2529,7 +2446,6 @@ FAIL :bytes_per_row_alignment:method="CopyT2B";format="astc-12x12-unorm-srgb";di
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=2) INFO: subcase ran
   - (in subcase: bytesPerRow=512;copyHeightInBlocks=3) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.copyTextureToBuffer: copySize.height(1) is not divisible by blockHeight(12)
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/inter_stage-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/inter_stage-expected.txt
@@ -77,14 +77,12 @@ PASS :max_shader_variable_location:isAsync=true;locationDelta=-1
 PASS :max_shader_variable_location:isAsync=true;locationDelta=-2
 FAIL :max_variables_count,output:isAsync=false;numVariablesDelta=0;topology="triangle-list" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: vertexScalarComponents > maxVertexShaderOutputComponents
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :max_variables_count,output:isAsync=false;numVariablesDelta=0;topology="point-list"
 PASS :max_variables_count,output:isAsync=false;numVariablesDelta=1;topology="triangle-list"
 FAIL :max_variables_count,output:isAsync=false;numVariablesDelta=-1;topology="point-list" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: vertexScalarComponents > maxVertexShaderOutputComponents
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :max_variables_count,output:isAsync=true;numVariablesDelta=0;topology="triangle-list" assert_unreached:
@@ -107,14 +105,12 @@ FAIL :max_variables_count,output:isAsync=true;numVariablesDelta=-1;topology="poi
  Reached unreachable code
 FAIL :max_variables_count,input:isAsync=false;numVariablesDelta=0;useExtraBuiltinInputs=false assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: vertexScalarComponents > maxVertexShaderOutputComponents
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :max_variables_count,input:isAsync=false;numVariablesDelta=0;useExtraBuiltinInputs=true
 PASS :max_variables_count,input:isAsync=false;numVariablesDelta=1;useExtraBuiltinInputs=false
 FAIL :max_variables_count,input:isAsync=false;numVariablesDelta=-1;useExtraBuiltinInputs=true assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: vertexScalarComponents > maxVertexShaderOutputComponents
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :max_variables_count,input:isAsync=true;numVariablesDelta=0;useExtraBuiltinInputs=false assert_unreached:

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt
@@ -4,7 +4,6 @@ FAIL :shift_left_abstract:inputSource="const";vectorize="_undef_" assert_unreach
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:49: shift left value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=2 assert_unreached:
@@ -12,7 +11,6 @@ FAIL :shift_left_abstract:inputSource="const";vectorize=2 assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:61: shift left value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=3 assert_unreached:
@@ -20,7 +18,6 @@ FAIL :shift_left_abstract:inputSource="const";vectorize=3 assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:64: shift left value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=4 assert_unreached:
@@ -28,7 +25,6 @@ FAIL :shift_left_abstract:inputSource="const";vectorize=4 assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     38:67: shift left value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :shift_left_concrete:type="i32";inputSource="const";vectorize="_undef_"
@@ -118,7 +114,6 @@ FAIL :shift_right_abstract:inputSource="const";vectorize="_undef_" assert_unreac
       at (elided: only 2 shown)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:49: shift right value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :shift_right_abstract:inputSource="const";vectorize=2 assert_unreached:
@@ -142,7 +137,6 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=2 assert_unreached:
       at (elided: only 2 shown)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:61: shift right value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :shift_right_abstract:inputSource="const";vectorize=3 assert_unreached:
@@ -162,7 +156,6 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=3 assert_unreached:
       at (elided: only 2 shown)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     363:65: shift right value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :shift_right_abstract:inputSource="const";vectorize=4 assert_unreached:
@@ -178,7 +171,6 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=4 assert_unreached:
       at (elided: only 2 shown)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     358:68: shift right value must be less than the bit width of the shifted value, which is 64
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :shift_right_concrete:type="i32";inputSource="const";vectorize="_undef_"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/workgroupUniformLoad-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/workgroupUniformLoad-expected.txt
@@ -36,7 +36,6 @@ FAIL :types:type="atomic%3Cu32%3E";wgsize=[1,1] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="atomic%3Cu32%3E";wgsize=[3,7] assert_unreached:
@@ -48,7 +47,6 @@ FAIL :types:type="atomic%3Cu32%3E";wgsize=[3,7] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="atomic%3Cu32%3E";wgsize=[1,128] assert_unreached:
@@ -60,7 +58,6 @@ FAIL :types:type="atomic%3Cu32%3E";wgsize=[1,128] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="atomic%3Cu32%3E";wgsize=[16,16] assert_unreached:
@@ -72,7 +69,6 @@ FAIL :types:type="atomic%3Cu32%3E";wgsize=[16,16] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="atomic%3Ci32%3E";wgsize=[1,1] assert_unreached:
@@ -84,7 +80,6 @@ FAIL :types:type="atomic%3Ci32%3E";wgsize=[1,1] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<i32>' to 'i32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="atomic%3Ci32%3E";wgsize=[3,7] assert_unreached:
@@ -96,7 +91,6 @@ FAIL :types:type="atomic%3Ci32%3E";wgsize=[3,7] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<i32>' to 'i32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="atomic%3Ci32%3E";wgsize=[1,128] assert_unreached:
@@ -108,7 +102,6 @@ FAIL :types:type="atomic%3Ci32%3E";wgsize=[1,128] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<i32>' to 'i32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="atomic%3Ci32%3E";wgsize=[16,16] assert_unreached:
@@ -120,7 +113,6 @@ FAIL :types:type="atomic%3Ci32%3E";wgsize=[16,16] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     13:18: cannot assign value of type 'atomic<i32>' to 'i32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="AtomicInStruct";wgsize=[1,1] assert_unreached:
@@ -132,7 +124,6 @@ FAIL :types:type="AtomicInStruct";wgsize=[1,1] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     17:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="AtomicInStruct";wgsize=[3,7] assert_unreached:
@@ -144,7 +135,6 @@ FAIL :types:type="AtomicInStruct";wgsize=[3,7] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     17:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="AtomicInStruct";wgsize=[1,128] assert_unreached:
@@ -156,7 +146,6 @@ FAIL :types:type="AtomicInStruct";wgsize=[1,128] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     17:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :types:type="AtomicInStruct";wgsize=[16,16] assert_unreached:
@@ -168,7 +157,6 @@ FAIL :types:type="AtomicInStruct";wgsize=[16,16] assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     17:18: cannot assign value of type 'atomic<u32>' to 'u32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size-expected.txt
@@ -486,7 +486,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=2 assert_unreached:
@@ -496,7 +495,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=4 assert_unreached:
@@ -506,7 +504,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=4 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=1;override2=1;override3=8
@@ -517,7 +514,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=2 assert_unreached:
@@ -527,7 +523,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=4 assert_unreached:
@@ -537,7 +532,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=4 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=1;override2=2;override3=8
@@ -548,7 +542,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=3;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=1;override2=3;override3=2 assert_unreached:
@@ -558,7 +551,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=3;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=1;override2=3;override3=4
@@ -570,7 +562,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=4;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=1;override2=4;override3=2 assert_unreached:
@@ -580,7 +571,6 @@ FAIL :workgroup_size_override_exp:override1=1;override2=4;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=1;override2=4;override3=4
@@ -592,7 +582,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=2 assert_unreached:
@@ -602,7 +591,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=4 assert_unreached:
@@ -612,7 +600,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=4 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=3;override2=1;override3=8
@@ -623,7 +610,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=2;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=3;override2=2;override3=2 assert_unreached:
@@ -633,7 +619,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=2;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=3;override2=2;override3=4
@@ -645,7 +630,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=3;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=3;override2=3;override3=2 assert_unreached:
@@ -655,7 +639,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=3;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=3;override2=3;override3=4
@@ -667,7 +650,6 @@ FAIL :workgroup_size_override_exp:override1=3;override2=4;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=3;override2=4;override3=2
@@ -680,7 +662,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=2 assert_unreached:
@@ -690,7 +671,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=4 assert_unreached:
@@ -700,7 +680,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=4 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=4;override2=1;override3=8
@@ -711,7 +690,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=2;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=4;override2=2;override3=2 assert_unreached:
@@ -721,7 +699,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=2;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=4;override2=2;override3=4
@@ -733,7 +710,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=3;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :workgroup_size_override_exp:override1=4;override2=3;override3=2 assert_unreached:
@@ -743,7 +719,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=3;override3=2 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=4;override2=3;override3=4
@@ -755,7 +730,6 @@ FAIL :workgroup_size_override_exp:override1=4;override2=4;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=4;override2=4;override3=2
@@ -768,7 +742,6 @@ FAIL :workgroup_size_override_exp:override1=8;override2=1;override3=1 assert_unr
       at (elided: below max severity)
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size_override_exp:override1=8;override2=1;override3=2

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
@@ -706,7 +706,6 @@ FAIL :address_space_access_mode:address_space="private";access_mode="";trailing_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:3: only variables in the <storage> address space may specify an access mode
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="private";access_mode="";trailing_comma=false
@@ -728,7 +727,6 @@ FAIL :address_space_access_mode:address_space="storage";access_mode="";trailing_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:34: Expected a Identifier, but got a >
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="storage";access_mode="";trailing_comma=false
@@ -744,7 +742,6 @@ FAIL :address_space_access_mode:address_space="storage";access_mode="read";trail
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:25: Expected a >, but got a ,
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="storage";access_mode="read";trailing_comma=false
@@ -762,7 +759,6 @@ FAIL :address_space_access_mode:address_space="storage";access_mode="read_write"
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:25: Expected a >, but got a ,
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="storage";access_mode="read_write";trailing_comma=false
@@ -778,7 +774,6 @@ FAIL :address_space_access_mode:address_space="uniform";access_mode="";trailing_
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:25: only variables in the <storage> address space may specify an access mode
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="uniform";access_mode="";trailing_comma=false
@@ -800,7 +795,6 @@ FAIL :address_space_access_mode:address_space="function";access_mode="";trailing
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     3:9: only variables in the <storage> address space may specify an access mode
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="function";access_mode="";trailing_comma=false
@@ -822,7 +816,6 @@ FAIL :address_space_access_mode:address_space="workgroup";access_mode="";trailin
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:3: only variables in the <storage> address space may specify an access mode
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="workgroup";access_mode="";trailing_comma=false
@@ -895,7 +888,6 @@ FAIL :var_access_mode_bad_other_template_contents:accessMode="read";prefix="stor
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:21: Expected a >, but got a ,
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="storage,";suffix=""
@@ -919,7 +911,6 @@ FAIL :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:21: Expected a >, but got a ,
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="storage,";suffix=""

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
@@ -830,7 +830,6 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="overflow";short_circuit=true assert_unr
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:21: value 2147483648 cannot be represented as 'i32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="overflow";short_circuit=false
@@ -853,7 +852,6 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=true assert
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:24: invalid division by zero
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=false
@@ -876,7 +874,6 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=true assert
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:30: value Infinity cannot be represented as 'f32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=false
@@ -899,7 +896,6 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=true assert_unre
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:21: value NaN cannot be represented as 'f32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=false
@@ -922,7 +918,6 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=true assert_unr
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:20: value 2147483648 cannot be represented as 'i32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=false
@@ -945,7 +940,6 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:23: invalid division by zero
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
@@ -968,7 +962,6 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:29: value Infinity cannot be represented as 'f32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
@@ -991,7 +984,6 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=true assert_unre
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:20: value NaN cannot be represented as 'f32'
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=false
@@ -1070,56 +1062,48 @@ FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=false asse
 FAIL :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=false
 FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=false
 FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=false
 FAIL :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=false
@@ -1213,26 +1197,22 @@ PASS :array_override:op="%26%26";a_val=1;b_val=0
 FAIL :array_override:op="%26%26";a_val=1;b_val=1 assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :array_override:op="%7C%7C";a_val=0;b_val=0
 FAIL :array_override:op="%7C%7C";a_val=0;b_val=1 assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :array_override:op="%7C%7C";a_val=1;b_val=0 assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :array_override:op="%7C%7C";a_val=1;b_val=1 assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
@@ -369,7 +369,6 @@ FAIL :array_zero_value:case="valid_array" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:57: cannot use override value in constant expression
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :array_zero_value:case="invalid_rta"
@@ -396,7 +395,6 @@ FAIL :array_value:case="valid_array" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:57: cannot use override value in constant expression
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :array_value:case="invalid_rta"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt
@@ -388,7 +388,6 @@ FAIL :function_attributes:case="diagnostic";placement="func" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:0: invalid attribute for function declaration
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :function_attributes:case="diagnostic";placement="param"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt
@@ -43,7 +43,6 @@ FAIL :blankspace:blankspace=["%C2%85","next_line"] assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%8E","left_to_right_mark"] assert_unreached:
@@ -56,7 +55,6 @@ FAIL :blankspace:blankspace=["%E2%80%8E","left_to_right_mark"] assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%8F","right_to_left_mark"] assert_unreached:
@@ -69,7 +67,6 @@ FAIL :blankspace:blankspace=["%E2%80%8F","right_to_left_mark"] assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%A8","line_separator"] assert_unreached:
@@ -82,7 +79,6 @@ FAIL :blankspace:blankspace=["%E2%80%A8","line_separator"] assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%A9","paragraph_separator"] assert_unreached:
@@ -95,7 +91,6 @@ FAIL :blankspace:blankspace=["%E2%80%A9","paragraph_separator"] assert_unreached
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :bom:include_bom=true

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt
@@ -29,7 +29,6 @@ FAIL :module_var_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:13: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :module_var_name:ident="bf16"
@@ -317,7 +316,6 @@ FAIL :module_const_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:6: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :module_const_name:ident="bf16"
@@ -605,7 +603,6 @@ FAIL :override_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:9: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :override_name:ident="bf16"
@@ -893,7 +890,6 @@ FAIL :function_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:3: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :function_name:ident="bf16"
@@ -1181,7 +1177,6 @@ FAIL :struct_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:7: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :struct_name:ident="bf16"
@@ -1469,7 +1464,6 @@ FAIL :alias_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:6: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :alias_name:ident="bf16"
@@ -1757,7 +1751,6 @@ FAIL :function_param_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :function_param_name:ident="bf16"
@@ -2047,7 +2040,6 @@ FAIL :function_const_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:8: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :function_const_name:ident="bf16"
@@ -2341,7 +2333,6 @@ FAIL :function_let_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:6: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :function_let_name:ident="bf16"
@@ -2635,7 +2626,6 @@ FAIL :function_var_name:ident="binding_array" assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:6: Expected a Identifier, but got a ReservedWord
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :function_var_name:ident="bf16"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
@@ -3395,7 +3395,6 @@ FAIL :interpolation_validation:attr="trailing_comma_one_arg" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:34: Expected a Identifier, but got a )
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :interpolation_validation:attr="trailing_comma_two_arg"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/workgroup_size-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/workgroup_size-expected.txt
@@ -30,7 +30,6 @@ PASS :workgroup_size:attr="trailing_comma_y"
 PASS :workgroup_size:attr="trailing_comma_z"
 FAIL :workgroup_size:attr="override_expr" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :workgroup_size:attr="mixed_abstract_signed"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continuing-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continuing-expected.txt
@@ -30,7 +30,6 @@ FAIL :placement:stmt="continuing_semicolon" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     9:43: Not a valid statement
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :placement:stmt="continuing_functionn_call"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/for-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/for-expected.txt
@@ -48,7 +48,6 @@ FAIL :parse:test="init_call" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:8: Expected one of `=`, `++`, or `--`
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :parse:test="init_phony" assert_unreached:
@@ -67,7 +66,6 @@ FAIL :parse:test="init_phony" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop initialization clause
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :parse:test="init_increment"
@@ -89,7 +87,6 @@ FAIL :parse:test="cont_call" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:10: Expected one of `=`, `++`, or `--`
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 FAIL :parse:test="cont_phony" assert_unreached:
@@ -108,7 +105,6 @@ FAIL :parse:test="cont_phony" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop update clause
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :parse:test="cont_increment"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt
@@ -133,7 +133,6 @@ FAIL :parse:test="in_for_init" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop initialization clause
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :parse:test="in_for_init_semi"
@@ -150,7 +149,6 @@ FAIL :parse:test="in_for_update" assert_unreached:
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop update clause
-    TestFailedButDeviceReusable@
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :parse:test="in_for_update_semi"

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -163,7 +163,7 @@ private:
     mutable BytecodeIndex m_bytecodeIndex { 0 };
 };
 
-std::unique_ptr<Vector<StackFrame>> getStackTrace(VM& vm, JSObject* obj, bool useCurrentFrame, JSCell* ownerOfCallLinkInfo, CallLinkInfo* callLinkInfo)
+std::unique_ptr<Vector<StackFrame>> getStackTrace(VM& vm, JSObject* obj, bool useCurrentFrame, JSCell* ownerOfCallLinkInfo, CallLinkInfo* callLinkInfo, JSCell* subclassCaller)
 {
     JSGlobalObject* globalObject = obj->globalObject();
     if (!globalObject->stackTraceLimit())
@@ -171,7 +171,7 @@ std::unique_ptr<Vector<StackFrame>> getStackTrace(VM& vm, JSObject* obj, bool us
 
     size_t framesToSkip = useCurrentFrame ? 0 : 1;
     std::unique_ptr<Vector<StackFrame>> stackTrace = makeUnique<Vector<StackFrame>>();
-    vm.interpreter.getStackTrace(obj, *stackTrace, framesToSkip, globalObject->stackTraceLimit().value_or(0), nullptr, ownerOfCallLinkInfo, callLinkInfo);
+    vm.interpreter.getStackTrace(obj, *stackTrace, framesToSkip, globalObject->stackTraceLimit().value_or(0), subclassCaller, ownerOfCallLinkInfo, callLinkInfo);
     return stackTrace;
 }
 

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -66,7 +66,7 @@ JS_EXPORT_PRIVATE JSObject* createOutOfMemoryError(JSGlobalObject*, const String
 JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorType, const String&);
 JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorTypeWithExtension, const String&);
 
-std::unique_ptr<Vector<StackFrame>> getStackTrace(VM&, JSObject*, bool useCurrentFrame, JSCell* ownerOfCallLinkInfo = nullptr, CallLinkInfo* = nullptr);
+std::unique_ptr<Vector<StackFrame>> getStackTrace(VM&, JSObject*, bool useCurrentFrame, JSCell* ownerOfCallLinkInfo = nullptr, CallLinkInfo* = nullptr, JSCell* subclassCaller = nullptr);
 std::tuple<CodeBlock*, BytecodeIndex> getBytecodeIndex(VM&, CallFrame*);
 bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, LineColumn&, String& sourceURL);
 bool addErrorInfo(VM&, Vector<StackFrame>*, JSObject*);

--- a/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
@@ -66,7 +66,9 @@ JSC_DEFINE_HOST_FUNCTION(constructErrorConstructor, (JSGlobalObject* globalObjec
     Structure* errorStructure = JSC_GET_DERIVED_STRUCTURE(vm, errorStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(ErrorInstance::create(globalObject, errorStructure, message, options, nullptr, TypeNothing, ErrorType::Error, false)));
+    bool isErrorSubclass = newTarget != callFrame->jsCallee();
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(ErrorInstance::create(globalObject, errorStructure, message, options, nullptr, TypeNothing, ErrorType::Error, false, isErrorSubclass ? newTarget : nullptr)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callErrorConstructor, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -54,10 +54,10 @@ public:
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    static ErrorInstance* create(VM& vm, Structure* structure, const String& message, JSValue cause, SourceAppender appender = nullptr, RuntimeType type = TypeNothing, ErrorType errorType = ErrorType::Error, bool useCurrentFrame = true)
+    static ErrorInstance* create(VM& vm, Structure* structure, const String& message, JSValue cause, SourceAppender appender = nullptr, RuntimeType type = TypeNothing, ErrorType errorType = ErrorType::Error, bool useCurrentFrame = true, JSCell* subclassCaller = nullptr)
     {
         ErrorInstance* instance = new (NotNull, allocateCell<ErrorInstance>(vm)) ErrorInstance(vm, structure, errorType);
-        instance->finishCreation(vm, message, cause, appender, type, useCurrentFrame);
+        instance->finishCreation(vm, message, cause, appender, type, useCurrentFrame, subclassCaller);
         return instance;
     }
 
@@ -69,7 +69,7 @@ public:
     }
 
     JS_EXPORT_PRIVATE static ErrorInstance* create(JSGlobalObject*, String&& message, ErrorType, LineColumn, String&& sourceURL, String&& stackString, String&& cause = { });
-    static ErrorInstance* create(JSGlobalObject*, Structure*, JSValue message, JSValue options, SourceAppender = nullptr, RuntimeType = TypeNothing, ErrorType = ErrorType::Error, bool useCurrentFrame = true);
+    static ErrorInstance* create(JSGlobalObject*, Structure*, JSValue message, JSValue options, SourceAppender = nullptr, RuntimeType = TypeNothing, ErrorType = ErrorType::Error, bool useCurrentFrame = true, JSCell* subclassCaller = nullptr);
 
     bool hasSourceAppender() const { return !!m_sourceAppender; }
     SourceAppender sourceAppender() const { return m_sourceAppender; }
@@ -121,7 +121,7 @@ public:
 protected:
     explicit ErrorInstance(VM&, Structure*, ErrorType);
 
-    void finishCreation(VM&, const String& message, JSValue cause, SourceAppender = nullptr, RuntimeType = TypeNothing, bool useCurrentFrame = true);
+    void finishCreation(VM&, const String& message, JSValue cause, SourceAppender = nullptr, RuntimeType = TypeNothing, bool useCurrentFrame = true, JSCell* subclassCaller = nullptr);
     void finishCreation(VM&, const String& message, JSValue cause, JSCell* owner, CallLinkInfo*);
     void finishCreation(VM&, String&& message, LineColumn, String&& sourceURL, String&& stackString, String&& cause);
 


### PR DESCRIPTION
#### 70c384691cea5902c989c46fe58067d1e90882c9
<pre>
[JSC] Error subclass stack traces should skip constructor frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=266943">https://bugs.webkit.org/show_bug.cgi?id=266943</a>

Reviewed by Yusuke Suzuki.

Currently, when Error subclasses are thrown, JSC includes the super() call
in the stack trace as the first frame, which provides unhelpful implementation
details to users. V8 skips these constructor frames.

This patch makes JSC match V8&apos;s behavior by detecting Error subclass
construction and skipping the constructor frame during stack trace generation.

For example, given this code:

  class MyError extends Error {}
  function throwMyError() {
      throw new MyError(&quot;my error&quot;);
  }
  throwMyError();

Before this patch, the stack trace would show:

  Exception: Error: my error
  MyError@
  throwMyError@./WebKitBuild/Debug/test.js:3:22
  global code@./WebKitBuild/Debug/test.js:5:13

After this patch, it correctly shows:

  Exception: Error: my error
  throwMyError@./WebKitBuild/Debug/test.js:3:22
  global code@./WebKitBuild/Debug/test.js:5:13

* JSTests/stress/stack-trace-error-subclasses.js: Added.
(shouldThrow):
(throw.new.Error):
(throw.new.Error.throwMyError):
(MyError2):
(throwMyError):
(i.shouldThrow):
(throwMyError.MyError):
(throwMyError.throwMyError):
* LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/createPipelineLayout-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/image_copy/buffer_related-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/inter_stage-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/workgroupUniformLoad-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/workgroup_size-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continuing-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/for-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt:
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::getStackTrace):
* Source/JavaScriptCore/runtime/Error.h:
* Source/JavaScriptCore/runtime/ErrorConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::create):
(JSC::ErrorInstance::finishCreation):
* Source/JavaScriptCore/runtime/ErrorInstance.h:
(JSC::ErrorInstance::create):

Canonical link: <a href="https://commits.webkit.org/299375@main">https://commits.webkit.org/299375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/222f0f4a4b826803a8636b624e1af79e2c6f7025

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124993 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90169 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59678 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24630 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68653 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110923 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128044 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117319 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98601 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44044 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22050 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42253 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51260 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146015 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45047 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37555 "jscore-tests (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->