### PR TITLE
[macOS] camera OS indicator does not go away when stopping camera and screenshare

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -262,10 +262,9 @@ void ScreenCaptureKitCaptureSource::stop()
     });
     [contentStream() stopCaptureWithCompletionHandler:stopHandler.get()];
 
-    if (m_sessionSource) {
+    // We do not nullify m_sessionSource to keep the picker active since it is helping capture for some fullscreen cases.
+    if (m_sessionSource)
         m_contentFilter = m_sessionSource->contentFilter();
-        m_sessionSource = nullptr;
-    }
 }
 
 void ScreenCaptureKitCaptureSource::end()
@@ -399,9 +398,6 @@ RetainPtr<SCStreamConfiguration> ScreenCaptureKitCaptureSource::streamConfigurat
 void ScreenCaptureKitCaptureSource::startContentStream()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
-    if (contentStream())
-        return;
 
     if (!m_captureHelper)
         m_captureHelper = adoptNS([[WebCoreScreenCaptureKitHelper alloc] initWithCallback:this]);


### PR DESCRIPTION
#### ac56c26f923ddb22d407c58f04e62ca32d41e9ce
<pre>
[macOS] camera OS indicator does not go away when stopping camera and screenshare
<a href="https://rdar.apple.com/152962650">rdar://152962650</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297718">https://bugs.webkit.org/show_bug.cgi?id=297718</a>

Reviewed by Eric Carlson.

We need to do two things:
- When capture starts, make sure the picker is active.
- When capture is muted, make sure the picker stays active as long as the muted source may be unmuted. This is to ensure that capturing applications that can fullscreen (like KeyNotes) is working appropriately
- When capture is ended, make sure the picker is inactive if there is no other source (started or muted).

To do so, we do the following:
- We move the setActive logic to WebDisplayMediaPromptHelper startObservingPicker/stopObservingPicker.
- We make sure that ScreenCaptureKitCaptureSource keeps its m_sessionSource alive when stopped. This prevents the picker to be set back to inactive too early.
- We continue to recreate m_sessionSource whenever starting to capture (initial start or unmute) to keep the existing code as is.
- We make sure that ScreenCaptureKitCaptureSource clears its m_sessionSource when ended.

Manually tested by muting/unmuting capture and capturing KeyNotes app/fullscreening it.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::stop):
(WebCore::ScreenCaptureKitCaptureSource::startContentStream):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(-[WebDisplayMediaPromptHelper startObservingPicker:]):
(-[WebDisplayMediaPromptHelper stopObservingPicker:]):
(WebCore::ScreenCaptureKitSharingSessionManager::cancelPicking):
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker):
(-[WebDisplayMediaPromptHelper hasObservingSession]): Deleted.

Canonical link: <a href="https://commits.webkit.org/299161@main">https://commits.webkit.org/299161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86a27bef518b3e5492b23c859ae842314c61cbe2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70086 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a403cbdc-88c5-48b9-bf4d-abe1b15d1d30) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89584 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59186 "Found 16 new test failures: css3/filters/drop-shadow-current-color.html fast/canvas/offscreen-no-script-context-crash.html http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html ietestcenter/Javascript/15.5.5.5.2-3-7.html imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html inspector/cpu-profiler/tracking.html js/dom/typed-array-access.html js/no-iterator-constructors.html storage/indexeddb/intversion-long-queue.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49f57744-d728-4656-b877-ff3d170f4815) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70076 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1b0f213-cbb5-4bde-bc21-d4297c8c080c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67865 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127281 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98257 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24941 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41389 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50499 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44285 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47630 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->