### PR TITLE
Fix aspect-ratio items with percentage max-width collapsing to zero

### DIFF
--- a/LayoutTests/fast/css/aspect-ratio-percent-max-width-expected.html
+++ b/LayoutTests/fast/css/aspect-ratio-percent-max-width-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+
+<div style="width: 100px;">
+  <div style="width: 100px; height: 100px; background-color: green;"></div>
+</div>
+<div style="width: 100px;">
+  <div style="width: 100px; height: 100px; background-color: green;"></div>
+</div>

--- a/LayoutTests/fast/css/aspect-ratio-percent-max-width.html
+++ b/LayoutTests/fast/css/aspect-ratio-percent-max-width.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="match" href="aspect-ratio-percent-max-width-expected.html">
+<div style="width: min-content;">
+  <div style="max-width: calc(80% + 20px); height: 100px; aspect-ratio: 1; background-color: green;"></div>
+</div>
+<div style="width: min-content;">
+  <div style="max-width: 100%; height: 100px; aspect-ratio: 1; background-color: green;"></div>
+</div>

--- a/LayoutTests/fast/grid/grid-item-aspect-ratio-expected.html
+++ b/LayoutTests/fast/grid/grid-item-aspect-ratio-expected.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+    .grid-container {
+        width: 100%;
+        display: grid;
+        justify-content: start;
+        grid-template-rows: 100px;
+    }
+    .grid-container-column {
+        width: 100%;
+        display: grid;
+        align-content: start;
+        grid-template-columns: 100px;
+    }
+    .aspect-ratio-item {
+        aspect-ratio: 1;
+        background: red;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div class="grid-container">
+    <div class="aspect-ratio-item"></div>
+</div>
+<div class="grid-container">
+    <div class="aspect-ratio-item"></div>
+</div>
+<div class="grid-container">
+    <div class="aspect-ratio-item"></div>
+</div>
+<div class="grid-container-column">
+    <div class="aspect-ratio-item"></div>
+</div>
+<div class="grid-container-column">
+    <div class="aspect-ratio-item"></div>
+</div>
+<div class="grid-container-column">
+    <div class="aspect-ratio-item"></div>
+</div>

--- a/LayoutTests/fast/grid/grid-item-aspect-ratio.html
+++ b/LayoutTests/fast/grid/grid-item-aspect-ratio.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="match" href="grid-item-aspect-ratio-expected.html">
+<style>
+    .grid-container {
+        width: 100%;
+        display: grid;
+        justify-content: start;
+        grid-template-rows: 100px;
+    }
+    .grid-container-column {
+        width: 100%;
+        display: grid;
+        align-content: start;
+        grid-template-columns: 100px;
+    }
+    .item-max-width {
+        aspect-ratio: 1;
+        background: red;
+        height: 100px;
+        max-width: 100%;
+    }
+    .item-min-width-percent {
+        aspect-ratio: 1;
+        background: red;
+        height: 100px;
+        min-width: 0%;
+    }
+    .item-min-width {
+        aspect-ratio: 1;
+        background: red;
+        height: 100px;
+        min-width: 0px;
+    }
+    .item-max-height {
+        aspect-ratio: 1;
+        background: red;
+        width: 100px;
+        max-height: 100%;
+    }
+    .item-min-height-percent {
+        aspect-ratio: 1;
+        background: red;
+        width: 100px;
+        min-height: 0%;
+    }
+    .item-min-height {
+        aspect-ratio: 1;
+        background: red;
+        width: 100px;
+        min-height: 0px;
+    }
+</style>
+<div class="grid-container">
+    <div class="item-max-width"></div>
+</div>
+<div class="grid-container">
+    <div class="item-min-width-percent"></div>
+</div>
+<div class="grid-container">
+    <div class="item-min-width"></div>
+</div>
+<div class="grid-container-column">
+    <div class="item-max-height"></div>
+</div>
+<div class="grid-container-column">
+    <div class="item-min-height-percent"></div>
+</div>
+<div class="grid-container-column">
+    <div class="item-min-height"></div>
+</div>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2243,10 +2243,21 @@ void RenderBlock::computePreferredLogicalWidths()
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth;
     } else if (shouldComputeLogicalWidthFromAspectRatio()) {
-        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = (computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
-        m_minPreferredLogicalWidth = std::max(0_lu, m_minPreferredLogicalWidth);
-        m_maxPreferredLogicalWidth = std::max(0_lu, m_maxPreferredLogicalWidth);
-    } else 
+        // https://www.w3.org/TR/css-sizing-3/#cyclic-percentage-contribution
+        // "If the box is non-replaced, then the entire value of any max size property or
+        // preferred size property specified as an expression containing a percentage that is
+        // cyclic is treated for the purpose of calculating the box's intrinsic size contributions
+        // only as that property's initial value."
+        // We skip all percentage constraints here, not just cyclic ones. In the non-cyclic case
+        // (containing block has definite width), this is acceptable because percentage constraints
+        // will be correctly applied during the layout pass in computeLogicalWidth().
+        bool hasPercentageConstraint = style().logicalMaxWidth().isPercentOrCalculated() || style().logicalMinWidth().isPercentOrCalculated();
+        if (hasPercentageConstraint)
+            m_maxPreferredLogicalWidth = std::max(0_lu, computeUnconstrainedLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
+        else
+            m_maxPreferredLogicalWidth = std::max(0_lu, computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
+        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth;
+    } else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
 
     RenderBox::computePreferredLogicalWidths(styleToUse.logicalMinWidth(), styleToUse.logicalMaxWidth(), borderAndPaddingLogicalWidth());

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2934,7 +2934,8 @@ template<typename Keyword> void RenderBox::computeIntrinsicKeywordLogicalWidths(
         computeIntrinsicKeywordLogicalWidths(minLogicalWidth, maxLogicalWidth);
     else {
         if (shouldComputeLogicalWidthFromAspectRatio()) {
-            minLogicalWidth = maxLogicalWidth = computeLogicalWidthFromAspectRatioInternal() - borderAndPadding;
+            maxLogicalWidth = computeUnconstrainedLogicalWidthFromAspectRatio() - borderAndPadding;
+            minLogicalWidth = maxLogicalWidth;
             if (firstChild() && style().logicalMinWidth().isAuto()) {
                 LayoutUnit minChildrenLogicalWidth;
                 LayoutUnit maxChildrenLogicalWidth;
@@ -5230,7 +5231,7 @@ bool RenderBox::shouldComputeLogicalWidthFromAspectRatio() const
     return overridingBorderBoxLogicalHeight() || shouldComputeLogicalWidthFromAspectRatioAndInsets(*this) || style().logicalHeight().isFixed() || isResolvablePercentageHeight() || isResolveableStretchSize(style().logicalHeight());
 }
 
-LayoutUnit RenderBox::computeLogicalWidthFromAspectRatioInternal() const
+LayoutUnit RenderBox::computeUnconstrainedLogicalWidthFromAspectRatio() const
 {
     ASSERT(shouldComputeLogicalWidthFromAspectRatio());
     auto computedValues = computeLogicalHeight(logicalHeight(), logicalTop());
@@ -5241,7 +5242,7 @@ LayoutUnit RenderBox::computeLogicalWidthFromAspectRatioInternal() const
 
 LayoutUnit RenderBox::computeLogicalWidthFromAspectRatio() const
 {
-    auto logicalWidth = computeLogicalWidthFromAspectRatioInternal();
+    LayoutUnit logicalWidth = computeUnconstrainedLogicalWidthFromAspectRatio();
     LayoutUnit containerWidthInInlineDirection = std::max<LayoutUnit>(0, containingBlockLogicalWidthForContent());
     return constrainLogicalWidthByMinMax(logicalWidth, containerWidthInInlineDirection, *containingBlock(), AllowIntrinsic::No);
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -689,7 +689,7 @@ protected:
     bool shouldComputeLogicalWidthFromAspectRatio() const;
     bool isResolveableStretchSize(const auto& size) const { return size.isStretch() && containingBlockHasDefiniteBlockSize(); }
     bool isUnresolveableStretchSize(const auto& size) const { return size.isStretch() && !containingBlockHasDefiniteBlockSize(); }
-    LayoutUnit computeLogicalWidthFromAspectRatioInternal() const;
+    LayoutUnit computeUnconstrainedLogicalWidthFromAspectRatio() const;
     LayoutUnit computeLogicalWidthFromAspectRatio() const;
     std::pair<LayoutUnit, LayoutUnit> computeMinMaxLogicalWidthFromAspectRatio() const;
     std::pair<LayoutUnit, LayoutUnit> computeMinMaxLogicalHeightFromAspectRatio() const;
@@ -778,7 +778,7 @@ protected:
 
     // The preferred logical width of the element if it were to break its lines at every possible opportunity.
     LayoutUnit m_minPreferredLogicalWidth;
-    
+
     // The preferred logical width of the element if it never breaks any lines at all.
     LayoutUnit m_maxPreferredLogicalWidth;
 


### PR DESCRIPTION
#### f7a85fb9452f0a72d1afc8a9564eca2b9c50722c
<pre>
Fix aspect-ratio items with percentage max-width collapsing to zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=293914">https://bugs.webkit.org/show_bug.cgi?id=293914</a>
&lt;<a href="https://rdar.apple.com/152456882">rdar://152456882</a>&gt;

Reviewed by NOBODY (OOPS!).

During intrinsic sizing (grid track sizing or min-content containers),
containingBlockLogicalWidthForContent() may return 0 because the container&apos;s
width depends on the size of its children. When computeLogicalWidthFromAspectRatio()
resolved a percentage max-width against this zero available width, it
collapsed the intrinsic contribution to zero.

This PR updates RenderBlock::computePreferredLogicalWidths() to skip
min/max constraints during intrinsic sizing per spec:

<a href="https://www.w3.org/TR/css-sizing-3/#cyclic-percentage-contribution">https://www.w3.org/TR/css-sizing-3/#cyclic-percentage-contribution</a>:

&quot;If the box is non-replaced, then the entire value of any max size property
or preferred size property specified as an expression containing a percentage
that is cyclic is treated for the purpose of calculating the box&apos;s intrinsic
size contributions only as that property&apos;s initial value.&quot;
&quot;For the min size properties, a cyclic percentage is resolved against zero
for determining intrinsic size contributions.&quot;

* LayoutTests/fast/css/aspect-ratio-percent-max-width-expected.html: Added.
* LayoutTests/fast/css/aspect-ratio-percent-max-width.html: Added.
* LayoutTests/fast/grid/grid-item-aspect-ratio-expected.html: Added.
* LayoutTests/fast/grid/grid-item-aspect-ratio.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computePreferredLogicalWidths):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeIntrinsicKeywordLogicalWidths const):
(WebCore::RenderBox::computeUnconstrainedLogicalWidthFromAspectRatio const):
(WebCore::RenderBox::computeLogicalWidthFromAspectRatio const):
(WebCore::RenderBox::computeLogicalWidthFromAspectRatioInternal const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7a85fb9452f0a72d1afc8a9564eca2b9c50722c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117605 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca8d2592-4cf5-4c72-a7ee-447f105f85dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125072 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88157 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c24d7bd1-0761-42cb-becb-3e2789cbf433) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105669 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65ce7c3a-8645-4ada-a7b7-aa713b94a3a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26407 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17857 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172620 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133348 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133357 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96231 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27908 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21212 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101301 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33524 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->