### PR TITLE
Handle null media accessibility caption profile

### DIFF
--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -97,6 +97,7 @@ private:
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     void updateTimerFired();
+    bool hasNullCaptionProfile() const;
 
     String captionsWindowCSS() const;
     String captionsBackgroundCSS() const;

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
@@ -55,4 +55,5 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, MediaAccessibility, kMAAudibleMe
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebCore, MediaAccessibility, MAImageCaptioningCopyCaptionWithSource, CFStringRef, (CGImageSourceRef imageSource, CFErrorRef *error), (imageSource, error))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, MediaAccessibility, MAAudibleMediaPrefCopyPreferDescriptiveVideo, CFBooleanRef, (), ())
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebCore, MediaAccessibility, MACaptionAppearanceIsCustomized, bool, (MACaptionAppearanceDomain domain), (domain));
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebCore, MediaAccessibility, MACaptionAppearanceCopyActiveProfileID, CFStringRef, (), ());
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
@@ -78,6 +78,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, MediaAccessibility, MAAudibleMediaPrefCop
 #define MAAudibleMediaPrefCopyPreferDescriptiveVideo softLink_MediaAccessibility_MAAudibleMediaPrefCopyPreferDescriptiveVideo
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceIsCustomized, bool, (MACaptionAppearanceDomain domain), (domain))
 #define MACaptionAppearanceIsCustomized softLink_MediaAccessibility_MACaptionAppearanceIsCustomized
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyActiveProfileID, CFStringRef, (), ())
+#define MACaptionAppearanceCopyActiveProfileID softLink_MediaAccessibility_MACaptionAppearanceCopyActiveProfileID
 
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 


### PR DESCRIPTION
#### e8284c96eb6205fa9ad7a78207394d1ef2984b9c
<pre>
Handle null media accessibility caption profile
<a href="https://bugs.webkit.org/show_bug.cgi?id=297872">https://bugs.webkit.org/show_bug.cgi?id=297872</a>
<a href="https://rdar.apple.com/159134245">rdar://159134245</a>

Reviewed by Eric Carlson.

This patch handles the case that MACaptionActiveProfile is set to the empty string.
In this case we do not add any style to WebVTT cues.

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::captionDisplayMode const):
(WebCore::CaptionUserPreferencesMediaAF::setCaptionDisplayMode):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersCaptions const):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersSubtitles const):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersTextDescriptions const):
(WebCore::CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance const):
(WebCore::CaptionUserPreferencesMediaAF::setPreferredLanguage):
(WebCore::CaptionUserPreferencesMediaAF::preferredLanguages const):
(WebCore::CaptionUserPreferencesMediaAF::setPreferredAudioCharacteristic):
(WebCore::CaptionUserPreferencesMediaAF::preferredAudioCharacteristics const):
(WebCore::CaptionUserPreferencesMediaAF::nullCaptionProfile const):
(WebCore::CaptionUserPreferencesMediaAF::captionsStyleSheetOverride const):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h:

Canonical link: <a href="https://commits.webkit.org/299204@main">https://commits.webkit.org/299204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d6bdb40f86f2b5cb2e25d4d5e9b7a82c630b9b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70159 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8895e2bd-18d4-4255-a322-2404f4e57d3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89635 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59271 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e947670-3c93-411a-8cac-5601310b05fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70128 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6136580-d53b-4164-8185-1238b4e8e049) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24028 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67942 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98311 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98098 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43495 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41468 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18836 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50569 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44355 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47700 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->