### PR TITLE
[WPE] Launching MiniBrowser on DRM mode doesn't pick VSync clock

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
@@ -71,6 +71,7 @@ Crtc::Crtc(drmModeCrtc* crtc, unsigned index, Properties&& properties)
     , m_y(crtc->y)
     , m_width(crtc->width)
     , m_height(crtc->height)
+    , m_bufferID(crtc->buffer_id)
     , m_properties(WTFMove(properties))
 {
     if (crtc->mode_valid)

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -56,6 +56,7 @@ public:
     uint32_t y() const { return m_y; }
     uint32_t width() const { return m_width; }
     uint32_t height() const { return m_height; }
+    uint32_t bufferID() const { return m_bufferID; }
     const std::optional<drmModeModeInfo>& currentMode() const { return m_currentMode; }
     const Properties& properties() const { return m_properties; }
 
@@ -68,6 +69,7 @@ private:
     uint32_t m_y { 0 };
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
+    uint32_t m_bufferID { 0 };
     std::optional<drmModeModeInfo> m_currentMode;
     Properties m_properties;
 };

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -390,6 +390,8 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
         height = mode->vdisplay;
     }
 
+    wpeScreenDRMCreateDumbBufferIfNeeded(WPE_SCREEN_DRM(displayDRM->priv->screen.get()), displayDRM->priv->fd.value(), displayDRM->priv->connector->id());
+
     double scale = scaleFromEnvironment.value_or(wpeScreenDRMGuessScale(WPE_SCREEN_DRM(displayDRM->priv->screen.get())));
     RELEASE_ASSERT(wpe_settings_set_double(wpe_display_get_settings(WPE_DISPLAY(displayDRM)), WPE_SETTING_DRM_SCALE, scale, WPE_SETTINGS_SOURCE_PLATFORM, nullptr));
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
+#include <xf86drm.h>
 
 /**
  * WPEScreenDRM:
@@ -41,6 +42,10 @@ struct _WPEScreenDRMPrivate {
     std::unique_ptr<WPE::DRM::Crtc> crtc;
     drmModeModeInfo mode;
     GRefPtr<WPEScreenSyncObserver> syncObserver;
+    struct {
+        uint32_t bufferID;
+        uint32_t frameBufferID;
+    } dumb;
 };
 WEBKIT_DEFINE_FINAL_TYPE(WPEScreenDRM, wpe_screen_drm, WPE_TYPE_SCREEN, WPEScreen)
 
@@ -180,4 +185,52 @@ double wpeScreenDRMGuessScale(WPEScreenDRM* screen)
         return 1.0;
 
     return 2.0;
+}
+
+void wpeScreenDRMCreateDumbBufferIfNeeded(WPEScreenDRM* screen, int fd, uint32_t connectorID)
+{
+    auto* priv = screen->priv;
+    if (priv->crtc->bufferID())
+        return;
+
+    // We need to ensure the CRTC has a buffer for the vblank monitor to work.
+    constexpr uint32_t bitsPerPixel = 32;
+    constexpr uint8_t depth = 24;
+    uint32_t handle, pitch;
+    uint64_t size;
+    auto ret = drmModeCreateDumbBuffer(fd, priv->mode.hdisplay, priv->mode.vdisplay, bitsPerPixel, 0, &handle, &pitch, &size);
+    if (ret) {
+        drmError(ret, "drmModeCreateDumbBuffer");
+        return;
+    }
+
+    uint32_t frameBufferID;
+    ret = drmModeAddFB(fd, priv->mode.hdisplay, priv->mode.vdisplay, depth, bitsPerPixel, pitch, handle, &frameBufferID);
+    if (ret) {
+        drmError(ret, "drmModeAddFB");
+        drmModeDestroyDumbBuffer(fd, handle);
+    }
+
+    ret = drmModeSetCrtc(fd, priv->crtc->id(), frameBufferID, 0, 0, &connectorID, 1, &priv->mode);
+    if (ret) {
+        drmError(ret, "drmModeSetCrtc");
+        drmModeRmFB(fd, frameBufferID);
+        drmModeDestroyDumbBuffer(fd, handle);
+        return;
+    }
+
+    priv->dumb.bufferID = handle;
+    priv->dumb.frameBufferID = frameBufferID;
+}
+
+void wpeScreenDRMDestroyDumbBufferIfNeeded(WPEScreenDRM* screen, int fd)
+{
+    auto* priv = screen->priv;
+    if (!priv->dumb.bufferID)
+        return;
+
+    drmModeRmFB(fd, priv->dumb.frameBufferID);
+    drmModeDestroyDumbBuffer(fd, priv->dumb.bufferID);
+    priv->dumb.bufferID = 0;
+    priv->dumb.frameBufferID = 0;
 }

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h
@@ -32,3 +32,5 @@ WPEScreen* wpeScreenDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&&, const WPE::DRM:
 drmModeModeInfo* wpeScreenDRMGetMode(WPEScreenDRM*);
 const WPE::DRM::Crtc wpeScreenDRMGetCrtc(WPEScreenDRM*);
 double wpeScreenDRMGuessScale(WPEScreenDRM*);
+void wpeScreenDRMCreateDumbBufferIfNeeded(WPEScreenDRM*, int, uint32_t connectorID);
+void wpeScreenDRMDestroyDumbBufferIfNeeded(WPEScreenDRM*, int);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -355,6 +355,8 @@ static bool wpeViewDRMCommitAtomic(WPEViewDRM* view, WPE::DRM::Buffer* buffer, s
         return false;
     }
 
+    wpeScreenDRMDestroyDumbBufferIfNeeded(screen, fd);
+
     return true;
 }
 
@@ -380,6 +382,8 @@ static bool wpeViewDRMCommitLegacy(WPEViewDRM* view, const WPE::DRM::Buffer& buf
         g_set_error_literal(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: failed to request page flip");
         return false;
     }
+
+    wpeScreenDRMDestroyDumbBufferIfNeeded(screen, fd);
 
     return true;
 }


### PR DESCRIPTION
#### 378c859a6e51b19ea340d33aa44de3e1c7e84c71
<pre>
[WPE] Launching MiniBrowser on DRM mode doesn&apos;t pick VSync clock
<a href="https://bugs.webkit.org/show_bug.cgi?id=297892">https://bugs.webkit.org/show_bug.cgi?id=297892</a>

Reviewed by Nikolas Zimmermann.

Function &apos;drmWaitVBlank&apos; needs a file descriptor with a frame buffer
attached in order to work. However, a trace shows the function call
that tries to attach the frame buffer, &apos;drmAddFrameBuffer&apos;, happens after.

To make &apos;drmWaitVBlank&apos; work before the frame buffer is ready, a mock
frame buffer is attached temporarily to the file descriptor before the
actual frame buffer is created.

Patch by Carlos Garcia Campos &lt;cgarcia@igalia.com&gt;

* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp:
(WPE::DRM::Crtc::Crtc):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h:
(WPE::DRM::Crtc::bufferID const):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMSetup):
* Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp:
(wpeScreenDRMCreateDumbBufferIfNeeded):
(wpeScreenDRMDestroyDumbBufferIfNeeded):
* Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMCommitAtomic):
(wpeViewDRMCommitLegacy):

Canonical link: <a href="https://commits.webkit.org/299155@main">https://commits.webkit.org/299155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa5418fbb82f554e5583b5f30155ae5a02544e8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70092 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89588 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59190 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29678 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127287 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98262 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98048 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21438 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41398 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18814 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50505 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->