### PR TITLE
[ews] Update MailNotifier as per new buildbot versions

### DIFF
--- a/Tools/CISupport/ews-build-webserver/master.cfg
+++ b/Tools/CISupport/ews-build-webserver/master.cfg
@@ -111,12 +111,13 @@ loadConfig.loadBuilderConfig(
 
 c['workers'] = c['builders'] = []
 
+generator = reporters.BuildStatusGenerator(mode=('exception'))
+
 mail_notifier = reporters.MailNotifier(
-    fromaddr='ews-build@webkit{}.org'.format(custom_suffix),
+    fromaddr=f'ews-build@webkit{custom_suffix}.org',
     sendToInterestedUsers=False,
     extraRecipients=['webkit-ews-bot-watchers@group.apple.com'],
-    mode=('exception'),
-    addPatch=False)
+    generators=[generator])
 
 if not is_test_mode_enabled:
     hostname =  socket.gethostname().strip()


### PR DESCRIPTION
#### aba7dfac2796d413956ba39e047d7b52a8de4b01
<pre>
[ews] Update MailNotifier as per new buildbot versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=297902">https://bugs.webkit.org/show_bug.cgi?id=297902</a>
<a href="https://rdar.apple.com/159192294">rdar://159192294</a>

Reviewed by Brianna Fan.

Buildbot version 3 removed support for few MailNotifier parameters, especially mode.

* Tools/CISupport/ews-build-webserver/master.cfg:

Canonical link: <a href="https://commits.webkit.org/299164@main">https://commits.webkit.org/299164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4b9ed858568c2569016db033907c89fbf715a9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37749 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/28385 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70108 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c10b92ea-fbb0-48c7-ab1a-5913a885dbc6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119949 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/38442 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/46331 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89600 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59206 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57c49973-d23a-40d9-b61a-2297ef52b5e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121023 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/38442 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/28385 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70093 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fc1225c-b9b7-4b97-b6d1-a9caa3a4d655) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/38442 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/28385 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67889 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/38442 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/28385 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127302 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44974 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/46331 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98276 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/117491 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45335 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/28385 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98063 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43462 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/28385 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41419 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18817 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44846 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44306 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47651 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->