### PR TITLE
[Site Isolation] change downcast to dynamicDowncast in JSDOMBindingSecurity::remoteFrameAccessError

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -27,8 +27,10 @@
 #include "HTTPParsers.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMWindowBase.h"
+#include "JSDOMWindowCustom.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
+#include "RemoteDOMWindow.h"
 #include "SecurityOrigin.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
@@ -46,8 +48,8 @@ void printErrorMessageForFrame(LocalFrame* frame, const String& message)
 // FIXME: Refactor to share code with LocalDOMWindow::crossDomainAccessErrorMessage.
 static String remoteFrameAccessError(JSC::JSGlobalObject* lexicalGlobalObject)
 {
-    auto& active = activeDOMWindow(*lexicalGlobalObject);
-    Ref activeOrigin = active.document()->securityOrigin();
+    RefPtr remoteWindow = dynamicDowncast<RemoteDOMWindow>(asJSDOMWindow(lexicalGlobalObject)->wrapped());
+    Ref activeOrigin = remoteWindow ? remoteWindow->frame()->frameDocumentSecurityOriginOrOpaque() : activeDOMWindow(*lexicalGlobalObject).document()->securityOrigin();
     return makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a cross-origin frame. Protocols, domains, and ports must match."_s);
 }
 


### PR DESCRIPTION
#### 8fb7be5683f43a48a723b6a950bfe6268fe02118
<pre>
[Site Isolation] change downcast to dynamicDowncast in JSDOMBindingSecurity::remoteFrameAccessError
<a href="https://bugs.webkit.org/show_bug.cgi?id=297874">https://bugs.webkit.org/show_bug.cgi?id=297874</a>
<a href="https://rdar.apple.com/159134034">rdar://159134034</a>

Reviewed by Alex Christensen.

Change a downcast to a dynamicDowncast to handle cases where an invalid downcast between a RemoteDOMWindow to a LocalDOMWindow was attempted. Previously, if the cast failed, an assert was tripped and caused a crash.

See Bugzilla for steps to reproduce. The crash only occurred with Site Isolation enabled.

* Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp:
(WebCore::remoteFrameAccessError):

Canonical link: <a href="https://commits.webkit.org/299777@main">https://commits.webkit.org/299777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c70e65ee6fd36e3f95e441c44753d8285d0a622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91239 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60544 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25820 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99857 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99700 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25313 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23176 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43688 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52625 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->