### PR TITLE
Represent ImageOnlyFailures with a separate icon when looking at results on the databases

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
@@ -29,6 +29,7 @@ class Expectations
             success: computedStyle.getPropertyValue('--greenLight').trim(),
             warning: computedStyle.getPropertyValue('--orangeDark').trim(),
             failed: computedStyle.getPropertyValue('--redLight').trim(),
+            image: computedStyle.getPropertyValue('--blueLight').trim(),
             timedout: computedStyle.getPropertyValue('--orangeLight').trim(),
             crashed: computedStyle.getPropertyValue('--purpleLight').trim(),
         };
@@ -87,10 +88,11 @@ Expectations.stateToIdMap = {
     WARNING: 0x38,
     PASS: 0x40,
 };
-Expectations.failureTypes = ['warning', 'failed', 'timedout', 'crashed'];
+Expectations.failureTypes = ['warning', 'failed', 'image', 'timedout', 'crashed'];
 Expectations.failureTypeMap = {
     warning: 'WARNING',
-    failed: 'ERROR',
+    failed: 'FAIL',
+    image: 'IMAGE',
     timedout: 'TIMEOUT',
     crashed: 'CRASH',
 }
@@ -103,6 +105,7 @@ Expectations.symbolMap = {
     success: '✓',
     warning: '?',
     failed: '𝖷',
+    image: 'I',
     timedout: timeoutImage,
     crashed: '!',
 }

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -1289,8 +1289,12 @@ function Legend(callback=null, plural=false, defaultWillFilterExpected=false, fl
             unexpected: plural ? 'Some tests reported warnings' : 'Test warning',
         },
         failed: {
-            expected: plural ? 'Some tests unexpectedly failed' : 'Unexpectedly failed',
-            unexpected: plural ? 'Some tests failed' : 'Test failed',
+            expected: plural ? 'Some tests unexpectedly failed' : 'Unexpectedly text failed',
+            unexpected: plural ? 'Some tests failed' : 'Test text failed',
+        },
+        image: {
+            expected: plural ? 'Some tests unexpectedly image failed' : 'Unexpectedly image failed',
+            unexpected: plural ? 'Some tests image failed' : 'Test image failed',
         },
         timedout: {
             expected: plural ? 'Some tests unexpectedly timed out' : 'Unexpectedly timed out',

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/webkit.css
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/webkit.css
@@ -28,7 +28,7 @@ Copyright (C) 2019 Apple Inc. All rights reserved.
   --blueDarker: #0262ca;
   --blueDark: #066ee0;
   --blue: #0070c9;
-  --blueLight: #3b99fc;
+  --blueLight: #36C5F0;
   --blueLighter: #9dccfe;
   --blueLightest: #f5f9fe;
   --blueHighLight: #aed4fd;
@@ -726,6 +726,10 @@ pre {
   background-color: var(--redLight);
 }
 
+.dot.image {
+  background-color: var(--blueLight);
+}
+
 .dot.error {
   background-color: var(--orangeLight);
 }
@@ -824,6 +828,10 @@ pre {
 
 .dot.selector input:checked + .dot.failed {
   box-shadow: 0px 0px 5px 1px var(--redLight);
+}
+
+.dot.selector input:checked + .dot.image {
+  box-shadow: 0px 0px 5px 1px var(--blueLight);
 }
 
 .dot.selector input:checked + .dot.error {


### PR DESCRIPTION
#### 46ce1f805fa2745fe7a479673f845c7537cbbc6b
<pre>
Represent ImageOnlyFailures with a separate icon when looking at results on the databases
<a href="https://bugs.webkit.org/show_bug.cgi?id=248911">https://bugs.webkit.org/show_bug.cgi?id=248911</a>
<a href="https://rdar.apple.com/102920285">rdar://102920285</a>

Reviewed by Jonathan Bedard.

It would be easier if ImageOnlyFailures were marked with a different
icon from text failures. The changes in this commit are to effectivly
mark ImageOnlyFailures with a blue I instead of a red X. And the colour
blue has been specifically chosen as one that is colour blind friendly.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js:
(Expectations.colorMap):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/webkit.css:
(:root):

Canonical link: <a href="https://commits.webkit.org/299143@main">https://commits.webkit.org/299143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2c135348f73b01ab7fb2aeb8c6f19fc52635a65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9012490e-0ccb-46f4-94bc-d662f9109130) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a4eae6a-bdb9-4295-bc52-815dbf97f1ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70031 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9121ec4a-028c-4439-a493-2b381b08e587) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/117350 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23922 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67801 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127221 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98210 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/117410 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41328 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44765 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44225 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->