### PR TITLE
[AutoFill Debugging] Streamline debug text output (prune redundant items and coalesce adjacent text runs)

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -1,48 +1,32 @@
-container=root,rect=[…]
-    rect=[…],role='banner'
-        rect=[…],aria-label='Main Page Title'
-            text='Welcome to Test Page\n\n',rect=[…]
-    container=navigation,rect=[…],role='navigation',aria-label='Main navigation'
-        container=list,rect=[…]
-            container=list-item,rect=[…]
-                type=link,uid=…,rect=[…],eventListeners=[click],url='mailto:wenson_hsieh@apple.com'
-                    text='Section 1\n',rect=[…]
-            container=list-item,rect=[…]
-                type=link,uid=…,rect=[…],eventListeners=[click],url='https://example.com/'
-                    text='Section 2\n',rect=[…]
-    rect=[…],role='main'
-        container=section,rect=[…],aria-label='Interactive Elements'
-            container=button,uid=…,rect=[…],eventListeners=[click],aria-label='Test button'
-                text='Click Me',rect=[…]
-            text='This button does nothing\n',rect=[…]
-            type=textFormControl,controlType='text',uid=…,rect=[…],placeholder='Enter text here'
-                text='Enter text here\n',rect=[…]
-            uid=…,rect=[…],role='button',eventListeners=[click,keyboard]
-                text='Clickable Div\n',rect=[…]
-        container=section,rect=[…],aria-label='Content with Roles'
-            container=article,rect=[…],role='article'
-                text='Article Title\n\n',rect=[…]
-                text='January 1, 2024',rect=[…]
-                text='This is some article content with ',rect=[…]
-                text='highlighted text',rect=[…]
-                text='.\n\n',rect=[…]
-            rect=[…],role='complementary',aria-label='Related information'
-                text='Related Links\n\n',rect=[…]
-                container=list,rect=[…]
-                    container=list-item,rect=[…]
-                        type=link,uid=…,rect=[…],eventListeners=[hover],url='https://webkit.org/'
-                            text='Example Link\n',rect=[…]
-                    container=list-item,rect=[…]
-                        type=link,uid=…,rect=[…],eventListeners=[hover],url='https://apple.com/'
-                            text='Test Link\n',rect=[…]
-            rect=[…],role='region'
-                rect=[…],role='status'
-                    text='Ready\n',rect=[…]
-                container=button,uid=…,rect=[…],eventListeners=[click]
-                    text='Update Status',rect=[…]
-    rect=[…],role='contentinfo'
-        text='Footer content with ',rect=[…]
-        rect=[…],role='img',aria-label='copyright symbol'
-            text='©',rect=[…]
-        text=' 2024\n\n',rect=[…]
+root
+    role='banner'
+        aria-label='Main Page Title','Welcome to Test Page',[…]
+    navigation,role='navigation',aria-label='Main navigation'
+        list
+            list-item
+                link,uid=…,events=[click],url='mailto:wenson_hsieh@apple.com','Section 1',[…]
+            list-item
+                link,uid=…,events=[click],url='https://example.com/','Section 2',[…]
+    role='main'
+        section,aria-label='Interactive Elements'
+            button,uid=…,events=[click],aria-label='Test button','Click Me',[…]
+            '        \nThis button does nothing\n\n        ',[…]
+            textFormControl,'text',uid=…,placeholder='Enter text here','Enter text here',[…]
+            uid=…,role='button',events=[click,keyboard],'Clickable Div',[…]
+        section,aria-label='Content with Roles'
+            article,role='article','            \n\n                \nArticle Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.\n\n\n        ',[…]
+            role='complementary',aria-label='Related information'
+                '            \nRelated Links\n\n\n            ',[…]
+                list
+                    list-item
+                        link,uid=…,events=[hover],url='https://webkit.org/','Example Link',[…]
+                    list-item
+                        link,uid=…,events=[hover],url='https://apple.com/','Test Link',[…]
+            role='region'
+                role='status','Ready',[…]
+                button,uid=…,events=[click],'Update Status',[…]
+    role='contentinfo'
+        '    \nFooter content with ',[…]
+        role='img',aria-label='copyright symbol','©',[…]
+        ' 2024',[…]
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2456,7 +2456,7 @@ window.UIHelper = class UIHelper {
                 if (options.normalize) {
                     debugText = debugText
                         .replace(/uid=\d+/g, "uid=…")
-                        .replace(/rect=\[[^\]]+\]/g, "rect=[…]")
+                        .replace(/\[\d+,\d+;\d+x\d+\]/g, "[…]")
                         .replace(/\t/g, "    ");
                 }
                 resolve(debugText);


### PR DESCRIPTION
#### 36615bee766c36705ff40a0ee99145973d03e0ed
<pre>
[AutoFill Debugging] Streamline debug text output (prune redundant items and coalesce adjacent text runs)
<a href="https://bugs.webkit.org/show_bug.cgi?id=297830">https://bugs.webkit.org/show_bug.cgi?id=297830</a>
<a href="https://rdar.apple.com/159027795">rdar://159027795</a>

Reviewed by Richard Robinson and Timothy Hatcher.

Further streamlime the output of `-_debugTextWithConfiguration:completionHandler:`:

-   Limit `rect` output to only leaf nodes in the item tree.

-   Allow adjacent text nodes to be coalesced, as long as they both only represent text nodes (as
    opposed to links, or other elements with relevant DOM attributes).

-   Drop the `container=` and `type=` prefixes in the output text (these are self-explanatory based
    on their respective values anyways).

-   For items with only a single text node as the child, append the single text node to the end of
    its parent in the debug text output, rather than leaving the text on a separate line.

-   Trim trailing or leading newlines in text content, adjusting selection ranges to match.

-   Prune any `containerType` items that lack any accessibility attributes, and that also don&apos;t
    contain any visible text (or only contain other `containerType`s that are pruned). Buttons are
    the only exception to this.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:

Rebaseline an existing test.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::pruneWhitespaceRecursive):
(WebCore::TextExtraction::pruneEmptyContainersRecursive):
(WebCore::TextExtraction::extractItem):
(WebCore::TextExtraction::pruneRedundantItemsRecursive): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(WKTextExtractionItem.textRepresentationRecursive(_:)):
(WKTextExtractionItem.textRepresentationParts):
(WKTextExtractionContainerItem.textRepresentationParts):
(WKTextExtractionContentEditableItem.textRepresentationParts):
(WKTextExtractionTextFormControlItem.textRepresentationParts):
(WKTextExtractionLinkItem.textRepresentationParts):
(WKTextExtractionTextItem.textRepresentationParts):
(WKTextExtractionScrollableItem.textRepresentationParts):
(WKTextExtractionSelectItem.textRepresentationParts):
(WKTextExtractionImageItem.textRepresentationParts):
(WKTextExtractionPopupMenu.textRepresentation):

Canonical link: <a href="https://commits.webkit.org/299100@main">https://commits.webkit.org/299100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c78f2d3bc72a2b803ff6006dfe0294e12a818edb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123993 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69879 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9efc3d10-3c7d-49f9-b55a-2a9e769c1ca0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46110 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/246eb882-0b6f-4b68-aafd-0be1c71166ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69927 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2ccb0b5-b5b5-40a5-8032-023d17b6dab1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67657 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127077 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33697 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98098 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97886 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24902 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43276 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41168 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50299 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44084 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->