### PR TITLE
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 6)

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -721,6 +721,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/system-preview/ARKitBadgeSystemImage.h
 
+    Modules/url-pattern/URLPattern.h
+    Modules/url-pattern/URLPatternComponent.h
+    Modules/url-pattern/URLPatternInit.h
+
     Modules/web-locks/WebLock.h
     Modules/web-locks/WebLockIdentifier.h
     Modules/web-locks/WebLockManagerSnapshot.h

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(MEDIA_SESSION)
 
+#include "MediaMetadataInit.h"
 #include <WebCore/CachedImageClient.h>
 #include <WebCore/CachedResourceHandle.h>
-#include "MediaMetadataInit.h"
 #include <WebCore/MediaSession.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Function.h>

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "URLPatternComponent.h"
-#include "URLPatternInit.h"
+#include <WebCore/URLPatternComponent.h>
+#include <WebCore/URLPatternInit.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "WebCodecsCodecState.h"
 #include <WebCore/ActiveDOMObject.h>
 #include <WebCore/EventTarget.h>
-#include "WebCodecsCodecState.h"
 #include <wtf/Deque.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>

--- a/Source/WebCore/bridge/objc/WebScriptObjectPrivate.h
+++ b/Source/WebCore/bridge/objc/WebScriptObjectPrivate.h
@@ -23,8 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#import "WebScriptObject.h"
 #import <JavaScriptCore/JSCJSValue.h>
+#import <WebCore/WebScriptObject.h>
 #import <wtf/RefPtr.h>
 
 namespace JSC {

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "CachedScript.h"
 #include <WebCore/CachedResourceClient.h>
 #include <WebCore/CachedResourceHandle.h>
-#include "CachedScript.h"
 #include <WebCore/Document.h>
 #include <WebCore/LoadableScript.h>
 #include <WebCore/LoadableScriptError.h>

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.h
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "AttributedString.h"
-#import "SimpleRange.h"
+#import <WebCore/AttributedString.h>
+#import <WebCore/SimpleRange.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/FormattingState.h
+++ b/Source/WebCore/layout/FormattingState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingContext.h>
+#include "FormattingContext.h"
 #include <WebCore/LayoutState.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingContext.h>
+#include "FormattingContext.h"
 #include <WebCore/LayoutElementBox.h>
 #include <WebCore/PlacedFloats.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingContext.h>
+#include "FormattingContext.h"
 #include <WebCore/LayoutBoxGeometry.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/FormattingQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingQuirks.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingContext.h>
+#include "FormattingContext.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/BlockFormattingGeometry.h>
-#include <WebCore/BlockFormattingQuirks.h>
-#include <WebCore/BlockFormattingState.h>
-#include <WebCore/FormattingContext.h>
+#include "BlockFormattingGeometry.h"
+#include "BlockFormattingQuirks.h"
+#include "BlockFormattingState.h"
+#include "FormattingContext.h"
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingGeometry.h>
+#include "FormattingGeometry.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingQuirks.h>
+#include "FormattingQuirks.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingState.h>
+#include "FormattingState.h"
 #include <WebCore/PlacedFloats.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/BlockFormattingContext.h>
-#include <WebCore/BlockFormattingQuirks.h>
-#include <WebCore/TableWrapperBlockFormattingQuirks.h>
+#include "BlockFormattingContext.h"
+#include "BlockFormattingQuirks.h"
+#include "TableWrapperBlockFormattingQuirks.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingQuirks.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/BlockFormattingQuirks.h>
+#include "BlockFormattingQuirks.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include "FlexFormattingUtils.h"
 #include <WebCore/FlexFormattingConstraints.h>
-#include <WebCore/FlexFormattingUtils.h>
 #include <WebCore/FlexLayout.h>
 #include <WebCore/FlexRect.h>
 #include <WebCore/LayoutIntegrationUtils.h>

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingGeometry.h>
+#include "FormattingGeometry.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
+#include "InlineFormattingConstraints.h"
 #include "InlineFormattingUtils.h"
+#include "IntrinsicWidthHandler.h"
 #include <WebCore/InlineDisplayContent.h>
-#include <WebCore/InlineFormattingConstraints.h>
 #include <WebCore/InlineLayoutState.h>
 #include <WebCore/InlineQuirks.h>
-#include <WebCore/IntrinsicWidthHandler.h>
 #include <WebCore/LayoutIntegrationUtils.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h
+++ b/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/InlineContentCache.h>
+#include "InlineContentCache.h"
 #include <WebCore/LineLayoutResult.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include "InlineContentCache.h"
 #include <WebCore/AbstractLineBuilder.h>
-#include <WebCore/InlineContentCache.h>
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingGeometry.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingGeometry.h>
+#include "FormattingGeometry.h"
 #include "TableGrid.h"
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingQuirks.h>
+#include "FormattingQuirks.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/FormattingConstraints.h>
-#include <WebCore/InlineFormattingConstraints.h>
+#include "InlineFormattingConstraints.h"
 #include "LayoutBoxGeometry.h"
-#include <WebCore/LayoutIntegrationBoxTreeUpdater.h>
+#include "LayoutIntegrationBoxTreeUpdater.h"
+#include <WebCore/FormattingConstraints.h>
 #include <WebCore/LayoutState.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/LayoutIntegrationBoxTreeUpdater.h>
+#include "LayoutIntegrationBoxTreeUpdater.h"
 #include <WebCore/LayoutState.h>
 #include <WebCore/RenderObjectEnums.h>
 #include <wtf/CheckedPtr.h>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/LayoutIntegrationBoxTreeUpdater.h>
+#include "LayoutIntegrationBoxTreeUpdater.h"
 #include <WebCore/LayoutPoint.h>
 #include <WebCore/LayoutRect.h>
 #include <wtf/WeakListHashSet.h>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -26,18 +26,18 @@
 #pragma once
 
 #include "InlineDamage.h"
+#include "InlineFormattingConstraints.h"
 #include "InlineFormattingContext.h"
 #include "InlineIteratorInlineBox.h"
+#include "LayoutIntegrationBoxGeometryUpdater.h"
+#include "LayoutIntegrationBoxTreeUpdater.h"
+#include "SVGTextChunk.h"
 #include <WebCore/FloatRect.h>
-#include <WebCore/InlineFormattingConstraints.h>
 #include <WebCore/InlineIteratorLineBox.h>
 #include <WebCore/InlineIteratorTextBox.h>
-#include <WebCore/LayoutIntegrationBoxGeometryUpdater.h>
-#include <WebCore/LayoutIntegrationBoxTreeUpdater.h>
 #include <WebCore/LayoutPoint.h>
 #include <WebCore/LayoutState.h>
 #include <WebCore/RenderObjectEnums.h>
-#include "SVGTextChunk.h"
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/layouttree/LayoutContainingBlockChainIterator.h
+++ b/Source/WebCore/layout/layouttree/LayoutContainingBlockChainIterator.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingContext.h>
+#include "FormattingContext.h"
 #include <WebCore/LayoutElementBox.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/mac/WebCoreFrameView.h
+++ b/Source/WebCore/page/mac/WebCoreFrameView.h
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#import "ScrollTypes.h"
+#import <WebCore/ScrollTypes.h>
 #import <wtf/Platform.h>
 #import <wtf/NakedPtr.h>
 

--- a/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.h
+++ b/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#import "SearchPopupMenu.h"
+#import <WebCore/SearchPopupMenu.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h
@@ -26,9 +26,10 @@
 #pragma once
 
 #import <wtf/Platform.h>
+
 #if PLATFORM(COCOA)
 
-#import "PlatformDynamicRangeLimit.h"
+#import <WebCore/PlatformDynamicRangeLimit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
@@ -26,8 +26,8 @@
 #import <QuartzCore/QuartzCore.h>
 
 #ifdef __cplusplus
-#import "FloatPoint.h"
-#import "ScrollingNodeID.h"
+#import <WebCore/FloatPoint.h>
+#import <WebCore/ScrollingNodeID.h>
 #import <wtf/Vector.h>
 #endif
 

--- a/Source/WebCore/platform/mac/StringUtilities.h
+++ b/Source/WebCore/platform/mac/StringUtilities.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#import "PlatformExportMacros.h"
+#import <WebCore/PlatformExportMacros.h>
 #import <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.h
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenPlaceholderView.h
@@ -27,8 +27,13 @@
 
 #if PLATFORM(MAC)
 
+#import <AppKit/NSView.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
+
+@class NSResponder;
+@class NSTextField;
+@class NSVisualEffectView;
 
 WEBCORE_EXPORT @interface WebCoreFullScreenPlaceholderView : NSView {
 @private

--- a/Source/WebCore/platform/mac/WebCoreFullScreenWarningView.h
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenWarningView.h
@@ -27,7 +27,11 @@
 
 #if PLATFORM(MAC) && ENABLE(FULLSCREEN_API)
 
+#import <AppKit/NSBox.h>
+#import <WebCore/PlatformExportMacros.h>
 #import <wtf/RetainPtr.h>
+
+@class NSTextField;
 
 WEBCORE_EXPORT @interface WebCoreFullScreenWarningView : NSBox {
 @private

--- a/Source/WebCore/platform/mac/WebCoreFullScreenWindow.h
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenWindow.h
@@ -23,8 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wtf/Platform.h>
+#import <wtf/Platform.h>
+
 #if PLATFORM(MAC)
+
+#import <AppKit/NSWindow.h>
+#import <WebCore/PlatformExportMacros.h>
 
 WEBCORE_EXPORT @interface WebCoreFullScreenWindow : NSWindow
 @end

--- a/Source/WebCore/platform/mac/WebCoreView.h
+++ b/Source/WebCore/platform/mac/WebCoreView.h
@@ -23,6 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#import <wtf/Platform.h>
+
+#if USE(APPKIT)
+#import <AppKit/NSView.h>
+#endif
+
 @interface NSView (WebCoreView)
 - (NSView *)_webcore_effectiveFirstResponder;
 @end

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -23,9 +23,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#import "RangeResponseGenerator.h"
-#import "SecurityOrigin.h"
 #import <Foundation/NSURLSession.h>
+#import <WebCore/RangeResponseGenerator.h>
+#import <WebCore/SecurityOrigin.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/HashSet.h>
 #import <wtf/Lock.h>

--- a/Source/WebCore/rendering/LineClampUpdater.h
+++ b/Source/WebCore/rendering/LineClampUpdater.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/RenderLayoutState.h>
+#include "RenderLayoutState.h"
 #include <WebCore/RenderView.h>
 #include <wtf/CheckedPtr.h>
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -25,8 +25,9 @@
 
 #if PLATFORM(MAC)
 
-#import "RenderThemeCocoa.h"
+#import <WebCore/RenderThemeCocoa.h>
 
+OBJC_CLASS NSPopUpButtonCell;
 OBJC_CLASS WebCoreRenderThemeNotificationObserver;
 
 namespace WebCore {

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -23,11 +23,11 @@
 
 #pragma once
 
+#include "StyleSVGPaint.h"
 #include <WebCore/RenderStyle.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/SVGRenderStyleDefs.h>
 #include <WebCore/StyleRareInheritedData.h>
-#include "StyleSVGPaint.h"
 #include <WebCore/StyleURL.h>
 #include <WebCore/WindRule.h>
 

--- a/Source/WebCore/workers/service/RouterCondition.h
+++ b/Source/WebCore/workers/service/RouterCondition.h
@@ -28,7 +28,7 @@
 #include <WebCore/FetchRequestDestination.h>
 #include <WebCore/FetchRequestMode.h>
 #include <WebCore/RunningStatus.h>
-#include "URLPattern.h"
+#include <WebCore/URLPattern.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
 


### PR DESCRIPTION
#### 6edea7eed32f44bc63ec3684c91521a9a072faae
<pre>
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 6)
<a href="https://rdar.apple.com/159037620">rdar://159037620</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297834">https://bugs.webkit.org/show_bug.cgi?id=297834</a>

Reviewed by Aditya Keerthi.

Fix some more module verification violations by adding missing headers and making private headers
project and vice versa.

* Source/WebCore/Modules/mediasession/MediaMetadata.h:
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/editing/cocoa/NodeHTMLConverter.h:
* Source/WebCore/layout/FormattingState.h:
* Source/WebCore/layout/floats/FloatingContext.h:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/FormattingQuirks.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h:
* Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.h:
* Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingQuirks.h:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h:
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h:
* Source/WebCore/layout/formattingContexts/table/TableFormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/layouttree/LayoutContainingBlockChainIterator.h:
* Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h:
* Source/WebCore/rendering/LineClampUpdater.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/workers/service/RouterCondition.h:

Canonical link: <a href="https://commits.webkit.org/299117@main">https://commits.webkit.org/299117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3640e0be18b2442b536b18a898cb4542dbfd5ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69913 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7b67d5f-0150-4e78-bd34-32d11a781f13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89452 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59069 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e684c4eb-7eab-44d1-88e2-0e62150c1761) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69948 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d984d36f-dd8d-429a-b295-9b9c96b6062b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67687 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127107 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98120 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97908 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24913 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21277 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41210 "Hash a3640e0b for PR 49822 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50329 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44115 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45804 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->