### PR TITLE
Re-enable TestWebKitAPI.WebTransport.ServerBidirectional

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -202,8 +202,7 @@ TEST(WebTransport, Unidirectional)
     EXPECT_TRUE(challenged);
 }
 
-// FIXME: Fix and enable this test.
-TEST(WebTransport, DISABLED_ServerBidirectional)
+TEST(WebTransport, ServerBidirectional)
 {
     WebTransportServer echoServer([](ConnectionGroup group) -> ConnectionTask {
         auto connection = co_await group.receiveIncomingConnection();


### PR DESCRIPTION
#### 9f2ae406b992e5d2ae874d1df6dea861ec83341d
<pre>
Re-enable TestWebKitAPI.WebTransport.ServerBidirectional
<a href="https://bugs.webkit.org/show_bug.cgi?id=297869">https://bugs.webkit.org/show_bug.cgi?id=297869</a>
<a href="https://rdar.apple.com/159130910">rdar://159130910</a>

Unreviewed.

I verified this test passed many times on macOS and iOS.  I&apos;m not sure why I disabled
it, but it no longer needs to be disabled.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, ServerBidirectional)):
(TestWebKitAPI::TEST(WebTransport, DISABLED_ServerBidirectional)): Deleted.

Canonical link: <a href="https://commits.webkit.org/299132@main">https://commits.webkit.org/299132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a12e7489db44111c87b85bf0c5af14b91a8eadcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70004 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3cd3ea7a-292d-4f81-8581-fa4ec0159137) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89521 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59128 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8685f202-561d-4001-aefe-ecd04392dbf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70014 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/696ce406-8d16-401b-89b3-fbed6efbbfba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67779 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127197 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98191 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97979 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41306 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18806 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44744 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44204 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45893 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->