### PR TITLE
Use Expected for errors in WebExtension

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
@@ -246,14 +246,13 @@ RefPtr<JSON::Object> WebExtensionLocalization::localizationJSONForWebExtension(W
 
     auto path = pathBuilder.toString();
 
-    RefPtr<API::Error> error;
-    auto jsonString = webExtension.resourceStringForPath(path, error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes);
-    if (error) {
-        webExtension.recordErrorIfNeeded(error);
+    auto jsonStringResult = webExtension.resourceStringForPath(path, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes);
+    if (!jsonStringResult) {
+        webExtension.recordErrorIfNeeded(jsonStringResult.error());
         return nullptr;
     }
 
-    RefPtr json = JSON::Value::parseJSON(jsonString);
+    RefPtr json = JSON::Value::parseJSON(jsonStringResult.value());
     return json ? json->asObject() : nullptr;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -367,9 +367,8 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
 
         RefPtr extension = m_extension;
         for (NSString *scriptPath in scriptPaths) {
-            RefPtr<API::Error> error;
-            if (!extension->resourceStringForPath(scriptPath, error)) {
-                recordError(*error);
+            if (auto scriptValue = extension->resourceStringForPath(scriptPath); !scriptValue) {
+                recordErrorIfNeeded(scriptValue.error());
                 *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", scriptPath).createNSString().autorelease();
                 return false;
             }
@@ -382,9 +381,8 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         });
 
         for (NSString *styleSheetPath in styleSheetPaths) {
-            RefPtr<API::Error> error;
-            if (!extension->resourceStringForPath(styleSheetPath, error)) {
-                recordError(*error);
+            if (auto styleSheetValue = extension->resourceStringForPath(styleSheetPath); !styleSheetValue) {
+                recordErrorIfNeeded(styleSheetValue.error());
                 *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", styleSheetPath).createNSString().autorelease();
                 return false;
             }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -89,14 +89,14 @@ static NSArray *getFrames(_WKFrameTreeNode *currentNode, const WebExtensionScrip
 
 std::optional<SourcePair> sourcePairForResource(const String& path, WebExtensionContext& extensionContext)
 {
-    RefPtr<API::Error> error;
     Ref extension = extensionContext.extension();
-    auto scriptString = extension->resourceStringForPath(path, error, WebExtension::CacheResult::Yes);
-    if (!scriptString || error) {
-        extensionContext.recordErrorIfNeeded(error);
+    auto scriptStringResult = extension->resourceStringForPath(path, WebExtension::CacheResult::Yes);
+    if (!scriptStringResult) {
+        extensionContext.recordErrorIfNeeded(scriptStringResult.error());
         return std::nullopt;
     }
 
+    auto scriptString = scriptStringResult.value();
     scriptString = extensionContext.localizedResourceString(scriptString, extension->resourceMIMETypeForPath(path));
 
     return SourcePair { scriptString, { extensionContext.baseURL(), path } };

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -241,8 +241,8 @@ public:
 
     String resourceMIMETypeForPath(const String&);
 
-    String resourceStringForPath(const String&, RefPtr<API::Error>&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
-    RefPtr<API::Data> resourceDataForPath(const String&, RefPtr<API::Error>&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
+    Expected<String, RefPtr<API::Error>> resourceStringForPath(const String&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
+    Expected<Ref<API::Data>, RefPtr<API::Error>> resourceDataForPath(const String&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
 
     RefPtr<WebExtensionLocalization> localization();
 
@@ -277,7 +277,7 @@ public:
     const String& sidebarTitle();
 #endif
 
-    RefPtr<WebCore::Icon> iconForPath(const String&, RefPtr<API::Error>&, WebCore::FloatSize sizeForResizing = { }, std::optional<double> displayScale = std::nullopt);
+    Expected<Ref<WebCore::Icon>, RefPtr<API::Error>> iconForPath(const String&, WebCore::FloatSize sizeForResizing = { }, std::optional<double> displayScale = std::nullopt);
 
     size_t bestIconSize(const JSON::Object&, size_t idealPixelSize);
     String pathForBestImage(const JSON::Object&, size_t idealPixelSize);
@@ -381,7 +381,7 @@ private:
 
     URL resourceFileURLForPath(const String&);
 
-    std::optional<WebExtension::DeclarativeNetRequestRulesetData> parseDeclarativeNetRequestRulesetObject(const JSON::Object&, RefPtr<API::Error>&);
+    Expected<WebExtension::DeclarativeNetRequestRulesetData, Ref<API::Error>> parseDeclarativeNetRequestRulesetObject(const JSON::Object&);
 
     InjectedContentVector m_staticInjectedContents;
     WebAccessibleResourcesVector m_webAccessibleResources;


### PR DESCRIPTION
#### 7a2430f73eb2e5fe6adc7ebc5fc789a6ab4cd0c9
<pre>
Use Expected for errors in WebExtension
<a href="https://bugs.webkit.org/show_bug.cgi?id=297831">https://bugs.webkit.org/show_bug.cgi?id=297831</a>

Reviewed by Timothy Hatcher.

Follow-up to 299009@main, use Expected&lt;bool, RefPtr&lt;API::Error&gt;&gt; or the appropriate return type in WebExtension,
dropping outError. As well, make sure to passthrough the underlyingError when creating new API::Errors.

* Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp:
(WebKit::WebExtensionLocalization::localizationJSONForWebExtension):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceDataForPath):
(WebKit::WebExtension::iconForPath):
(WebKit::WebExtension::bestIcon):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addInjectedContent):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::sourcePairForResource):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::manifestObject):
(WebKit::WebExtension::resourceStringForPath):
(WebKit::WebExtension::createError):
(WebKit::WebExtension::populateActionPropertiesIfNeeded):
(WebKit::WebExtension::parseDeclarativeNetRequestRulesetObject):
(WebKit::WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::iconForPath):

Canonical link: <a href="https://commits.webkit.org/300035@main">https://commits.webkit.org/300035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d167d88f86893fe312b20efb3d476901bab2a93a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73159 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91969 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61184 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72653 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32141 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130350 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100578 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100480 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23935 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44697 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19210 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53576 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->