### PR TITLE
Add performance tests for WebGL and 2D contexts as ImageSource of 2D context drawImage

### DIFF
--- a/PerformanceTests/Canvas/drawImageSourceCanvas2D.html
+++ b/PerformanceTests/Canvas/drawImageSourceCanvas2D.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2000;
+source.height = 2000;
+var ctx1 = source.getContext("2d");
+ctx1.globalCompositeOperation = "copy";
+
+target.width = source.width;
+target.height = source.height;
+var ctx2 = target.getContext("2d");
+ctx2.globalCompositeOperation = "copy";
+var i = 0;
+PerfTestRunner.measureRunsPerSecond({run: function() {
+    ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
+    ctx1.fillRect(0, 0, source.width, source.height);
+    i += 1;
+   if (i > 255)
+        i = 0;
+    ctx2.drawImage(source, 0, 0);   
+    ctx2.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+}});
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/drawImageSourceCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceCanvasWebGL.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2000;
+source.height = 2000;
+var gl = source.getContext("webgl2");
+
+target.width = source.width;
+target.height = source.height;
+var ctx = target.getContext("2d");
+ctx.globalCompositeOperation = "copy";
+var i = 0;
+PerfTestRunner.measureRunsPerSecond({run: function() {
+    gl.clearColor(0, i, 0, 0.5);
+    i += 0.01;
+    if (i > 1.0)
+        i = 0;
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    ctx.drawImage(source, 0, 0);   
+}});
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/drawImageSourceImageBitmapCanvas2D.html
+++ b/PerformanceTests/Canvas/drawImageSourceImageBitmapCanvas2D.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2000;
+source.height = 2000;
+var ctx1 = source.getContext("2d");
+ctx1.globalCompositeOperation = "copy";
+
+target.width = source.width;
+target.height = source.height;
+var ctx2 = target.getContext("2d");
+ctx2.globalCompositeOperation = "copy";
+
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
+        ctx1.fillRect(0, 0, source.width, source.height);
+        let imageBitmap = await createImageBitmap(source);
+        ctx2.drawImage(imageBitmap, 0, 0);   
+    }
+    ctx2.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/drawImageSourceImageBitmapCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceImageBitmapCanvasWebGL.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2000;
+source.height = 2000;
+var gl = source.getContext("webgl2");
+
+target.width = source.width;
+target.height = source.height;
+var ctx = target.getContext("2d");
+ctx.globalCompositeOperation = "copy";
+
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        gl.clearColor(0, i / 100.0, 0, 0.5);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        let imageBitmap = await createImageBitmap(source);
+        ctx.drawImage(imageBitmap, 0, 0);
+    }
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvas2D.html
+++ b/PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvas2D.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+var source = new OffscreenCanvas(2000, 2000);
+var ctx1 = source.getContext("2d");
+ctx1.globalCompositeOperation = "copy";
+
+target.width = source.width;
+target.height = source.height;
+var ctx2 = target.getContext("2d");
+ctx2.globalCompositeOperation = "copy";
+
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
+        ctx1.fillRect(0, 0, source.width, source.height);
+        let imageBitmap = await createImageBitmap(source);
+        ctx2.drawImage(imageBitmap, 0, 0);   
+    }
+    ctx2.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvasWebGL.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+var source = new OffscreenCanvas(2000, 2000);
+var gl = source.getContext("webgl2");
+
+target.width = source.width;
+target.height = source.height;
+var ctx = target.getContext("2d");
+ctx.globalCompositeOperation = "copy";
+
+var isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: done, unit: 'ms' });
+function done() {
+    isDone = true;
+}
+async function runTest() {
+    let startTime = PerfTestRunner.now();
+    for (let i = 0.0; i < 100.0; i += 1.0) {
+        gl.clearColor(0, i / 100.0, 0, 0.5);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        let imageBitmap = await createImageBitmap(source);
+        ctx.drawImage(imageBitmap, 0, 0);
+    }
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/drawImageSourceOffscreenCanvas2D.html
+++ b/PerformanceTests/Canvas/drawImageSourceOffscreenCanvas2D.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+var source = new OffscreenCanvas(2000, 2000);
+var ctx1 = source.getContext("2d");
+ctx1.globalCompositeOperation = "copy";
+
+target.width = source.width;
+target.height = source.height;
+var ctx2 = target.getContext("2d");
+ctx2.globalCompositeOperation = "copy";
+var i = 0;
+PerfTestRunner.measureRunsPerSecond({run: function() {
+    ctx1.fillStyle = `rgba(0, ${i}, 0, 0.5)`;
+    ctx1.fillRect(0, 0, source.width, source.height);
+    i += 1;
+   if (i > 255)
+        i = 0;
+    ctx2.drawImage(source, 0, 0);   
+    ctx2.getImageData(0, 0, 1, 1); // FIXME: WebKit does not have backpressure, draws too much.
+}});
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/drawImageSourceOffscreenCanvasWebGL.html
+++ b/PerformanceTests/Canvas/drawImageSourceOffscreenCanvasWebGL.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style type="text/css">
+canvas {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+var source = new OffscreenCanvas(2000, 2000);
+var gl = source.getContext("webgl2");
+
+target.width = source.width;
+target.height = source.height;
+var ctx = target.getContext("2d");
+ctx.globalCompositeOperation = "copy";
+var i = 0;
+PerfTestRunner.measureRunsPerSecond({run: function() {
+    gl.clearColor(0, i, 0, 0.5);
+    i += 0.01;
+    if (i > 1.0)
+        i = 0;
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    ctx.drawImage(source, 0, 0);   
+}});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 25d187fd9da62555f5eb1db339872d145de23224
<pre>
Add performance tests for WebGL and 2D contexts as ImageSource of 2D context drawImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=297852">https://bugs.webkit.org/show_bug.cgi?id=297852</a>
<a href="https://rdar.apple.com/problem/159098378">rdar://problem/159098378</a>

Reviewed by Simon Fraser.

Add few tests to test CanvasRenderingContext2D.drawImage() with 2D contexts
and WebGL.

* PerformanceTests/Canvas/drawImageSourceCanvas2D.html: Added.
* PerformanceTests/Canvas/drawImageSourceCanvasWebGL.html: Added.
* PerformanceTests/Canvas/drawImageSourceImageBitmapCanvas2D.html: Added.
* PerformanceTests/Canvas/drawImageSourceImageBitmapCanvasWebGL.html: Added.
* PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvas2D.html: Added.
* PerformanceTests/Canvas/drawImageSourceImageBitmapOffscreenCanvasWebGL.html: Added.
* PerformanceTests/Canvas/drawImageSourceOffscreenCanvas2D.html: Added.
* PerformanceTests/Canvas/drawImageSourceOffscreenCanvasWebGL.html: Added.

Canonical link: <a href="https://commits.webkit.org/299148@main">https://commits.webkit.org/299148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98c50097515f51ff29bd488432bf2ea96b2e530c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124058 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69947 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9203a40f-39a6-4408-8809-82a35e82d6dc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89478 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59092 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16e46ad9-d414-402b-a625-ddad3fc34a3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69974 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0dfcca77-92de-4030-b926-2453be89f6d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29549 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67722 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127140 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98148 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24933 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41248 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44688 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->