### PR TITLE
[iOS] Text selection is lost immediately when long pressing on a PDF document in a web app

### DIFF
--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
@@ -58,7 +58,6 @@ struct InteractionInformationAtPosition {
     enum class Selectability : uint8_t {
         Selectable,
         UnselectableDueToFocusableElement,
-        UnselectableDueToLargeElementBounds,
         UnselectableDueToUserSelectNoneOrQuirk,
         UnselectableDueToMediaControls,
     };

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -25,7 +25,6 @@
 [Nested] enum class WebKit::InteractionInformationAtPosition::Selectability : uint8_t {
     Selectable,
     UnselectableDueToFocusableElement,
-    UnselectableDueToLargeElementBounds,
     UnselectableDueToUserSelectNoneOrQuirk,
     UnselectableDueToMediaControls,
 };

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2796,12 +2796,6 @@ std::optional<SimpleRange> WebPage::rangeForGranularityAtPoint(LocalFrame& frame
     return std::nullopt;
 }
 
-static inline bool rectIsTooBigForSelection(const IntRect& blockRect, const LocalFrame& frame)
-{
-    const float factor = 0.97;
-    return blockRect.height() > frame.view()->unobscuredContentRect().height() * factor;
-}
-
 void WebPage::updateFocusBeforeSelectingTextAtLocation(const IntPoint& point)
 {
     static constexpr OptionSet hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowVisibleChildFrameContentOnly };
@@ -3685,12 +3679,6 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
         if (RefPtr element = dynamicDowncast<Element>(*hitNode)) {
             if (isAssistableElement(*element))
                 return InteractionInformationAtPosition::Selectability::UnselectableDueToFocusableElement;
-
-            if (rectIsTooBigForSelection(info.bounds, *result.innerNodeFrame())) {
-                // We don't want to select blocks that are larger than 97% of the visible area of the document.
-                // FIXME: Is this heuristic still needed, now that block selection has been removed?
-                return InteractionInformationAtPosition::Selectability::UnselectableDueToLargeElementBounds;
-            }
 
             if (hostVideoElementIgnoringImageOverlay(*hitNode))
                 return InteractionInformationAtPosition::Selectability::UnselectableDueToMediaControls;


### PR DESCRIPTION
#### c6e77058d1bc5a23b153506efa1238a568dfef1b
<pre>
[iOS] Text selection is lost immediately when long pressing on a PDF document in a web app
<a href="https://bugs.webkit.org/show_bug.cgi?id=297849">https://bugs.webkit.org/show_bug.cgi?id=297849</a>
<a href="https://rdar.apple.com/157692157">rdar://157692157</a>

Reviewed by Tim Horton.

Safari web apps configure WKWebViews with allowsLinkPreview == NO.

This knob toggles the enablement of the highlight long press GR on the
content view. On a long tap, when we eventually receive the &quot;Ended&quot;
state in the GR&apos;s action selector, we attempt a synthetic click at the
last touch point, which has the undesired effect of clearing out the
active text selection.

Ideally, the highlight is not activated when we&apos;re selecting text. We
explicitly handle this in textInteractionGesture:shouldBeginAtPoint:,
but out logic breaks down because we do not believe there is selectable
text under the last touch point. This happens because during position
information computating in the web process, the node (for PDF content)
fails the rectIsTooBigForSelection() check.

Given the rect size check was introduced in support of block selections
(c.f. 175893@main), which is no longer a supported text selection
modality, it seems fair for us to drop this check. This also has the
effect of the plugin no longer losing its text selection!

No new test coverage, sadly, because I could not figure out a working
combination of long press GR state transitions to reproduce the failure
case.

* Source/WebKit/Shared/ios/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::selectionPositionInformation):
(WebKit::rectIsTooBigForSelection): Deleted.

Canonical link: <a href="https://commits.webkit.org/299120@main">https://commits.webkit.org/299120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afbfe6642f9b5f3c37ebcc0ed8b35360bfa2be41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69932 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2e69460-69fa-4b54-93e8-c192acf44dfb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89465 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8f8361b-9104-4390-a1f3-7aaf0b5d6872) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69961 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dccbc6d8-952c-4e64-b2f5-da8d2d11890d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29536 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67707 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127126 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98135 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97923 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43316 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21296 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41231 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18801 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50348 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44134 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->