### PR TITLE
REGRESSION(298480@main): [ macOS wk2 ] http/tests/navigation/ping-attribute/anchor-cookie.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js
+++ b/LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js
@@ -21,12 +21,13 @@ function clearLastPingResultAndRunTest(callback)
 {
     function done()
     {
+        console.log("FAILED: delete ping failed!");
         if (window.testRunner)
             testRunner.notifyDone();
     }
 
     var xhr = new XMLHttpRequest;
-    xhr.open("GET", "../resources/delete-ping.py", true /* async */);
+    xhr.open("GET", "../../resources/delete-ping.py", true /* async */);
     xhr.send(null);
     xhr.onload = callback;
     xhr.onerror = done;

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2406,8 +2406,6 @@ webkit.org/b/297251 fast/mediastream/getUserMedia-echoCancellation.html [ Pass F
 
 webkit.org/b/297343 [ Debug ] ipc/storage-area-cache-use-after-free.html [ Slow ]
 
-webkit.org/b/297428 http/tests/navigation/ping-attribute/anchor-cookie.html [ Pass Failure ]
-
 webkit.org/b/297483 fast/scrolling/mac/scrollend-event-on-select-element.html [ Pass Failure ]
 
 webkit.org/b/297551 imported/w3c/web-platform-tests/event-timing/buffered-and-duration-threshold.html [ Pass Failure ]


### PR DESCRIPTION
#### cd89250ae42922f9f63c00d756a4868790bdd792
<pre>
REGRESSION(298480@main): [ macOS wk2 ] http/tests/navigation/ping-attribute/anchor-cookie.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=297428">https://bugs.webkit.org/show_bug.cgi?id=297428</a>
<a href="https://rdar.apple.com/158358934">rdar://158358934</a>

Reviewed by Basuke Suzuki.

The test was flaky because it was using an incorrect URL for delete-ping.py and it
was calling `notifyDone()` on failure, which would abort the test at a random time.

* LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js:
(clearLastPingResultAndRunTest.done):
(clearLastPingResultAndRunTest):
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/299131@main">https://commits.webkit.org/299131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f79662209eb7514b965bc838e4a2b712778fea5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69931 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72146d76-37f8-4a67-843f-d446b094feee) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89464 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59080 "Too many flaky failures: css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, ietestcenter/Javascript/15.4.4.17-7-b-1.html, imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https.html?3-3, imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https.html?4-last, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker.html, js/array-enumerators-functions.html, js/array-every.html, js/array-fill.html, js/array-filter.html, js/dfg-arguments-osr-exit.html, js/dom/document-all-is-callable-builtins.html, js/dom/modules/import-incorrect-relative-specifier.html, js/structuredClone/structured-clone-of-CachedString-in-map.html, js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html, storage/indexeddb/error-causes-abort-by-default.html, storage/indexeddb/modern/idbcursor-continue-primary-key-1.html, storage/indexeddb/modern/idbdatabase-deleteobjectstore-failures-private.html, storage/indexeddb/mozilla/delete-result.html, storage/indexeddb/mozilla/event-source-private.html, storage/indexeddb/mozilla/event-source.html, storage/indexeddb/persistence.html, webgl/2.0.0/conformance2/textures/image/tex-2d-r8-red-unsigned_byte.html, webgl/2.0.y/conformance/uniforms/null-uniform-location.html, webgl/2.0.y/conformance2/glsl3/compound-assignment-type-combination.html, webgl/webgl-and-dom-in-gpup.html, webgl/webgl-backing-store-size-update.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e82d9615-82b8-4d77-a090-f10b3665c674) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5383c5dd-4749-4f71-b56b-aab09c3afe7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23826 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67706 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127125 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98134 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97922 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21290 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41230 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44673 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44133 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47478 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45822 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->