### PR TITLE
Remove unused `MutableCSSSelector::appendTagHistory` overload

### DIFF
--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -239,31 +239,6 @@ void MutableCSSSelector::appendTagHistoryAsRelative(std::unique_ptr<MutableCSSSe
     appendTagHistory(relation, WTFMove(selector));
 }
 
-void MutableCSSSelector::appendTagHistory(Combinator relation, std::unique_ptr<MutableCSSSelector> selector)
-{
-    auto* end = this;
-    while (end->tagHistory())
-        end = end->tagHistory();
-
-    CSSSelector::Relation selectorRelation;
-    switch (relation) {
-    case Combinator::Child:
-        selectorRelation = CSSSelector::Relation::Child;
-        break;
-    case Combinator::DescendantSpace:
-        selectorRelation = CSSSelector::Relation::DescendantSpace;
-        break;
-    case Combinator::DirectAdjacent:
-        selectorRelation = CSSSelector::Relation::DirectAdjacent;
-        break;
-    case Combinator::IndirectAdjacent:
-        selectorRelation = CSSSelector::Relation::IndirectAdjacent;
-        break;
-    }
-    end->setRelation(selectorRelation);
-    end->setTagHistory(WTFMove(selector));
-}
-
 void MutableCSSSelector::prependTagSelector(const QualifiedName& tagQName, bool tagIsForNamespaceRule)
 {
     auto second = makeUnique<MutableCSSSelector>();

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -34,13 +34,6 @@ using MutableCSSSelectorList = Vector<std::unique_ptr<MutableCSSSelector>>;
 class MutableCSSSelector {
     WTF_MAKE_TZONE_ALLOCATED(MutableCSSSelector);
 public:
-    enum class Combinator {
-        Child,
-        DescendantSpace,
-        DirectAdjacent,
-        IndirectAdjacent
-    };
-
     static std::unique_ptr<MutableCSSSelector> parsePseudoClassSelector(StringView, const CSSSelectorParserContext&);
     static std::unique_ptr<MutableCSSSelector> parsePseudoElementSelector(StringView, const CSSSelectorParserContext&);
     static std::unique_ptr<MutableCSSSelector> parsePagePseudoSelector(StringView);
@@ -106,7 +99,6 @@ public:
     void clearTagHistory() { m_tagHistory.reset(); }
     void insertTagHistory(CSSSelector::Relation before, std::unique_ptr<MutableCSSSelector>, CSSSelector::Relation after);
     void appendTagHistory(CSSSelector::Relation, std::unique_ptr<MutableCSSSelector>);
-    void appendTagHistory(Combinator, std::unique_ptr<MutableCSSSelector>);
     void appendTagHistoryAsRelative(std::unique_ptr<MutableCSSSelector>);
     void prependTagSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
     std::unique_ptr<MutableCSSSelector> releaseTagHistory();


### PR DESCRIPTION
#### 06f4f99463ce2bf20d97ce1e59421aacf2e0823b
<pre>
Remove unused `MutableCSSSelector::appendTagHistory` overload
<a href="https://bugs.webkit.org/show_bug.cgi?id=297822">https://bugs.webkit.org/show_bug.cgi?id=297822</a>
<a href="https://rdar.apple.com/159009955">rdar://159009955</a>

Reviewed by Alan Baradlay.

It was added in 158526@main for the `&gt;&gt;` selector, but it has since been removed from the spec and WebKit (in 193141@main).

* Source/WebCore/css/parser/MutableCSSSelector.cpp:
* Source/WebCore/css/parser/MutableCSSSelector.h:

Canonical link: <a href="https://commits.webkit.org/299092@main">https://commits.webkit.org/299092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d21714aa29af63924b728c123fef64a8d04e0789

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69807 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78d37503-64f8-43e8-aed9-250d5b4c7544) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89392 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/58647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7204511-a018-4765-ae3d-79428384d05b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69885 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/017b7d8e-694b-4330-95d6-4677d600f4c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29442 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67586 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127013 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97839 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41059 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50235 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44019 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47366 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45710 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->