### PR TITLE
[GStreamer] Audio is distorted in Kaltura videos

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1511,6 +1511,8 @@ webkit.org/b/254514 media/media-source/media-source-seek-unbuffered.html [ Failu
 # MSE failures
 webkit.org/b/167108 imported/w3c/web-platform-tests/media-source/URL-createObjectURL-revoke.html [ Failure ]
 
+webkit.org/b/297905 media/media-source/media-managedmse-append.html [ Timeout ]
+
 # Need changes in the demuxers and AppendPipeline to enable aborts not followed by an initialization segment:
 
 webkit.org/b/224767 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html [ Crash Pass ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-remove-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-remove-expected.txt
@@ -1,0 +1,18 @@
+
+PASS Test remove with an negative start.
+PASS Test remove with non-finite start.
+PASS Test remove with a start beyond the duration.
+PASS Test remove with a start larger than the end.
+PASS Test remove with a NEGATIVE_INFINITY end.
+PASS Test remove with a NaN end.
+PASS Test remove after SourceBuffer removed from mediaSource.
+PASS Test remove with a NaN duration.
+PASS Test remove while update pending.
+PASS Test aborting a remove operation.
+PASS Test remove with a start at the duration.
+PASS Test remove transitioning readyState from 'ended' to 'open'.
+FAIL Test removing all appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.518) }" but got "{ [0.000, 6.518) }"
+FAIL Test removing beginning of appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.518) }" but got "{ [0.000, 6.518) }"
+FAIL Test removing the middle of appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.518) }" but got "{ [0.000, 6.518) }"
+FAIL Test removing the end of appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.518) }" but got "{ [0.000, 6.518) }"
+

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -478,22 +478,6 @@ void registerWebKitGStreamerElements()
         // We don't want autoaudiosink to autoplug our sink.
         gst_element_register(0, "webkitaudiosink", GST_RANK_NONE, WEBKIT_TYPE_AUDIO_SINK);
 
-        // If the FDK-AAC decoder is available, promote it.
-        GRefPtr<GstElementFactory> elementFactory = adoptGRef(gst_element_factory_find("fdkaacdec"));
-        if (elementFactory)
-            gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(elementFactory.get()), GST_RANK_PRIMARY);
-        else
-            g_warning("The GStreamer FDK AAC plugin is missing, AAC playback is unlikely to work.");
-
-        // Downrank the libav AAC decoders, due to their broken LC support, as reported in:
-        // https://ffmpeg.org/pipermail/ffmpeg-devel/2019-July/247063.html
-        std::array<ASCIILiteral, 3> elementNames { "avdec_aac"_s, "avdec_aac_fixed"_s, "avdec_aac_latm"_s };
-        for (auto& elementName : elementNames) {
-            GRefPtr<GstElementFactory> avAACDecoderFactory = adoptGRef(gst_element_factory_find(elementName));
-            if (avAACDecoderFactory)
-                gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(avAACDecoderFactory.get()), GST_RANK_MARGINAL);
-        }
-
         // Prevent decodebin(3) from auto-plugging hlsdemux if it was disabled. UAs should be able
         // to fallback to MSE when this happens.
         const char* hlsSupport = g_getenv("WEBKIT_GST_ENABLE_HLS_SUPPORT");

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -848,6 +848,7 @@ GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, 
     // more orthogonal.
     ASCIILiteral elementClass = "identity"_s;
 
+    GRefPtr<GstElement> result;
     if (mediaType == "audio/x-opus"_s) {
         // Necessary for: metadata filling.
         // Frame durations are optional in Matroska/WebM. Although frame durations are not required
@@ -881,13 +882,23 @@ GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, 
         case 2:
             // MPEG-2 Part 7 Advanced Audio Coding (ISO 13818-7) -- MPEG-2 AAC, the original AAC format, widely used,
             // has extensions retrofitted.
-        case 4:
+        case 4: {
             // MPEG-4 Part 3 Audio (ISO 14496-3) -- MPEG-4 Audio, which more often than not also contains AAC audio,
             // defines several extensions to the original AAC, also widely used.
             // Not to be confused with the MP4 file format, which is a container format, not an audio stream format,
             // and can incidentally contain MPEG-4 audio.
-            elementClass = "aacparse"_s;
+            // Make sure each frame has a header, as mandated by the frame() syntax element
+            // specified in Section 2.4.1.2 of ISO 11172-3. Without specifying a stream-format,
+            // aacparse will fallback to raw, which might confuse some decoders (avdec) leading to
+            // garbled audio rendering.
+            GUniqueOutPtr<GError> error;
+            result = gst_parse_bin_from_description("aacparse ! capsfilter caps=\"audio/mpeg, stream-format=(string)adts\"", TRUE, &error.outPtr());
+            if (result)
+                gst_object_set_name(GST_OBJECT_CAST(result.get()), parserName.ascii().data());
+            else
+                GST_WARNING_OBJECT(bin, "Unable to create AAC parser: %s", error->message);
             break;
+        }
         default:
             GST_WARNING_OBJECT(bin, "Unsupported audio mpeg caps: %" GST_PTR_FORMAT, caps);
         }
@@ -901,8 +912,10 @@ GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, 
         elementClass = "ccconverter"_s;
     }
 
-    GST_DEBUG_OBJECT(bin, "Creating %s parser for stream with caps %" GST_PTR_FORMAT, elementClass.characters(), caps);
-    GRefPtr<GstElement> result(makeGStreamerElement(elementClass, parserName));
+    if (!result) {
+        GST_DEBUG_OBJECT(bin, "Creating %s parser for stream with caps %" GST_PTR_FORMAT, elementClass.characters(), caps);
+        result = makeGStreamerElement(elementClass, parserName);
+    }
     if (!result && elementClass != "identity"_s) {
         GST_WARNING_OBJECT(bin, "Couldn't create %s, there might be problems processing some MSE streams. "
             "Continue at your own risk and consider adding %s to your build.", elementClass.characters(), elementClass.characters());
@@ -1122,18 +1135,16 @@ void AppendPipeline::Track::emplaceOptionalElementsForFormat(GstBin* bin, const 
     gst_bin_add_many(bin, parser.get(), encoder.get(), nullptr);
     GST_INFO_OBJECT(bin, "linking elements...");
     auto linkingOk = gst_element_link_many(parser.get(), encoder.get(), appsink.get(), nullptr);
-    if (!linkingOk)
+    if (!linkingOk) {
         GST_ERROR_OBJECT(bin, "linking elements failed!");
-
+        return;
+    }
     gst_element_sync_state_with_parent(encoder.get());
     gst_element_sync_state_with_parent(parser.get());
 
-    encoderPad = adoptGRef(gst_element_get_static_pad(encoder.get(), "sink"));
     entryPad = adoptGRef(gst_element_get_static_pad(parser.get(), "sink"));
 
-    ASSERT(encoderPad);
     ASSERT(GST_PAD_IS_LINKED(appsinkPad.get()));
-    ASSERT(GST_PAD_IS_LINKED(encoderPad.get()));
 
     if (streamType == StreamType::Text)
         finalCaps = adoptGRef(gst_caps_new_empty_simple("application/x-subtitle-vtt"));

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -90,7 +90,6 @@ private:
         GRefPtr<GstElement> encoder;
         GRefPtr<GstElement> appsink;
         GRefPtr<GstPad> entryPad; // Sink pad of the parser/GstIdentity.
-        GRefPtr<GstPad> encoderPad; // Sink pad of the encoder/GstIdentity.
         GRefPtr<GstPad> appsinkPad;
 
         RefPtr<WebCore::TrackPrivateBase> webKitTrack;


### PR DESCRIPTION
#### b87a52fd5788fcd275446bb61c2ca49b8f85430a
<pre>
[GStreamer] Audio is distorted in Kaltura videos
<a href="https://bugs.webkit.org/show_bug.cgi?id=297116">https://bugs.webkit.org/show_bug.cgi?id=297116</a>

Reviewed by Xabier Rodriguez-Calvar.

Re-allow decodebin(3) to autoplug avdec_aac decoders after making sure the MSE AAC parser emits
frames with ADTS headers. Raw AAC doesn&apos;t seem very well supported in avdec_aac, leading to garbled
audio rendering.

The fdkaacdec decoder handles raw AAC better, but depends on FDK-AAC which might not be shipped by
every distro, or requires explicit installation from non-free repositories.

Canonical link: <a href="https://commits.webkit.org/299318@main">https://commits.webkit.org/299318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/884dd5bf77e95ee804d2e2828017ff9a72b16e2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89710 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59348 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24116 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100166 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127455 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98392 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98179 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50671 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->