### PR TITLE
Push guard page de/allocation down into OSAllocator.

### DIFF
--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,21 +37,24 @@ public:
         UnknownUsage = -1,
         FastMallocPages = VM_TAG_FOR_TCMALLOC_MEMORY,
         JSJITCodePages = VM_TAG_FOR_EXECUTABLEALLOCATOR_MEMORY,
+#if OS(LINUX) || OS(HAIKU)
+        UncommittedPages = -2,
+#endif
     };
 
     // The requested alignment must be a power of two and greater than the system page size.
     // The memory returned by this cannot be released as on Windows there's no guaranteed API to
     // get an aligned address and the size + alignment then rounding trick cannot release the unused parts
     // due to how the Windows syscalls work.
-    WTF_EXPORT_PRIVATE static void* tryReserveUncommittedAligned(size_t, size_t alignment, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
+    WTF_EXPORT_PRIVATE static void* tryReserveUncommittedAligned(size_t, size_t alignment, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
 
     // These methods are symmetric; reserveUncommitted allocates VM in an uncommitted state,
     // releaseDecommitted should be called on a region of VM allocated by a single reservation,
     // the memory must all currently be in a decommitted state. reserveUncommitted returns to
     // you memory that is zeroed.
-    WTF_EXPORT_PRIVATE static void* reserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
-    WTF_EXPORT_PRIVATE static void* tryReserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
-    WTF_EXPORT_PRIVATE static void releaseDecommitted(void*, size_t);
+    WTF_EXPORT_PRIVATE static void* reserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void* tryReserveUncommitted(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void releaseDecommitted(void*, size_t, unsigned numberOfGuardPagesOnEachEnd);
 
     // These methods are symmetric; they commit or decommit a region of VM (uncommitted VM should
     // never be accessed, since the OS may not have attached physical memory for these regions).
@@ -62,8 +65,8 @@ public:
     // These methods are symmetric; reserveAndCommit allocates VM in an committed state,
     // decommitAndRelease should be called on a region of VM allocated by a single reservation,
     // the memory must all currently be in a committed state.
-    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
-    WTF_EXPORT_PRIVATE static void* tryReserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
+    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
+    WTF_EXPORT_PRIVATE static void* tryReserveAndCommit(size_t, Usage = UnknownUsage, void* address = nullptr, bool writable = true, bool executable = false, bool jitCageEnabled = false, unsigned numGuardPagesToAddOnEachEnd = 0);
     static void decommitAndRelease(void* base, size_t size);
 
     // These methods are akin to reserveAndCommit/decommitAndRelease, above - however rather than
@@ -93,7 +96,7 @@ inline void* OSAllocator::reserveAndCommit(size_t reserveSize, size_t commitSize
 
 inline void OSAllocator::decommitAndRelease(void* releaseBase, size_t releaseSize)
 {
-    releaseDecommitted(releaseBase, releaseSize);
+    releaseDecommitted(releaseBase, releaseSize, 0);
 }
 
 template<typename T>

--- a/Source/WTF/wtf/PageAllocation.h
+++ b/Source/WTF/wtf/PageAllocation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,7 +102,7 @@ public:
 
 private:
     PageAllocation(void* base, size_t size)
-        : PageBlock(base, size, false)
+        : PageBlock(base, size)
     {
     }
 };

--- a/Source/WTF/wtf/PageBlock.h
+++ b/Source/WTF/wtf/PageBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,13 +74,13 @@ class PageBlock {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(PageBlock);
 public:
     PageBlock() = default;
-    PageBlock(void*, size_t, bool hasGuardPages);
+    PageBlock(void*, size_t);
     
     void* base() const { return m_base; }
     void* end() const { return static_cast<uint8_t*>(m_base) + size(); }
     size_t size() const { return m_size; }
 
-    operator bool() const { return !!m_realBase; }
+    operator bool() const { return !!m_base; }
 
     bool contains(void* containedBase, size_t containedSize)
     {
@@ -89,14 +89,12 @@ public:
     }
 
 private:
-    void* m_realBase { nullptr };
     void* m_base { nullptr };
     size_t m_size { 0 };
 };
 
-inline PageBlock::PageBlock(void* base, size_t size, bool hasGuardPages)
-    : m_realBase(base)
-    , m_base(static_cast<char*>(base) + ((base && hasGuardPages) ? pageSize() : 0))
+inline PageBlock::PageBlock(void* base, size_t size)
+    : m_base(base)
     , m_size(size)
 {
 }

--- a/Source/WTF/wtf/PageReservation.h
+++ b/Source/WTF/wtf/PageReservation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -89,46 +89,40 @@ public:
         return m_committed;
     }
 
-    static PageReservation reserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, std::optional<uintptr_t> address = { }, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation reserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
-        ASSERT(isPageAligned(address.value_or(0)));
+        ASSERT(isPageAligned(addressHint));
         if (commit)
-            return PageReservation(OSAllocator::reserveAndCommit(size, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, false), size, writable, executable, jitCageEnabled, false);
-        return PageReservation(OSAllocator::reserveUncommitted(size, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, false), size, writable, executable, jitCageEnabled, false);
+            return PageReservation(OSAllocator::reserveAndCommit(size, usage, addressHint, writable, executable, jitCageEnabled), size, writable, executable, jitCageEnabled);
+        return PageReservation(OSAllocator::reserveUncommitted(size, usage, addressHint, writable, executable, jitCageEnabled), size, writable, executable, jitCageEnabled);
     }
 
-    static PageReservation tryReserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, std::optional<uintptr_t> address = { }, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation tryReserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
-        ASSERT(isPageAligned(address.value_or(0)));
+        ASSERT(isPageAligned(addressHint));
         if (commit)
-            return PageReservation(OSAllocator::tryReserveAndCommit(size, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, false), size, writable, executable, jitCageEnabled, false);
-        return PageReservation(OSAllocator::tryReserveUncommitted(size, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, false), size, writable, executable, jitCageEnabled, false);
+            return PageReservation(OSAllocator::tryReserveAndCommit(size, usage, addressHint, writable, executable, jitCageEnabled), size, writable, executable, jitCageEnabled);
+        return PageReservation(OSAllocator::tryReserveUncommitted(size, usage, addressHint, writable, executable, jitCageEnabled), size, writable, executable, jitCageEnabled);
     }
 
-    static PageReservation reserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, std::optional<uintptr_t> address = { }, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation reserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
-        ASSERT(isPageAligned(address.value_or(0)));
-        // Account for guard pages
-        if (address.has_value() && address.value() >= pageSize())
-            address.value() -= pageSize();
+        ASSERT(isPageAligned(addressHint));
         if (commit)
-            return PageReservation(OSAllocator::reserveAndCommit(size + pageSize() * 2, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);
-        return PageReservation(OSAllocator::reserveUncommitted(size + pageSize() * 2, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);
+            return PageReservation(OSAllocator::reserveAndCommit(size, usage, addressHint, writable, executable, jitCageEnabled, 1), size, writable, executable, jitCageEnabled, 1);
+        return PageReservation(OSAllocator::reserveUncommitted(size, usage, addressHint, writable, executable, jitCageEnabled, 1), size, writable, executable, jitCageEnabled, 1);
     }
 
-    static PageReservation tryReserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, std::optional<uintptr_t> address = { }, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
+    static PageReservation tryReserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, void* addressHint = nullptr, bool writable = true, bool executable = false, bool commit = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
-        ASSERT(isPageAligned(address.value_or(0)));
-        // Account for guard pages
-        if (address.has_value() && address.value() >= pageSize())
-            address.value() -= pageSize();
+        ASSERT(isPageAligned(addressHint));
         if (commit)
-            return PageReservation(OSAllocator::tryReserveAndCommit(size + pageSize() * 2, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);
-        return PageReservation(OSAllocator::tryReserveUncommitted(size + pageSize() * 2, usage, std::bit_cast<void*>(address.value_or(0)), writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);
+            return PageReservation(OSAllocator::tryReserveAndCommit(size, usage, addressHint, writable, executable, jitCageEnabled, 1), size, writable, executable, jitCageEnabled, 1);
+        return PageReservation(OSAllocator::tryReserveUncommitted(size, usage, addressHint, writable, executable, jitCageEnabled, 1), size, writable, executable, jitCageEnabled, 1);
     }
 
 
@@ -144,21 +138,23 @@ public:
         ASSERT(tmp);
         ASSERT(!*this);
 
-        OSAllocator::releaseDecommitted(tmp.base(), tmp.size());
+        OSAllocator::releaseDecommitted(tmp.base(), tmp.size(), tmp.m_numberOfGuardPagesOnEachEnd);
     }
 
 private:
-    PageReservation(void* base, size_t size, bool writable, bool executable, bool, bool hasGuardPages)
-        : PageBlock(base, size, hasGuardPages)
+    PageReservation(void* base, size_t size, bool writable, bool executable, bool, unsigned numberOfGuardPagesOnEachEnd = 0)
+        : PageBlock(base, size)
         , m_committed(0)
         , m_writable(writable)
         , m_executable(executable)
+        , m_numberOfGuardPagesOnEachEnd(numberOfGuardPagesOnEachEnd)
     {
     }
 
     size_t m_committed { 0 };
     bool m_writable { false };
     bool m_executable { false };
+    unsigned m_numberOfGuardPagesOnEachEnd { 0 };
 };
 
 }

--- a/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
@@ -38,9 +38,9 @@
 
 namespace WTF {
 
-void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
 {
-    ASSERT_UNUSED(includesGuardPages, !includesGuardPages);
+    UNUSED_PARAM(numGuardPagesToAddOnEachEnd); // Guard pages not supported, and will be ignored.
     ASSERT_UNUSED(jitCageEnabled, !jitCageEnabled);
     ASSERT_UNUSED(executable, !executable);
     ASSERT_UNUSED(address, !address);
@@ -58,11 +58,11 @@ void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address,
     return result;
 }
 
-void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
 {
     UNUSED_PARAM(usage);
     UNUSED_PARAM(writable);
-    ASSERT_UNUSED(includesGuardPages, !includesGuardPages);
+    UNUSED_PARAM(numGuardPagesToAddOnEachEnd); // Guard pages not supported, and will be ignored.
     ASSERT_UNUSED(jitCageEnabled, !jitCageEnabled);
     ASSERT_UNUSED(executable, !executable);
     ASSERT_UNUSED(address, !address);
@@ -74,16 +74,16 @@ void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, void* addres
     return result;
 }
 
-void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
 {
-    void* result = tryReserveUncommitted(bytes, usage, address, writable, executable, jitCageEnabled, includesGuardPages);
+    void* result = tryReserveUncommitted(bytes, usage, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd);
     RELEASE_ASSERT(result);
     return result;
 }
 
-void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
 {
-    ASSERT_UNUSED(includesGuardPages, !includesGuardPages);
+    ASSERT_UNUSED(numGuardPagesToAddOnEachEnd, !numGuardPagesToAddOnEachEnd);
     ASSERT_UNUSED(jitCageEnabled, !jitCageEnabled);
     ASSERT_UNUSED(executable, !executable);
     ASSERT_UNUSED(address, !address);
@@ -98,9 +98,9 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
     return result;
 }
 
-void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
 {
-    void* result = tryReserveAndCommit(bytes, usage, address, writable, executable, jitCageEnabled, includesGuardPages);
+    void* result = tryReserveAndCommit(bytes, usage, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd);
     RELEASE_ASSERT(result);
     return result;
 }
@@ -124,8 +124,9 @@ void OSAllocator::hintMemoryNotNeededSoon(void* address, size_t bytes)
     UNUSED_PARAM(bytes);
 }
 
-void OSAllocator::releaseDecommitted(void* address, size_t bytes)
+void OSAllocator::releaseDecommitted(void* address, size_t bytes, unsigned numGuardPagesToAddOnEachEnd)
 {
+    UNUSED_PARAM(numGuardPagesToAddOnEachEnd); // Guard pages not supported, and will be ignored.
     bool success = memory_extra::vss::release(address, bytes);
     RELEASE_ASSERT(success);
 }

--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -45,19 +45,19 @@ static inline DWORD protection(bool writable, bool executable)
         (writable ? PAGE_READWRITE : PAGE_READONLY);
 }
 
-void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage, void* address, bool writable, bool executable, bool, bool)
+void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage, void* address, bool writable, bool executable, bool, unsigned)
 {
     return VirtualAlloc(address, bytes, MEM_RESERVE, protection(writable, executable));
 }
 
-void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
 {
-    void* result = tryReserveUncommitted(bytes, usage, address, writable, executable, jitCageEnabled, includesGuardPages);
+    void* result = tryReserveUncommitted(bytes, usage, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd);
     RELEASE_ASSERT(result);
     return result;
 }
 
-void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage usage, void* address, bool writable, bool executable, bool, bool)
+void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage usage, void* address, bool writable, bool executable, bool, unsigned)
 {
     ASSERT(hasOneBitSet(alignment) && alignment >= pageSize());
 
@@ -77,14 +77,14 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
     return aligned;
 }
 
-void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage, void* address, bool writable, bool executable, bool, bool)
+void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage, void* address, bool writable, bool executable, bool, unsigned)
 {
     return VirtualAlloc(address, bytes, MEM_RESERVE | MEM_COMMIT, protection(writable, executable));
 }
 
-void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
 {
-    void* result = tryReserveAndCommit(bytes, usage, address, writable, executable, jitCageEnabled, includesGuardPages);
+    void* result = tryReserveAndCommit(bytes, usage, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd);
     RELEASE_ASSERT(result);
     return result;
 }
@@ -117,7 +117,7 @@ void OSAllocator::decommit(void* address, size_t bytes)
     VirtualUnlock(address, bytes);
 }
 
-void OSAllocator::releaseDecommitted(void* address, size_t bytes)
+void OSAllocator::releaseDecommitted(void* address, size_t bytes, unsigned)
 {
     // See comment in OSAllocator::decommit(). Similarly, when bytes is 0, we
     // don't want to release anything. So, don't call VirtualFree() below.


### PR DESCRIPTION
#### 69371bd0991ed38ae47d56b9bb2dc7f940e9a3e3
<pre>
Push guard page de/allocation down into OSAllocator.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297841">https://bugs.webkit.org/show_bug.cgi?id=297841</a>
<a href="https://rdar.apple.com/159065710">rdar://159065710</a>

Reviewed by Yusuke Suzuki.

Previously, PageReservation can increase the allocation size by 2 pages to include guard pages.
It then tells OSAllocator that there are guard pages included by passing a includesGuardPages
bool.  Based on this includesGuardPages bool, OSAllocator also assumes that the allocation
size includes exactly 2 page sized guard regions on each end.  Unfortunately, this treatment
is not applied consistents everywhere.  For example,

1. OSAllocator::tryReserveUncommitted() calls tryReserveAndCommit() with includesGuardPages
   being true.  tryReserveAndCommit() allocates the buffer including the guard pages, and maps
   the guard pages to be PROT_NONE.  Then, tryReserveUncommitted() fails to account for the
   Guard pages and madvise() the whole range as MADV_FREE_REUSABLE (including guard pages).
   This madvise fails, because it&apos;s not allowed to do this to the PROT_NONE guard pages.

2. PageReservation::deallocate() calls OSAllocator::releaseDecommitted() on its base() for
   size() bytes.  base() is not the base of the allocation, but just the start of the usable
   section after the guard page at the start.  releaseDecommitted() munmaps that memory range.
   However, if there are guard regions on each end, the pages for the guard regions are never
   munmapped.

This change makes the division of labor and responsibility clearer:
1. PageReservation just specifies how many guard pages it wants on each end, if any.
2. OSAllocator takes care of allocation / deallocation, including for guard pages.

So, PageReservation will now pass in the number of pages it wants as guard on each end.
OSAllocator takes care of the rest.  Similarly. PageReservation::deallocate() also passes in
the number of pages it requested as guard on each end, and OSAllocator::releaseDecommitted()
does the right thing to munmap the actual memory range including any guard regions.

This approach simplifies the logic significantly, and makes it easier to get right:

1. PageBlock::m_realBase was initialized but never used.  It can not be removed.  It also makes
   it clear that PageBlock is not responsible for dealing with guard regions.

2. PageReservation can now think of its buffer size request without needing to do any padding
   math to account for guard regions.

3. PageReservation can now think of its addressHint without needing to do any padding math to
   account for guard regions.

PageReservation no longer needs to do any padding math for the guard regions.  OSAllocator will
take care of that as needed.  This is also fine from a performance angle.  OSAllocator calls are
already dominated by the mmap and munmap calls.  The extra arithmetic for the padding math is
not going to move the needle in terms of perf impact.

Two additional changes:

4. Change addressHints to be specified using a void* instead of a std::optional.  There&apos;s no
   value add with using a std::optional for it.  An addressHint of nullptr would indicated that
   no hint is specified.  This is already consistent with the convention mmap and munmap expects.

5. Change Linux&apos;s OSAllocator::tryReserveUncommitted() to also forward to OSAllocator::tryReserveAndCommit()
   to do the mapping just like for OS(DARWIN), instead of rolling its own.  There were only 2
   differences between the 2 implementations to begin with:

   a. Linux&apos;s OSAllocator::tryReserveUncommitted() sets the MAP_NORESERVE flag for its call to
      mmap().  We now achieve this by repurposing the unused usage parameter to pass a new
      OSAllocator::UncommittedPages value.  This value tells OSAllocator::tryReserveAndCommit()
      to add the MAP_NORESERVE flag for Linux.

   b. After the mmap call, Linux&apos;s OSAllocator::tryReserveUncommitted() does a madvise() with
      MADV_DONTNEED instead of MADV_FREE_REUSABLE.  We retain this behavior by keeping different
      madvise() calls for the 2 ports.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):
* Source/WTF/wtf/OSAllocator.h:
(WTF::OSAllocator::decommitAndRelease):
* Source/WTF/wtf/PageAllocation.h:
(WTF::PageAllocation::PageAllocation):
* Source/WTF/wtf/PageBlock.h:
(WTF::PageBlock::operator bool const):
(WTF::PageBlock::PageBlock):
* Source/WTF/wtf/PageReservation.h:
(WTF::PageReservation::reserve):
(WTF::PageReservation::tryReserve):
(WTF::PageReservation::reserveWithGuardPages):
(WTF::PageReservation::tryReserveWithGuardPages):
(WTF::PageReservation::deallocate):
(WTF::PageReservation::PageReservation):
* Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp:
(WTF::OSAllocator::tryReserveAndCommit):
(WTF::OSAllocator::tryReserveUncommitted):
(WTF::OSAllocator::reserveUncommitted):
(WTF::OSAllocator::tryReserveUncommittedAligned):
(WTF::OSAllocator::reserveAndCommit):
(WTF::OSAllocator::releaseDecommitted):
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveAndCommit):
(WTF::OSAllocator::tryReserveUncommitted):
(WTF::OSAllocator::reserveUncommitted):
(WTF::OSAllocator::tryReserveUncommittedAligned):
(WTF::OSAllocator::reserveAndCommit):
(WTF::OSAllocator::releaseDecommitted):
* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryReserveUncommitted):
(WTF::OSAllocator::reserveUncommitted):
(WTF::OSAllocator::tryReserveUncommittedAligned):
(WTF::OSAllocator::tryReserveAndCommit):
(WTF::OSAllocator::reserveAndCommit):
(WTF::OSAllocator::releaseDecommitted):

Canonical link: <a href="https://commits.webkit.org/299145@main">https://commits.webkit.org/299145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0095d6b140d95aa118b5413222290e5fa0ef232c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117991 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124138 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70026 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86106b43-6153-4683-b1d9-fb98bd4b97f4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89543 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59148 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdfaae5f-442b-41c0-94fd-1d7c2abcae95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70036 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5acc4303-f58c-467d-822e-18763e5549f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23925 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67802 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110102 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127222 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116501 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98215 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98003 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41329 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18810 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50440 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145199 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44226 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37353 "Found 1 new JSC binary failure: testapi, Found 20043 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47571 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->