### PR TITLE
<animateMotion> non-path animations should apply the 'rotate' attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL <animateMotion> from/to animation with rotate=auto assert_approx_equals: bbox x expected 0 +/- 0.5 but got -200
+PASS <animateMotion> from/to animation with rotate=auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-horizontal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-horizontal-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <animateMotion> from/to animation with rotate=auto and horizontal motion
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-horizontal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-horizontal.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<title>&lt;animateMotion> from/to animation with rotate=auto and horizontal motion</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/SVGAnimationTestCase-testharness.js"></script>
+<svg>
+  <rect x="-200" width="200" height="100" fill="blue">
+    <animateMotion id="anim" from="-300,50" to="200,50" rotate="auto"
+                   fill="freeze" dur="4s"/>
+  </rect>
+</svg>
+<script>
+const rootSVGElement = document.querySelector('svg');
+
+function assert_bbox_position(element, x, y) {
+  const bbox = element.getBBox();
+  const epsilon = 0.5;
+  assert_approx_equals(bbox.x, x, epsilon, 'bbox x');
+  assert_approx_equals(bbox.y, y, epsilon, 'bbox y');
+}
+
+// delta = to - from = (500, 0). The slope angle is atan2(0, 500) = 0deg, so
+// the element translates horizontally with no rotation. This covers the
+// fromPoint.y == toPoint.y (delta.y == 0) case.
+function sample1() {
+  assert_bbox_position(rootSVGElement, -500, 50);
+}
+
+function sample2() {
+  assert_bbox_position(rootSVGElement, -250, 50);
+}
+
+function sample3() {
+  assert_bbox_position(rootSVGElement, 0, 50);
+}
+
+smil_async_test(t => {
+  const expectedValues = [
+    // [animationId, time, sampleCallback]
+    ['anim', 0.0, sample1],
+    ['anim', 2.0, sample2],
+    ['anim', 4.0, sample3],
+  ];
+  runAnimationTest(t, expectedValues);
+});
+
+window.animationStartsImmediately = true;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-no-motion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-no-motion-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <animateMotion> from/to animation with rotate=auto and no motion
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-no-motion.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-no-motion.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<title>&lt;animateMotion> from/to animation with rotate=auto and no motion</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/SVGAnimationTestCase-testharness.js"></script>
+<svg>
+  <rect x="-200" width="200" height="100" fill="blue">
+    <animateMotion id="anim" from="100,100" to="100,100" rotate="auto"
+                   fill="freeze" dur="4s"/>
+  </rect>
+</svg>
+<script>
+const rootSVGElement = document.querySelector('svg');
+
+function assert_bbox_position(element, x, y) {
+  const bbox = element.getBBox();
+  const epsilon = 0.5;
+  // A NaN angle would propagate through rotate() and make these NaN, so the
+  // approx_equals assertions below double as a NaN guard.
+  assert_approx_equals(bbox.x, x, epsilon, 'bbox x');
+  assert_approx_equals(bbox.y, y, epsilon, 'bbox y');
+}
+
+// delta = to - from = (0, 0). The slope angle is atan2(0, 0), which must
+// resolve to 0deg (not NaN), so the element is translated to (100, 100) with
+// no rotation. This covers the fromPoint == toPoint (zero delta) case.
+function sample1() {
+  assert_bbox_position(rootSVGElement, -100, 100);
+}
+
+function sample2() {
+  assert_bbox_position(rootSVGElement, -100, 100);
+}
+
+function sample3() {
+  assert_bbox_position(rootSVGElement, -100, 100);
+}
+
+smil_async_test(t => {
+  const expectedValues = [
+    // [animationId, time, sampleCallback]
+    ['anim', 0.0, sample1],
+    ['anim', 2.0, sample2],
+    ['anim', 4.0, sample3],
+  ];
+  runAnimationTest(t, expectedValues);
+});
+
+window.animationStartsImmediately = true;
+</script>

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2008 Apple Inc. All rights reserved.
- * Copyright (C) 2013 Google Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -116,10 +116,10 @@ SVGAnimateMotionElement::RotateMode SVGAnimateMotionElement::rotateMode() const
     static MainThreadNeverDestroyed<const AtomString> autoReverse("auto-reverse"_s);
     auto& rotate = getAttribute(SVGNames::rotateAttr);
     if (rotate == autoAtom())
-        return RotateAuto;
+        return RotateMode::Auto;
     if (rotate == autoReverse)
-        return RotateAutoReverse;
-    return RotateAngle;
+        return RotateMode::AutoReverse;
+    return RotateMode::Angle;
 }
 
 void SVGAnimateMotionElement::updateAnimationPath()
@@ -212,6 +212,9 @@ void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned 
     if (!isAdditive())
         transform->makeIdentity();
 
+    float angle = 0;
+
+    // Non-path animation
     if (animationMode() != AnimationMode::Path) {
         FloatPoint toPointAtEndOfDuration = m_toPoint;
         if (isAccumulated() && repeatCount && m_toPointAtEndOfDuration)
@@ -224,26 +227,34 @@ void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned 
         animateAdditiveNumber(percentage, repeatCount, m_fromPoint.y(), m_toPoint.y(), toPointAtEndOfDuration.y(), animatedY);
 
         transform->translate(animatedX, animatedY);
-        return;
+
+        // Compute angle from fromPoint -> toPoint.
+        FloatPoint delta(m_toPoint.x() - m_fromPoint.x(), m_toPoint.y() - m_fromPoint.y());
+        angle = rad2deg(delta.slopeAngleRadians());
+    } else {
+        // Path animation
+        buildTransformForProgress(transform, percentage);
+
+        if (isAccumulated() && repeatCount) {
+            for (unsigned i = 0; i < repeatCount; ++i)
+                buildTransformForProgress(transform, 1);
+        }
+
+        auto traversalState = m_animationPath.traversalStateAtLength(m_animationPath.length() * percentage);
+        angle = traversalState.normalAngle();
     }
 
-    buildTransformForProgress(transform, percentage);
-
-    // Handle accumulate="sum".
-    if (isAccumulated() && repeatCount) {
-        for (unsigned i = 0; i < repeatCount; ++i)
-            buildTransformForProgress(transform, 1);
-    }
-    float positionOnPath = m_animationPath.length() * percentage;
-    auto traversalState(m_animationPath.traversalStateAtLength(positionOnPath));
-
-    // The 'angle' below is in 'degrees'.
-    float angle = traversalState.normalAngle();
-    RotateMode rotateMode = this->rotateMode();
-    if (rotateMode != RotateAuto && rotateMode != RotateAutoReverse)
-        return;
-    if (rotateMode == RotateAutoReverse)
+    switch (rotateMode()) {
+    case RotateMode::Auto:
+        break;
+    case RotateMode::AutoReverse:
         angle += 180;
+        break;
+    case RotateMode::Angle:
+        angle = 0;
+        break;
+    }
+
     transform->rotate(angle);
 }
 

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -51,10 +51,10 @@ private:
     void applyResultsToTarget() override;
     std::optional<float> calculateDistance(const String& fromString, const String& toString) override;
 
-    enum RotateMode {
-        RotateAngle,
-        RotateAuto,
-        RotateAutoReverse
+    enum class RotateMode : uint8_t {
+        Angle,
+        Auto,
+        AutoReverse
     };
     RotateMode rotateMode() const;
     void buildTransformForProgress(AffineTransform*, float percentage);


### PR DESCRIPTION
#### 50984dcaa2fdad2d3f8277b63cc473ca18aeee5c
<pre>
&lt;animateMotion&gt; non-path animations should apply the &apos;rotate&apos; attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=257907">https://bugs.webkit.org/show_bug.cgi?id=257907</a>
<a href="https://rdar.apple.com/problem/110915794">rdar://problem/110915794</a>

Reviewed by Nikolas Zimmermann.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src/+/7f43c0d43ff1b00697461a588118d69e8d86238a">https://chromium.googlesource.com/chromium/src/+/7f43c0d43ff1b00697461a588118d69e8d86238a</a>

&lt;animateMotion&gt; animations specified use the &apos;path&apos; attribute (or an
&lt;mpath&gt; etc) are not special in any way with respect to the &apos;rotate&apos;
attribute and its effects.

Refactor SVGAnimateMotionElement::calculateAnimatedValue() so that said
attribute is also applied in the non-path animation case as well.

In addition, this made `RotateMode` as enum class and used it throughout
code and removed `default` handling of RotateMode, since all cases are
handled properly.

* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::rotateMode const):
(WebCore::SVGAnimateMotionElement::calculateAnimatedValue):
* Source/WebCore/svg/SVGAnimateMotionElement.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-expected.txt: Progression

Also added tests covering the degenerate &lt;animateMotion&gt; cases where the
from/to points share a coordinate (fromPoint.y == toPoint.y) or are
identical (zero delta), guarding against a NaN angle out of atan2.

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-horizontal-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-horizontal.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-no-motion-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto-no-motion.html: Added.

Canonical link: <a href="https://commits.webkit.org/314508@main">https://commits.webkit.org/314508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28682a158310bd1297aa8ced88c8de18281f5764

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122894 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6248caf-bbaf-4b9d-9c90-ac8c9a0b4442) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128722 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90645 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50d30f75-1699-49bd-b4db-8198e221e76b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168598 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31054 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109246 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24999e78-8577-4e45-917b-eb41e4986d1d) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30548 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28726 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22761 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177205 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30117 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28218 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests; 4 flakes 2 failures; Uploaded test results; 3 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137045 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136978 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37057 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102378 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32265 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25175 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111470 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37793 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3256 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38039 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37937 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->