### PR TITLE
[JSC] Add `@neverInline` attribute for JS builtins

### DIFF
--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
@@ -136,6 +136,8 @@ class BuiltinsGenerator:
         inlineAttribute = "None"
         if function.is_always_inline:
             inlineAttribute = "Always"
+        elif function.is_never_inline:
+            inlineAttribute = "Never"
 
         return {
             'codeName': BuiltinsGenerator.mangledNameForFunction(function) + 'Code',

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
@@ -45,6 +45,7 @@ _FRAMEWORK_CONFIG_MAP = {
 functionHeadRegExp = re.compile(r"(?:@[\w|=\[\] \"\.]+\s*\n)*(?:async\s+)?function\s+\w+\s*\(.*?\)", re.MULTILINE | re.DOTALL)
 functionLinkTimeConstantRegExp = re.compile(r".*^@linkTimeConstant", re.MULTILINE | re.DOTALL)
 functionAlwaysInlineRegExp = re.compile(r".*^@alwaysInline", re.MULTILINE | re.DOTALL)
+functionNeverInlineRegExp = re.compile(r".*^@neverInline", re.MULTILINE | re.DOTALL)
 functionVisibilityRegExp = re.compile(r".*^@visibility=(\w+)", re.MULTILINE | re.DOTALL)
 functionNakedConstructorRegExp = re.compile(r".*^@nakedConstructor", re.MULTILINE | re.DOTALL)
 functionIntrinsicRegExp = re.compile(r".*^@intrinsic=(\w+)", re.MULTILINE | re.DOTALL)
@@ -105,7 +106,7 @@ class BuiltinObject:
 
 
 class BuiltinFunction:
-    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, intrinsic, visibility, overridden_name):
+    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, is_never_inline, intrinsic, visibility, overridden_name):
         self.function_name = function_name
         self.function_source = function_source
         self.parameters = parameters
@@ -113,6 +114,7 @@ class BuiltinFunction:
         self.is_constructor = is_constructor
         self.is_naked_constructor = is_naked_constructor
         self.is_always_inline = is_always_inline
+        self.is_never_inline = is_never_inline
         self.is_link_time_constant = is_link_time_constant
         self.intrinsic = intrinsic
         self.visibility = visibility
@@ -151,6 +153,7 @@ class BuiltinFunction:
         is_link_time_constant = functionLinkTimeConstantRegExp.match(function_source) != None
         is_naked_constructor = functionNakedConstructorRegExp.match(function_source) != None
         is_always_inline = functionAlwaysInlineRegExp.match(function_source) != None
+        is_never_inline = functionNeverInlineRegExp.match(function_source) is not None
         if is_naked_constructor:
             is_constructor = True
 
@@ -176,7 +179,7 @@ class BuiltinFunction:
         if overridden_name[-1] == "\"":
             overridden_name += "_s"
 
-        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, intrinsic, visibility, overridden_name)
+        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, is_never_inline, intrinsic, visibility, overridden_name)
 
     def __str__(self):
         interface = "%s(%s)" % (self.function_name, ', '.join(self.parameters))

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -203,6 +203,9 @@ FunctionExecutable* UnlinkedFunctionExecutable::link(VM& vm, ScriptExecutable* t
     if (overrideLineNumber)
         result->setOverrideLineNumber(*overrideLineNumber);
 
+    if (inlineAttribute() == InlineAttribute::Never)
+        result->setNeverInline(true);
+
     if (hasFunctionOverride) [[unlikely]]
         result->overrideInfo(overrideInfo);
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -311,7 +311,7 @@ private:
     LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures;
     uint8_t m_functionMode : 2; // FunctionMode
     uint8_t m_derivedContextType : 2;
-    uint8_t m_inlineAttribute : 1;
+    uint8_t m_inlineAttribute : 2;
 
     union {
         WriteBarrier<UnlinkedFunctionCodeBlock> m_unlinkedCodeBlockForCall;

--- a/Source/JavaScriptCore/runtime/InlineAttribute.h
+++ b/Source/JavaScriptCore/runtime/InlineAttribute.h
@@ -30,6 +30,7 @@ namespace JSC {
 enum class InlineAttribute : uint8_t {
     None,
     Always,
+    Never,
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 81cd57ae80ca47a6ad3beaab8ced487b69351f99
<pre>
[JSC] Add `@neverInline` attribute for JS builtins
<a href="https://bugs.webkit.org/show_bug.cgi?id=297890">https://bugs.webkit.org/show_bug.cgi?id=297890</a>

Reviewed by Yusuke Suzuki.

This patch adds the `@neverInline` attribute for JS builtin functions to prevent
them from being inlined by the DFG JIT compiler. This attribute uses the same
mechanism as `$vm.noInline` to suppress inlining by setting the `m_neverInlined`
flag on the FunctionExecutable.

This new attribute is not expected to be used frequently. However, it will be useful
for special use cases such as implementing asynchronous stack traces[1].

[1]: <a href="https://bugs.webkit.org/show_bug.cgi?id=296261">https://bugs.webkit.org/show_bug.cgi?id=296261</a>

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py:
(BuiltinsGenerator.generate_embedded_code_data_for_function):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py:
(BuiltinFunction.__init__):
(BuiltinFunction.fromString):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::link):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/runtime/InlineAttribute.h:

Canonical link: <a href="https://commits.webkit.org/299245@main">https://commits.webkit.org/299245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a258d3bbda0b17c19f8539a12d3fc7367c185af7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70075 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89576 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59179 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23962 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67854 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110150 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127270 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116549 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98249 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98035 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43435 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41378 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50488 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145247 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44274 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37366 "") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->