### PR TITLE
dNR: include the rest of the parameters on the MatchedRuleInfoDebug object

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -310,11 +310,13 @@ static std::optional<Expected<ContentExtensionRule, std::error_code>> loadRuleId
     if (!identifier.has_value())
         return makeUnexpected(ContentExtensionError::JSONInvalidRuleIdentifier);
 
+    auto rulesetIdentifier = ruleObject.getString("_rulesetIdentifier"_s);
+
     auto trigger = loadTrigger(ruleObject);
     if (!trigger.has_value())
         return makeUnexpected(trigger.error());
 
-    return { { { WTFMove(trigger.value()), Action { ReportIdentifierAction { identifier.value() } } } } };
+    return { { { WTFMove(trigger.value()), Action { ReportIdentifierAction { rulesetIdentifier, identifier.value() } } } } };
 }
 
 static Expected<Vector<ContentExtensionRule>, std::error_code> loadEncodedRules(const String& ruleJSON, CSSSelectorsAllowed selectorsAllowed)

--- a/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
+++ b/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
@@ -7,28 +7,35 @@
 namespace WebCore {
 
 struct ContentRuleListMatchedRule {
+    struct MatchedRule {
+        double ruleId;
+        String rulesetId;
+        std::optional<String> extensionId;
+    };
+
     struct Request {
+        double frameId;
+        double parentFrameId;
+        String method;
+        String requestId;
+        double tabId;
+        String type;
+        String url;
+        std::optional<String> initiator;
         std::optional<String> documentId;
         std::optional<String> documentLifecycle;
-        std::optional<double> frameId;
         std::optional<String> frameType;
-        std::optional<String> initiator;
-        std::optional<String> method;
         std::optional<String> parentDocumentId;
-        std::optional<double> parentFrameId;
-        std::optional<String> requestId;
-        std::optional<String> type;
-        std::optional<String> url;
     };
 
-    struct MatchedRule {
-        std::optional<String> extensionId;
-        std::optional<double> ruleId;
-        std::optional<String> rulesetId;
-    };
+    ContentRuleListMatchedRule(MatchedRule rule, Request request)
+        : rule(rule)
+        , request(request)
+    {
+    }
 
-    Request request;
     MatchedRule rule;
+    Request request;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ResourceLoadInfo.cpp
+++ b/Source/WebCore/loader/ResourceLoadInfo.cpp
@@ -228,6 +228,39 @@ ASCIILiteral resourceTypeToString(OptionSet<ResourceType> resourceTypes)
     }
 }
 
+ASCIILiteral resourceTypeToStringForMatchedRule(OptionSet<ResourceType> resourceTypes)
+{
+    switch (*resourceTypes.begin()) {
+    case ResourceType::TopDocument:
+        return "main_frame"_s;
+    case ResourceType::ChildDocument:
+        return "sub_frame"_s;
+    case ResourceType::Image:
+        return "image"_s;
+    case ResourceType::StyleSheet:
+        return "stylesheet"_s;
+    case ResourceType::Script:
+        return "script"_s;
+    case ResourceType::Font:
+        return "font"_s;
+    case ResourceType::WebSocket:
+        return "websocket"_s;
+    case ResourceType::Fetch:
+        return "xmlhttprequest"_s;
+    case ResourceType::Media:
+        return "media"_s;
+    case ResourceType::Ping:
+        return "ping"_s;
+    case ResourceType::CSPReport:
+        return "csp_report"_s;
+    case ResourceType::SVGDocument:
+    case ResourceType::Popup:
+    case ResourceType::Other:
+    default:
+        return "other"_s;
+    }
+}
+
 } // namespace WebCore::ContentExtensions
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -102,6 +102,7 @@ std::optional<OptionSet<LoadContext>> readLoadContext(StringView);
 std::optional<RequestMethod> readRequestMethod(StringView);
 
 ASCIILiteral resourceTypeToString(OptionSet<ResourceType>);
+ASCIILiteral resourceTypeToStringForMatchedRule(OptionSet<ResourceType>);
 
 struct ResourceLoadInfo {
     URL resourceURL;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6148,28 +6148,29 @@ struct WebCore::ContentRuleListResults {
 };
 
 struct WebCore::ContentRuleListMatchedRule {
-    WebCore::ContentRuleListMatchedRule::Request request;
     WebCore::ContentRuleListMatchedRule::MatchedRule rule;
+    WebCore::ContentRuleListMatchedRule::Request request;
 };
 
 [Nested] struct WebCore::ContentRuleListMatchedRule::Request {
+    double frameId;
+    double parentFrameId;
+    String method;
+    String requestId;
+    double tabId;
+    String type;
+    String url;
+    std::optional<String> initiator;
     std::optional<String> documentId;
     std::optional<String> documentLifecycle;
-    std::optional<double> frameId;
     std::optional<String> frameType;
-    std::optional<String> initiator;
-    std::optional<String> method;
     std::optional<String> parentDocumentId;
-    std::optional<double> parentFrameId;
-    std::optional<String> requestId;
-    std::optional<String> type;
-    std::optional<String> url;
 };
 
 [Nested] struct WebCore::ContentRuleListMatchedRule::MatchedRule {
+    double ruleId;
+    String rulesetId;
     std::optional<String> extensionId;
-    std::optional<double> ruleId;
-    std::optional<String> rulesetId;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -51,7 +51,7 @@ public:
 #if ENABLE(CONTENT_EXTENSIONS)
     // This should be incremented every time a functional change is made to the bytecode, file format, etc.
     // to prevent crashing while loading old data.
-    static constexpr uint32_t CurrentContentRuleListFileVersion = 20;
+    static constexpr uint32_t CurrentContentRuleListFileVersion = 21;
 
     static ContentRuleListStore& defaultStoreSingleton();
     static Ref<ContentRuleListStore> storeWithPath(const WTF::String& storePath);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -675,6 +675,9 @@ void WebExtensionController::handleContentRuleListMatchedRule(WebPageProxyIdenti
         if (!tab)
             break;
 
+        // FIXME: <rdar://99141106> Implement declarativeNetRequest.testMatchOutcome; until then, extensionId should be null
+        matchedRule.rule.extensionId = std::nullopt;
+        matchedRule.request.tabId = toWebAPI(tab->identifier());
         context->handleContentRuleListMatchedRule(*tab, matchedRule);
 
         break;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
@@ -27,10 +27,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_EXTERN NSString * const sessionRulesetID;
+WK_EXTERN NSString * const dynamicRulesetID;
+
 WK_EXTERN
 @interface _WKWebExtensionDeclarativeNetRequestRule : NSObject
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary errorString:(NSString * _Nullable * _Nullable)outErrorString NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString * _Nullable * _Nullable)outErrorString NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -38,6 +41,7 @@ WK_EXTERN
 
 @property (nonatomic, readonly) NSInteger ruleID;
 @property (nonatomic, readonly) NSInteger priority;
+@property (nonatomic, readonly, copy) NSString *rulesetID;
 @property (nonatomic, readonly, copy) NSDictionary *action;
 @property (nonatomic, readonly, copy) NSDictionary *condition;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -26,6 +26,9 @@
 #import "config.h"
 #import "_WKWebExtensionDeclarativeNetRequestRule.h"
 
+NSString * const sessionRulesetID = @"_session";
+NSString * const dynamicRulesetID = @"_dynamic";
+
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #if !__has_feature(objc_arc)
@@ -112,7 +115,7 @@ using namespace WebKit;
 
 @implementation _WKWebExtensionDeclarativeNetRequestRule
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary errorString:(NSString **)outErrorString
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString **)outErrorString
 {
     if (!(self = [super init]))
         return nil;
@@ -138,6 +141,8 @@ using namespace WebKit;
 
         return nil;
     }
+
+    _rulesetID = rulesetID;
 
     NSString *exceptionString;
     if (!validateDictionary(ruleDictionary, nil, requiredKeysInRuleDictionary, keyToExpectedValueTypeInRuleDictionary, &exceptionString)) {
@@ -879,6 +884,7 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
         @"trigger": triggerDictionary,
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
         @"_identifier": @(_ruleID),
+        @"_rulesetIdentifier": _rulesetID,
 #endif
     };
 
@@ -1252,7 +1258,7 @@ static NSInteger priorityForRuleType(NSString *ruleType)
 
 @implementation _WKWebExtensionDeclarativeNetRequestRule
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary errorString:(NSString **)outErrorString
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString **)outErrorString
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 WK_EXTERN
 @interface _WKWebExtensionDeclarativeNetRequestTranslator : NSObject
 
-+ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSArray<NSArray<NSDictionary *> *> *)jsonObjects errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
-+ (NSArray<NSArray<NSDictionary *> *> *)jsonObjectsFromData:(NSArray<NSData *> *)jsonDataArray errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
++ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjects errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
++ (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjectsFromData:(NSDictionary<NSString *, NSData *> *)jsonData errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -740,7 +740,7 @@ private:
     // DeclarativeNetRequest methods.
     // Loading/unloading static rules
     void loadDeclarativeNetRequestRules(CompletionHandler<void(bool)>&&);
-    void compileDeclarativeNetRequestRules(NSArray *, CompletionHandler<void(bool)>&&);
+    void compileDeclarativeNetRequestRules(NSDictionary *, CompletionHandler<void(bool)>&&);
     void unloadDeclarativeNetRequestState();
     String declarativeNetRequestContentRuleListFilePath();
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -82,6 +82,7 @@ static NSString * const methodKey = @"method";
 static NSString * const parentDocumentIdKey = @"parentDocumentId";
 static NSString * const parentFrameIdKey = @"parentFrameId";
 static NSString * const requestIdKey = @"requestId";
+static NSString * const tabIdKey = @"tabId";
 static NSString * const typeKey = @"type";
 static NSString * const urlKey = @"url";
 
@@ -96,22 +97,23 @@ static inline NSDictionary *toWebAPI(const WebCore::ContentRuleListMatchedRule& 
     NSMutableDictionary *request = [NSMutableDictionary dictionary];
     NSMutableDictionary *rule = [NSMutableDictionary dictionary];
 
-    request[documentIdKey] = matchedRuleInfo.request.documentId.has_value() ? matchedRuleInfo.request.documentId.value().createNSString().get() : nil;
-    request[documentLifecycleKey] = matchedRuleInfo.request.documentId.has_value() ? matchedRuleInfo.request.documentLifecycle.value().createNSString().get() : nil;
-    request[frameIdKey] = matchedRuleInfo.request.frameId.has_value() ? @(matchedRuleInfo.request.frameId.value()) : nil;
-    request[frameTypeKey] = matchedRuleInfo.request.frameType.has_value() ? matchedRuleInfo.request.frameType.value().createNSString().get() : nil;
+    request[frameIdKey] = @(matchedRuleInfo.request.frameId);
+    request[parentFrameIdKey] = @(matchedRuleInfo.request.parentFrameId);
+    request[methodKey] = matchedRuleInfo.request.method.createNSString().get();
+    request[requestIdKey] = matchedRuleInfo.request.requestId.createNSString().get();
+    request[typeKey] = matchedRuleInfo.request.type.createNSString().get();
+    request[tabIdKey] = @(matchedRuleInfo.request.tabId);
+    request[urlKey] = matchedRuleInfo.request.url.createNSString().get();
     request[initiatorKey] = matchedRuleInfo.request.initiator.has_value() ? matchedRuleInfo.request.initiator.value().createNSString().get() : nil;
-    request[methodKey] = matchedRuleInfo.request.method.has_value() ? matchedRuleInfo.request.method.value().createNSString().get() : nil;
+    request[documentIdKey] = matchedRuleInfo.request.documentId.has_value() ? matchedRuleInfo.request.documentId.value().createNSString().get() : nil;
+    request[documentLifecycleKey] = matchedRuleInfo.request.documentLifecycle.has_value() ? matchedRuleInfo.request.documentLifecycle.value().createNSString().get() : nil;
+    request[frameTypeKey] = matchedRuleInfo.request.frameType.has_value() ? matchedRuleInfo.request.frameType.value().createNSString().get() : nil;
     request[parentDocumentIdKey] = matchedRuleInfo.request.parentDocumentId.has_value() ? matchedRuleInfo.request.parentDocumentId.value().createNSString().get() : nil;
-    request[parentFrameIdKey] = matchedRuleInfo.request.parentFrameId.has_value() ? @(matchedRuleInfo.request.parentFrameId.value()) : nil;
-    request[requestIdKey] = matchedRuleInfo.request.requestId.has_value() ? matchedRuleInfo.request.requestId.value().createNSString().get() : nil;
-    request[typeKey] = matchedRuleInfo.request.type.has_value() ? matchedRuleInfo.request.type.value().createNSString().get() : nil;
-    request[urlKey] = matchedRuleInfo.request.url.has_value() ? matchedRuleInfo.request.url.value().createNSString().get() : nil;
     result[requestKey] = [request copy];
 
+    rule[ruleIdKey] = @(matchedRuleInfo.rule.ruleId);
+    rule[rulesetIdKey] = matchedRuleInfo.rule.rulesetId.createNSString().get();
     rule[extensionIdKey] = matchedRuleInfo.rule.extensionId.has_value() ? matchedRuleInfo.rule.extensionId.value().createNSString().get() : nil;
-    rule[ruleIdKey] = matchedRuleInfo.rule.ruleId.has_value() ? @(matchedRuleInfo.rule.ruleId.value()) : nil;
-    rule[rulesetIdKey] = matchedRuleInfo.rule.rulesetId.has_value() ? matchedRuleInfo.rule.rulesetId.value().createNSString().get() : nil;
     result[ruleKey] = [rule copy];
 
     return [result copy];
@@ -175,7 +177,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
     NSString *ruleErrorString;
     size_t index = 0;
     for (NSDictionary *ruleDictionary in rulesToAdd) {
-        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
+        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:dynamicRulesetID errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
             *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;
@@ -246,7 +248,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
     NSString *ruleErrorString;
     size_t index = 0;
     for (NSDictionary *ruleDictionary in rulesToAdd) {
-        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
+        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:sessionRulesetID errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
             *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -3434,23 +3434,23 @@ TEST_F(ContentExtensionTest, ReportIdentifierAction)
 {
     // Different identifiers
     auto backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/first\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/second\"},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/first\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset 1\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/second\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset 2\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/first"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/second"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/first"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset 1"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/second"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset 2"_s, 2 } })));
 
     // Different action types and identifiers
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"cookies\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"css\"},\"_identifier\":2},"_s
-        "{\"action\":{\"type\":\"notify\",\"notification\":\"test\"},\"trigger\":{\"url-filter\":\"notify\"},\"_identifier\":3}"_s
+        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"cookies\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"css\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"notify\",\"notification\":\"test\"},\"trigger\":{\"url-filter\":\"notify\"},\"_identifier\":3,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/cookies"_s)), Vector<Action>::from(Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/css"_s)), Vector<Action>::from(Action { ContentExtensions::ReportIdentifierAction { 2 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".hidden"_s } } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/notify"_s)), Vector<Action>::from(Action { ContentExtensions::NotifyAction { { "test"_s } } }, Action { ContentExtensions::ReportIdentifierAction { 3 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/cookies"_s)), Vector<Action>::from(Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/css"_s)), Vector<Action>::from(Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".hidden"_s } } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/notify"_s)), Vector<Action>::from(Action { ContentExtensions::NotifyAction { { "test"_s } } }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 3 } })));
 
     // With and without identifiers
     backend = makeBackend("["_s
@@ -3458,67 +3458,67 @@ TEST_F(ContentExtensionTest, ReportIdentifierAction)
         "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"without-id\"}}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/with-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/with-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { ""_s, 1 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/without-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() })));
 
     // Multiple matches with one request
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":2},"_s
-        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".ad\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":3}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".ad\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":3,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/multi-test"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } }, Action { ContentExtensions::ReportIdentifierAction { 3 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".ad"_s } } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/multi-test"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } }, Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 3 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".ad"_s } } })));
 
     // With conditions
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"if-domain\":[\"example.com\"]},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"unless-domain\":[\"trusted.com\"]},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"if-domain\":[\"example.com\"]},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"unless-domain\":[\"trusted.com\"]},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://example.com/"_s)),
-        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://other.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://other.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://trusted.com/"_s)), Vector<Action>()));
 
     // With resource types
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"script\"]},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"image\"]},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"script\"]},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"image\"]},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.js"_s, ResourceType::Script)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.png"_s, ResourceType::Image)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.js"_s, ResourceType::Script)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.png"_s, ResourceType::Image)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.html"_s)), Vector<Action>()));
 
     // With ignore rules
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
         "{\"action\":{\"type\":\"ignore-previous-rules\"},\"trigger\":{\"url-filter\":\"ignore-previous\"}},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/block-me"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/block-me"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/ignore-previous-block-me"_s)),
-        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } }), true));
+        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } }), true));
 
     // With load types
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"third-party\"]},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"first-party\"]},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"third-party\"]},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"first-party\"]},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://analytics.com/track.js"_s, "https://example.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/analytics"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://analytics.com/track.js"_s, "https://example.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/analytics"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
 
     // With complex regex
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"^https://[a-z]+\\\\.ads\\\\.com/\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"\\\\.jpg\\\\?.*tracking\"},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"^https://[a-z]+\\\\.ads\\\\.com/\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"\\\\.jpg\\\\?.*tracking\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://cdn.ads.com/banner"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/image.jpg?tracking=123"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://cdn.ads.com/banner"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/image.jpg?tracking=123"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b222c16121ee83743e34c9fb60f221bff3a63639
<pre>
dNR: include the rest of the parameters on the MatchedRuleInfoDebug object
<a href="https://bugs.webkit.org/show_bug.cgi?id=297881">https://bugs.webkit.org/show_bug.cgi?id=297881</a>
<a href="https://rdar.apple.com/157880177">rdar://157880177</a>

Reviewed by Brian Weinstein.

This patch makes the necessary changes to include the rest of the information on the MatchedRuleInfo
object that&apos;s passed to the onRuleMatchedDebug listeners.

Most of the request properties could easily be set with the information that is already available in
ContentExtensionsBackend::processContentRuleListsForLoad. However, we are missing the rulesetId
property of the rule object, and it&apos;s not readily available because compiled content rule lists do
not track which ruleset a rule belongs to. This patch updates the ReportIdentifierAction to inherit
from ActionWithStringMetadata so that we can serialize its ruleset identifier too in addition to the
rule identifier.

For cleaner code, we&apos;ve chosen to serialize the ruleset identifier repeatedly because most popular
dNR web extensions appear to choose fairly short strings for the IDs. If this proves to consume too
much memory in the future, we can update the strings to be serialized once and store an index to it
in the ReportIdentifierAction.

The identifiers of static rulesets are set in the manifest. Session and dynamic rules have the
identifier, &quot;_session&quot; and &quot;_dynamic,&quot; respectively.

For information about the properties that we&apos;ve added, take a look at:
<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/onRuleMatchedDebug#listener">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/onRuleMatchedDebug#listener</a>

It&apos;s worth noting that we aren&apos;t including the parentDocumentId right now because there is some work
to be done to support it with site isolation turned on. That work is tracked with: <a href="https://rdar.apple.com/159289161">rdar://159289161</a>

Added a new tests and updated existing tests to validate this fix.

* Source/WebCore/contentextensions/ContentExtensionActions.h:
(WebCore::ContentExtensions::ReportIdentifierAction::ReportIdentifierAction):
(WebCore::ContentExtensions::ReportIdentifierAction::isolatedCopy const):
(WebCore::ContentExtensions::ReportIdentifierAction::isolatedCopy):
(WebCore::ContentExtensions::ReportIdentifierAction::serialize const):
(WebCore::ContentExtensions::ReportIdentifierAction::deserialize):
(WebCore::ContentExtensions::ReportIdentifierAction::serializedLength):
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadRuleIdentifier):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/contentextensions/ContentRuleListMatchedRule.h:
(WebCore::ContentRuleListMatchedRule::ContentRuleListMatchedRule):
* Source/WebCore/loader/ResourceLoadInfo.cpp:
(WebCore::ContentExtensions::resourceTypeToStringForMatchedRule):
* Source/WebCore/loader/ResourceLoadInfo.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::handleContentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::handleContentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule _webKitRuleWithWebKitActionType:chromeActionType:condition:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm:
(WebKit::for):
(+[_WKWebExtensionDeclarativeNetRequestTranslator jsonObjectsFromData:errorStrings:]):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules):
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, ReportIdentifierAction)):

Canonical link: <a href="https://commits.webkit.org/299333@main">https://commits.webkit.org/299333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b8727def53f3eb1eca74231ba75e72a6cfa838c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70707 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58343840-0502-4fc1-bd40-c094b5b3baa3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46910 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d8d5821-01da-42db-a282-4cef325af8ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121600 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/31088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/106376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70551 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26d542de-6bfd-4094-b8a6-3c6022f1eb21) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/24487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68484 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/100526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/24677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127885 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45554 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45918 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/102596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/98465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/43913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18904 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51102 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->