### PR TITLE
Implement speculation rules - same origin conservative prefetch (no DocumentLoader)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -916,6 +916,17 @@ imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/docume
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.html [ Skip ]
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url-cross-origin.html [ Skip ]
 
+# This is failing because the navigationTiming timestamps are not correct.
+imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=afterResponse [ Pass Failure ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=waitingForRedirect [ Pass Failure ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https.html?include=waitingForResponse [ Pass Failure ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https.html?3-3 [ Pass Failure ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub.html [ DumpJSConsoleLogInStdErr ]
+# This is passing, but timing out as `Clear-Site-Data: *` is making the test framework fail to get its own messages.
+imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html [ Skip ]
+# This is timing out because we do not support singleton prefetch matching, and the different initiators have different FrameLoaders.
+imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https.html [ Skip ]
+
 # Newly imported WPT ref tests failures.
 imported/w3c/web-platform-tests/compat/webkit-box-fieldset.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/support/clear-site-data-cache.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/support/clear-site-data-cache.py
@@ -1,0 +1,203 @@
+"""
+Loaded in Step 2/4/Optional 6 (/clear-site-data/clear-cache.https.html)
+Sending Message for Step 3/5/Optional 7 (/clear-site-data/clear-cache.https.html)
+"""
+import uuid
+import random
+
+def generate_png(width, height, color=(0, 0, 0)):
+    import zlib
+    import struct
+    def chunk(chunk_type, data):
+        return (
+            struct.pack(">I", len(data)) +
+            chunk_type +
+            data +
+            struct.pack(">I", zlib.crc32(chunk_type + data) & 0xffffffff)
+        )
+
+    # PNG signature
+    png = b"\x89PNG\r\n\x1a\n"
+
+    # IHDR chunk
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png += chunk(b'IHDR', ihdr)
+
+    # IDAT chunk: RGB pixels
+    row = b'\x00' + bytes(color * width)
+    raw = row * height
+    idat = zlib.compress(raw)
+    png += chunk(b'IDAT', idat)
+
+    # IEND chunk
+    png += chunk(b'IEND', b'')
+    return png
+
+def main(request, response):
+    # type of response:
+    # - General purpose: returns random uuid or forwards uuid from iframe
+    #   - "single_html": Main page html file with a different postMessage uuid on each response
+    # - Pages for simple testing normal http cache:
+    #   - "json": Json that always responds with a different uuid in a single-element array
+    #   - "html_embed_json": Main page html that embeds a cachable version of the above json
+    # - Pages for testing specialized caches
+    #   - "image": Image that returns random dimensions up to 1024x1024 each time
+    #   - "html_embed_image": Main page html that embeds a cachable version of the above image
+    #   - "css": Style sheet with random uuid variable
+    #   - "html_embed_css": Main page html that embeds a cachable version of the above css
+    #   - "js": Script that returns a different uuid each time
+    #   - "html_embed_js": Main page html that embeds a cachable version of the above js file
+    response_type = request.GET.first(b"response")
+
+    cache_helper = request.GET.first(b"cache_helper")
+
+    # force enable caching when present or force disable if not
+    cache = b"cache" in request.GET
+    clear = None
+    if b"clear" in request.GET:
+        clear = request.GET.first(b"clear")
+    if b"clear_first" in request.GET:
+        if request.server.stash.take(cache_helper) is None:
+            clear = request.GET.first(b"clear_first")
+            request.server.stash.put(cache_helper, ())
+
+    headers = []
+    if response_type == b"json":
+        headers += [(b"Content-Type", b"application/json")]
+    elif response_type == b"image":
+        headers += [(b"Content-Type", b"image/png")]
+    elif response_type == b"css":
+        headers += [(b"Content-Type", b"text/css")]
+    elif response_type == b"js":
+        headers += [(b"Content-Type", b"text/javascript")]
+    else:
+        headers += [(b"Content-Type", b"text/html")]
+
+    headers += [(b"Access-Control-Allow-Origin", b"*")]
+    if cache:
+        headers += [(b"cache-control", b"public, max-age=31536000, immutable")]
+    else:
+        headers += [(b"cache-control", b"no-store")]
+
+    if clear is not None:
+        if clear == b"all":
+            headers += [(b"Clear-Site-Data", b'"*"')]
+        else:
+            headers += [(b"Clear-Site-Data", b'"' + clear + b'"')]
+
+    if response_type == b"single_html":
+        iframe = ""
+        if b"iframe" in request.GET:
+            # forward message from iframe to opener
+            iframe_url = request.GET.first(b"iframe").decode()
+            content = f'''
+                <script>
+                    // forward iframe uuid to opener
+                    window.addEventListener('message', function(event) {{
+                        if(window.opener) {{
+                            window.opener.postMessage(event.data, "*");
+                        }} else {{
+                            window.parent.postMessage(event.data, "*");
+                        }}
+                        window.close();
+                    }});
+                </script>
+                <br>
+                {request.url}<br>
+                {iframe_url}<br>
+                <iframe src="{iframe_url}"></iframe>
+                </body>
+            '''
+        else:
+            # send unique UUID. Cache got cleared when uuids don't match.
+            u = uuid.uuid4()
+            content = f'''
+                <script>
+                    if(window.opener) {{
+                        window.opener.postMessage("{u}", "*");
+                    }} else {{
+                        window.parent.postMessage("{u}", "*");
+                    }}
+                    window.close();
+                </script>
+                <body>
+                    {request.url}
+                </body>'''
+    elif response_type == b"json":
+        # send unique UUID. helper for below "html_embed_json"
+        content = f'''["{uuid.uuid4()}"]'''
+    elif response_type == b"html_embed_json":
+        url = request.url_parts.path + "?response=json&cache&cache_helper=" + cache_helper.decode()
+        content = f'''
+            <script>
+                fetch("{url}")
+                    .then(response => response.json())
+                    .then(uuid => {{
+                        window.opener.postMessage(uuid[0], "*");
+                        window.close();
+                    }});
+            </script>
+            <body>
+                {request.url}<br>
+                {url}
+            </body>'''
+    elif response_type == b"image":
+        # send uniquely sized images, because that info can be retrived from html and definitly using the image cache
+        # helper for below "html_embed_image"
+        content = generate_png(random.randint(1, 1024), random.randint(1, 1024))
+    elif response_type == b"html_embed_image":
+        urls = [request.url_parts.path + "?response=image&cache&cache_helper=" + cache_helper.decode() + "&img=" + str(i) for i in range(2)]
+        content = f'''
+            <!DOCTYPE html>
+            <script>
+                addEventListener("load", () => {{
+                    let img1 = document.getElementById("randomess1");
+                    let img2 = document.getElementById("randomess2");
+                    let id = img1.naturalWidth + "x" + img1.naturalHeight;
+                    id += "-" + img2.naturalWidth + "x" + img2.naturalHeight
+                    window.opener.postMessage(id, "*");
+                    window.close();
+                }})
+            </script>
+            <body>
+                {request.url}<br>
+                <img id="randomess1" src="{urls[0]}"></img><br>
+                <img id="randomess2" src="{urls[1]}"></img><br>
+            </body>'''
+    elif response_type == b"css":
+        # send unique UUID. helper for below "html_embed_css"
+        content = f'''
+        :root {{
+            --uuid: "{uuid.uuid4()}"
+        }}'''
+    elif response_type == b"html_embed_css":
+        url = request.url_parts.path + "?response=css&cache&cache_helper=" + cache_helper.decode()
+        content = f'''
+            <!DOCTYPE html>
+            <link rel="stylesheet" href="{url}">
+            <script>
+                let computed = getComputedStyle(document.documentElement);
+                let uuid = computed.getPropertyValue("--uuid").trim().replaceAll('"', '');
+                window.opener.postMessage(uuid, "*");
+                window.close();
+            </script>
+            <body>
+                {request.url}<br>
+                {url}
+            </body>'''
+    elif response_type == b"js":
+        # send unique UUID. helper for below "html_embed_js"
+        content = f'''
+            window.opener.postMessage("{uuid.uuid4()}", "*");
+            window.close();
+        '''
+    elif response_type == b"html_embed_js":
+        url = request.url_parts.path + "?response=js&cache&cache_helper=" + cache_helper.decode()
+        content = f'''
+            <script src="{url}"></script>
+            <body>
+                {request.url}<br>
+                {url}
+            </body>'''
+
+    return 200, headers, content

--- a/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/support/clear-site-data-prefetchCache.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/support/clear-site-data-prefetchCache.py
@@ -1,0 +1,18 @@
+def main(request, response):
+    headers = [(b"Content-Type", b"text/html")]
+    headers += [(b"Clear-Site-Data", b'"prefetchCache"')]
+    content = f'''
+        <script>
+            setTimeout(() => {{
+                if(window.opener) {{
+                    window.opener.postMessage("message", "*");
+                }} else {{
+                    window.parent.postMessage("message", "*");
+                }}
+                window.close();
+            }}, 1000);
+        </script>
+        <body>
+            {request.url}
+        </body>'''
+    return 200, headers, content

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/external-speculation-rules-errors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/external-speculation-rules-errors-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Test that an external speculation rules script fires an error event Test timed out
-NOTRUN Test that an external speculation rules script fires an error event, regardless of attribute order
-NOTRUN Test that an external speculation rules script in markup fires an error event
+PASS Test that an external speculation rules script fires an error event
+PASS Test that an external speculation rules script fires an error event, regardless of attribute order
+PASS Test that an external speculation rules script in markup fires an error event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/invalid-rules.https_prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/invalid-rules.https_prefetch-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS an unrecognized key in a prefetch rule should prevent it from being preloaded
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/invalid-rules.https_prerender-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/invalid-rules.https_prerender-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS an unrecognized key in a prerender rule should prevent it from being preloaded
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https-expected.txt
@@ -1,4 +1,5 @@
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL test anonymous-client url prefetch for cross origin pages assert_equals: expected (string) "prefetch;anonymous-client-ip" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt
@@ -1,4 +1,8 @@
-
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2f958f30-2590-4c7f-8c48-2d27061bc962 due to access control checks.
+CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2aa4c567-6ca0-45a6-96d8-6846ef6822c6 due to access control checks.
+CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2f958f30-2590-4c7f-8c48-2d27061bc962 due to access control checks.
+CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=11e644f8-fb6a-4c3c-9266-91c4978d8e0b due to access control checks.
+CONSOLE MESSAGE: Fetch API cannot load https://localhost:9443/common/dispatcher/dispatcher.py?uuid=2f958f30-2590-4c7f-8c48-2d27061bc962 due to access control checks.
+FAIL: Timed out waiting for notifyDone to be called
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changed-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Cookie-Indices should prevent a prefetch from being used if the cookie has changed.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Cookie-Indices should prevent a prefetch from succeeding if the cookie changed, with a redirect assert_equals: expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect2-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS If the redirect needs to be rerequested but goes to the same place and that one doesn't vary, we actually can use the prefetched final response.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect3-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL If the redirect needs to be rerequested and goes elsewhere, we cannot can use the prefetched final response. assert_equals: expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchanged-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchanged-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Cookie-Indices should not prevent a prefetch from succeeding if the cookie has not changed.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchangedWithRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchangedWithRedirect-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Cookie-Indices should not prevent a prefetch from succeeding with unchanged cookies, even with redirect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https-expected.txt
@@ -1,4 +1,9 @@
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL speculation rules based prefetch should not use cookies for cross origin urls and should issue only the IP-anonymized request if that one is first. assert_equals: expected "prefetch" but got "navigate"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL speculation rules based prefetch should not use cookies for cross origin urls. assert_equals: expected (undefined) undefined but got (string) "1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https-expected.txt
@@ -1,4 +1,5 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+Harness Error (TIMEOUT), message = null
 
+TIMEOUT Prefetches from different initiator Documents with same RenderFrameHost Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-1-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Cross-initiator prefetches using ServiceWorker tricks assert_equals: Prefetch should not work due to ServiceWorker. expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-2-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Cross-initiator prefetches using ServiceWorker tricks assert_equals: Prefetch should not work due to ServiceWorker. expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_same-site-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Cross-initiator prefetches using ServiceWorker tricks assert_equals: Prefetch should not work due to ServiceWorker. expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test document rule with conjunction predicate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS document-rules
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS document-rules
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test document rule with no predicate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test href_matches document rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test that selector_matches predicates respect changes immediately
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS invalid predicate should not throw error or start prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test that changing the href of an invalid link to a matching value triggers a prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test that matching link in a shadow tree is prefetched
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test that a fragment link to the current document does not prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test that adding a second rule set triggers prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test document rule with negation predicate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test document rule with disjunction predicate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test selector_matches document rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL test selector_matches with link inside display locked container assert_equals: expected 0 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL test selector_matches with link inside display:none container assert_equals: expected 0 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test selector_matches with :root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL test that unslotted link never matches document rule assert_equals: expected 0 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS browser should remove duplicate urls from prefetch buffer.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS fragment links to the current document URL are not prefetched
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS rules should be accepted without an explicit source
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_cross-site-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS <a>
+FAIL <a target="blank"> assert_in_array: value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS <a>
+FAIL <a target="blank"> assert_in_array: value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_cross-site-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS location.href across iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_same-site-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS location.href across iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_cross-site-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS window.open()
+FAIL window.open(noopener) assert_in_array: value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS window.open()
+FAIL window.open(noopener) assert_in_array: value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS browser should be able to prefetch multiple urls
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=false-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&bypass_cache=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=false-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "navigational-prefetch" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&bypass_cache=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming.deliveryType test, same origin prefetch. assert_equals: expected (string) "navigational-prefetch" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=afterResponse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=afterResponse-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS PerformanceNavigationTiming data should show 'instantaneous' events completed beforehand
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=noPrefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=noPrefetch-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS PerformanceNavigationTiming data should be in the correct order (no prefetch)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming data should show noticeable TTFB if the response is slow assert_in_array: https://localhost:9443/speculation-rules/prefetch/resources/executor.sub.html?uuid=22276614-64d7-455b-9ab6-3319ba6335ab&page=2 should have been prefetched. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming data should show noticeable TTFB if the response is slow assert_in_array: https://localhost:9443/speculation-rules/prefetch/resources/slow-executor.py?uuid=254ec368-3261-4dc7-bdc0-5344facac3c6&delay=3&page=2 should have been prefetched. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_bypass_cache=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_default-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&bypass_cache=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch. assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch. assert_greater_than: expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Check that the HTTP cache doesn't cache when the server conditionally responds with 503 for prefetch requests. assert_equals: Should use the non-prefetched 200, instead of the prefetched 503 expected "200" but got "503"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS post navigations should not use cached prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Base case. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":false,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":false,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":false}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt
@@ -1,4 +1,6 @@
+CONSOLE MESSAGE: Refused to load https://localhost:9443/resources/testdriver.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://localhost:9443/resources/testdriver-vendor.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://localhost:9443/resources/testdriver-actions.js because it does not appear in the script-src directive of the Content Security Policy.
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL It should accept the speculation rules when the main page has strict CSP. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":false,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":false,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":true}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=EmptyRuleSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=EmptyRuleSet-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject an empty speculation rules set.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailCORS-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailCORS-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules set if CORS fails.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseRuleSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseRuleSet-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules set if it cannot parse it.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseSpeculationRulesHeader-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseSpeculationRulesHeader-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules set if it fails to parse the SpeculationRules header.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL It should follow redirects and fetch the speculation rules set. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":true,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":false,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":false}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InnerListInSpeculationRulesHeader-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InnerListInSpeculationRulesHeader-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules passed as inner list in the SpeculationRules header.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidMimeType-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidMimeType-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules set with invalid MIME type.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidUrlForSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidUrlForSpeculationRulesSet-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules set with invalid URL.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForCandidate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForCandidate-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should resolve the relative candidate URLs in the speculation rules set based on the speculation rules set's URL
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL It should fetch a speculation rules set using its relative URL. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":false,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":true,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":false}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode199-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode199-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules set with unsuccessful status code.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode404-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode404-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS It should reject the speculation rules set with unsuccessful status code.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=UseNonUTF8EncodingForSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=UseNonUTF8EncodingForSpeculationRulesSet-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS The speculation rules set should always be encoded using UTF-8.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=http-expected.txt
@@ -1,4 +1,5 @@
+CONSOLE MESSAGE: Prefetch request denied: URL must be secure (HTTPS)
+CONSOLE MESSAGE: Prefetch request denied: URL must be secure (HTTPS)
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test single http url prefetch from a http url
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&to_protocol=https-expected.txt
@@ -1,4 +1,5 @@
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL test single https url prefetch from a http url assert_in_array: Prefetch should work for HTTPS urls. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=http-expected.txt
@@ -1,4 +1,5 @@
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
+CONSOLE MESSAGE: Prefetch request denied: not same origin as document
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test single http url prefetch from a https url
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&to_protocol=https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test single https url prefetch from a https url
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=200&should_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=200&should_prefetch=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Check that only prefetched requests with status in 200-299 range are used.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=250&should_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=250&should_prefetch=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Check that only prefetched requests with status in 200-299 range are used.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=299&should_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=299&should_prefetch=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Check that only prefetched requests with status in 200-299 range are used.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&should_prefetch=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&should_prefetch=false-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Check that only prefetched requests with status in 200-299 range are used. assert_equals: Prefetch should not work for request statue:400. expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&should_prefetch=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&should_prefetch=false-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Check that only prefetched requests with status in 200-299 range are used. assert_equals: Prefetch should not work for request statue:500. expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub-expected.txt
@@ -1,4 +1,5 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL prefetches can be used for traversal navigations assert_in_array: traversal should use prefetch value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS History's Document is used for traversal navigations
+FAIL prefetches can be used for reload navigations assert_in_array: reload should use prefetch value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: expected (string) "" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Test that prefetches use/store responses to/from the HTTP cache. assert_equals: expected (string) "" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-initial-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Navigate to the final URL of the prefetch
+PASS Navigation is redirected to the final URL of the prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-redirect-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Navigate to the final URL of the prefetch
+PASS Navigation is redirected to the final URL of the prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=same-origin-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Navigate to the final URL of the prefetch
+PASS Navigation is redirected to the final URL of the prefetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-initial-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS redirect-received-before-navigation-start
+PASS redirect-received-after-navigation-start
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-redirect-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS redirect-received-before-navigation-start
+PASS redirect-received-after-navigation-start
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=same-origin-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS redirect-received-before-navigation-start
+PASS redirect-received-after-navigation-start
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-initial-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS redirect-received-before-navigation-start
+PASS redirect-received-after-navigation-start
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS redirect-received-before-navigation-start
+PASS redirect-received-after-navigation-start
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=same-origin-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS redirect-received-before-navigation-start
+PASS redirect-received-after-navigation-start
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_1-1-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS with "strict-origin" referrer policy in rule set overriding "strict-origin-when-cross-origin" of referring page
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_2-2-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS with "strict-origin" referrer policy in rule set override "no-referrer" of link
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_3-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_3-3-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL with "no-referrer" referrer policy in rule set overriding "unsafe-url" of cross-site referring page assert_equals: must send no referrer expected (undefined) undefined but got (string) "https://localhost:9443/speculation-rules/prefetch/resources/executor.sub.html?uuid=7fcccd00-8e7b-48e3-82ec-e69b1e627487"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_4-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_4-4-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL unrecognized policies invalidate the rule assert_equals: must not be prefetched expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_5-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_5-5-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS unrecognized policies in link referrerpolicy attribute are ignored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_6-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_6-6-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL treat legacy referrer policy values as invalid assert_equals: must not be prefetched expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_7-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_7-7-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL with "unsafe-url" referrer policy in rule set overriding "strict-origin" of cross-site referring page assert_equals: must not be prefetched expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_8-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_8-last-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS with empty string referrer policy in rule set defaulting to "strict-origin" of referring page
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_1-1-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS with "unsafe-url" referrer policy on same-site referring page
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_2-2-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL with "unsafe-url" referrer policy on cross-site referring page assert_equals: must not be prefetched expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_3-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_3-last-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL with "unsafe-url" referrer policy on cross-site referring page with document rule assert_equals: must not be prefetched expected (undefined) undefined but got (string) "prefetch"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_1-1-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS with "strict-origin-when-cross-origin" referrer policy
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_2-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_2-2-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS with "strict-origin" referrer policy
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_3-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_3-3-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS with "no-referrer" referrer policy
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_4-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_4-last-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL with "strict-origin" link referrer policy overriding "no-referrer" of referring page assert_equals: expected (string) "https://localhost:9443/" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_1-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_1-1-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS speculation rules based prefetch should use cookies for same origin urls.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_2-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_2-last-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS same origin prefetch with no referrer works when cookies are present.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https-expected.txt
@@ -1,4 +1,6 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Sec-Fetch-Dest
+PASS Sec-Fetch-Mode
+PASS Sec-Fetch-Dest with redirects
+PASS Sec-Fetch-Mode with redirects
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=false-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=false-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS test www-authenticate basic does not forward credentials to cross-origin pages.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=true-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL test www-authenticate basic does not forward credentials to cross-origin pages. assert_equals: expected (undefined) undefined but got (string) "user"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/script-supports.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/script-supports.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL HTMLScriptElement.supports returns true for 'speculationrules' assert_true: expected true got false
+PASS HTMLScriptElement.supports returns true for 'speculationrules'
 PASS HTMLScriptElement.supports returns false for unsupported types
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-prefetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-prefetch.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL cross-site prefetch should not have Sec-Speculation-Tags be sent assert_equals: expected "__no_tags__" but got "tag1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-to-same-site-redirection-prefetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-to-same-site-redirection-prefetch.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL same-site redirection prefetch should have Sec-Speculation-Tags even if cross-site url in the redirection chain assert_equals: expected "\"tag1\"" but got "tag1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
@@ -1,4 +1,7 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags: deduped and sorted tags assert_equals: expected "\"abc\", \"def\", \"ghi\", \"jkl\", \"null\"" but got "def, def"
+FAIL Sec-Speculation-Tags: deduped and sorted tags within rules assert_equals: expected "null, \"abc\", \"def\", \"ghi\", \"jkl\", \"null\"" but got "def"
+FAIL Sec-Speculation-Tags: deduped and sorted tags within multiple rulesets assert_equals: expected "\"abc\", \"def\", \"ghi\", \"jkl\"" but got "def, jkl"
+FAIL Sec-Speculation-Tags: 'null' tags and no tags within multiple rulesets assert_equals: expected "null, \"abc\", \"def\", \"null\"" but got ""
+FAIL Sec-Speculation-Tags: removed ruleset assert_equals: expected "\"def\", \"ghi\", \"jkl\"" but got "def, jkl"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prerender-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prerender-expected.txt
@@ -1,4 +1,7 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags: deduped and sorted tags assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags: deduped and sorted tags within rules assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags: deduped and sorted tags within multiple rulesets assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags: 'null' tags and no tags within multiple rulesets assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags: removed ruleset assert_equals: expected (string) "prefetch;prerender" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prefetch-expected.txt
@@ -1,4 +1,12 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags [rule-based]: integer tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [rule-based]: object tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [rule-based]: null value tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [rule-based]: non-printable character tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [rule-based]: string with non-printable character tag assert_false: expected false got true
+PASS Sec-Speculation-Tags [rule-based]: non-ascii string tag
+FAIL Sec-Speculation-Tags [rule-based]: 0x19 tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [rule-based]: 0x20 tag assert_equals: expected "\" \"" but got ""
+FAIL Sec-Speculation-Tags [rule-based]: 0x7E tag assert_equals: expected "\"~\"" but got "~"
+FAIL Sec-Speculation-Tags [rule-based]: 0x7F tag assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prerender-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prerender-expected.txt
@@ -1,4 +1,12 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Sec-Speculation-Tags [rule-based]: integer tag
+PASS Sec-Speculation-Tags [rule-based]: object tag
+PASS Sec-Speculation-Tags [rule-based]: null value tag
+PASS Sec-Speculation-Tags [rule-based]: non-printable character tag
+PASS Sec-Speculation-Tags [rule-based]: string with non-printable character tag
+PASS Sec-Speculation-Tags [rule-based]: non-ascii string tag
+PASS Sec-Speculation-Tags [rule-based]: 0x19 tag
+FAIL Sec-Speculation-Tags [rule-based]: 0x20 tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: 0x7E tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+PASS Sec-Speculation-Tags [rule-based]: 0x7F tag
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
@@ -1,4 +1,14 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
+Harness Error (TIMEOUT), message = null
 
+FAIL Sec-Speculation-Tags [ruleset-based]: integer tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [ruleset-based]: object tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [ruleset-based]: null value tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [ruleset-based]: non-printable character tag assert_false: expected false got true
+FAIL Sec-Speculation-Tags [ruleset-based]: string with non-printable character tag assert_false: expected false got true
+TIMEOUT Sec-Speculation-Tags [ruleset-based]: non-ascii string tag Test timed out
+NOTRUN Sec-Speculation-Tags [ruleset-based]: 0x19 tag
+NOTRUN Sec-Speculation-Tags [ruleset-based]: 0x20 tag
+NOTRUN Sec-Speculation-Tags [ruleset-based]: 0x7E tag
+NOTRUN Sec-Speculation-Tags [ruleset-based]: 0x7F tag
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prerender-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prerender-expected.txt
@@ -1,4 +1,12 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+PASS Sec-Speculation-Tags [ruleset-based]: integer tag
+PASS Sec-Speculation-Tags [ruleset-based]: object tag
+PASS Sec-Speculation-Tags [ruleset-based]: null value tag
+PASS Sec-Speculation-Tags [ruleset-based]: non-printable character tag
+PASS Sec-Speculation-Tags [ruleset-based]: string with non-printable character tag
+PASS Sec-Speculation-Tags [ruleset-based]: non-ascii string tag
+PASS Sec-Speculation-Tags [ruleset-based]: 0x19 tag
+FAIL Sec-Speculation-Tags [ruleset-based]: 0x20 tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: 0x7E tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+PASS Sec-Speculation-Tags [ruleset-based]: 0x7F tag
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/no-tags.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/no-tags.https-expected.txt
@@ -1,4 +1,4 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags: no tags (prefetch) assert_equals: Sec-Speculation-Tags expected "null" but got ""
+FAIL Sec-Speculation-Tags: no tags (prerender) promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: PrerenderingRemoteContextHelper"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point down assert_equals: Sec-Speculation-Tags expected "\"conservative\", \"moderate\"" but got "conservative"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point hover assert_equals: Sec-Speculation-Tags expected "\"moderate\"" but got "conservative"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prerender-target-hint.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prerender-target-hint.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags: tags with prerender target hint assert_equals: expected (string) "prefetch;prerender" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt
@@ -1,4 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL same-site to cross-site redirection prefetch should not have Sec-Speculation-Tags be sent assert_equals: expected "__no_tags__" but got "tag1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&type=prefetch-expected.txt
@@ -1,4 +1,10 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags [rule-based]: string tag assert_equals: expected "\"my-rules\"" but got "my-rules"
+FAIL Sec-Speculation-Tags [rule-based]: 'null' string tag assert_equals: expected "\"null\"" but got "null"
+FAIL Sec-Speculation-Tags [rule-based]: empty string tag assert_equals: expected "\"\"" but got ""
+FAIL Sec-Speculation-Tags [rule-based]: single space tag assert_equals: expected "\" \"" but got ""
+FAIL Sec-Speculation-Tags [rule-based]: double quote tag assert_equals: expected "\"\\\"\"" but got "\""
+FAIL Sec-Speculation-Tags [rule-based]: double quotes tag assert_equals: expected "\"\\\"\\\"\\\"\"" but got "\"\"\""
+FAIL Sec-Speculation-Tags [rule-based]: backslash tag assert_equals: expected "\"\\\\\"" but got "\\"
+FAIL Sec-Speculation-Tags [rule-based]: backslashes tag assert_equals: expected "\"\\\\\\\\\\\\\"" but got "\\\\\\"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&type=prerender-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&type=prerender-expected.txt
@@ -1,4 +1,10 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags [rule-based]: string tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: 'null' string tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: empty string tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: single space tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: double quote tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: double quotes tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: backslash tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [rule-based]: backslashes tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
@@ -1,4 +1,10 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags [ruleset-based]: string tag assert_equals: expected "\"my-rules\"" but got "my-rules"
+FAIL Sec-Speculation-Tags [ruleset-based]: 'null' string tag assert_equals: expected "\"null\"" but got "null"
+FAIL Sec-Speculation-Tags [ruleset-based]: empty string tag assert_equals: expected "\"\"" but got ""
+FAIL Sec-Speculation-Tags [ruleset-based]: single space tag assert_equals: expected "\" \"" but got ""
+FAIL Sec-Speculation-Tags [ruleset-based]: double quote tag assert_equals: expected "\"\\\"\"" but got "\""
+FAIL Sec-Speculation-Tags [ruleset-based]: double quotes tag assert_equals: expected "\"\\\"\\\"\\\"\"" but got "\"\"\""
+FAIL Sec-Speculation-Tags [ruleset-based]: backslash tag assert_equals: expected "\"\\\\\"" but got "\\"
+FAIL Sec-Speculation-Tags [ruleset-based]: backslashes tag assert_equals: expected "\"\\\\\\\\\\\\\"" but got "\\\\\\"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&type=prerender-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&type=prerender-expected.txt
@@ -1,4 +1,10 @@
 
-Harness Error (FAIL), message = Error: assert_implements: <script type="speculationrules"> must be supported undefined
-
+FAIL Sec-Speculation-Tags [ruleset-based]: string tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: 'null' string tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: empty string tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: single space tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: double quote tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: double quotes tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: backslash tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
+FAIL Sec-Speculation-Tags [ruleset-based]: backslashes tag assert_equals: expected (string) "prefetch;prerender" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/constants.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/constants.sub.js
@@ -15,6 +15,7 @@ if (url_has_flag('h2')) {
 }
 
 const SCHEME_DOMAIN_PORT = __SCHEME + '://' + __SERVER__NAME + ':' + __PORT;
+const SCHEME_CROSSDOMAIN_PORT = __SCHEME + '://' + '{{hosts[alt][www]}}' + ':' + __PORT;
 
 function url_has_variant(variant) {
   const params = new URLSearchParams(location.search);

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1516,6 +1516,17 @@ imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-
 imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-spv-asynch.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.serviceworker.html [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html?cross-site-1 [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html?cross-site-2 [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html?same-site [ Skip ]
+
+imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https.html [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html?cross-site [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html?same-site [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https.html?prefetch=true [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https.html?prefetch=true&bypass_cache=true [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https.html?1-1 [ Skip ]
+imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https.html?2-last [ Skip ]
 
 imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-websocket-allowed.sub.html [ Skip ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7321,6 +7321,23 @@ SpeakerSelectionRequiresUserGesture:
     WebCore:
       default: true
 
+SpeculationRulesPrefetchEnabled:
+  type: bool
+  status: testable 
+  category: html
+  humanReadableName: "SpeculationRules prefetch"
+  humanReadableDescription: "SpeculationRules prefetch"
+  defaultValue:
+    WebKitLegacy:
+      default: false 
+    WebKit:
+      default: false 
+    WebCore:
+      default: false 
+  disableInLockdownMode: true
+  sharedPreferenceForWebProcess: true
+  richJavaScript: true
+
 SpeechRecognitionEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1224,6 +1224,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/SlotAssignmentMode.h
     dom/SpaceSplitString.h
     dom/SpatialBackdropSource.h
+    dom/SpeculationRulesMatcher.h
     dom/StartViewTransitionOptions.h
     dom/StaticRange.h
     dom/StyledElement.h
@@ -1571,6 +1572,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/CustomHeaderFields.h
     loader/DocumentLoadTiming.h
     loader/DocumentLoader.h
+    loader/DocumentPrefetcher.h
     loader/DocumentWriter.h
     loader/EmptyClients.h
     loader/EmptyFrameLoaderClient.h
@@ -1634,6 +1636,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/ResourceMonitorThrottlerHolder.h
     loader/ResourceTimingInformation.h
     loader/ShouldTreatAsContinuingLoad.h
+    loader/SpeculationRules.h
     loader/SubframeLoader.h
     loader/SubresourceLoader.h
     loader/SubstituteData.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1352,6 +1352,7 @@ dom/SimulatedClick.cpp
 dom/SlotAssignment.cpp
 dom/SpaceSplitString.cpp
 dom/SpatialBackdropSource.cpp
+dom/SpeculationRulesMatcher.cpp
 dom/StaticNodeList.cpp
 dom/StaticRange.cpp
 dom/StringCallback.cpp
@@ -1983,6 +1984,7 @@ loader/DefaultResourceLoadPriority.cpp
 loader/DocumentLoader.cpp
 loader/DocumentThreadableLoader.cpp
 loader/DocumentWriter.cpp
+loader/DocumentPrefetcher.cpp
 loader/EmptyClients.cpp
 loader/FTPDirectoryParser.cpp
 loader/FetchIdioms.cpp
@@ -2030,6 +2032,7 @@ loader/ResourceTimingInformation.cpp
 loader/ServerTiming.cpp
 loader/ServerTimingParser.cpp
 loader/SinkDocument.cpp
+loader/SpeculationRules.cpp
 loader/SubframeLoader.cpp
 loader/SubresourceIntegrity.cpp
 loader/SubresourceLoader.cpp

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -55,6 +55,7 @@
 #include "ScriptSourceCode.h"
 #include "ScriptableDocumentParser.h"
 #include "Settings.h"
+#include "SpeculationRules.h"
 #include "TrustedType.h"
 #include "UserGestureIndicator.h"
 #include "WebCoreJITOperations.h"
@@ -969,6 +970,15 @@ void ScriptController::registerImportMap(const ScriptSourceCode& sourceCode, con
 
     if (newImportMap)
         globalObject->importMap().mergeExistingAndNewImportMaps(WTFMove(newImportMap.value()), reporter);
+}
+
+void ScriptController::registerSpeculationRules(const ScriptSourceCode& sourceCode, const URL& baseURL)
+{
+    RefPtr document = m_frame->document();
+    if (!document || !document->settings().speculationRulesPrefetchEnabled())
+        return;
+
+    document->speculationRules()->parseSpeculationRules(sourceCode.source(), baseURL, document->url());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -175,6 +175,7 @@ public:
     void reportExceptionFromScriptError(LoadableScript::Error, bool);
 
     void registerImportMap(const ScriptSourceCode&, const URL& baseURL);
+    void registerSpeculationRules(const ScriptSourceCode&, const URL& baseURL);
 
 private:
     ValueOrException executeScriptInWorld(DOMWrapperWorld&, RunJavaScriptParameters&&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -283,6 +283,8 @@
 #include "ShadowRoot.h"
 #include "SleepDisabler.h"
 #include "SocketProvider.h"
+#include "SpeculationRules.h"
+#include "SpeculationRulesMatcher.h"
 #include "SpeechRecognition.h"
 #include "StartViewTransitionOptions.h"
 #include "StaticNodeList.h"
@@ -645,6 +647,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     , ScriptExecutionContext(Type::Document, identifier)
     , FrameDestructionObserver(frame)
     , m_settings(settings)
+    , m_speculationRules(SpeculationRules::create())
     , m_parserContentPolicy(DefaultParserContentPolicy)
     , m_creationURL(url)
     , m_domTreeVersion(++s_globalTreeVersion)
@@ -2918,6 +2921,10 @@ void Document::resolveStyle(ResolveStyleType type)
 
     if (CheckedPtr styleOriginatedTimelinesController = this->styleOriginatedTimelinesController())
         styleOriginatedTimelinesController->documentDidResolveStyle();
+
+    // Re-evaluate speculation rules after style changes to ensure CSS selector
+    // matching works with updated styles.
+    considerSpeculationRules();
 }
 
 void Document::updateTextRenderer(Text& text, unsigned offsetOfReplacedText, unsigned lengthOfReplacedText)
@@ -4668,6 +4675,37 @@ void Document::updateBaseURL()
         m_baseURL = URL();
 
     invalidateCachedCSSParserContext();
+    considerSpeculationRules();
+}
+
+void Document::considerSpeculationRules()
+{
+    RefPtr frame = this->frame();
+    if (!frame || frame->documentIsBeingReplaced() || !frame->window() || !isHTMLDocument())
+        return;
+    auto anchors = links();
+    auto iterator = anchors->createIterator(this);
+    for (RefPtr<Node> element = iterator.next(); element; element = iterator.next()) {
+        if (RefPtr anchorElement = dynamicDowncast<HTMLAnchorElement>(element.get())) {
+            if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(*this, *anchorElement))
+                anchorElement->setShouldBePrefetched(prefetchRule->conservative, Vector<String>(prefetchRule->tags), String(prefetchRule->referrerPolicy));
+        }
+    }
+    // Prefetch all the URL lists that need to be prefetched immediately
+    for (const auto& rule : speculationRules()->prefetchRules()) {
+        for (const auto& url : rule.urls)
+            frame->loader().prefetch(url, Vector<String>(rule.tags), String(rule.referrerPolicy), true);
+    }
+}
+
+const Ref<SpeculationRules> Document::speculationRules() const
+{
+    return m_speculationRules;
+}
+
+Ref<SpeculationRules> Document::speculationRules()
+{
+    return m_speculationRules;
 }
 
 void Document::setBaseURLOverride(const URL& url)
@@ -11798,6 +11836,17 @@ double Document::lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey& key) 
     if (!m_randomCachingKeyMap)
         m_randomCachingKeyMap = CSSCalc::RandomCachingKeyMap::create();
     return m_randomCachingKeyMap->lookupCSSRandomBaseValue(key);
+}
+
+void Document::prefetch(const URL& url, const Vector<String>& tags, const String& referrerPolicy, bool lowPriority)
+{
+    if (!m_cachedResourceLoader)
+        return;
+
+    if (!frame())
+        return;
+
+    frame()->loader().prefetch(url, tags, referrerPolicy, lowPriority);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -241,6 +241,7 @@ class SerializedScriptValue;
 class Settings;
 class SleepDisabler;
 class SpaceSplitString;
+class SpeculationRules;
 class SpeechRecognition;
 class StorageConnection;
 class StringCallback;
@@ -848,6 +849,11 @@ public:
     const AtomString& baseTarget() const { return m_baseTarget; }
     HTMLBaseElement* firstBaseElement() const;
     void processBaseElement();
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#consider-speculation
+    void considerSpeculationRules();
+    const Ref<SpeculationRules> speculationRules() const;
+    Ref<SpeculationRules> speculationRules();
 
     URL baseURLForComplete(const URL& baseURLOverride) const;
     WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
@@ -2008,6 +2014,7 @@ public:
     void attributeAddedToElement(const QualifiedName& attribute);
     void elementDisconnectedFromDocument(const Element&);
 
+    WEBCORE_EXPORT void prefetch(const URL&, const Vector<String>&, const String&, bool lowPriority = false);
 
 protected:
     enum class ConstructionFlag : uint8_t {
@@ -2191,6 +2198,8 @@ private:
     const Ref<const Settings> m_settings;
 
     const std::unique_ptr<Quirks> m_quirks;
+
+    const Ref<SpeculationRules> m_speculationRules;
 
     RefPtr<LocalDOMWindow> m_domWindow;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -37,6 +37,8 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameLoader.h"
+#include "HTMLAnchorElement.h"
+#include "HTMLCollection.h"
 #include "HTMLNames.h"
 #include "HTMLScriptElement.h"
 #include "IgnoreDestructiveWriteCountIncrementer.h"
@@ -161,6 +163,10 @@ std::optional<ScriptType> ScriptElement::determineScriptType(const String& type,
     if (equalLettersIgnoringASCIICase(type, "importmap"_s))
         return ScriptType::ImportMap;
 
+    // Step 12. Otherwise, if the script block's type string is an ASCII case-insensitive match for the string "speculationrules", then set el's type to "speculationrules".
+    if (equalLettersIgnoringASCIICase(type, "speculationrules"_s))
+        return ScriptType::SpeculationRules;
+
     return std::nullopt;
 }
 
@@ -259,7 +265,17 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
         break;
     }
     case ScriptType::ImportMap: {
-        // If the element’s node document's acquiring import maps is false, then queue a task to fire an event named error at the element, and return.
+        // If the element's node document's acquiring import maps is false, then queue a task to fire an event named error at the element, and return.
+        if (hasSourceAttribute()) {
+            element->protectedDocument()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [protectedThis = Ref { *this }] {
+                protectedThis->dispatchErrorEvent();
+            });
+            return false;
+        }
+        break;
+    }
+    case ScriptType::SpeculationRules: {
+        // If the element has a source attribute, queue a task to fire an event named error at the element, and return.
         if (hasSourceAttribute()) {
             element->protectedDocument()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [protectedThis = Ref { *this }] {
                 protectedThis->dispatchErrorEvent();
@@ -293,16 +309,18 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
         ASSERT(hasAsyncAttribute() || m_forceAsync);
         document->protectedScriptRunner()->queueScriptForExecution(*this, *protectedLoadableScript(), ScriptRunner::ASYNC_EXECUTION);
     } else if (!hasSourceAttribute() && m_parserInserted == ParserInserted::Yes && !document->haveStylesheetsLoaded()) {
-        ASSERT(scriptType == ScriptType::Classic || scriptType == ScriptType::ImportMap);
+        ASSERT(scriptType == ScriptType::Classic || scriptType == ScriptType::ImportMap || scriptType == ScriptType::SpeculationRules);
         m_willBeParserExecuted = true;
         m_readyToBeParserExecuted = true;
     } else {
-        ASSERT(scriptType == ScriptType::Classic || scriptType == ScriptType::ImportMap);
+        ASSERT(scriptType == ScriptType::Classic || scriptType == ScriptType::ImportMap || scriptType == ScriptType::SpeculationRules);
         TextPosition position = document->isInDocumentWrite() ? TextPosition() : scriptStartPosition;
         if (scriptType == ScriptType::Classic)
             executeClassicScript(ScriptSourceCode(sourceText, m_taintedOrigin, URL(document->url()), position, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(*this)));
-        else
+        else if (scriptType == ScriptType::ImportMap)
             registerImportMap(ScriptSourceCode(sourceText, m_taintedOrigin, URL(document->url()), position, JSC::SourceProviderSourceType::ImportMap));
+        else
+            registerSpeculationRules(ScriptSourceCode(sourceText, m_taintedOrigin, URL(document->url()), position, JSC::SourceProviderSourceType::Program));
     }
 
     return true;
@@ -619,5 +637,41 @@ ScriptElement* dynamicDowncastScriptElement(Element& element)
         return htmlElement;
     return dynamicDowncast<SVGScriptElement>(element);
 }
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#register-speculation-rules
+void ScriptElement::registerSpeculationRules(const ScriptSourceCode& sourceCode)
+{
+    ASSERT(m_alreadyStarted);
+    ASSERT(scriptType() == ScriptType::SpeculationRules);
+
+    Ref element = this->element();
+    Ref document = element->document();
+    RefPtr frame = document->frame();
+
+    if (sourceCode.isEmpty()) {
+        dispatchErrorEvent();
+        return;
+    }
+
+    if (!m_isExternalScript) {
+        if (!document->contentSecurityPolicy())
+            return;
+        CheckedRef contentSecurityPolicy = *document->contentSecurityPolicy();
+        if (!contentSecurityPolicy->allowNonParserInsertedScripts(URL(), document->url(), m_startLineNumber, element->nonce(), emptyString(), sourceCode.source(), m_parserInserted))
+            return;
+
+        if (!contentSecurityPolicy->allowInlineScript(document->url().string(), m_startLineNumber, sourceCode.source(), element, element->nonce(), element->isInUserAgentShadowTree()))
+            return;
+    }
+
+    if (!frame)
+        return;
+
+    frame->checkedScript()->registerSpeculationRules(sourceCode, document->baseURL());
+    document->considerSpeculationRules();
+}
+
+// TODO: Also implement unregister/update speculation rules
+// https://whatpr.org/html/11426/c9c4d33...28571ea/scripting.html#:~:text=The%20script%20%20HTML%20element,result%20%20given%20%20changedNode%20.
 
 }

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -58,6 +58,7 @@ public:
     void executeClassicScript(const ScriptSourceCode&);
     void executeModuleScript(LoadableModuleScript&);
     void registerImportMap(const ScriptSourceCode&);
+    void registerSpeculationRules(const ScriptSourceCode&);
 
     void executePendingScript(PendingScript&);
 

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -41,6 +41,7 @@ public:
     bool isClassicScript() const { return scriptType() == ScriptType::Classic; }
     bool isModuleScript() const { return scriptType() == ScriptType::Module; }
     bool isImportMap() const { return scriptType() == ScriptType::ImportMap; }
+    bool isSpeculationRules() const { return scriptType() == ScriptType::SpeculationRules; }
 
     const String& crossOriginMode() const { return m_crossOriginMode; }
 

--- a/Source/WebCore/dom/ScriptType.h
+++ b/Source/WebCore/dom/ScriptType.h
@@ -28,8 +28,8 @@
 namespace WebCore {
 
 // https://html.spec.whatwg.org/multipage/scripting.html#concept-script-type
-enum class ScriptType : uint8_t { Classic, Module, ImportMap };
-static constexpr unsigned bitWidthOfScriptType = 2;
-static_assert(static_cast<unsigned>(ScriptType::ImportMap) <= ((1U << bitWidthOfScriptType) - 1));
+enum class ScriptType : uint8_t { Classic, Module, ImportMap, SpeculationRules };
+static constexpr unsigned bitWidthOfScriptType = 3;
+static_assert(static_cast<unsigned>(ScriptType::SpeculationRules) <= ((1U << bitWidthOfScriptType) - 1));
 
 }

--- a/Source/WebCore/dom/SpeculationRulesMatcher.cpp
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SpeculationRulesMatcher.h"
+
+#include "Document.h"
+#include "Element.h"
+#include "HTMLAnchorElement.h"
+#include "JSDOMGlobalObject.h"
+#include "ScriptController.h"
+#include "SelectorQuery.h"
+#include "SpeculationRules.h"
+#include "URLPattern.h"
+#include "URLPatternOptions.h"
+
+namespace WebCore {
+
+static bool matches(const SpeculationRules::DocumentPredicate&, Ref<Document>, Ref<HTMLAnchorElement>);
+
+static bool matches(const SpeculationRules::URLPatternPredicate& predicate, Ref<HTMLAnchorElement> anchor)
+{
+    for (const auto& patternString : predicate.patterns) {
+        ExceptionOr<Ref<URLPattern>> patternExceptionOr = URLPattern::create(anchor->protectedDocument(), patternString, String(anchor->document().baseURL().string()), URLPatternOptions());
+        if (!patternExceptionOr.hasException()) {
+            Ref<URLPattern> pattern = patternExceptionOr.returnValue();
+            auto result = pattern->test(anchor->protectedDocument(), anchor->href().string(), String(anchor->document().baseURL().string()));
+            if (!result.hasException() && result.returnValue())
+                return true;
+        }
+    }
+    return false;
+}
+
+static bool matches(const SpeculationRules::CSSSelectorPredicate& predicate, Ref<Element> element)
+{
+    for (const auto& selectorString : predicate.selectors) {
+        auto query = element->protectedDocument()->selectorQueryForString(selectorString);
+        if (query.hasException())
+            continue;
+        if (query.returnValue().matches(element.get()))
+            return true;
+    }
+    return false;
+}
+
+static bool matches(const Box<SpeculationRules::Conjunction>& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    for (const auto& clause : predicate->clauses) {
+        if (!matches(clause, document, anchor))
+            return false;
+    }
+    return true;
+}
+
+static bool matches(const Box<SpeculationRules::Disjunction>& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    if (predicate->clauses.isEmpty())
+        return false;
+
+    for (const auto& clause : predicate->clauses) {
+        if (matches(clause, document, anchor))
+            return true;
+    }
+    return false;
+}
+
+static bool matches(const Box<SpeculationRules::Negation>& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    return !matches(*predicate->clause, document, anchor);
+}
+
+static bool matches(const SpeculationRules::DocumentPredicate& predicate, Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    return WTF::switchOn(predicate.value(),
+        [&] (const SpeculationRules::URLPatternPredicate& p) { return matches(p, anchor); },
+        [&] (const SpeculationRules::CSSSelectorPredicate& p) { return matches(p, anchor); },
+        [&] (const Box<SpeculationRules::Conjunction>& p) { return matches(p, document, anchor); },
+        [&] (const Box<SpeculationRules::Disjunction>& p) { return matches(p, document, anchor); },
+        [&] (const Box<SpeculationRules::Negation>& p) { return matches(p, document, anchor); }
+    );
+}
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#document-rule-predicate-matching
+std::optional<PrefetchRule> SpeculationRulesMatcher::hasMatchingRule(Ref<Document> document, Ref<HTMLAnchorElement> anchor)
+{
+    const auto& speculationRules = document->speculationRules();
+    const auto& url = anchor->href();
+
+    for (const auto& rule : speculationRules->prefetchRules()) {
+        for (const auto& href : rule.urls) {
+            if (href == url)
+                return PrefetchRule { rule.tags, rule.referrerPolicy, rule.eagerness == SpeculationRules::Eagerness::Conservative };
+        }
+
+        if (rule.predicate && matches(rule.predicate.value(), document, anchor))
+            return PrefetchRule { rule.tags, rule.referrerPolicy, rule.eagerness == SpeculationRules::Eagerness::Conservative || rule.eagerness == SpeculationRules::Eagerness::Moderate };
+    }
+
+    return std::nullopt;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/SpeculationRulesMatcher.h
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+class URL;
+} // namespace WTF
+
+namespace WebCore {
+
+class Document;
+class HTMLAnchorElement;
+
+struct PrefetchRule {
+    Vector<String> tags;
+    String referrerPolicy;
+    bool conservative;
+};
+
+class SpeculationRulesMatcher {
+public:
+    static std::optional<PrefetchRule> hasMatchingRule(Ref<Document>, Ref<HTMLAnchorElement>);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/TrustedHTML.h
+++ b/Source/WebCore/dom/TrustedHTML.h
@@ -28,6 +28,7 @@
 #include "ScriptWrappable.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TrustedTypePolicy.h"
 
+#include "ExceptionCode.h"
 #include "ExceptionOr.h"
 #include "TrustedHTML.h"
 #include "TrustedScript.h"

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -56,6 +56,7 @@
 #include "SecurityOrigin.h"
 #include "SecurityPolicy.h"
 #include "Settings.h"
+#include "SpeculationRulesMatcher.h"
 #include "SystemPreviewInfo.h"
 #include "URLKeepingBlobAlive.h"
 #include "UserGestureIndicator.h"
@@ -159,6 +160,9 @@ static void appendServerMapMousePosition(StringBuilder& url, Event& event)
 
 void HTMLAnchorElement::defaultEventHandler(Event& event)
 {
+    if (m_shouldBeConservativelyPrefetched && (event.type() == eventNames().keydownEvent || event.type() == eventNames().mousedownEvent || event.type() == eventNames().pointerdownEvent))
+        document().prefetch(href(), m_speculationRulesTags, m_prefetchReferrerPolicy);
+
     if (isLink()) {
         if (focused() && isEnterKeyKeydownEvent(event) && treatLinkAsLiveForEventType(NonMouseEvent)) {
             event.setDefaultHandled();
@@ -236,6 +240,10 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
             m_relList->associatedAttributeValueChanged();
     } else if (name == nameAttr)
         protectedDocument()->processInternalResourceLinks(this);
+
+    // Check speculation rules for any attribute change to catch either an href attribute change
+    // or anything that can impact CSS selectors.
+    checkForSpeculationRules();
 }
 
 bool HTMLAnchorElement::isURLAttribute(const Attribute& attribute) const
@@ -707,12 +715,30 @@ Node::InsertedIntoAncestorResult HTMLAnchorElement::insertedIntoAncestor(Inserti
 {
     auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     document().processInternalResourceLinks(this);
+    checkForSpeculationRules();
     return result;
 }
 
 void HTMLAnchorElement::setFullURL(const URL& fullURL)
 {
     setAttributeWithoutSynchronization(hrefAttr, AtomString { fullURL.string() });
+    checkForSpeculationRules();
+}
+
+void HTMLAnchorElement::setShouldBePrefetched(bool conservative, Vector<String>&& tags, String&& referrerPolicy)
+{
+    m_shouldBeImmediatelyPrefetched = !conservative;
+    m_shouldBeConservativelyPrefetched = conservative;
+    m_speculationRulesTags = WTFMove(tags);
+    m_prefetchReferrerPolicy = WTFMove(referrerPolicy);
+    if (m_shouldBeImmediatelyPrefetched)
+        document().prefetch(href(), m_speculationRulesTags, m_prefetchReferrerPolicy, true);
+}
+
+void HTMLAnchorElement::checkForSpeculationRules()
+{
+    if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(document(), *this))
+        setShouldBePrefetched(prefetchRule->conservative, WTFMove(prefetchRule->tags), WTFMove(prefetchRule->referrerPolicy));
 }
 
 }

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -85,6 +85,8 @@ public:
 
     AtomString target() const override;
 
+    void setShouldBePrefetched(bool conservative, Vector<String>&& tags, String&& referrerPolicy);
+
 protected:
     HTMLAnchorElement(const QualifiedName&, Document&);
 
@@ -128,6 +130,13 @@ private:
 
     URL fullURL() const final { return href(); }
     void setFullURL(const URL&) final;
+
+    void checkForSpeculationRules();
+
+    bool m_shouldBeImmediatelyPrefetched { false };
+    bool m_shouldBeConservativelyPrefetched { false };
+    Vector<String> m_speculationRulesTags;
+    String m_prefetchReferrerPolicy;
 
     bool m_hasRootEditableElementForSelectionOnMouseDown { false };
     bool m_wasShiftKeyDownOnMouseDown { false };

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -64,7 +64,7 @@ public:
     using HTMLElement::ref;
     using HTMLElement::deref;
 
-    static bool supports(StringView type) { return type == "classic"_s || type == "module"_s || type == "importmap"_s; }
+    static bool supports(StringView type) { return type == "classic"_s || type == "module"_s || type == "importmap"_s || type == "speculationrules"_s; }
 
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriority() const final;

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DocumentPrefetcher.h"
+
+#include "CachedRawResource.h"
+#include "CachedResourceClient.h"
+#include "CachedResourceLoader.h"
+#include "CachedResourceRequest.h"
+#include "CookieJar.h"
+#include "Document.h"
+#include "DocumentLoader.h"
+#include "Frame.h"
+#include "FrameLoader.h"
+#include "FrameLoaderClient.h"
+#include "NetworkLoadMetrics.h"
+#include "ReferrerPolicy.h"
+#include "ResourceRequest.h"
+#include "SecurityOrigin.h"
+#include "SecurityPolicy.h"
+#include "ServiceWorkerTypes.h"
+#include "SubstituteData.h"
+#include <wtf/Box.h>
+
+namespace WebCore {
+
+DocumentPrefetcher::DocumentPrefetcher(FrameLoader& frameLoader)
+    : m_frameLoader(frameLoader)
+{
+}
+
+DocumentPrefetcher::~DocumentPrefetcher()
+{
+    clear();
+}
+
+static bool isPassingSecurityChecks(const URL& url, Document& document)
+{
+    Ref documentOrigin = document.securityOrigin();
+    Ref urlOrigin = SecurityOrigin::create(url);
+    if (!documentOrigin->isSameOriginAs(urlOrigin)) {
+        document.addConsoleMessage(MessageSource::Security, MessageLevel::Error,
+            makeString("Prefetch request denied: not same origin as document"_s));
+        return false;
+    }
+
+    if (!SecurityOrigin::isSecure(url)) {
+        document.addConsoleMessage(MessageSource::Security, MessageLevel::Error,
+            makeString("Prefetch request denied: URL must be secure (HTTPS)"_s));
+        return false;
+    }
+
+    return true;
+}
+
+static ResourceRequest makePrefetchRequest(const URL& url, const Vector<String>& tags, const String& referrerPolicyString, const URL& referrerURL, const Document& document)
+{
+    String urlString = url.string();
+    ResourceRequest request { WTFMove(urlString) };
+    request.setPriority(ResourceLoadPriority::VeryLow);
+
+    if (!tags.isEmpty()) {
+        StringBuilder builder;
+        for (size_t i = 0; i < tags.size(); ++i) {
+            builder.append(tags[i]);
+            if (i < tags.size() - 1)
+                builder.append(", "_s);
+        }
+        request.setHTTPHeaderField(HTTPHeaderName::SecSpeculationTags, builder.toString());
+    }
+    request.setHTTPHeaderField(HTTPHeaderName::SecPurpose, "prefetch"_s);
+
+    ReferrerPolicy policy = ReferrerPolicy::Default;
+    if (!referrerPolicyString.isEmpty())
+        policy = parseReferrerPolicy(referrerPolicyString, ReferrerPolicySource::SpeculationRules).value_or(ReferrerPolicy::Default);
+    else
+        policy = document.referrerPolicy();
+
+    String referrer = SecurityPolicy::generateReferrerHeader(policy, url, referrerURL, OriginAccessPatternsForWebProcess::singleton());
+    if (!referrer.isEmpty())
+        request.setHTTPReferrer(WTFMove(referrer));
+
+    return request;
+}
+
+void DocumentPrefetcher::prefetch(const URL& url, const Vector<String>& tags, const String& referrerPolicyString, bool lowPriority)
+{
+    WeakRef<FrameLoader> frameLoader = m_frameLoader;
+    if (!frameLoader.ptr())
+        return;
+    RefPtr<Document> document = frameLoader->frame().document();
+    if (!document)
+        return;
+
+    if (m_prefetchedResources.contains(url))
+        return;
+
+    if (!url.isValid())
+        return;
+
+    if (!isPassingSecurityChecks(url, *document.get()))
+        return;
+
+    // TODO: This needs to be specified.
+    if (url.hasFragmentIdentifier() && equalIgnoringFragmentIdentifier(url, document->url()))
+        return;
+
+    ResourceRequest request = makePrefetchRequest(url, tags, referrerPolicyString, frameLoader->outgoingReferrerURL(), *document);
+
+    ResourceLoaderOptions prefetchOptions(
+        SendCallbackPolicy::SendCallbacks,
+        ContentSniffingPolicy::DoNotSniffContent,
+        DataBufferingPolicy::BufferData,
+        StoredCredentialsPolicy::Use,
+        ClientCredentialPolicy::MayAskClientForCredentials,
+        FetchOptions::Credentials::Include,
+        SecurityCheckPolicy::DoSecurityCheck,
+        FetchOptions::Mode::Navigate,
+        CertificateInfoPolicy::IncludeCertificateInfo,
+        ContentSecurityPolicyImposition::DoPolicyCheck,
+        DefersLoadingPolicy::AllowDefersLoading,
+        CachingPolicy::AllowCachingPrefetch
+    );
+    prefetchOptions.destination = FetchOptions::Destination::Document;
+    CachedResourceRequest prefetchRequest(WTFMove(request), prefetchOptions);
+    if (lowPriority)
+        prefetchRequest.setPriority(ResourceLoadPriority::Low);
+
+    auto resourceErrorOr = document->protectedCachedResourceLoader()->requestRawResource(WTFMove(prefetchRequest));
+
+    if (!resourceErrorOr)
+        return;
+    auto prefetchedResource = resourceErrorOr.value();
+    if (prefetchedResource) {
+        m_prefetchedResources.set(url, prefetchedResource);
+        prefetchedResource->addClient(*this);
+    }
+}
+
+void DocumentPrefetcher::responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&& completionHandler)
+{
+    if (completionHandler)
+        completionHandler();
+}
+
+void DocumentPrefetcher::redirectReceived(CachedResource& resource, ResourceRequest&& request, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
+{
+    URL originalURL;
+    for (auto& [url, prefetchedResource] : m_prefetchedResources) {
+        if (prefetchedResource.get() == &resource) {
+            originalURL = url;
+            break;
+        }
+    }
+
+    if (!originalURL.isEmpty()) {
+        URL redirectURL = request.url();
+
+        if (m_notifyWhenFinishedURLs.contains(originalURL)) {
+            if (auto prefetchedResource = m_prefetchedResources.take(originalURL))
+                m_prefetchedResources.set(redirectURL, prefetchedResource);
+
+            if (auto metrics = m_prefetchedNetworkLoadMetrics.take(originalURL))
+                m_prefetchedNetworkLoadMetrics.set(redirectURL, WTFMove(metrics));
+        }
+
+        bool hadPendingNotification = m_notifyWhenFinishedURLs.remove(originalURL);
+        if (hadPendingNotification)
+            m_notifyWhenFinishedURLs.add(redirectURL);
+    }
+
+    completionHandler(WTFMove(request));
+}
+
+void DocumentPrefetcher::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess)
+{
+    m_finishedURLs.add(resource.url());
+    URL completedURL;
+    for (auto& [url, prefetchedResource] : m_prefetchedResources) {
+        if (prefetchedResource.get() == &resource && !m_prefetchedNetworkLoadMetrics.contains(url)) {
+            m_prefetchedNetworkLoadMetrics.set(url, Box<NetworkLoadMetrics>::create(metrics));
+            completedURL = url;
+            break;
+        }
+    }
+
+    if (resource.hasClient(*this))
+        resource.removeClient(*this);
+}
+
+void DocumentPrefetcher::clearPrefetchedAssets()
+{
+#if ASSERT_ENABLED
+    for (auto& [url, prefetchedResource] : m_prefetchedResources) {
+        if (prefetchedResource)
+            removeAssociatedResource(*prefetchedResource);
+    }
+#endif
+    m_prefetchedResources.clear();
+    m_prefetchedNetworkLoadMetrics.clear();
+    m_notifyWhenFinishedURLs.clear();
+    m_finishedURLs.clear();
+}
+
+void DocumentPrefetcher::clear()
+{
+    clearPrefetchedAssets();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedResourceClient.h"
+#include "CachedResourceHandle.h"
+
+#include <wtf/CompletionHandler.h>
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/URLHash.h>
+
+
+namespace WebCore {
+
+class CachedRawResource;
+class DocumentLoader;
+class FrameLoader;
+class ResourceRequest;
+class NetworkLoadMetrics;
+
+class DocumentPrefetcher : public RefCounted<DocumentPrefetcher>, public CachedRawResourceClient {
+public:
+    static Ref<DocumentPrefetcher> create(FrameLoader& frameLoader) { return adoptRef(*new DocumentPrefetcher(frameLoader)); }
+    explicit DocumentPrefetcher(FrameLoader&);
+    ~DocumentPrefetcher();
+
+    void prefetch(const URL&, const Vector<String>& tags, const String& referrerPolicyString, bool lowPriority = false);
+
+    // CachedRawResourceClient
+    void responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;
+    void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) override;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) override;
+    CachedResourceClientType resourceClientType() const override { return RawResourceType; }
+
+    bool isFinished(const URL& url) const { return m_finishedURLs.contains(url); }
+
+    void notifyWhenFinished(const URL& url) { m_notifyWhenFinishedURLs.add(url); }
+    bool isNotifyingWhenFinished(const URL& url) const { return m_notifyWhenFinishedURLs.contains(url); }
+
+private:
+    void clear();
+    void clearPrefetchedAssets();
+
+    WeakRef<FrameLoader> m_frameLoader;
+    HashMap<URL, CachedResourceHandle<CachedRawResource>> m_prefetchedResources;
+    HashMap<URL, Box<NetworkLoadMetrics>> m_prefetchedNetworkLoadMetrics;
+    HashSet<URL> m_notifyWhenFinishedURLs;
+    HashSet<URL> m_finishedURLs;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -95,9 +95,10 @@ static constexpr unsigned bitWidthOfDefersLoadingPolicy = 1;
 
 enum class CachingPolicy : uint8_t {
     AllowCaching,
-    DisallowCaching
+    DisallowCaching,
+    AllowCachingPrefetch
 };
-static constexpr unsigned bitWidthOfCachingPolicy = 1;
+static constexpr unsigned bitWidthOfCachingPolicy = 2;
 
 enum class ClientCredentialPolicy : bool {
     CannotAskClientForCredentials,

--- a/Source/WebCore/loader/SpeculationRules.cpp
+++ b/Source/WebCore/loader/SpeculationRules.cpp
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SpeculationRules.h"
+
+#include <wtf/HashSet.h>
+#include <wtf/JSONValues.h>
+#include <wtf/URL.h>
+#include <wtf/URLHash.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+Ref<SpeculationRules> SpeculationRules::create()
+{
+    return adoptRef(*new SpeculationRules);
+}
+
+const Vector<SpeculationRules::Rule>& SpeculationRules::prefetchRules() const
+{
+    return m_prefetchRules;
+}
+
+SpeculationRules::DocumentPredicate::DocumentPredicate(PredicateVariant&& value)
+    : m_value(WTFMove(value))
+{
+}
+
+const SpeculationRules::DocumentPredicate::PredicateVariant& SpeculationRules::DocumentPredicate::value() const
+{
+    return m_value;
+}
+
+static std::optional<Vector<String>> parseStringOrStringList(JSON::Object& object, const String& key)
+{
+    Vector<String> result;
+    auto value = object.getValue(key);
+    if (!value)
+        return Vector<String> { };
+
+    if (value->type() == JSON::Value::Type::String) {
+        String stringValue = value->asString();
+        if (!stringValue.isNull()) {
+            result.append(stringValue);
+            return result;
+        }
+    }
+
+    if (value->type() == JSON::Value::Type::Array) {
+        auto arrayValue = value->asArray();
+        if (arrayValue) {
+            for (auto& item : *arrayValue) {
+                if (item->type() == JSON::Value::Type::String) {
+                    String element = item->asString();
+                    if (element.isNull())
+                        return std::nullopt;
+                    result.append(element);
+                } else
+                    return std::nullopt;
+            }
+            return result;
+        }
+    }
+
+    return Vector<String> { };
+}
+
+static std::optional<SpeculationRules::DocumentPredicate> parseDocumentPredicate(JSON::Object&);
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#parsing-a-document-rule-predicate-from-a-map
+static std::optional<SpeculationRules::DocumentPredicate> parseDocumentPredicate(JSON::Object& object)
+{
+    auto andValue = object.getValue("and"_s);
+    if (andValue && andValue->type() == JSON::Value::Type::Array) {
+        auto array = andValue->asArray();
+        if (array) {
+            SpeculationRules::Conjunction conjunction;
+            for (auto& item : *array) {
+                auto clauseObject = item->asObject();
+                if (!clauseObject)
+                    return std::nullopt;
+                auto predicate = parseDocumentPredicate(*clauseObject);
+                if (!predicate)
+                    return std::nullopt;
+                conjunction.clauses.append(WTFMove(*predicate));
+            }
+            return { { Box<SpeculationRules::Conjunction>::create(WTFMove(conjunction)) } };
+        }
+    }
+
+    auto orValue = object.getValue("or"_s);
+    if (orValue && orValue->type() == JSON::Value::Type::Array) {
+        auto array = orValue->asArray();
+        if (array) {
+            SpeculationRules::Disjunction disjunction;
+            for (auto& item : *array) {
+                auto clauseObject = item->asObject();
+                if (!clauseObject)
+                    return std::nullopt;
+                auto predicate = parseDocumentPredicate(*clauseObject);
+                if (!predicate)
+                    return std::nullopt;
+                disjunction.clauses.append(WTFMove(*predicate));
+            }
+            return { { Box<SpeculationRules::Disjunction>::create(WTFMove(disjunction)) } };
+        }
+    }
+
+    auto notValue = object.getValue("not"_s);
+    if (notValue && notValue->type() == JSON::Value::Type::Object) {
+        auto clauseObject = notValue->asObject();
+        if (clauseObject) {
+            auto predicate = parseDocumentPredicate(*clauseObject);
+            if (!predicate)
+                return std::nullopt;
+            SpeculationRules::Negation negation { Box<SpeculationRules::DocumentPredicate>::create(WTFMove(*predicate)) };
+            return { { Box<SpeculationRules::Negation>::create(WTFMove(negation)) } };
+        }
+    }
+
+    SpeculationRules::URLPatternPredicate urlPredicate;
+    auto urlMatches = parseStringOrStringList(object, "url_matches"_s);
+    if (urlMatches)
+        urlPredicate.patterns.appendVector(*urlMatches);
+    auto hrefMatches = parseStringOrStringList(object, "href_matches"_s);
+    if (hrefMatches)
+        urlPredicate.patterns.appendVector(*hrefMatches);
+
+    SpeculationRules::CSSSelectorPredicate selectorPredicate;
+    auto selectorMatches = parseStringOrStringList(object, "selector_matches"_s);
+    if (selectorMatches)
+        selectorPredicate.selectors.appendVector(*selectorMatches);
+
+    bool hasURLPredicate = !urlPredicate.patterns.isEmpty();
+    bool hasSelectorPredicate = !selectorPredicate.selectors.isEmpty();
+
+    if (hasURLPredicate && hasSelectorPredicate) {
+        SpeculationRules::Conjunction conjunction;
+        conjunction.clauses.append(SpeculationRules::DocumentPredicate { WTFMove(urlPredicate) });
+        conjunction.clauses.append(SpeculationRules::DocumentPredicate { WTFMove(selectorPredicate) });
+        return { { Box<SpeculationRules::Conjunction>::create(WTFMove(conjunction)) } };
+    }
+
+    if (hasURLPredicate)
+        return { { WTFMove(urlPredicate) } };
+
+    if (hasSelectorPredicate)
+        return { { WTFMove(selectorPredicate) } };
+
+    return std::nullopt;
+}
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#parse-a-speculation-rule
+static std::optional<SpeculationRules::Rule> parseSingleRule(const JSON::Object& input, const String& rulesetLevelTag, const URL& rulesetBaseURL, const URL& documentBaseURL)
+{
+    const HashSet<String> allowedKeys = {
+        "source"_s, "urls"_s, "where"_s, "requires"_s, "target_hint"_s,
+        "referrer_policy"_s, "relative_to"_s, "eagerness"_s,
+        "expects_no_vary_search"_s, "tag"_s
+    };
+    for (const auto& key : input.keys()) {
+        if (!allowedKeys.contains(key))
+            return std::nullopt;
+    }
+
+    String source;
+    auto sourceValue = input.getValue("source"_s);
+    if (sourceValue && sourceValue->type() == JSON::Value::Type::String)
+        source = sourceValue->asString();
+
+    if (source.isEmpty()) {
+        bool hasURLs = !!input.getValue("urls"_s);
+        bool hasWhere = !!input.getValue("where"_s);
+        if (hasURLs && !hasWhere)
+            source = "list"_s;
+        else if (hasWhere && !hasURLs)
+            source = "document"_s;
+        else
+            return std::nullopt;
+    }
+
+    if (source != "list"_s && source != "document"_s)
+        return std::nullopt;
+
+    SpeculationRules::Rule rule;
+
+    if (source == "list"_s) {
+        if (input.getValue("where"_s))
+            return std::nullopt;
+
+        auto urlsValue = input.getValue("urls"_s);
+        if (!urlsValue || urlsValue->type() != JSON::Value::Type::Array)
+            return std::nullopt;
+        auto urlsArray = urlsValue->asArray();
+        if (!urlsArray)
+            return std::nullopt;
+
+        URL currentBaseURL = rulesetBaseURL;
+        auto relativeToValue = input.getValue("relative_to"_s);
+        if (relativeToValue && relativeToValue->type() == JSON::Value::Type::String) {
+            String relativeTo = relativeToValue->asString();
+            if (relativeTo != "ruleset"_s && relativeTo != "document"_s)
+                return std::nullopt;
+            if (relativeTo == "document"_s)
+                currentBaseURL = documentBaseURL;
+        }
+
+        for (const auto& urlValue : *urlsArray) {
+            if (urlValue->type() != JSON::Value::Type::String)
+                return std::nullopt;
+            String urlString = urlValue->asString();
+            URL parsedURL(currentBaseURL, urlString);
+            if (parsedURL.isValid() && (parsedURL.protocolIs("http"_s) || parsedURL.protocolIs("https"_s)))
+                rule.urls.append(parsedURL);
+        }
+        rule.eagerness = SpeculationRules::Eagerness::Immediate;
+
+    } else { // source == "document"_s
+        if (input.getValue("urls"_s) || input.getValue("relative_to"_s))
+            return std::nullopt;
+
+        auto whereValue = input.getValue("where"_s);
+        if (whereValue && whereValue->type() == JSON::Value::Type::Object) {
+            auto whereObject = whereValue->asObject();
+            if (whereObject) {
+                auto predicate = parseDocumentPredicate(*whereObject);
+                if (!predicate)
+                    return std::nullopt;
+                rule.predicate = WTFMove(*predicate);
+            }
+        } else {
+            // No "where" means match all links, which is an empty conjunction.
+            rule.predicate = { { Box<SpeculationRules::Conjunction>::create() } };
+        }
+        rule.eagerness = SpeculationRules::Eagerness::Conservative;
+    }
+
+    auto requiresValue = input.getValue("requires"_s);
+    if (requiresValue && requiresValue->type() == JSON::Value::Type::Array) {
+        auto requiresArray = requiresValue->asArray();
+        if (requiresArray) {
+            for (const auto& reqValue : *requiresArray) {
+                if (reqValue->type() != JSON::Value::Type::String)
+                    return std::nullopt;
+                String requirement = reqValue->asString();
+                if (requirement != "anonymous-client-ip-when-cross-origin"_s)
+                    return std::nullopt;
+                rule.requirements.append(requirement);
+            }
+        }
+    }
+
+    auto referrerPolicyValue = input.getValue("referrer_policy"_s);
+    if (referrerPolicyValue && referrerPolicyValue->type() == JSON::Value::Type::String)
+        rule.referrerPolicy = referrerPolicyValue->asString();
+
+    auto eagernessValue = input.getValue("eagerness"_s);
+    if (eagernessValue && eagernessValue->type() == JSON::Value::Type::String) {
+        String eagernessString = eagernessValue->asString();
+        if (eagernessString == "immediate"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Immediate;
+        else if (eagernessString == "eager"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Eager;
+        else if (eagernessString == "moderate"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Moderate;
+        else if (eagernessString == "conservative"_s)
+            rule.eagerness = SpeculationRules::Eagerness::Conservative;
+        else
+            return std::nullopt;
+    }
+
+    auto noVarySearchValue = input.getValue("expects_no_vary_search"_s);
+    if (noVarySearchValue && noVarySearchValue->type() == JSON::Value::Type::String)
+        rule.noVarySearchHint = noVarySearchValue->asString();
+
+    if (!rulesetLevelTag.isNull())
+        rule.tags.append(rulesetLevelTag);
+
+    auto tagValue = input.getValue("tag"_s);
+    if (tagValue && tagValue->type() == JSON::Value::Type::String) {
+        String ruleTag = tagValue->asString();
+        if (!ruleTag.containsOnlyASCII())
+            return std::nullopt;
+        rule.tags.append(ruleTag);
+    }
+
+    if (rule.tags.isEmpty())
+        rule.tags.append(String()); // Append null string
+
+    return rule;
+}
+
+static std::optional<Vector<SpeculationRules::Rule>> parseRules(const JSON::Object& object, const String& key, const String& rulesetLevelTag, const URL& rulesetBaseURL, const URL& documentBaseURL)
+{
+    auto value = object.getValue(key);
+    if (!value || value->type() != JSON::Value::Type::Array)
+        return Vector<SpeculationRules::Rule> { };
+    auto array = value->asArray();
+    if (!array)
+        return Vector<SpeculationRules::Rule> { };
+
+    Vector<SpeculationRules::Rule> rules;
+    for (auto& item : *array) {
+        auto ruleObject = item->asObject();
+        if (!ruleObject)
+            return std::nullopt;
+        if (auto rule = parseSingleRule(*ruleObject, rulesetLevelTag, rulesetBaseURL, documentBaseURL))
+            rules.append(WTFMove(*rule));
+        else
+            return std::nullopt; // Invalid rule in the list.
+    }
+    return rules;
+}
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html#parse-speculation-rules
+void SpeculationRules::parseSpeculationRules(const StringView& text, const URL& rulesetBaseURL, const URL& documentBaseURL)
+{
+    auto jsonValue = JSON::Value::parseJSON(text);
+    if (!jsonValue)
+        return;
+
+    auto jsonObject = jsonValue->asObject();
+    if (!jsonObject)
+        return;
+
+    String rulesetLevelTag;
+    auto tagValue = jsonObject->getValue("tag"_s);
+    if (tagValue && tagValue->type() == JSON::Value::Type::String)
+        rulesetLevelTag = tagValue->asString();
+
+    auto prefetch = parseRules(*jsonObject, "prefetch"_s, rulesetLevelTag, rulesetBaseURL, documentBaseURL);
+    if (!prefetch)
+        return;
+    m_prefetchRules.appendVector(WTFMove(*prefetch));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/loader/SpeculationRules.h
+++ b/Source/WebCore/loader/SpeculationRules.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Box.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/URL.h>
+#include <wtf/Variant.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+// https://wicg.github.io/nav-speculation/speculation-rules.html
+class SpeculationRules : public RefCounted<SpeculationRules> {
+public:
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#valid-eagerness-strings
+    enum class Eagerness : uint8_t {
+        Immediate,
+        Eager,
+        Moderate,
+        Conservative,
+    };
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#document-rule-predicate
+    struct DocumentPredicate;
+
+    struct URLPatternPredicate {
+        Vector<String> patterns;
+    };
+
+    struct CSSSelectorPredicate {
+        Vector<String> selectors;
+    };
+
+    struct Conjunction {
+        Vector<DocumentPredicate> clauses;
+    };
+
+    struct Disjunction {
+        Vector<DocumentPredicate> clauses;
+    };
+
+    struct Negation {
+        Box<DocumentPredicate> clause;
+    };
+
+    struct DocumentPredicate {
+        WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DocumentPredicate);
+    public:
+        using PredicateVariant = WTF::Variant<URLPatternPredicate, CSSSelectorPredicate, Box<Conjunction>, Box<Disjunction>, Box<Negation>>;
+
+        DocumentPredicate(PredicateVariant&& value);
+        DocumentPredicate(DocumentPredicate&&) = default;
+        DocumentPredicate& operator=(DocumentPredicate&&) = default;
+
+        const PredicateVariant& value() const;
+
+    private:
+        PredicateVariant m_value;
+    };
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule
+    struct Rule {
+        Vector<URL> urls;
+        std::optional<DocumentPredicate> predicate;
+        Eagerness eagerness;
+        String referrerPolicy;
+        Vector<String> tags;
+        Vector<String> requirements;
+        String noVarySearchHint;
+    };
+
+    static Ref<SpeculationRules> create();
+
+    // https://wicg.github.io/nav-speculation/speculation-rules.html#parse-speculation-rules
+    WEBCORE_EXPORT void parseSpeculationRules(const StringView&, const URL& rulesetBaseURL, const URL& documentBaseURL);
+
+    const Vector<Rule>& prefetchRules() const;
+
+private:
+    SpeculationRules() = default;
+
+    Vector<Rule> m_prefetchRules;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -293,6 +293,7 @@ static bool shouldIgnoreHeaderForCacheReuse(HTTPHeaderName name)
     case HTTPHeaderName::Pragma:
     case HTTPHeaderName::Referer:
     case HTTPHeaderName::SecPurpose:
+    case HTTPHeaderName::SecSpeculationTags:
     case HTTPHeaderName::UserAgent:
         return true;
 

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -271,7 +271,7 @@ public:
     bool shouldSendResourceLoadCallbacks() const { return m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks; }
     DataBufferingPolicy dataBufferingPolicy() const { return m_options.dataBufferingPolicy; }
 
-    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching; }
+    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching || m_options.cachingPolicy == CachingPolicy::AllowCachingPrefetch; }
     const ResourceLoaderOptions& options() const { return m_options; }
 
     virtual void destroyDecodedData() { }

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -71,7 +71,7 @@ public:
     void setInitiatorType(const AtomString&);
     const AtomString& initiatorType() const;
 
-    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching; }
+    bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching || m_options.cachingPolicy == CachingPolicy::AllowCachingPrefetch; }
     void setCachingPolicy(CachingPolicy policy) { m_options.cachingPolicy = policy;  }
 
     // Whether this request should impact request counting and delay window.onload.

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -45,9 +45,9 @@ namespace WebCore {
 
 static double networkLoadTimeToDOMHighResTimeStamp(MonotonicTime timeOrigin, MonotonicTime timeStamp)
 {
-    if (!timeStamp)
-        return 0.0;
     ASSERT(timeOrigin);
+    if (!timeStamp || timeStamp < timeOrigin)
+        return 0.0;
     return Performance::reduceTimeResolution(timeStamp - timeOrigin).milliseconds();
 }
 

--- a/Source/WebCore/platform/ReferrerPolicy.cpp
+++ b/Source/WebCore/platform/ReferrerPolicy.cpp
@@ -83,6 +83,7 @@ std::optional<ReferrerPolicy> parseReferrerPolicy(StringView policyString, Refer
     case ReferrerPolicySource::MetaTag:
         return parseReferrerPolicyToken(policyString, ShouldParseLegacyKeywords::Yes);
     case ReferrerPolicySource::ReferrerPolicyAttribute:
+    case ReferrerPolicySource::SpeculationRules:
         return parseReferrerPolicyToken(policyString, ShouldParseLegacyKeywords::No);
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/ReferrerPolicy.h
+++ b/Source/WebCore/platform/ReferrerPolicy.h
@@ -50,7 +50,7 @@ enum class ReferrerPolicy : uint8_t {
     Default = StrictOriginWhenCrossOrigin
 };
 
-enum class ReferrerPolicySource : uint8_t { MetaTag, HTTPHeader, ReferrerPolicyAttribute };
+enum class ReferrerPolicySource : uint8_t { MetaTag, HTTPHeader, ReferrerPolicyAttribute, SpeculationRules };
 std::optional<ReferrerPolicy> parseReferrerPolicy(StringView, ReferrerPolicySource);
 String referrerPolicyToString(const ReferrerPolicy&);
 

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -29,6 +29,7 @@
 #include "CookieJar.h"
 #include "HTTPHeaderMap.h"
 #include "NetworkStorageSession.h"
+#include "ResourceLoaderOptions.h"
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include "SameSiteInfo.h"
@@ -147,11 +148,11 @@ Seconds computeFreshnessLifetimeForHTTPFamily(const ResourceResponse& response, 
     }
 }
 
-void updateRedirectChainStatus(RedirectChainCacheStatus& redirectChainCacheStatus, const ResourceResponse& response)
+void updateRedirectChainStatus(RedirectChainCacheStatus& redirectChainCacheStatus, const ResourceResponse& response, const ResourceLoaderOptions& options)
 {
     if (redirectChainCacheStatus.status == RedirectChainCacheStatus::Status::NotCachedRedirection)
         return;
-    if (response.cacheControlContainsNoStore() || response.cacheControlContainsNoCache() || response.cacheControlContainsMustRevalidate()) {
+    if (options.cachingPolicy != CachingPolicy::AllowCachingPrefetch && (response.cacheControlContainsNoStore() || response.cacheControlContainsNoCache() || response.cacheControlContainsMustRevalidate())) {
         redirectChainCacheStatus.status = RedirectChainCacheStatus::Status::NotCachedRedirection;
         return;
     }

--- a/Source/WebCore/platform/network/CacheValidation.h
+++ b/Source/WebCore/platform/network/CacheValidation.h
@@ -36,6 +36,7 @@ class HTTPHeaderMap;
 class NetworkStorageSession;
 class ResourceRequest;
 class ResourceResponse;
+struct ResourceLoaderOptions;
 
 struct RedirectChainCacheStatus {
     enum class Status : uint8_t {
@@ -54,7 +55,7 @@ struct RedirectChainCacheStatus {
 WEBCORE_EXPORT Seconds computeCurrentAge(const ResourceResponse&, WallTime responseTimestamp);
 WEBCORE_EXPORT Seconds computeFreshnessLifetimeForHTTPFamily(const ResourceResponse&, WallTime responseTimestamp);
 WEBCORE_EXPORT void updateResponseHeadersAfterRevalidation(ResourceResponse&, const ResourceResponse& validatingResponse);
-WEBCORE_EXPORT void updateRedirectChainStatus(RedirectChainCacheStatus&, const ResourceResponse&);
+WEBCORE_EXPORT void updateRedirectChainStatus(RedirectChainCacheStatus&, const ResourceResponse&, const ResourceLoaderOptions&);
 
 enum ReuseExpiredRedirectionOrNot { DoNotReuseExpiredRedirection, ReuseExpiredRedirection };
 WEBCORE_EXPORT bool redirectChainAllowsReuse(RedirectChainCacheStatus, ReuseExpiredRedirectionOrNot);

--- a/Source/WebCore/platform/network/HTTPHeaderNames.in
+++ b/Source/WebCore/platform/network/HTTPHeaderNames.in
@@ -91,6 +91,7 @@ Sec-Fetch-Dest
 Sec-Fetch-Mode
 Sec-Fetch-Site
 Sec-Purpose
+Sec-Speculation-Tags
 Sec-WebSocket-Accept
 Sec-WebSocket-Extensions
 Sec-WebSocket-Key

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -565,7 +565,15 @@ void WebFrameLoaderClient::dispatchDidDispatchOnloadEvents()
 
 void WebFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
 {
-    m_webFrame->_private->provisionalURL = core(m_webFrame.get())->loader().provisionalDocumentLoader()->url().string().createNSString();
+    auto* frame = core(m_webFrame.get());
+    if (!frame)
+        return;
+
+    auto* provisionalDocumentLoader = frame->loader().provisionalDocumentLoader();
+    if (!provisionalDocumentLoader)
+        return;
+
+    m_webFrame->_private->provisionalURL = provisionalDocumentLoader->url().string().createNSString().autorelease();
 
     WebView *webView = getWebView(m_webFrame.get());
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);


### PR DESCRIPTION
#### 5c7cd1cbc4ccca4d2171e4d99106bee2925c4e56
<pre>
Implement speculation rules - same origin conservative prefetch (no DocumentLoader)

Reviewed by NOBODY (OOPS!).

This implements an initial version of same-origin prefetch speculation rules.

The feature enables prefetching an HTML document ahead of time (&quot;immediate&quot; eagerness),
or when the user started clicking an anchor element pointing at it (&quot;conservative&quot; eagerness).
That prefetched document is then used when the user actually navigates to this URL,
resulting in significant performance improvements.
Subresources of the prefetched document are not yet loaded before navigation, nor does it begin its processing.

HTML spec PR for speculation rules: <a href="https://github.com/whatwg/html/pull/11426">https://github.com/whatwg/html/pull/11426</a>
Spec for the prefetch parts: <a href="https://wicg.github.io/nav-speculation/prefetch.html">https://wicg.github.io/nav-speculation/prefetch.html</a>

* LayoutTests/TestExpectations: Add a few failing expectations.
* LayoutTests/imported/w3c/web-platform-tests/clear-site-data/support/clear-site-data-cache.py: Added.
(generate_png):
(generate_png.chunk):
(main):
* LayoutTests/imported/w3c/web-platform-tests/clear-site-data/support/clear-site-data-prefetchCache.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/external-speculation-rules-errors-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/invalid-rules.https_prefetch-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/invalid-rules.https_prerender-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/anonymous-client.https-expected.txt: Failure instead of timeout.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changed-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect2-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=changedWithRedirect3-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchanged-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cookie-indices.https_include=unchangedWithRedirect-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies-anonymous-client-ip-duplicate.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/cross-origin-cookies.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators-2.https-expected.txt: Timeout.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-1-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_cross-site-2-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https_same-site-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=and-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedByBaseElement-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=baseURLChangedBySameDocumentNavigation-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=defaultPredicate-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=hrefMatches-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=immediateMutation-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=invalidPredicate-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkHrefChanged-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkInShadowTree-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=linkToSelfFragment-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=newRuleSetAdded-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=not-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=or-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatches-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayLocked-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesDisplayNone-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=selectorMatchesScopingRoot-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules.https_include=unslottedLink-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/duplicate-urls.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/fragment.https-expected.txt: Progrssion.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/implicit-source.https-expected.txt: Progrssion.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_cross-site-expected.txt: Progrsssion (partial failure).
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https_same-site-expected.txt: Progrsssion (partial failure).
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_cross-site-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https_same-site-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_cross-site-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https_same-site-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/multiple-url.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&amp;bypass_cache=false-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=false&amp;bypass_cache=true-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&amp;bypass_cache=false-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-delivery-type.https_prefetch=true&amp;bypass_cache=true-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=afterResponse-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=noPrefetch-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForRedirect-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-requestStart-responseStart.https_include=waitingForResponse-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_bypass_cache=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_default-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&amp;bypass_cache=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-http-cache-interference.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/no-prefetch-for-post.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=EmptyRuleSet-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailCORS-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseRuleSet-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FailToParseSpeculationRulesHeader-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InnerListInSpeculationRulesHeader-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidMimeType-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=InvalidUrlForSpeculationRulesSet-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForCandidate-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode199-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=StatusCode404-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=UseNonUTF8EncodingForSpeculationRulesSet-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&amp;to_protocol=http-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=http&amp;to_protocol=https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&amp;to_protocol=http-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-single.https_from_protocol=https&amp;to_protocol=https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=200&amp;should_prefetch=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=250&amp;should_prefetch=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=299&amp;should_prefetch=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=400&amp;should_prefetch=false-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-status.https_status=500&amp;should_prefetch=false-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-traverse-reload.sub-expected.txt: Progression (partial failure).
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_cross-site-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https_same-site-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-initial-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=cross-site-redirect-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https_origin=same-origin-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-initial-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=cross-site-redirect-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https_origin=same-origin-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-initial-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=same-origin-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_1-1-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_2-2-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_3-3-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_4-4-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_5-5-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_6-6-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_7-7-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-from-rules.https_8-last-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_1-1-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_2-2-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy-not-accepted.https_3-last-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_1-1-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_2-2-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_3-3-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/referrer-policy.https_4-last-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_1-1-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/same-origin-cookies.https_2-last-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/sec-fetch-headers.https-expected.txt: Progression (partial failure).
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=false-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/user-pass.https_cross-origin=true-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/script-supports.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-prefetch.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-to-same-site-redirection-prefetch.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prerender-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&amp;type=prefetch-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&amp;type=prerender-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&amp;type=prefetch-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&amp;type=prerender-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/no-tags.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prerender-target-hint.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&amp;type=prefetch-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&amp;type=prerender-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&amp;type=prefetch-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&amp;type=prerender-expected.txt: Failure.
* LayoutTests/imported/w3c/web-platform-tests/websockets/constants.sub.js: Updated.
* LayoutTests/platform/mac-wk1/TestExpectations: Skip service-worker reliant tests.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Add a preference to enable the feature.
* Source/WebCore/Headers.cmake: Add new headers.
* Source/WebCore/Sources.txt: Add new source files.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Add new files.
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::registerSpeculationRules): Parse and set new speculation rules.
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
(WebCore::Document::resolveStyle): Call considerSpeculationRules.
(WebCore::Document::updateBaseURL): Call considerSpeculationRules.
(WebCore::Document::considerSpeculationRules): Check if speculation rules indicate we need to prefetch new documents.
(WebCore::Document::speculationRules const):
(WebCore::Document::speculationRules):
(WebCore::Document::prefetch): Kick off a document prefetch.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::determineScriptType): Add &quot;speculationrules&quot; as a script type.
(WebCore::ScriptElement::prepareScript): Call registerSpeculationRules.
(WebCore::ScriptElement::registerSpeculationRules): Register speculation rules for the document.
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
(WebCore::ScriptElementCachedScriptFetcher::isSpeculationRules const):
* Source/WebCore/dom/ScriptType.h:
* Source/WebCore/dom/SpeculationRulesMatcher.cpp: Implements speculation rules matching.
(WebCore::matches): Checks if a rule matches.
(WebCore::SpeculationRulesMatcher::hasMatchingRule): Entry point that that checks if an anchor element should be prefetched.
* Source/WebCore/dom/SpeculationRulesMatcher.h:
* Source/WebCore/dom/TrustedHTML.h: Unified build fix.
* Source/WebCore/dom/TrustedTypePolicy.cpp: Unified build fix.
* Source/WebCore/html/HTMLAnchorElement.cpp: Check if an anchor should be prefetched.
(WebCore::HTMLAnchorElement::defaultEventHandler): Implements the &quot;conservative&quot; eagerness heuristic and prefetches matching anchors on keydown/pointerdown.
(WebCore::HTMLAnchorElement::attributeChanged): Check speculation rules on attribute change.
(WebCore::HTMLAnchorElement::insertedIntoAncestor): Check speculation rules on insertion.
(WebCore::HTMLAnchorElement::setFullURL): Check speculation rules when the URL changes.
(WebCore::HTMLAnchorElement::setShouldBePrefetched): Indicates that an anchor should be prefetched.
(WebCore::HTMLAnchorElement::checkForSpeculationRules): Checks speculations rules and called setShouldBePrefetched.
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLScriptElement.h: Add &quot;speculationrules&quot; script type.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::commitData): Grab network metrics from the prefetched resource.
(WebCore::DocumentLoader::loadMainResource):
(WebCore::DocumentLoader::becomeMainResourceClient): Handle the &quot;prefetched and loaded&quot; case.
* Source/WebCore/loader/DocumentPrefetcher.cpp: Handle document prefetching.
(WebCore::DocumentPrefetcher::DocumentPrefetcher):
(WebCore::DocumentPrefetcher::~DocumentPrefetcher):
(WebCore::isPassingSecurityChecks): Run security checks.
(WebCore::makePrefetchRequest): Request the prefetched document.
(WebCore::DocumentPrefetcher::prefetch): Prefetch the document if it passes all checks.
(WebCore::DocumentPrefetcher::responseReceived): Implement responseReceived to run the completion handler.
(WebCore::DocumentPrefetcher::redirectReceived): Handle redirect responses.
(WebCore::DocumentPrefetcher::notifyFinished): Handle the resource finish notification.
(WebCore::DocumentPrefetcher::clearPrefetchedAssets): Clear all the prefetched assets from this prefetcher.
(WebCore::DocumentPrefetcher::clear): Clear the prefetcher.
* Source/WebCore/loader/DocumentPrefetcher.h:
(WebCore::DocumentPrefetcher::create):
(WebCore::DocumentPrefetcher::isFinished const):
(WebCore::DocumentPrefetcher::notifyWhenFinished):
(WebCore::DocumentPrefetcher::isNotifyingWhenFinished const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameLoader): Initialize m_documentPrefetcher.
(WebCore::FrameLoader::loadWithNavigationAction): Return the prefetch documentLoader if one exists.
(WebCore::FrameLoader::loadWithDocumentLoader): Remove const from ResourceRequest.
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy): Match navigation with a prefetched resource.
(WebCore::FrameLoader::prefetch): Prefetch a document.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/loader/SpeculationRules.cpp: Added.
(WebCore::SpeculationRules::create):
(WebCore::SpeculationRules::prefetchRules const):
(WebCore::SpeculationRules::DocumentPredicate::DocumentPredicate):
(WebCore::SpeculationRules::DocumentPredicate::value const):
(WebCore::parseStringOrStringList):
(WebCore::parseDocumentPredicate):
(WebCore::parseSingleRule):
(WebCore::parseRules):
(WebCore::SpeculationRules::parseSpeculationRules):
* Source/WebCore/loader/SpeculationRules.h: Added.
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::shouldIgnoreHeaderForCacheReuse):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource):
(WebCore::CachedResource::redirectReceived):
(WebCore::CachedResource::addClientToSet):
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::allowsCaching const):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::allowedByContentSecurityPolicy const): Add MainResource as an option.
(WebCore::CachedResourceLoader::shouldUpdateCachedResourceWithCurrentRequest):
(WebCore::isResourceSuitableForDirectReuse):
(WebCore::CachedResourceLoader::updateCachedResourceWithCurrentRequest):
(WebCore::CachedResourceLoader::determineRevalidationPolicy const):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
(WebCore::CachedResourceRequest::allowsCaching const):
* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::networkLoadTimeToDOMHighResTimeStamp): Avoid negative timestamps.
* Source/WebCore/platform/ReferrerPolicy.cpp:
(WebCore::parseReferrerPolicy): Add SpeculationRules as a source for referrer policy.
* Source/WebCore/platform/ReferrerPolicy.h:
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::updateRedirectChainStatus):
* Source/WebCore/platform/network/CacheValidation.h:
* Source/WebCore/platform/network/HTTPHeaderNames.in: Add Sec-Speculation-Tags.
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7cd1cbc4ccca4d2171e4d99106bee2925c4e56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118420 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38101 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28750 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46683 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89873 "Found 12 new test failures: http/tests/referrer-policy/same-origin/same-origin.html imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html?cross-site-1 imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html?cross-site imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https.html?cross-site imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html?cross-site imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html?include=CSPExemption imported/w3c/web-platform-tests/speculation-rules/prefetch/prefetch-uses-cache.sub.https.html?cross-site imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-middle-of-prefetch.https.html?origin=cross-site-initial imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-url.https.html?origin=cross-site-initial imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-initial ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59471 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 13 flakes 40 failures; Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121373 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30908 "Found 22 new test failures: http/tests/referrer-policy-iframe/origin/cross-origin-http-http.html http/tests/referrer-policy-iframe/origin/same-origin.html http/tests/referrer-policy-iframe/same-origin/same-origin.html http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http-http.html http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/same-origin.html http/tests/referrer-policy-iframe/strict-origin/same-origin.html http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-http.html http/tests/referrer-policy-iframe/unsafe-url/same-origin.html http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-http.html http/tests/referrer-policy/no-referrer-when-downgrade/same-origin.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29965 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24289 "Found 60 new test failures: animations/needs-layout.html fast/canvas/canvas-ellipse-connecting-line.html fast/css/aspect-ratio-min-height-replaced.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/navigation/ping-attribute/anchor-same-origin.html http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-http.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68248 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110538 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100342 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24894 "Found 9 new test failures: http/tests/referrer-policy-iframe/origin-when-cross-origin/same-origin.html http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-http.html http/tests/referrer-policy/no-referrer-when-downgrade/same-origin.html http/tests/referrer-policy/no-referrer/same-origin.html http/tests/referrer-policy/origin-when-cross-origin/same-origin.html http/tests/referrer-policy/same-origin/same-origin.html http/tests/referrer-policy/strict-origin-when-cross-origin/same-origin.html http/tests/security/frameNavigation/context-for-location-href.html http/tests/security/frameNavigation/context-for-location.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127658 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116934 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45327 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34190 "Found 6 new test failures: http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/same-origin.html http/tests/referrer-policy/origin-when-cross-origin/same-origin.html http/tests/referrer-policy/unsafe-url/cross-origin-http-http.html http/tests/referrer-policy/unsafe-url/same-origin.html http/tests/security/frameNavigation/context-for-location-href.html http/tests/security/frameNavigation/context-for-location.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98544 "Found 17 new test failures: http/tests/referrer-policy/no-referrer-when-downgrade/same-origin.html http/tests/referrer-policy/no-referrer/same-origin.html http/tests/referrer-policy/strict-origin-when-cross-origin/same-origin.html http/tests/referrer-policy/unsafe-url/cross-origin-http-http.html http/tests/referrer-policy/unsafe-url/same-origin.html imported/w3c/web-platform-tests/speculation-rules/prefetch/different-initiators.sub.https.html?cross-site-1 imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html?cross-site imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-iframe-location-href.sub.https.html?cross-site imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html?cross-site imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html?include=CSPExemption ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98329 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43742 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21729 "Found 9 new test failures: http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-http.html http/tests/referrer-policy-iframe/unsafe-url/same-origin.html http/tests/referrer-policy/no-referrer/same-origin.html http/tests/referrer-policy/origin-when-cross-origin/same-origin.html http/tests/referrer-policy/strict-origin-when-cross-origin/same-origin.html http/tests/referrer-policy/unsafe-url/cross-origin-http-http.html http/tests/referrer-policy/unsafe-url/same-origin.html http/tests/security/frameNavigation/context-for-location-href.html http/tests/security/frameNavigation/context-for-location.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41824 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45197 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50875 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145630 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44660 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37453 "Found 1 new JSC binary failure: testapi, Found 19698 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/EH/101832.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->