### PR TITLE
[GTK][WPE] Add ConnectionGLib

### DIFF
--- a/Source/WTF/wtf/glib/GSocketMonitor.cpp
+++ b/Source/WTF/wtf/glib/GSocketMonitor.cpp
@@ -55,11 +55,14 @@ gboolean GSocketMonitor::socketSourceCallback(GSocket*, GIOCondition condition, 
     return result;
 }
 
-void GSocketMonitor::start(GSocket* socket, GIOCondition condition, RunLoop& runLoop, Function<gboolean(GIOCondition)>&& callback)
+void GSocketMonitor::start(GSocket* socket, GIOCondition condition, RunLoop& runLoop, GCancellable* cancellable, Function<gboolean(GIOCondition)>&& callback)
 {
     stop();
 
-    m_cancellable = adoptGRef(g_cancellable_new());
+    if (cancellable)
+        m_cancellable = cancellable;
+    else
+        m_cancellable = adoptGRef(g_cancellable_new());
     m_source = adoptGRef(g_socket_create_source(socket, condition, m_cancellable.get()));
     g_source_set_name(m_source.get(), "[WebKit] Socket monitor");
     m_callback = WTFMove(callback);

--- a/Source/WTF/wtf/glib/SocketConnection.cpp
+++ b/Source/WTF/wtf/glib/SocketConnection.cpp
@@ -44,7 +44,7 @@ SocketConnection::SocketConnection(GRefPtr<GSocketConnection>&& connection, cons
 
     auto* socket = g_socket_connection_get_socket(m_connection.get());
     g_socket_set_blocking(socket, FALSE);
-    m_readMonitor.start(socket, G_IO_IN, RunLoop::currentSingleton(), [this, protectedThis = Ref { *this }](GIOCondition condition) -> gboolean {
+    m_readMonitor.start(socket, G_IO_IN, RunLoop::currentSingleton(), nullptr, [this, protectedThis = Ref { *this }](GIOCondition condition) -> gboolean {
         if (isClosed())
             return G_SOURCE_REMOVE;
 
@@ -240,7 +240,7 @@ void SocketConnection::waitForSocketWritability()
     if (m_writeMonitor.isActive())
         return;
 
-    m_writeMonitor.start(g_socket_connection_get_socket(m_connection.get()), G_IO_OUT, RunLoop::currentSingleton(), [this, protectedThis = Ref { *this }] (GIOCondition condition) -> gboolean {
+    m_writeMonitor.start(g_socket_connection_get_socket(m_connection.get()), G_IO_OUT, RunLoop::currentSingleton(), nullptr, [this, protectedThis = Ref { *this }] (GIOCondition condition) -> gboolean {
         if (condition & G_IO_OUT) {
             // We can't stop the monitor from this lambda, because stop destroys the lambda.
             RunLoop::currentSingleton().dispatch([this, protectedThis] {

--- a/Source/WebKit/Platform/IPC/IPCUtilities.h
+++ b/Source/WebKit/Platform/IPC/IPCUtilities.h
@@ -62,7 +62,7 @@ enum PlatformConnectionOptions {
     SetCloexecOnServer = 1 << 1,
 };
 
-SocketPair createPlatformConnection(unsigned options = SetCloexecOnClient | SetCloexecOnServer);
+SocketPair createPlatformConnection(int socketType, unsigned options = SetCloexecOnClient | SetCloexecOnServer);
 
 #endif
 

--- a/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
+++ b/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
@@ -1,0 +1,575 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Connection.h"
+
+#if USE(GLIB)
+#include "IPCUtilities.h"
+#include "Logging.h"
+#include "UnixMessage.h"
+#include <gio/gio.h>
+#include <gio/gunixfdmessage.h>
+#include <sys/socket.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/UniStdExtras.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+
+#if OS(ANDROID)
+#include <android/hardware_buffer.h>
+#include <wtf/SafeStrerror.h>
+#endif
+
+namespace IPC {
+
+static constexpr size_t s_messageMaxSize = 4096;
+static constexpr size_t s_attachmentMaxAmount = 254;
+
+class AttachmentInfo {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AttachmentInfo);
+public:
+    AttachmentInfo()
+    {
+        // The entire AttachmentInfo is passed to write(), so we have to zero our
+        // padding bytes to avoid writing uninitialized memory.
+        zeroBytes(*this);
+    }
+
+    AttachmentInfo(const AttachmentInfo& info)
+        : AttachmentInfo()
+    {
+        *this = info;
+    }
+
+    AttachmentInfo& operator=(const AttachmentInfo&) = default;
+
+    // The attachment is not null unless explicitly set.
+    void setNull() { m_isNull = true; }
+    bool isNull() const { return m_isNull; }
+
+#if OS(ANDROID)
+    enum class Type : uint8_t {
+        Unset = 0,
+        FileDescriptor,
+        HardwareBuffer,
+    };
+
+    Type type() const { return m_type; }
+    void setType(Type type) { m_type = type; }
+#endif // OS(ANDROID)
+
+private:
+    // The AttachmentInfo will be copied using memcpy, so all members must be trivially copyable.
+    bool m_isNull;
+#if OS(ANDROID)
+    Type m_type;
+#endif
+};
+
+static_assert(sizeof(MessageInfo) + sizeof(AttachmentInfo) * s_attachmentMaxAmount <= s_messageMaxSize, "s_messageMaxSize is too small.");
+
+void Connection::platformInitialize(Identifier&& identifier)
+{
+    GUniqueOutPtr<GError> error;
+    m_socket = adoptGRef(g_socket_new_from_fd(identifier.handle.release(), &error.outPtr()));
+    if (!m_socket) {
+        // Note: g_socket_new_from_fd() takes ownership of the fd only on success, so if this error
+        // were not fatal, we would need to close it here.
+        g_error("Failed to adopt IPC::Connection socket: %s", error->message);
+    }
+    g_socket_set_blocking(m_socket.get(), FALSE);
+
+    m_cancellable = adoptGRef(g_cancellable_new());
+    m_readBuffer.reserveInitialCapacity(s_messageMaxSize);
+    m_fileDescriptors.reserveInitialCapacity(s_attachmentMaxAmount);
+}
+
+void Connection::platformInvalidate()
+{
+    GUniqueOutPtr<GError> error;
+    g_socket_close(m_socket.get(), &error.outPtr());
+    if (error)
+        RELEASE_LOG_ERROR(IPC, "Failed to close WebKit IPC socket: %s", error->message);
+
+    if (!m_isConnected)
+        return;
+
+    g_cancellable_cancel(m_cancellable.get());
+    m_readSocketMonitor.stop();
+    m_writeSocketMonitor.stop();
+
+    m_isConnected = false;
+}
+
+std::unique_ptr<Decoder> Connection::createMessageDecoder()
+{
+    if (m_readBuffer.size() < sizeof(MessageInfo)) {
+        RELEASE_LOG_FAULT(IPC, "createMessageDecoder: read buffer size is smaller than MessageInfo");
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    auto messageData = m_readBuffer.mutableSpan();
+    auto& messageInfo = consumeAndReinterpretCastTo<MessageInfo>(messageData);
+    if (messageInfo.attachmentCount() > s_attachmentMaxAmount || (!messageInfo.isBodyOutOfLine() && messageInfo.bodySize() > s_messageMaxSize)) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    auto attachmentCount = messageInfo.attachmentCount();
+    if (!attachmentCount)
+        return Decoder::create(messageData.first(messageInfo.bodySize()), { });
+
+    if (messageInfo.isBodyOutOfLine())
+        attachmentCount--;
+
+    Vector<Attachment> attachments(attachmentCount);
+    size_t fdIndex = 0;
+    for (size_t i = 0; i < attachmentCount; ++i) {
+        auto& attachmentInfo = consumeAndReinterpretCastTo<AttachmentInfo>(messageData);
+        size_t attachmentIndex = attachmentCount - i - 1;
+#if OS(ANDROID)
+        switch (attachmentInfo.type()) {
+        case AttachmentInfo::Type::FileDescriptor:
+            if (attachmentInfo.isNull())
+                attachments[attachmentIndex] = UnixFileDescriptor();
+            else
+                attachments[attachmentIndex] = WTFMove(m_fileDescriptors[fdIndex++]);
+            break;
+        case AttachmentInfo::Type::HardwareBuffer:
+            if (attachmentInfo.isNull())
+                attachments[attachmentIndex] = nullptr;
+            else {
+                RELEASE_ASSERT(!m_incomingHardwareBuffers.isEmpty());
+                attachments[attachmentIndex] = WTFMove(m_incomingHardwareBuffers.first());
+                m_incomingHardwareBuffers.removeAt(0);
+            }
+            break;
+        case AttachmentInfo::Type::Unset:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+#else
+        if (!attachmentInfo.isNull())
+            attachments[attachmentIndex] = WTFMove(m_fileDescriptors[fdIndex++]);
+#endif
+    }
+
+    if (!messageInfo.isBodyOutOfLine())
+        return Decoder::create(messageData.first(messageInfo.bodySize()), WTFMove(attachments));
+
+    ASSERT(messageInfo.bodySize());
+    auto& attachmentInfo = reinterpretCastSpanStartTo<AttachmentInfo>(messageData);
+    if (attachmentInfo.isNull()) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    auto handle = WebCore::SharedMemory::Handle { WTFMove(m_fileDescriptors[fdIndex]), messageInfo.bodySize() };
+    auto messageBody = WebCore::SharedMemory::map(WTFMove(handle), WebCore::SharedMemory::Protection::ReadOnly);
+    if (!messageBody) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    return Decoder::create(messageBody->mutableSpan().first(messageInfo.bodySize()), WTFMove(attachments));
+}
+
+static ssize_t readBytesFromSocket(GSocket* socket, Vector<uint8_t>& buffer, Vector<UnixFileDescriptor>& fileDescriptors, GCancellable* cancellable, GError** error)
+{
+    GUniqueOutPtr<GSocketControlMessage*> messages;
+    gint messagesCount = 0;
+    gint flags = 0;
+    GInputVector inputVector = { buffer.mutableSpan().data(), buffer.size() };
+    auto bytesRead = g_socket_receive_message(socket, nullptr, &inputVector, 1, &messages.outPtr(), &messagesCount, &flags, cancellable, error);
+    if (bytesRead <= 0)
+        return bytesRead;
+
+    if (flags & MSG_CTRUNC) {
+        // Control data has been discarded, so consider this a read failure.
+        return -1;
+    }
+
+    buffer.shrink(bytesRead);
+    for (int i = 0; i < messagesCount; ++i) {
+        GRefPtr<GSocketControlMessage> controlMessage = adoptGRef(G_SOCKET_CONTROL_MESSAGE(messages.get()[i]));
+        if (!G_IS_UNIX_FD_MESSAGE(controlMessage.get()))
+            continue;
+
+        gint fdsCount;
+        GUniquePtr<gint> fds(g_unix_fd_message_steal_fds(G_UNIX_FD_MESSAGE(controlMessage.get()), &fdsCount));
+        for (int i = 0; i < fdsCount; ++i) {
+            int fd = fds.get()[i];
+            if (!setCloseOnExec(fd)) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
+
+            fileDescriptors.append(UnixFileDescriptor { fd, UnixFileDescriptor::Adopt });
+        }
+    }
+
+    return bytesRead;
+}
+
+void Connection::readyReadHandler()
+{
+#if OS(ANDROID)
+    if (m_pendingIncomingHardwareBufferCount) {
+        if (!receiveIncomingHardwareBuffers())
+            return;
+
+        if (auto decoder = createMessageDecoder()
+            processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)));
+    }
+#endif
+
+    while (true) {
+        m_readBuffer.grow(m_readBuffer.capacity());
+        m_fileDescriptors.shrink(0);
+
+        GUniqueOutPtr<GError> error;
+        auto bytesRead = readBytesFromSocket(m_socket.get(), m_readBuffer, m_fileDescriptors, m_cancellable.get(), &error.outPtr());
+        if (bytesRead < 0) {
+            if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
+                return;
+
+            if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) || g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+                connectionDidClose();
+                return;
+            }
+
+            if (m_isConnected) {
+                RELEASE_LOG_ERROR(IPC, "Error receiving IPC message on socket %d in process %d: %s", g_socket_get_fd(m_socket.get()), getpid(), error->message);
+                connectionDidClose();
+            }
+            return;
+        }
+
+        if (!bytesRead) {
+            connectionDidClose();
+            return;
+        }
+
+#if OS(ANDROID)
+        RELEASE_ASSERT(m_readBuffer.size() >= sizeof(MessageInfo));
+        const auto& messageInfo = reinterpretCastSpanStartTo<MessageInfo>(m_readBuffer.span());
+        if (auto hardwareBufferCount = messageInfo.hardwareBufferCount()) {
+            RELEASE_ASSERT(m_incomingHardwareBuffers.isEmpty());
+            RELEASE_ASSERT(!m_pendingIncomingHardwareBufferCount);
+            m_pendingIncomingHardwareBufferCount = hardwareBufferCount;
+            if (!receiveIncomingHardwareBuffers())
+                return;
+        }
+#endif // OS(ANDROID)
+
+        if (auto decoder = createMessageDecoder())
+            processIncomingMessage(makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)));
+    }
+}
+
+bool Connection::platformPrepareForOpen()
+{
+    return true;
+}
+
+void Connection::platformOpen()
+{
+    RefPtr<Connection> protectedThis(this);
+    m_isConnected = true;
+
+    m_readSocketMonitor.start(m_socket.get(), G_IO_IN, m_connectionQueue->runLoop(), m_cancellable.get(), [protectedThis] (GIOCondition condition) -> gboolean {
+        if (condition & G_IO_HUP || condition & G_IO_ERR || condition & G_IO_NVAL) {
+            protectedThis->connectionDidClose();
+            return G_SOURCE_REMOVE;
+        }
+
+        if (condition & G_IO_IN) {
+            protectedThis->readyReadHandler();
+            return G_SOURCE_CONTINUE;
+        }
+
+        ASSERT_NOT_REACHED();
+        return G_SOURCE_REMOVE;
+    });
+
+    // Schedule a call to readyReadHandler. Data may have arrived before installation of the signal handler.
+    m_connectionQueue->dispatch([protectedThis] {
+        protectedThis->readyReadHandler();
+    });
+}
+
+bool Connection::platformCanSendOutgoingMessages() const
+{
+#if OS(ANDROID)
+    return !m_hasPendingOutputMessage && m_outgoingHardwareBuffers.isEmpty();
+#else
+    return !m_hasPendingOutputMessage;
+#endif
+}
+
+bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
+{
+    static_assert(sizeof(MessageInfo) + s_attachmentMaxAmount * sizeof(size_t) <= s_messageMaxSize, "Attachments fit to message inline");
+
+    UnixMessage outputMessage(encoder.get());
+    if (outputMessage.attachments().size() > (s_attachmentMaxAmount - 1)) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+
+    size_t messageSizeWithBodyInline = sizeof(MessageInfo) + (outputMessage.attachments().size() * sizeof(AttachmentInfo)) + outputMessage.bodySize();
+    if (messageSizeWithBodyInline > s_messageMaxSize && outputMessage.bodySize()) {
+        if (!outputMessage.setBodyOutOfLine())
+            return false;
+    }
+
+    return sendOutputMessage(WTFMove(outputMessage));
+}
+
+bool Connection::sendOutputMessage(UnixMessage&& outputMessage)
+{
+#if OS(ANDROID)
+    RELEASE_ASSERT(m_outgoingHardwareBuffers.isEmpty());
+    Vector<RefPtr<AHardwareBuffer>, 2> hardwareBuffers;
+#endif
+    ASSERT(!m_hasPendingOutputMessage);
+
+    auto& messageInfo = outputMessage.messageInfo();
+    const auto& attachments = outputMessage.attachments();
+    GOutputVector outputVector[3];
+    int outputVectorLength = 0;
+
+    outputVector[outputVectorLength++] = { reinterpret_cast<void*>(&messageInfo), sizeof(messageInfo) };
+    GRefPtr<GSocketControlMessage> controlMessage;
+    if (!attachments.isEmpty()) {
+        Vector<AttachmentInfo> attachmentInfo(attachments.size());
+        Vector<int> fds;
+        fds.reserveInitialCapacity(attachments.size());
+        for (size_t i = 0; i < attachments.size(); ++i) {
+#if OS(ANDROID)
+            RELEASE_ASSERT(attachmentInfo[i].type() == AttachmentInfo::Type::Unset);
+            switchOn(attachments[i],
+                [&](const UnixFileDescriptor& fd) {
+                    attachmentInfo[i].setType(AttachmentInfo::Type::FileDescriptor);
+                    if (fd)
+                        fds.append(fd.value());
+                    else
+                        attachmentInfo[i].setNull();
+                },
+                [&](const RefPtr<AHardwareBuffer>& buffer) {
+                    attachmentInfo[i].setType(AttachmentInfo::Type::HardwareBuffer);
+                    if (buffer)
+                        hardwareBuffers.append(buffer);
+                    else
+                        attachmentInfo[i].setNull();
+                }
+            );
+#else
+            if (attachments[i])
+                fds.append(attachments[i].value());
+            else
+                attachmentInfo[i].setNull();
+#endif
+        }
+
+        if (!fds.isEmpty()) {
+            // Use g_unix_fd_message_new_with_fd_list() to create the message without duplicating the file descriptors.
+            GRefPtr<GUnixFDList> fdList = adoptGRef(g_unix_fd_list_new_from_array(fds.span().data(), fds.size()));
+            controlMessage = adoptGRef(g_unix_fd_message_new_with_fd_list(fdList.get()));
+        }
+
+        outputVector[outputVectorLength++] = { attachmentInfo.mutableSpan().data(), sizeof(AttachmentInfo) * attachments.size() };
+    }
+
+    if (!messageInfo.isBodyOutOfLine() && outputMessage.bodySize())
+        outputVector[outputVectorLength++] = { reinterpret_cast<void*>(outputMessage.body().data()), outputMessage.bodySize() };
+
+    auto* controlMessagePtr = controlMessage.get();
+    GUniqueOutPtr<GError> error;
+    auto bytesWritten = g_socket_send_message(m_socket.get(), nullptr, outputVector, outputVectorLength,
+        controlMessagePtr ? &controlMessagePtr : nullptr, controlMessagePtr ? 1 : 0, 0, m_cancellable.get(), &error.outPtr());
+    if (controlMessage) {
+        // File descriptors are owned by UnixMessage, so steal them from the control message to avoid a double close.
+        g_free(g_unix_fd_message_steal_fds(G_UNIX_FD_MESSAGE(controlMessage.get()), nullptr));
+    }
+    if (bytesWritten >= 0) {
+#if OS(ANDROID)
+        RELEASE_ASSERT(m_outgoingHardwareBuffers.isEmpty());
+        m_outgoingHardwareBuffers = WTFMove(hardwareBuffers);
+        if (!sendOutgoingHardwareBuffers())
+            return false;
+#endif
+        return true;
+    }
+
+    if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK)) {
+        m_hasPendingOutputMessage = true;
+        m_writeSocketMonitor.start(m_socket.get(), G_IO_OUT, m_connectionQueue->runLoop(), m_cancellable.get(), [this, protectedThis = Ref { *this }, message = WTFMove(outputMessage)] (GIOCondition condition) mutable -> gboolean {
+            if (condition & G_IO_OUT) {
+                ASSERT(m_hasPendingOutputMessage);
+                // We can't stop the monitor from this lambda, because stop destroys the lambda.
+                m_connectionQueue->dispatch([this, protectedThis = Ref { *this }, message = WTFMove(message)]() mutable {
+                    m_writeSocketMonitor.stop();
+                    m_hasPendingOutputMessage = false;
+                    if (m_isConnected) {
+                        sendOutputMessage(WTFMove(message));
+                        sendOutgoingMessages();
+                    }
+                });
+            }
+            return G_SOURCE_REMOVE;
+        });
+        return false;
+    }
+
+    if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) || g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+        connectionDidClose();
+        return false;
+    }
+
+    if (m_isConnected)
+        RELEASE_LOG_ERROR(IPC, "Error sending IPC message on socket %d in process %d: %s", g_socket_get_fd(m_socket.get()), getpid(), error->message);
+    return false;
+}
+
+std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()
+{
+    SocketPair socketPair = createPlatformConnection(SOCK_SEQPACKET);
+    return { { Identifier { WTFMove(socketPair.server) }, ConnectionHandle { WTFMove(socketPair.client) } } };
+}
+
+void Connection::sendCredentials() const
+{
+    ASSERT(m_socket);
+    g_socket_set_blocking(m_socket.get(), TRUE);
+    GRefPtr<GUnixConnection> connection = adoptGRef(G_UNIX_CONNECTION(g_object_new(G_TYPE_UNIX_CONNECTION, "socket", m_socket.get(), nullptr)));
+    GUniqueOutPtr<GError> error;
+    if (!g_unix_connection_send_credentials(connection.get(), m_cancellable.get(), &error.outPtr())) {
+        if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) || g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+            return;
+
+        g_error("Connection: Failed to send crendentials: %s", error->message);
+    }
+    g_socket_set_blocking(m_socket.get(), FALSE);
+}
+
+pid_t Connection::remoteProcessID(GSocket* socket)
+{
+    GRefPtr<GUnixConnection> connection = adoptGRef(G_UNIX_CONNECTION(g_object_new(G_TYPE_UNIX_CONNECTION, "socket", socket, nullptr)));
+    GUniqueOutPtr<GError> error;
+    GRefPtr<GCredentials> credentials = adoptGRef(g_unix_connection_receive_credentials(connection.get(), nullptr, &error.outPtr()));
+    if (!credentials)
+        g_error("Connection: failed to receive credentials: %s", error->message);
+
+    pid_t processID = g_credentials_get_unix_pid(credentials.get(), &error.outPtr());
+    if (error)
+        g_error("Connection: failed to get pid from credentials: %s", error->message);
+
+    return processID;
+}
+
+#if OS(ANDROID)
+bool Connection::sendOutgoingHardwareBuffers()
+{
+    while (!m_outgoingHardwareBuffers.isEmpty()) {
+        auto& buffer = m_outgoingHardwareBuffers.first();
+        RELEASE_ASSERT(buffer);
+
+        // There is no need to check for EINTR, it is handled internally.
+        int result = AHardwareBuffer_sendHandleToUnixSocket(buffer.get(), g_socket_get_fd(m_socket.get()));
+        if (!result) {
+            m_outgoingHardwareBuffers.removeAt(0);
+            continue;
+        }
+
+        if (result == -EAGAIN || result == -EWOULDBLOCK) {
+            m_writeSocketMonitor.start(m_socket.get(), G_IO_OUT, m_connectionQueue->runLoop(), m_cancellable.get(), [this, protectedThis = Ref { *this }] (GIOCondition condition) -> gboolean {
+                if (condition & G_IO_OUT) {
+                    RELEASE_ASSERT(!m_outgoingHardwareBuffers.isEmpty());
+                    // We can't stop the monitor from this lambda, because stop destroys the lambda.
+                    m_connectionQueue->dispatch([this, protectedThis = Ref { *this }] {
+                        m_writeSocketMonitor.stop();
+                        if (m_isConnected) {
+                            if (sendOutgoingHardwareBuffers())
+                                sendOutgoingMessages();
+                        }
+                    });
+                }
+                return G_SOURCE_REMOVE;
+            });
+            return false;
+        }
+
+        if (result == -EPIPE || result == -ECONNRESET || g_cancellable_is_cancelled(m_cancellable.get())) {
+            connectionDidClose();
+            return false;
+        }
+
+        if (m_isConnected) {
+            LOG_ERROR("Error sending AHardwareBuffer on socket %d in process %d: %s", g_socket_get_fd(m_socket.get()), getpid(), safeStrerror(-result).data());
+            connectionDidClose();
+        }
+        return false;
+    }
+
+    RELEASE_ASSERT(m_outgoingHardwareBuffers.isEmpty());
+    return true;
+}
+
+bool Connection::receiveIncomingHardwareBuffers()
+{
+    while (m_pendingIncomingHardwareBufferCount) {
+        AHardwareBuffer* buffer { nullptr };
+        int result = AHardwareBuffer_recvHandleFromUnixSocket(g_socket_get_fd(m_socket.get()), &buffer);
+        if (!result) {
+            m_pendingIncomingHardwareBufferCount--;
+            auto hardwareBuffer = adoptRef(buffer);
+            m_incomingHardwareBuffers.append(WTFMove(hardwareBuffer));
+            continue;
+        }
+
+        if (result == -EAGAIN || result == -EWOULDBLOCK)
+            return false;
+
+        if (result == -ECONNRESET || g_cancellable_is_cancelled(m_cancellable.get())) {
+            connectionDidClose();
+            return false;
+        }
+
+        if (m_isConnected) {
+            LOG_ERROR("Error receiving AHardwareBuffer on socket %d in process %d: %s", g_socket_get_fd(m_socket.get()), getpid(), safeStrerror(-result).data());
+            connectionDidClose();
+        }
+        return false;
+    }
+
+    return true;
+}
+#endif // OS(ANDROID)
+
+} // namespace IPC
+
+#endif // USE(GLIB)

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -43,6 +43,7 @@ list(APPEND WebKit_SOURCES
     Platform/IPC/unix/ArgumentCodersUnix.cpp
     Platform/IPC/unix/ConnectionUnix.cpp
     Platform/IPC/unix/IPCSemaphoreUnix.cpp
+    Platform/IPC/unix/IPCUtilitiesUnix.cpp
 
     Platform/classifier/ResourceLoadStatisticsClassifier.cpp
 

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -54,9 +54,11 @@ NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
 NetworkProcess/webrtc/NetworkRTCMonitor.cpp
 NetworkProcess/webrtc/NetworkRTCProvider.cpp
 
+Platform/IPC/glib/ConnectionGLib.cpp
+
 Platform/IPC/unix/ArgumentCodersUnix.cpp
-Platform/IPC/unix/ConnectionUnix.cpp
 Platform/IPC/unix/IPCSemaphoreUnix.cpp
+Platform/IPC/unix/IPCUtilitiesUnix.cpp
 
 Platform/classifier/ResourceLoadStatisticsClassifier.cpp
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -56,9 +56,11 @@ NetworkProcess/webrtc/NetworkRTCProvider.cpp
 
 Platform/IPC/android/ArgumentCodersAndroid.cpp
 
+Platform/IPC/glib/ConnectionGLib.cpp
+
 Platform/IPC/unix/ArgumentCodersUnix.cpp
-Platform/IPC/unix/ConnectionUnix.cpp
 Platform/IPC/unix/IPCSemaphoreUnix.cpp
+Platform/IPC/unix/IPCUtilitiesUnix.cpp
 
 Platform/classifier/ResourceLoadStatisticsClassifier.cpp
 

--- a/Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
+++ b/Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
@@ -61,7 +61,7 @@ static const char* defaultProcessPath(ProcessLauncher::ProcessType processType)
 
 void ProcessLauncher::launchProcess()
 {
-    IPC::SocketPair socketPair = IPC::createPlatformConnection(IPC::PlatformConnectionOptions::SetCloexecOnServer);
+    IPC::SocketPair socketPair = IPC::createPlatformConnection(SOCK_SEQPACKET, IPC::PlatformConnectionOptions::SetCloexecOnServer);
 
     int sendBufSize = 32 * 1024;
     setsockopt(socketPair.server.value(), SOL_SOCKET, SO_SNDBUF, &sendBufSize, 4);


### PR DESCRIPTION
#### 0d195d406a9f3e43668024ffff6b0ca79f7ac56c
<pre>
[GTK][WPE] Add ConnectionGLib
<a href="https://bugs.webkit.org/show_bug.cgi?id=297897">https://bugs.webkit.org/show_bug.cgi?id=297897</a>

Reviewed by Michael Catanzaro.

Add a Connection implementation using GLib sockets API and simplifying
the code by stop supporting stream sockets.

Canonical link: <a href="https://commits.webkit.org/299386@main">https://commits.webkit.org/299386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/470c5c3aba36076c06a09fc0daeaac1c78481f74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90029 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59570 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24463 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68458 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110739 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127859 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117135 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98667 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98451 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21890 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42032 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18930 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45398 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51076 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145831 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44861 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37494 "Found 1 new JSC binary failure: testapi, Found 18593 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->