### PR TITLE
Build fix for showNotification: completionHandler.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
@@ -63,7 +63,7 @@ WK_EXTERN
 - (void)unsubscribeFromPushServiceForScope:(NSURL *)scopeURL completionHandler:(void (^)(BOOL unsubscribed, NSError *))completionHandler;
 - (void)getSubscriptionForScope:(NSURL *)scopeURL completionHandler:(void (^)(_WKWebPushSubscriptionData *, NSError *))completionHandler;
 - (void)getNextPendingPushMessage:(void (^)(_WKWebPushMessage *))completionHandler;
-- (void)showNotification:(_WKNotificationData *)notificationData completionHandler:(void (^)())completionHandler;
+- (void)showNotification:(_WKNotificationData *)notificationData completionHandler:(void (^)(void))completionHandler;
 - (void)getNotifications:(NSURL *)scopeURL tag:(NSString *)tag completionHandler:(void (^)(NSArray<_WKNotificationData *> *, NSError *))completionHandler;
 - (void)cancelNotification:(NSURL *)securityOriginURL uuid:(NSUUID *)notificationIdentifier;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
@@ -170,7 +170,7 @@ static _WKWebPushPermissionState toWKPermissionsState(WebCore::PushPermissionSta
 }
 
 
-- (void)showNotification:(_WKNotificationData *)notificationData completionHandler:(void (^)())completionHandler
+- (void)showNotification:(_WKNotificationData *)notificationData completionHandler:(void (^)(void))completionHandler
 {
     self._protectedConnection->showNotification([notificationData _getCoreData], [completionHandlerCopy = makeBlockPtr(completionHandler)] () {
         completionHandlerCopy();


### PR DESCRIPTION
#### 7e7db24a7e15babcdc9425f0cd797e2fa764c613
<pre>
Build fix for showNotification: completionHandler.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297844">https://bugs.webkit.org/show_bug.cgi?id=297844</a>
<a href="https://rdar.apple.com/159081226">rdar://159081226</a>

Unreviewed build fix.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(-[_WKWebPushDaemonConnection showNotification:completionHandler:]):
Declare void for the block arguments

Canonical link: <a href="https://commits.webkit.org/299103@main">https://commits.webkit.org/299103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a90592193b6aa51630821ed499ec36bc3fe85eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28191 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69914 "Failed to checkout and rebase branch from PR 49832") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0574aecc-e742-44de-8900-effcdf39f8fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46141 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/124025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/69914 "Failed to checkout and rebase branch from PR 49832") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/397e7398-7dcd-4eaa-8090-84f718c968fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120833 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/30458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c2bb30e-a2dd-4211-bb93-4b45e3eda0e8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/67688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127108 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44784 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45145 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/101923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/43302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41212 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18796 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44656 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50330 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44116 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45805 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->