### PR TITLE
Limit the scope of invalidation traversal for `:has(> .changed) .subject`

### DIFF
--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -49,7 +49,10 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
     auto canAffectElementsWithStyle = [&](MatchElement matchElement) {
         switch (matchElement) {
         case MatchElement::HasSibling:
+        case MatchElement::HasAnySibling:
         case MatchElement::HasChild:
+        case MatchElement::HasChildAncestor:
+        case MatchElement::HasChildParent:
             return isChild;
         case MatchElement::HasDescendant:
         case MatchElement::HasSiblingDescendant:

--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -129,6 +129,8 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
         case MatchElement::ParentSibling:
         case MatchElement::AncestorSibling:
         case MatchElement::HasChild:
+        case MatchElement::HasChildParent:
+        case MatchElement::HasChildAncestor:
         case MatchElement::HasDescendant:
         case MatchElement::HasSibling:
         case MatchElement::HasSiblingDescendant:

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -55,7 +55,9 @@ enum class MatchElement : uint8_t {
     HasSibling,
     HasSiblingDescendant,
     HasAnySibling,
-    HasNonSubject, // FIXME: This is a catch-all for cases where :has() is in a non-subject position.
+    HasChildParent,
+    HasChildAncestor,
+    HasNonSubject, // FIXME: This is a catch-all for the rest of cases where :has() is in a non-subject position.
     HasScopeBreaking, // FIXME: This is a catch-all for cases where :has() contains a scope breaking sub-selector like, like :has(:is(.x .y)).
     Host,
     HostChild


### PR DESCRIPTION
#### 197ddc80fe10e4d3bf8d2dcd12809af56d63577a
<pre>
Limit the scope of invalidation traversal for `:has(&gt; .changed) .subject`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297893">https://bugs.webkit.org/show_bug.cgi?id=297893</a>
<a href="https://rdar.apple.com/159173631">rdar://159173631</a>

Reviewed by Simon Fraser.

It is sufficient to traverse the subtree of the parent to invalidate in this case, rather than the entire DOM.

This helps with GitHub performance as it uses selectors of this type.

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::ClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::isSiblingOrSubject):
(WebCore::Style::isScopeBreaking):
(WebCore::Style::computeHasPseudoClassMatchElement):
(WebCore::Style::computeSubSelectorMatchElement):

Add two new MatchElement types for these cases:

`:has(&gt; .changed) .subject
`:has(&gt; .changed) &gt; .subject

* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

Traverse only the required subtrees for the new types.
Also document each invalidation traversal case.

Canonical link: <a href="https://commits.webkit.org/299162@main">https://commits.webkit.org/299162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56a9e192689510cbee81fc4443f08c47eaaaaf19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70090 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd92d001-491b-443d-9b2f-a5453364dc5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89585 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59187 "Too many flaky failures: compositing/transforms/transformed-replaced-with-shadow-children.html, css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/navigation/ping-attribute/anchor-cookie.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dfg-arguments-osr-exit.html, js/dfg-float32array.html, js/dfg-float64array.html, js/dfg-flush-get-local.html, js/dom/weak-gc-map-ensure-value-should-not-invoke-gc.html, storage/domstorage/localstorage/file-can-access.html, storage/indexeddb/cursor-leak.html, storage/indexeddb/cursor-overloads-private.html, storage/indexeddb/modern/transaction-scheduler-4.html, storage/indexeddb/objectstore-removeobjectstore.html, storage/indexeddb/pending-version-change-on-exit.html, streams/readable-stream-create-after-worker-terminates-crash.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-2d-r8ui-red_integer-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgb8-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-rgb8ui-rgb_integer-unsigned_byte.html, webgl/2.0.y/conformance/extensions/webgl-compressed-texture-size-limit.html, webgl/2.0.y/conformance2/rendering/attrib-type-match.html, webgl/2.0.y/conformance2/rendering/blitframebuffer-filter-outofbounds.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r8ui-red_integer-unsigned_byte.html, webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html, workers/btoa-oom.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab9f50f5-6bd0-4a77-b75b-c699ddca8f69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2d02ec1-82ce-4af6-9496-78ee2b34d18a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67870 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127285 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98260 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98046 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24942 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41394 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44829 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50503 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44289 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47634 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45978 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->