### PR TITLE
[GCC] Unreviewed, fix build for Debian Stable after 299142@main

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -630,12 +630,12 @@ template<typename... Ts> struct HoldsAlternative<Variant<Ts...>> {
     }
 };
 
-template<typename T, typename V> bool holdsAlternative(const V& v)
+template<typename T, typename V> constexpr bool holdsAlternative(const V& v)
 {
     return HoldsAlternative<V>::template holdsAlternative<T>(v);
 }
 
-template<size_t I, typename V> bool holdsAlternative(const V& v)
+template<size_t I, typename V> constexpr bool holdsAlternative(const V& v)
 {
     return HoldsAlternative<V>::template holdsAlternative<I>(v);
 }

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
@@ -68,7 +68,7 @@ struct TextDecorationLine {
     {
     }
 
-    bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(m_value); }
+    constexpr bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(m_value); }
     bool isSpellingError() const { return WTF::holdsAlternative<CSS::Keyword::SpellingError>(m_value); }
     bool isGrammarError() const { return WTF::holdsAlternative<CSS::Keyword::GrammarError>(m_value); }
     bool isFlags() const { return WTF::holdsAlternative<OptionSet<TextDecorationLineFlags>>(m_value); }


### PR DESCRIPTION
#### 45e657c98e413892b69aa9008947bf3b17846631
<pre>
[GCC] Unreviewed, fix build for Debian Stable after 299142@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=297756">https://bugs.webkit.org/show_bug.cgi?id=297756</a>

error: call to non-‘constexpr’ function ‘bool WebCore::Style::TextDecorationLine::isNone() const

Mark function &apos;isNone&apos; as well as &apos;holdsAlternative&apos; as constexpr.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::holdsAlternative):
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h:
(WebCore::Style::TextDecorationLine::isNone const):

Canonical link: <a href="https://commits.webkit.org/299190@main">https://commits.webkit.org/299190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf010644079f91c45f719ed9246aef8c3fc34d09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89697 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59335 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24102 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68029 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110315 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127436 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116714 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98381 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/117626 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98168 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21550 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18830 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50653 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145414 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44439 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37410 "Found 1 new JSC binary failure: testapi, Found 19694 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->