### PR TITLE
[JSC] Optimize `String#substring` like `String#slice` in DFT/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-substring-one-char.js
+++ b/JSTests/microbenchmarks/string-substring-one-char.js
@@ -1,0 +1,13 @@
+function test(str, start, end) {
+    return String.prototype.substring.call(str, start, end);
+}
+
+var str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium totam rem aperiam.";
+
+for (var i = 0; i < 1e6; ++i) {
+    var len = str.length;
+    var startIndex = (i * 7) % len;
+    var endIndex = startIndex + 1;
+    test(str, startIndex, endIndex);
+}
+

--- a/JSTests/stress/string-prototype-substring-index.js
+++ b/JSTests/stress/string-prototype-substring-index.js
@@ -1,0 +1,48 @@
+function test(str, start, end) {
+    return String.prototype.substring.call(str, start, end);
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+// negative startIndex x no endIndex
+{
+    const str = "Hello, World";
+    let result;
+    for (let i = 0; i < testLoopCount; i++) {
+        result = test(str, -5);
+        shouldBe(result, "Hello, World");
+    }
+}
+
+// negative startIndex x negative endIndex
+{
+    const str = "Hello, World";
+    let result;
+    for (let i = 0; i < testLoopCount; i++) {
+        result = test(str, -5, -3);
+        shouldBe(result, "");
+    }
+}
+
+// startIndex > endIndex
+{
+    const str = "Hello, World";
+    let result;
+    for (let i = 0; i < testLoopCount; i++) {
+        result = test(str, 5, 2);
+        shouldBe(result, "llo");
+    }
+}
+
+// NaN startIndex x NaN endIndex
+{
+    const str = "Hello, World";
+    let result;
+    for (let i = 0; i < testLoopCount; i++) {
+        result = test(str, NaN, NaN);
+        shouldBe(result, "");
+    }
+}

--- a/JSTests/stress/string-prototype-substring-onechar.js
+++ b/JSTests/stress/string-prototype-substring-onechar.js
@@ -1,0 +1,18 @@
+function test(str, start, end) {
+    return String.prototype.substring.call(str, start, end);
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+{
+    const str = "Hello, World";
+    let result;
+    for (let i = 0; i < testLoopCount; i++) {
+        result = test(str, 7, 8);
+        shouldBe(result.length, 1);
+        shouldBe(result, "W");
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1729,7 +1729,6 @@ public:
     void compileDefineDataProperty(Node*);
     void compileDefineAccessorProperty(Node*);
     void compileStringSlice(Node*);
-    void compileStringSubstring(Node*);
     void compileToLowerCase(Node*);
     void compileThrow(Node*);
     void compileThrowStaticError(Node*);
@@ -1863,6 +1862,7 @@ public:
     void emitGetCallee(CodeOrigin, GPRReg calleeGPR);
     void emitGetArgumentStart(CodeOrigin, GPRReg startGPR);
     void emitPopulateSliceIndex(Edge&, std::optional<GPRReg> indexGPR, GPRReg lengthGPR, GPRReg resultGPR);
+    void emitPopulateSubstringIndex(Edge&, GPRReg indexGPR, GPRReg lengthGPR, GPRReg resultGPR);
     
     // Generate an OSR exit fuzz check. Returns Jump() if OSR exit fuzz is not enabled, or if
     // it's in training mode.

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2675,13 +2675,9 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
     
+    case StringSubstring:
     case StringSlice: {
         compileStringSlice(node);
-        break;
-    }
-
-    case StringSubstring: {
-        compileStringSubstring(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5545,13 +5545,9 @@ void SpeculativeJIT::compile(Node* node)
         compileWeakMapSet(node);
         break;
 
+    case StringSubstring:
     case StringSlice: {
         compileStringSlice(node);
-        break;
-    }
-
-    case StringSubstring: {
-        compileStringSubstring(node);
         break;
     }
 


### PR DESCRIPTION
#### 88dc871707c10ef0718d2e103cab0b59235d804f
<pre>
[JSC] Optimize `String#substring` like `String#slice` in DFT/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=297878">https://bugs.webkit.org/show_bug.cgi?id=297878</a>

Reviewed by NOBODY (OOPS!).

We compile String#substring in DFG and FTL, but the compiled code
only calls the operation. On the other hand, String#slice, which
is a very similar function to String#substring, generates more
efficient code. (The only difference between these two functions
is the index calculation logic.)

This patch makes DFG/FTL compile efficient code for String#substring
similar to String#slice.

                                   TipOfTree                  Patched

string-substring-one-char        4.8044+-0.1616     ^      2.8242+-0.0865        ^ definitely 1.7011x faster

* JSTests/microbenchmarks/string-substring-one-char.js: Added.
(test):
* JSTests/stress/string-prototype-substring-index.js: Added.
(test):
(shouldBe):
(throw.new.Error):
* JSTests/stress/string-prototype-substring-onechar.js: Added.
(test):
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringSlice):
(JSC::DFG::SpeculativeJIT::compileStringSubstring): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::populateSubstringRange):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88dc871707c10ef0718d2e103cab0b59235d804f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70017 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89534 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59139 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67793 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110093 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127213 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116492 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98207 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97995 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41320 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50431 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145190 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44217 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37351 "Found 1 new JSC binary failure: testapi, Found 20063 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->