### PR TITLE
[macOS] Increase contrast setting requires Safari restart for colors to update, system accent color change does not trigger repaint

### DIFF
--- a/LayoutTests/accessibility/mac/increase-contrast-system-color-changes-expected-mismatch.html
+++ b/LayoutTests/accessibility/mac/increase-contrast-system-color-changes-expected-mismatch.html
@@ -1,0 +1,33 @@
+<html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<head>
+    <script src="../../../resources/accessibility-helper.js"></script>
+    <style>
+        div {
+            background-color: -apple-system-tertiary-label;
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+
+        function test() {
+            if (!window.testRunner)
+                return;
+
+            accessibilityController.injectAccessibilityPreference("com.apple.universalaccess", "increaseContrast", "0");
+
+            setTimeout(function () {
+                testRunner.notifyDone();
+            }, 50);
+        }
+    </script>
+</head>
+<body onload="test()">
+    <div id="div"></div>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/increase-contrast-system-color-changes.html
+++ b/LayoutTests/accessibility/mac/increase-contrast-system-color-changes.html
@@ -1,0 +1,33 @@
+<html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<head>
+    <script src="../../../resources/accessibility-helper.js"></script>
+    <style>
+        div {
+            background-color: -apple-system-tertiary-label;
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+
+        function test() {
+            if (!window.testRunner)
+                return;
+
+            accessibilityController.injectAccessibilityPreference("com.apple.universalaccess", "increaseContrast", "1");
+
+            setTimeout(function () {
+                testRunner.notifyDone();
+            }, 50);
+        }
+    </script>
+</head>
+<body onload="test()">
+    <div id="div"></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1179,7 +1179,6 @@ http/tests/security/contentSecurityPolicy/navigate-self-to-data-url.html [ Skip 
 accessibility/color-well.html [ Skip ]
 accessibility/color-well-legacy.html [ Skip ]
 accessibility/color-input-value-changes.html [ Skip ]
-accessibility/mac/media-query-values-change.html [ Skip ]
 editing/pasteboard/drag-and-drop-color-input-events.html [ Skip ]
 editing/pasteboard/drag-and-drop-color-input.html [ Skip ]
 fast/css/pseudo-visited-background-color-on-input.html [ ImageOnlyFailure ]
@@ -3223,5 +3222,9 @@ js/dom/lockdown-mode [ Skip ]
 
 # The decimal portion of the coordinates changes slightly between runs
 webkit.org/b/297993 imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked.html [ Skip ]
+
+# Accessibility setting injection is unavailable in WK1.
+webkit.org/b/298211 accessibility/mac/media-query-values-change.html [ Skip ]
+webkit.org/b/298211 accessibility/mac/increase-contrast-system-color-changes.html [ Skip ]
 
 webkit.org/b/289382 fast/canvas/offscreen-no-script-context-crash.html [ Skip ]

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1088,6 +1088,12 @@ void Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment()
         Ref { page.get() }->updateStyleAfterChangeInEnvironment();
 }
 
+void Page::updateControlTintsForAllPages()
+{
+    for (auto& page : allPages())
+        Ref { page.get() }->updateControlTints();
+}
+
 void Page::setNeedsRecalcStyleInAllFrames()
 {
     // FIXME: Figure out what this function is actually trying to add in different call sites.
@@ -5974,5 +5980,13 @@ void Page::updateDisplayEDRHeadroom()
 }
 
 #endif
+
+void Page::updateControlTints()
+{
+    forEachLocalFrame([] (LocalFrame& frame) {
+        if (RefPtr view = frame.view())
+            view->updateControlTints();
+    });
+}
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -374,6 +374,7 @@ public:
     WEBCORE_EXPORT static Ref<Page> create(PageConfiguration&&);
     WEBCORE_EXPORT ~Page();
 
+    static void updateControlTintsForAllPages();
     WEBCORE_EXPORT static void updateStyleForAllPagesAfterGlobalChangeInEnvironment();
     WEBCORE_EXPORT static void clearPreviousItemFromAllPages(BackForwardItemIdentifier);
 
@@ -1445,6 +1446,8 @@ private:
     void clearSampledPageTopColor();
 
     bool hasLocalMainFrame();
+
+    void updateControlTints();
 
     struct Internals;
     const UniqueRef<Internals> m_internals;

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -99,19 +99,28 @@
     if (!self)
         return nil;
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-        selector:@selector(systemColorsDidChange:) name:NSSystemColorsDidChangeNotification object:nil];
+    RetainPtr systemColorsChangedNotification = NSSystemColorsDidChangeNotification;
+    RetainPtr accessibilityDisplayOptionsChangedNotification = NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification;
 
+    [[NSNotificationCenter defaultCenter] addObserver:self
+        selector:@selector(systemColorsDidChange:) name:systemColorsChangedNotification.get() object:nil];
     [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
-        selector:@selector(systemColorsDidChange:) name:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil];
+        selector:@selector(accessibilityDisplayOptionsDidChange:) name:accessibilityDisplayOptionsChangedNotification.get() object:nil];
 
     return self;
+}
+
+- (void)accessibilityDisplayOptionsDidChange:(NSNotification *)notification
+{
+    UNUSED_PARAM(notification);
+    WebCore::RenderTheme::singleton().platformColorsDidChange();
 }
 
 - (void)systemColorsDidChange:(NSNotification *)notification
 {
     UNUSED_PARAM(notification);
     WebCore::RenderTheme::singleton().platformColorsDidChange();
+    WebCore::Page::updateControlTintsForAllPages();
 }
 
 @end

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -180,6 +180,7 @@ protected:
 
 #if PLATFORM(COCOA)
     void increaseFileDescriptorLimit();
+    static const WTF::String& increaseContrastPreferenceKey();
 #endif
 
 private:

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -237,13 +237,15 @@ void AuxiliaryProcess::preferenceDidUpdate(const String& domain, const String& k
     handlePreferenceChange(domain, key, value.get());
 }
 
-#if !HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && PLATFORM(IOS_FAMILY)
-static const WTF::String& increaseContrastPreferenceKey()
+const WTF::String& AuxiliaryProcess::increaseContrastPreferenceKey()
 {
+#if PLATFORM(MAC)
+    static NeverDestroyed<WTF::String> key(MAKE_STATIC_STRING_IMPL("increaseContrast"));
+#else
     static NeverDestroyed<WTF::String> key(MAKE_STATIC_STRING_IMPL("DarkenSystemColors"));
+#endif
     return key;
 }
-#endif
 
 #if USE(APPKIT)
 static const WTF::String& invertColorsPreferenceKey()

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1375,6 +1375,9 @@ void WebProcess::dispatchSimulatedNotificationsForPreferenceChange(const String&
         RetainPtr notificationCenter = [NSNotificationCenter defaultCenter];
         [notificationCenter postNotificationName:@"NSSystemColorsWillChangeNotification" object:nil];
         [notificationCenter postNotificationName:NSSystemColorsDidChangeNotification object:nil];
+    } else if (key == increaseContrastPreferenceKey()) {
+        RetainPtr notificationCenter = [[NSWorkspace sharedWorkspace] notificationCenter];
+        [notificationCenter postNotificationName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil];
     }
 #endif
     if (key == captionProfilePreferenceKey()) {


### PR DESCRIPTION
#### ebef4b11b989729196e56220ab9fc55580353b3b
<pre>
[macOS] Increase contrast setting requires Safari restart for colors to update, system accent color change does not trigger repaint
<a href="https://bugs.webkit.org/show_bug.cgi?id=297837">https://bugs.webkit.org/show_bug.cgi?id=297837</a>
<a href="https://rdar.apple.com/137778191">rdar://137778191</a>

Reviewed by Aditya Keerthi.

Since CFPrefs direct mode enablement (<a href="https://trac.webkit.org/changeset/258064/webkit)">https://trac.webkit.org/changeset/258064/webkit)</a>,
the web process never recieved notifications for updates to the increase contrast setting
value. As a result, the system color cache was never cleared. To fix this, forward
the notification from the UI process to the web process.

When the system accent color changes on macOS, the color cache is properly cleared,
but no repaint occurs. As a result, the updated color will not be reflected on the
page until a repaint is triggered by other means. To fix this, call new method
`Page::updateControlTintsForAllPages` when the system accent color changes,
which results in the repaint of all controls with control tint.

* LayoutTests/accessibility/mac/increase-contrast-system-color-changes-expected-mismatch.html: Added.
* LayoutTests/accessibility/mac/increase-contrast-system-color-changes.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateControlTintsForAllPages):
(WebCore::Page::updateControlTints):
* Source/WebCore/page/Page.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(-[WebCoreRenderThemeNotificationObserver init]):
(-[WebCoreRenderThemeNotificationObserver accessibilityDisplayOptionsDidChange:]):
(-[WebCoreRenderThemeNotificationObserver systemColorsDidChange:]):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::increaseContrastPreferenceKey):
(WebKit::increaseContrastPreferenceKey): Deleted.
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::dispatchSimulatedNotificationsForPreferenceChange):

Canonical link: <a href="https://commits.webkit.org/299445@main">https://commits.webkit.org/299445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1116f4fc0b93627f38ec94cd20cb68891302230f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71039 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a53531c-85ac-4faf-a32f-e94d411a3dc5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59799 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ec352b3-3841-4d89-90a5-b5aa6184c012) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9569b79c-a72e-41dd-844d-a18091dcfdd3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30439 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24784 "Found 1 new test failure: inspector/worker/dom-debugger-event-after-terminate-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68829 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128216 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45883 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34668 "Found 1 new test failure: imported/w3c/web-platform-tests/custom-elements/pseudo-class-defined-customized-builtins.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98957 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98737 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22195 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42452 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18948 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51431 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45219 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48565 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46905 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->