### PR TITLE
CLoop stack overflow detection code in llint_check_stack_and_vm_traps is incorrect.

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -575,10 +575,10 @@ UGPRPair SYSV_ABI llint_check_stack_and_vm_traps(CallFrame* callFrame, const JSI
 #if ENABLE(C_LOOP)
     Register* newTopOfStackRegister = reinterpret_cast<Register*>(newTopOfStack);
     if (newTopOfStackRegister < reinterpret_cast<Register*>(callFrame)) {
-        ASSERT(!vm.cloopStack().containsAddress(newTopOfStackRegister));
         if (!vm.ensureJSStackCapacityFor(newTopOfStackRegister))
             imminentOverflowDetected = true;
-    }
+    } else
+        imminentOverflowDetected = true; // Stack underflow == overflow.
 #else // not C_LOOP case
 
     void* softStackLimit = vm.softStackLimit();


### PR DESCRIPTION
#### 71841d28721fc87b5acfbf3e3fa2a95be3e16877
<pre>
CLoop stack overflow detection code in llint_check_stack_and_vm_traps is incorrect.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297868">https://bugs.webkit.org/show_bug.cgi?id=297868</a>
<a href="https://rdar.apple.com/159129933">rdar://159129933</a>

Reviewed by Dan Hecht.

llint_check_stack_and_vm_traps can be called either because a StackOverflow is imminent, or
if VMTraps has requested a stop via overloading m_trapAwareSoftStackLimit.  This function
(previously named llint_stack_check) was previously only called when a StackOverflow is
imminent.  As a result, the CLoopStack code in there were making such an assumption, but the
assumption can now be wrong.

Specifically, the fix entails:

1. Removing `ASSERT(!vm.cloopStack().containsAddress(newTopOfStackRegister));` which is now
   wrong because we may enter this code due a VMTraps requested stop instead of a
   StackOverflow.  Hence, newTopOfStackRegister is not guaranteed to be outside the bounds
   of the CLoop stack.

2. If the `(newTopOfStackRegister &lt; reinterpret_cast&lt;Register*&gt;(callFrame))` check fails,
   we have an imminent stack underflow situation, which we should treat as a StackOverflow.
   Previously, this code would unconditionally flow into a throw of StackOverflow error.
   This is no longer the case.  So, we need to explicitly set the imminentOverflowDetected
   bool to have it handled as a StackOverflow.

This issue was found by the existing testapi test.

* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::llint_check_stack_and_vm_traps):

Canonical link: <a href="https://commits.webkit.org/299133@main">https://commits.webkit.org/299133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff7b3e333f4c0c1838c5e8c3f435e27a9a005a23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70014 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ec21325-3269-4d2f-97c7-6a5c41f8c283) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46239 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d4652b6-4aa7-4f6c-9d58-3ec792f4f849) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30543 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/70022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9799e65-906c-425a-80a5-4a57894d7d68) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29610 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67790 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110090 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99965 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/24088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127210 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116489 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44882 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45243 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/102018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/43389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41317 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18807 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50428 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145187 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44214 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->