### PR TITLE
Introduce LoadMetadata for recording information relating to page loads.

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -134,6 +134,9 @@
 		53CAC0632C6FBD8200B1A77C /* ScopedPrintStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CAC0622C6FBD8200B1A77C /* ScopedPrintStream.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53F202252CAB267000A33D14 /* TaggedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F202242CAB267000A33D14 /* TaggedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53FC70D023FB950C005B1990 /* OSLogPrintStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */; };
+		56F5CB002E54CCCD0020E813 /* CrashAnnotations.h in Headers */ = {isa = PBXBuildFile; fileRef = 56F5CAFF2E54CCCD0020E813 /* CrashAnnotations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		56F5CB022E54CE9D0020E813 /* CrashAnnotations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56F5CB012E54CE9D0020E813 /* CrashAnnotations.cpp */; };
+		56F5CB062E54D3CC0020E813 /* ReportCrashSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 56F5CB052E54D3CC0020E813 /* ReportCrashSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C12460E2DC25A130077D423 /* SwiftCXXThunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C12460D2DC25A130077D423 /* SwiftCXXThunk.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C1F05932164356B0039302C /* CFURLExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F05912164356B0039302C /* CFURLExtras.cpp */; };
 		5C1F0595216437B30039302C /* URLCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F0594216437B30039302C /* URLCF.cpp */; };
@@ -1356,6 +1359,9 @@
 		53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSLogPrintStream.mm; sourceTree = "<group>"; };
 		553071C91C40427200384898 /* TinyLRUCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TinyLRUCache.h; sourceTree = "<group>"; };
 		5597F82C1D94B9970066BC21 /* SynchronizedFixedQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SynchronizedFixedQueue.h; sourceTree = "<group>"; };
+		56F5CAFF2E54CCCD0020E813 /* CrashAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashAnnotations.h; sourceTree = "<group>"; };
+		56F5CB012E54CE9D0020E813 /* CrashAnnotations.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CrashAnnotations.cpp; sourceTree = "<group>"; };
+		56F5CB052E54D3CC0020E813 /* ReportCrashSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReportCrashSPI.h; sourceTree = "<group>"; };
 		5B43383A5D0B463C9433D933 /* IndexMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexMap.h; sourceTree = "<group>"; };
 		5C12460D2DC25A130077D423 /* SwiftCXXThunk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftCXXThunk.h; sourceTree = "<group>"; };
 		5C1F05912164356B0039302C /* CFURLExtras.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CFURLExtras.cpp; sourceTree = "<group>"; };
@@ -3200,6 +3206,7 @@
 				DDF306CD27C08654006A526F /* NSObjCRuntimeSPI.h */,
 				DDF306CC27C08654006A526F /* objcSPI.h */,
 				DDF306C927C08654006A526F /* OSLogSPI.h */,
+				56F5CB052E54D3CC0020E813 /* ReportCrashSPI.h */,
 				DDF306C827C08654006A526F /* SecuritySPI.h */,
 				E32B4F3C2E0C698F00BDA4FD /* XTSPI.h */,
 			);
@@ -3292,6 +3299,8 @@
 			isa = PBXGroup;
 			children = (
 				1469419B16EAB10A0024E146 /* AutodrainedPool.cpp */,
+				56F5CB012E54CE9D0020E813 /* CrashAnnotations.cpp */,
+				56F5CAFF2E54CCCD0020E813 /* CrashAnnotations.h */,
 				CEA072A9236FFBF70018839C /* CrashReporter.cpp */,
 				CEA072A8236FFBF70018839C /* CrashReporter.h */,
 				143DDE9720C8BE99007F76FA /* Entitlements.h */,
@@ -3452,6 +3461,7 @@
 				FAC31B9D2D80083D006CCA20 /* CoroutineUtilities.h in Headers */,
 				DD3DC8D127A4BF8E007E5B61 /* CountingLock.h in Headers */,
 				DD3DC92627A4BF8E007E5B61 /* CPUTime.h in Headers */,
+				56F5CB002E54CCCD0020E813 /* CrashAnnotations.h in Headers */,
 				DDF3071127C086CC006A526F /* CrashReporter.h in Headers */,
 				DDF306DC27C08654006A526F /* CrashReporterClientSPI.h in Headers */,
 				DD3DC96D27A4BF8E007E5B61 /* CrossThreadCopier.h in Headers */,
@@ -3717,6 +3727,7 @@
 				DD3DC91D27A4BF8E007E5B61 /* RefPtr.h in Headers */,
 				4BF93AD32C8B53C100F0E06C /* RefTrackerMixin.h in Headers */,
 				3A5BCFA3298768E300E0ABB2 /* RefVector.h in Headers */,
+				56F5CB062E54D3CC0020E813 /* ReportCrashSPI.h in Headers */,
 				DD3DC8C727A4BF8E007E5B61 /* ResourceUsage.h in Headers */,
 				DD3DC92127A4BF8E007E5B61 /* RetainPtr.h in Headers */,
 				941C64A72CA5A2A000A63214 /* RetainReleaseSwift.h in Headers */,
@@ -4327,6 +4338,7 @@
 				0F8E85DB1FD485B000691889 /* CountingLock.cpp in Sources */,
 				E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */,
 				EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */,
+				56F5CB022E54CE9D0020E813 /* CrashAnnotations.cpp in Sources */,
 				CEA072AA236FFBF70018839C /* CrashReporter.cpp in Sources */,
 				515F794E1CFC9F4A00CCED93 /* CrossThreadCopier.cpp in Sources */,
 				517F82D71FD22F3000DA3DEA /* CrossThreadTaskHandler.cpp in Sources */,

--- a/Source/WTF/wtf/cocoa/CrashAnnotations.cpp
+++ b/Source/WTF/wtf/cocoa/CrashAnnotations.cpp
@@ -1,0 +1,44 @@
+/*
+* Copyright (C) 2019 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+* EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "CrashAnnotations.h"
+
+#if PLATFORM(COCOA)
+struct wtf_crash_annotations_t gWTFCrashAnnotations
+    __attribute__((section("__DATA," WTF_CRASH_ANNOTATIONS_SECTION)))
+    = { WTF_CRASH_ANNOTATIONS_VERSION, 0 };
+#endif
+
+namespace WTF {
+
+void setCrashLogInsecureLoad(bool hadInsecureLoad)
+{
+#if PLATFORM(COCOA)
+    gWTFCrashAnnotations.hadInsecureLoad = hadInsecureLoad;
+#endif
+}
+
+}

--- a/Source/WTF/wtf/cocoa/CrashAnnotations.h
+++ b/Source/WTF/wtf/cocoa/CrashAnnotations.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKWebProcessPlugInFrame.h>
+#pragma once
 
-@class JSContext;
-@class JSValue;
-@class WKWebProcessPlugInBrowserContextController;
+#if PLATFORM(COCOA)
+#include <wtf/spi/cocoa/ReportCrashSPI.h>
+#endif
 
-@interface WKWebProcessPlugInFrame (WKPrivate)
+namespace WTF {
 
-+ (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle;
-+ (instancetype)lookUpFrameFromJSContext:(JSContext *)context;
-+ (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value;
+WTF_EXPORT_PRIVATE void setCrashLogInsecureLoad(bool hadInsecureLoad);
 
-@property (nonatomic, readonly) WKWebProcessPlugInBrowserContextController *_browserContextController;
-
-@property (nonatomic, readonly) BOOL _hasCustomContentProvider;
-@property (nonatomic, readonly) NSArray *_certificateChain;
-@property (nonatomic, readonly) SecTrustRef _serverTrust;
-@property (nonatomic, readonly) NSURL *_provisionalURL;
-@property (nonatomic, readonly) NSString *_securityOrigin;
-@property (nonatomic, readonly) BOOL _hadInsecureLoad;
-
-@property (nonatomic, readonly) WKWebProcessPlugInFrame *_parentFrame;
-
-@end
+} // namespace WTF

--- a/Source/WTF/wtf/spi/cocoa/ReportCrashSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/ReportCrashSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKWebProcessPlugInFrame.h>
+#pragma once
 
-@class JSContext;
-@class JSValue;
-@class WKWebProcessPlugInBrowserContextController;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-@interface WKWebProcessPlugInFrame (WKPrivate)
+#define WTF_CRASH_ANNOTATIONS_VERSION 1
+#define WTF_CRASH_ANNOTATIONS_SECTION "__wtf_crash_info"
 
-+ (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle;
-+ (instancetype)lookUpFrameFromJSContext:(JSContext *)context;
-+ (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value;
+struct wtf_crash_annotations_t {
+    uint8_t version;
+    bool hadInsecureLoad;
+};
 
-@property (nonatomic, readonly) WKWebProcessPlugInBrowserContextController *_browserContextController;
+__attribute__((visibility("hidden")))
+extern struct wtf_crash_annotations_t gWTFCrashAnnotations;
 
-@property (nonatomic, readonly) BOOL _hasCustomContentProvider;
-@property (nonatomic, readonly) NSArray *_certificateChain;
-@property (nonatomic, readonly) SecTrustRef _serverTrust;
-@property (nonatomic, readonly) NSURL *_provisionalURL;
-@property (nonatomic, readonly) NSString *_securityOrigin;
-@property (nonatomic, readonly) BOOL _hadInsecureLoad;
-
-@property (nonatomic, readonly) WKWebProcessPlugInFrame *_parentFrame;
-
-@end
+#ifdef __cplusplus
+}
+#endif

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1895,6 +1895,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/LinkLoader.h
     loader/LinkLoaderClient.h
     loader/LinkPreloadResourceClients.h
+    loader/LoadMetadata.h
     loader/LoadSchedulingMode.h
     loader/LoadedFromOpaqueSource.h
     loader/LoaderMalloc.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2004,6 +2004,7 @@ loader/LinkHeader.cpp
 loader/LinkLoader.cpp
 loader/LinkPreloadResourceClients.cpp
 loader/LoaderMalloc.cpp
+loader/LoadMetadata.cpp
 loader/LoaderStrategy.cpp
 loader/LocalFrameLoaderClient.cpp
 loader/MediaResourceLoader.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2437,6 +2437,7 @@
 		55F1F4A427BC993300132A6B /* WebAssemblyCachedScriptSourceProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 55F1F4A227BC993200132A6B /* WebAssemblyCachedScriptSourceProvider.h */; };
 		55FA7FFB2110ECD7005AEFE7 /* SVGZoomAndPanType.h in Headers */ = {isa = PBXBuildFile; fileRef = 55FA7FFA2110ECD7005AEFE7 /* SVGZoomAndPanType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		55FD9FC127B20D520045DA1F /* WebAssemblyScriptSourceCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 55FD9FBF27B20D520045DA1F /* WebAssemblyScriptSourceCode.h */; };
+		56D4E80A2E30E978003861CC /* LoadMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 563D0FD82DFC4FA90024830D /* LoadMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5704405A1E53936200356601 /* JSAesCbcCfbParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 570440591E53936200356601 /* JSAesCbcCfbParams.h */; };
 		5706A6961DDE5C9500A03B14 /* CryptoAlgorithmRsaOaepParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 5706A6951DDE5C9500A03B14 /* CryptoAlgorithmRsaOaepParams.h */; };
 		5706A6981DDE5E4600A03B14 /* JSRsaOaepParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 5706A6971DDE5E4600A03B14 /* JSRsaOaepParams.h */; };
@@ -12482,6 +12483,8 @@
 		55FA7FFA2110ECD7005AEFE7 /* SVGZoomAndPanType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGZoomAndPanType.h; sourceTree = "<group>"; };
 		55FD9FBF27B20D520045DA1F /* WebAssemblyScriptSourceCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebAssemblyScriptSourceCode.h; sourceTree = "<group>"; };
 		560A7F202DB83BDE00B69AF8 /* SVGFilterEffectGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGFilterEffectGraph.h; sourceTree = "<group>"; };
+		563D0FD82DFC4FA90024830D /* LoadMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoadMetadata.h; sourceTree = "<group>"; };
+		56D4E8082E2FEFE5003861CC /* LoadMetadata.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LoadMetadata.cpp; sourceTree = "<group>"; };
 		570440571E53851600356601 /* CryptoAlgorithmAESCFBMac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmAESCFBMac.cpp; sourceTree = "<group>"; };
 		570440591E53936200356601 /* JSAesCbcCfbParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSAesCbcCfbParams.h; sourceTree = "<group>"; };
 		5704405B1E53937900356601 /* JSAesCbcCfbParams.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSAesCbcCfbParams.cpp; sourceTree = "<group>"; };
@@ -36118,6 +36121,8 @@
 				45B5D85F2A968620004C85A0 /* LoaderMalloc.h */,
 				51ABF64C16392E2800132A7A /* LoaderStrategy.cpp */,
 				51E6820F16387302003BBF3C /* LoaderStrategy.h */,
+				56D4E8082E2FEFE5003861CC /* LoadMetadata.cpp */,
+				563D0FD82DFC4FA90024830D /* LoadMetadata.h */,
 				E47FC8A125B84D71005495FC /* LoadSchedulingMode.h */,
 				656D37260ADBA5DE00A4554D /* LocalFrameLoaderClient.h */,
 				CEEFCD7719DB31F7003876D7 /* MediaResourceLoader.cpp */,
@@ -44093,6 +44098,7 @@
 				45B5D8612A968620004C85A0 /* LoaderMalloc.h in Headers */,
 				656D37320ADBA5DE00A4554D /* LoaderNSURLExtras.h in Headers */,
 				51E6821016387302003BBF3C /* LoaderStrategy.h in Headers */,
+				56D4E80A2E30E978003861CC /* LoadMetadata.h in Headers */,
 				E47FC8A325B84D72005495FC /* LoadSchedulingMode.h in Headers */,
 				06E81ED70AB5D5E900C87837 /* LocalCurrentGraphicsContext.h in Headers */,
 				1C43DE6B22AB4B8A001527D9 /* LocalCurrentTraitCollection.h in Headers */,

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -88,6 +88,7 @@
 #include "PolicyChecker.h"
 #include "ProgressTracker.h"
 #include "Quirks.h"
+#include "RegistrableDomain.h"
 #include "ResourceLoadObserver.h"
 #include "ResourceMonitor.h"
 #include "SWClientConnection.h"
@@ -614,6 +615,9 @@ void DocumentLoader::redirectReceived(CachedResource& resource, ResourceRequest&
 
 void DocumentLoader::redirectReceived(ResourceRequest&& request, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
+    if (redirectResponse.url().protocolIs("http"_s) && !areRegistrableDomainsEqual(request.url(), redirectResponse.url()))
+        m_loadMetadata.add(LoadMetadata::Insecure);
+
     if (m_serviceWorkerRegistrationData) {
         m_serviceWorkerRegistrationData = { };
         unregisterReservedServiceWorkerClient();
@@ -985,6 +989,9 @@ void DocumentLoader::responseReceived(ResourceResponse&& response, CompletionHan
     if (m_contentFilter && !m_contentFilter->continueAfterResponseReceived(response))
         return;
 #endif
+
+    if (response.url().protocolIs("http"_s))
+        m_loadMetadata.add(LoadMetadata::Insecure);
 
     Ref<DocumentLoader> protectedThis(*this);
     bool willLoadFallback = m_applicationCacheHost->maybeLoadFallbackForMainResponse(request(), response);

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -44,6 +44,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/HTTPSByDefaultMode.h>
 #include <WebCore/LinkIcon.h>
+#include <WebCore/LoadMetadata.h>
 #include <WebCore/NavigationAction.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/ResourceError.h>
@@ -504,6 +505,9 @@ public:
     OptionSet<AdvancedPrivacyProtections> navigationalAdvancedPrivacyProtections() const { return m_originatorAdvancedPrivacyProtections.value_or(m_advancedPrivacyProtections); }
     std::optional<OptionSet<AdvancedPrivacyProtections>> originatorAdvancedPrivacyProtections() const { return m_originatorAdvancedPrivacyProtections; }
 
+    void setLoadMetadata(OptionSet<LoadMetadata> metadata) { m_loadMetadata = metadata; }
+    OptionSet<LoadMetadata> loadMetadata() const { return m_loadMetadata; }
+
     void setIdempotentModeAutosizingOnlyHonorsPercentages(bool idempotentModeAutosizingOnlyHonorsPercentages) { m_idempotentModeAutosizingOnlyHonorsPercentages = idempotentModeAutosizingOnlyHonorsPercentages; }
     bool idempotentModeAutosizingOnlyHonorsPercentages() const { return m_idempotentModeAutosizingOnlyHonorsPercentages; }
 
@@ -784,6 +788,8 @@ private:
     InlineMediaPlaybackPolicy m_inlineMediaPlaybackPolicy { InlineMediaPlaybackPolicy::Default };
 
     Function<void(Document*)> m_whenDocumentIsCreatedCallback;
+
+    OptionSet<LoadMetadata> m_loadMetadata;
 
     bool m_idempotentModeAutosizingOnlyHonorsPercentages { false };
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/AdvancedPrivacyProtections.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/LoadMetadata.h>
 #include <WebCore/ReferrerPolicy.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
@@ -132,6 +133,9 @@ public:
     bool skipNavigateEvent() const { return m_skipNavigateEvent; }
     void setSkipNavigateEvent(bool value) { m_skipNavigateEvent = value; }
 
+    void setLoadMetadata(OptionSet<LoadMetadata> metadata) { m_loadMetadata = metadata; }
+    OptionSet<LoadMetadata> loadMetadata() const { return m_loadMetadata; }
+
 private:
     Ref<Document> m_requester;
     Ref<SecurityOrigin> m_requesterSecurityOrigin;
@@ -160,6 +164,7 @@ private:
     bool m_isFromNavigationAPI { false };
     bool m_isHandledByAboutSchemeHandler { false };
     bool m_skipNavigateEvent { false };
+    OptionSet<LoadMetadata> m_loadMetadata;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1732,6 +1732,7 @@ void FrameLoader::load(FrameLoadRequest&& request)
     loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
     if (auto advancedPrivacyProtections = request.advancedPrivacyProtections())
         loader->setOriginatorAdvancedPrivacyProtections(*advancedPrivacyProtections);
+    loader->setLoadMetadata(request.loadMetadata());
     addSameSiteInfoToRequestIfNeeded(loader->request());
     applyShouldOpenExternalURLsPolicyToNewDocumentLoader(protectedFrame(), loader, request);
     loader->setIsHandledByAboutSchemeHandler(request.isHandledByAboutSchemeHandler());
@@ -1769,6 +1770,11 @@ void FrameLoader::loadWithNavigationAction(ResourceRequest&& request, Navigation
     applyShouldOpenExternalURLsPolicyToNewDocumentLoader(protectedFrame(), loader, action.initiatedByMainFrame(), action.shouldOpenExternalURLsPolicy());
     loader->setIsContinuingLoadAfterProvisionalLoadStarted(shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
     loader->setIsRequestFromClientOrUserInput(action.isRequestFromClientOrUserInput());
+
+    if (auto requester = action.requester(); requester && requester->documentIdentifier) {
+        if (RefPtr requestingDocument = Document::allDocumentsMap().get(requester->documentIdentifier); requestingDocument)
+            loader->setLoadMetadata(requestingDocument->loader()->loadMetadata());
+    }
 
     if (action.lockHistory() == LockHistory::Yes) {
         if (RefPtr documentLoader = m_documentLoader)
@@ -2053,6 +2059,8 @@ void FrameLoader::reload(OptionSet<ReloadOption> options, bool isRequestFromClie
 
     loader->setContentExtensionEnablement({ options.contains(ReloadOption::DisableContentBlockers) ? ContentExtensionDefaultEnablement::Disabled : ContentExtensionDefaultEnablement::Enabled, { } });
     
+    loader->setLoadMetadata(documentLoader->loadMetadata());
+
     ResourceRequest& request = loader->request();
 
     // FIXME: We don't have a mechanism to revalidate the main resource without reloading at the moment.

--- a/Source/WebCore/loader/LoadMetadata.cpp
+++ b/Source/WebCore/loader/LoadMetadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKWebProcessPlugInFrame.h>
+#include "config.h"
+#include "LoadMetadata.h"
 
-@class JSContext;
-@class JSValue;
-@class WKWebProcessPlugInBrowserContextController;
+#include <wtf/Compiler.h>
+#include <wtf/cocoa/CrashAnnotations.h>
 
-@interface WKWebProcessPlugInFrame (WKPrivate)
+namespace WebCore {
 
-+ (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle;
-+ (instancetype)lookUpFrameFromJSContext:(JSContext *)context;
-+ (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value;
+void RecordLoadMetadata(OptionSet<LoadMetadata> loadMetadata)
+{
+    WTF::setCrashLogInsecureLoad(loadMetadata.contains(LoadMetadata::Insecure));
+}
 
-@property (nonatomic, readonly) WKWebProcessPlugInBrowserContextController *_browserContextController;
-
-@property (nonatomic, readonly) BOOL _hasCustomContentProvider;
-@property (nonatomic, readonly) NSArray *_certificateChain;
-@property (nonatomic, readonly) SecTrustRef _serverTrust;
-@property (nonatomic, readonly) NSURL *_provisionalURL;
-@property (nonatomic, readonly) NSString *_securityOrigin;
-@property (nonatomic, readonly) BOOL _hadInsecureLoad;
-
-@property (nonatomic, readonly) WKWebProcessPlugInFrame *_parentFrame;
-
-@end
+} // namespace WebCore

--- a/Source/WebCore/loader/LoadMetadata.h
+++ b/Source/WebCore/loader/LoadMetadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,18 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKWebProcessPlugInFrame.h>
+#include <WebCore/PlatformExportMacros.h>
 
-@class JSContext;
-@class JSValue;
-@class WKWebProcessPlugInBrowserContextController;
+#include <wtf/OptionSet.h>
 
-@interface WKWebProcessPlugInFrame (WKPrivate)
+#pragma once
 
-+ (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle;
-+ (instancetype)lookUpFrameFromJSContext:(JSContext *)context;
-+ (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value;
+namespace WebCore {
 
-@property (nonatomic, readonly) WKWebProcessPlugInBrowserContextController *_browserContextController;
+enum class LoadMetadata : uint8_t {
+    Insecure                = 1 << 0 // Content loaded via an insecure protocol.
+};
 
-@property (nonatomic, readonly) BOOL _hasCustomContentProvider;
-@property (nonatomic, readonly) NSArray *_certificateChain;
-@property (nonatomic, readonly) SecTrustRef _serverTrust;
-@property (nonatomic, readonly) NSURL *_provisionalURL;
-@property (nonatomic, readonly) NSString *_securityOrigin;
-@property (nonatomic, readonly) BOOL _hadInsecureLoad;
+WEBCORE_EXPORT void RecordLoadMetadata(OptionSet<LoadMetadata>);
 
-@property (nonatomic, readonly) WKWebProcessPlugInFrame *_parentFrame;
-
-@end
+} // namespace WebCore

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -299,6 +299,9 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     auto sandboxFlags = frame->effectiveSandboxFlags();
     auto isPerformingHTTPFallback = frameLoader->isHTTPFallbackInProgress() ? IsPerformingHTTPFallback::Yes : IsPerformingHTTPFallback::No;
 
+    if (frame->loader().documentLoader())
+        frame->loader().documentLoader()->setLoadMetadata(loader->loadMetadata());
+
 #if ENABLE(CONTENT_EXTENSIONS)
     if (frame->loader().documentLoader() && frame->loader().documentLoader()->hasActiveContentRuleListActions()) {
         if (RefPtr page = frame->page()) {

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -92,6 +92,8 @@ struct LoadParameters {
 
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion { 0 };
+
+    OptionSet<WebCore::LoadMetadata> loadMetadata;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -60,4 +60,6 @@ enum class WebCore::LockBackForwardList : bool;
 
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion;
+
+    OptionSet<WebCore::LoadMetadata> loadMetadata;
 };

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -33,6 +33,7 @@
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/LoadMetadata.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PrivateClickMeasurement.h>
@@ -89,6 +90,7 @@ struct NavigationActionData {
     WebCore::ResourceRequest originalRequest;
     WebCore::ResourceRequest request;
     String invalidURLString;
+    OptionSet<WebCore::LoadMetadata> loadMetadata;
 };
 
 }

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -63,4 +63,5 @@ struct WebKit::NavigationActionData {
     WebCore::ResourceRequest originalRequest;
     [EncodeRequestBody] WebCore::ResourceRequest request;
     String invalidURLString;
+    OptionSet<WebCore::LoadMetadata> loadMetadata;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9400,3 +9400,8 @@ struct WebCore::ParentalControlsURLFilterParameters {
 #endif
 };
 #endif
+
+header: <WebCore/LoadMetadata.h>
+[OptionSet] enum class WebCore::LoadMetadata : uint8_t {
+    Insecure,
+};

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -50,6 +50,7 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/LayoutMilestone.h>
+#include <WebCore/LoadMetadata.h>
 #include <WebCore/MediaProducer.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/Pagination.h>

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -296,6 +296,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
             mainFrame->remoteFrameSize()
         };
     }
+
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, WTFMove(creationParameters)), 0);
     if (!preferences->siteIsolationEnabled())
         process->addVisitedLinkStoreUser(page->visitedLinkStore(), page->identifier());

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2155,6 +2155,9 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.requiredCookiesVersion = protectedWebsiteDataStore()->cookiesVersion();
     loadParameters.originatingFrame = navigation.lastNavigationAction() ? std::optional(navigation.lastNavigationAction()->originatingFrameInfoData) : std::nullopt;
 
+    if (navigation.lastNavigationAction() && !(navigation.isRequestFromClientOrUserInput() || navigation.wasUserInitiated()))
+        loadParameters.loadMetadata = navigation.lastNavigationAction()->loadMetadata;
+
 #if ENABLE(CONTENT_EXTENSIONS)
     if (protectedPreferences()->iFrameResourceMonitoringEnabled())
         process->requestResourceMonitorRuleLists(protectedPreferences()->iFrameResourceMonitoringTestingSettingsEnabled());
@@ -2320,6 +2323,10 @@ void WebPageProxy::loadDataWithNavigationShared(Ref<WebProcessProxy>&& process, 
     loadParameters.shouldOpenExternalURLsPolicy = shouldOpenExternalURLsPolicy;
     loadParameters.isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
     loadParameters.isServiceWorkerLoad = isServiceWorkerPage();
+
+    if (navigation.lastNavigationAction() && !(navigation.isRequestFromClientOrUserInput() || navigation.wasUserInitiated()))
+        loadParameters.loadMetadata = navigation.lastNavigationAction()->loadMetadata;
+
     prepareToLoadWebPage(process, loadParameters);
 
     process->markProcessAsRecentlyUsed();
@@ -5074,6 +5081,10 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             loadParameters.ownerPermissionsPolicy = navigation->ownerPermissionsPolicy();
             loadParameters.isPerformingHTTPFallback = navigationAction->data().isPerformingHTTPFallback;
             loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());
+
+            if (navigation->lastNavigationAction() && !(navigation->isRequestFromClientOrUserInput() || navigation->wasUserInitiated()))
+                loadParameters.loadMetadata = navigation->lastNavigationAction()->loadMetadata;
+
             processNavigatingTo->send(Messages::WebPage::LoadRequest(WTFMove(loadParameters)), webPageIDInProcess(processNavigatingTo));
         }
 
@@ -5309,6 +5320,9 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         loadParameters.ownerPermissionsPolicy = navigation.ownerPermissionsPolicy();
         loadParameters.isPerformingHTTPFallback = isPerformingHTTPFallback == IsPerformingHTTPFallback::Yes;
         loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());
+
+        if (navigation.lastNavigationAction() && !(navigation.isRequestFromClientOrUserInput() || navigation.wasUserInitiated()))
+            loadParameters.loadMetadata = navigation.lastNavigationAction()->loadMetadata;
 
         if (navigation.isInitialFrameSrcLoad())
             frame.setIsPendingInitialHistoryItem(true);
@@ -8740,6 +8754,7 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
 
         if (openerAppInitiatedState)
             newPage->m_lastNavigationWasAppInitiated = *openerAppInitiatedState;
+
         RefPtr openedMainFrame = newPage->m_mainFrame ? newPage->m_mainFrame->opener() : nullptr;
 
         // FIXME: Move this to WebPageProxy constructor.

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -41,6 +41,7 @@
 #import <WebCore/IntPoint.h>
 #import <WebCore/LinkIconCollector.h>
 #import <WebCore/LinkIconType.h>
+#import <WebCore/LoadMetadata.h>
 #import <WebCore/LocalFrameInlines.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/AlignedStorage.h>
@@ -205,6 +206,11 @@ static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<Web
 - (NSURL *)_provisionalURL
 {
     return [NSURL _web_URLWithWTFString:_frame->provisionalURL()];
+}
+
+- (BOOL)_hadInsecureLoad
+{
+    return _frame->loadMetadata().contains(WebCore::LoadMetadata::Insecure);
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -397,6 +397,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         originalRequest, /* originalRequest */
         originalRequest, /* request */
         originalRequest.url().isValid() ? String() : originalRequest.url().string(), /* invalidURLString */
+        webFrame->loadMetadata(), /* loadMetadata */
     };
 
     auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page->identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -177,6 +177,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         navigationAction.originalRequest(),
         request,
         request.url().isValid() ? String() : request.url().string(),
+        requestingFrame ? requestingFrame->loadMetadata() : OptionSet<LoadMetadata> { }
     };
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -78,6 +78,7 @@
 #include <WebCore/HistoryController.h>
 #include <WebCore/HistoryItem.h>
 #include <WebCore/HitTestResult.h>
+#include <WebCore/LoadMetadata.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/MIMETypeRegistry.h>
@@ -520,6 +521,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         { }, /* originalRequest */
         { }, /* request */
         { }, /* invalidURLString */
+        m_frame->loadMetadata(), /* loadMetadata */
     };
 
     // Notify the UIProcess.
@@ -744,6 +746,9 @@ void WebLocalFrameLoaderClient::dispatchDidFinishDocumentLoad()
     RefPtr<API::Object> userData;
 
     RefPtr documentLoader = m_localFrame->loader().documentLoader();
+
+    if (documentLoader->loadMetadata().contains(WebCore::LoadMetadata::Insecure))
+        RecordLoadMetadata(documentLoader->loadMetadata());
 
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didFinishDocumentLoadForFrame(*webPage, m_frame, userData);
@@ -1027,6 +1032,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         { }, /* originalRequest */
         request,
         request.url().isValid() ? String() : request.url().string(), /* invalidURLString */
+        m_frame->loadMetadata(), /* loadMetadata */
     };
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForNewWindowAction(navigationActionData, frameName), [frame = m_frame, listenerID] (PolicyDecision&& policyDecision) {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1559,4 +1559,16 @@ void WebFrame::findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirec
     completionHandler(foundElementInRemoteFrame);
 }
 
+OptionSet<WebCore::LoadMetadata> WebFrame::loadMetadata() const
+{
+    if (m_coreFrame) {
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get())) {
+            if (RefPtr loader = localFrame->loader().documentLoader())
+                return loader->loadMetadata();
+        }
+    }
+
+    return { };
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -40,6 +40,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/HitTestRequest.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
+#include <WebCore/LoadMetadata.h>
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <WebCore/MarkupExclusionRule.h>
 #include <WebCore/ProcessIdentifier.h>
@@ -265,6 +266,8 @@ public:
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
 
     std::optional<WebCore::ResourceResponse> resourceResponseForURL(const URL&) const;
+
+    OptionSet<WebCore::LoadMetadata> loadMetadata() const;
 
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2169,6 +2169,7 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
         frameLoadRequest.setIsRequestFromClientOrUserInput();
     if (loadParameters.advancedPrivacyProtections)
         frameLoadRequest.setAdvancedPrivacyProtections(*loadParameters.advancedPrivacyProtections);
+    frameLoadRequest.setLoadMetadata(loadParameters.loadMetadata);
 
     if (loadParameters.effectiveSandboxFlags)
         localFrame->updateSandboxFlags(loadParameters.effectiveSandboxFlags, Frame::NotifyUIProcess::No);

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -179,6 +179,7 @@ Tests/WebKitCocoa/LoadDataWithNilMIMEType.mm
 Tests/WebKitCocoa/LoadFileThenReload.mm
 Tests/WebKitCocoa/LoadFileURL.mm
 Tests/WebKitCocoa/LoadInvalidURLRequest.mm
+Tests/WebKitCocoa/LoadMetadata.mm
 Tests/WebKitCocoa/LocalStorageClear.mm
 Tests/WebKitCocoa/LocalStorageDatabaseTracker.mm
 Tests/WebKitCocoa/LocalStorageNullEntries.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		56EEE4782D8D6B85003D4FB1 /* coreipc.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = 56EEE4772D8D6B85003D4FB1 /* coreipc.js */; };
 		56EEE4832D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 56EEE4822D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html */; };
 		56EEE48F2D8DB402003D4FB1 /* coreipc-helpers.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = 56EEE48E2D8DB402003D4FB1 /* coreipc-helpers.js */; };
+		56D4E82E2E32583F003861CC /* LoadMetadataPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 56D4E82D2E32583F003861CC /* LoadMetadataPlugin.mm */; };
 		57152B5E21CC2045000C37CA /* ApduTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57152B5D21CC2045000C37CA /* ApduTest.cpp */; };
 		57152B7821DD4E8D000C37CA /* U2fCommandConstructorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57D1D75E21DCB7A80093E86A /* U2fCommandConstructorTest.cpp */; };
 		572B403421769A88000AD43E /* CtapRequestTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 572B403321769A88000AD43E /* CtapRequestTest.cpp */; };
@@ -3037,6 +3038,9 @@
 		56EEE4772D8D6B85003D4FB1 /* coreipc.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = coreipc.js; sourceTree = "<group>"; };
 		56EEE4822D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "RemoteObjectRegistry-BadReplyBlock.html"; sourceTree = "<group>"; };
 		56EEE48E2D8DB402003D4FB1 /* coreipc-helpers.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "coreipc-helpers.js"; sourceTree = "<group>"; };
+		56D4E82C2E325827003861CC /* LoadMetadata.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadMetadata.mm; sourceTree = "<group>"; };
+		56D4E82D2E32583F003861CC /* LoadMetadataPlugin.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadMetadataPlugin.mm; sourceTree = "<group>"; };
+		56D4E82F2E325935003861CC /* LoadMetadataProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoadMetadataProtocol.h; sourceTree = "<group>"; };
 		5703BB8C2463F87200475FB2 /* web-authentication-make-credential-la-no-attestation.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-make-credential-la-no-attestation.html"; sourceTree = "<group>"; };
 		570D26F323C3CA5500D5CF67 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-make-credential-hid-pin-get-key-agreement-error.html"; sourceTree = "<group>"; };
 		570D26F523C3D32700D5CF67 /* web-authentication-make-credential-hid-pin.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-make-credential-hid-pin.html"; sourceTree = "<group>"; };
@@ -4837,6 +4841,9 @@
 				4612C2B8210A6ABF00B788A6 /* LoadFileThenReload.mm */,
 				51396E19222E4E8600A42FCE /* LoadFileURL.mm */,
 				57901FAC1CAF12C200ED64F9 /* LoadInvalidURLRequest.mm */,
+				56D4E82C2E325827003861CC /* LoadMetadata.mm */,
+				56D4E82D2E32583F003861CC /* LoadMetadataPlugin.mm */,
+				56D4E82F2E325935003861CC /* LoadMetadataProtocol.h */,
 				51E6A8921D2F1BEC00C004B6 /* LocalStorageClear.mm */,
 				CA38459520AE012E00990D3B /* LocalStorageDatabaseTracker.mm */,
 				46C519D81D355A7300DAA51A /* LocalStorageNullEntries.mm */,
@@ -8127,6 +8134,7 @@
 				F460F65B261119580064F2B6 /* InjectedBundleHitTestPlugIn.mm in Sources */,
 				0E404A8C2166DE0A008271BA /* InjectedBundleNodeHandleIsSelectElement.mm in Sources */,
 				79C5D431209D768300F1E7CA /* InjectedBundleNodeHandleIsTextField.mm in Sources */,
+				56D4E82E2E32583F003861CC /* LoadMetadataPlugin.mm in Sources */,
 				2D3CA3A8221DF4B40088E803 /* PageOverlayPlugin.mm in Sources */,
 				F44C7A0020F9EEBF0014478C /* ParserYieldTokenPlugIn.mm in Sources */,
 				A13EBBAB1B87434600097110 /* PlatformUtilitiesCocoa.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadMetadata.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadMetadata.mm
@@ -1,0 +1,538 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "HTTPServer.h"
+#import "LoadMetadataProtocol.h"
+#import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebCore/LoadMetadata.h>
+#import <WebKit/WKFrameInfoPrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/WKWebpagePreferencesPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/WebKit.h>
+#import <WebKit/_WKFeature.h>
+#import <WebKit/_WKFrameTreeNode.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <WebKit/_WKRemoteObjectInterface.h>
+#import <WebKit/_WKRemoteObjectRegistry.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <wtf/HashMap.h>
+#import <wtf/RetainPtr.h>
+
+@interface LoadMetadataRemoteObject : NSObject <LoadMetadataProtocol>
+@property (nonatomic, readonly) HashMap<pid_t, LoadMetadataType> pidLoadMetadatas;
+@property (nonatomic, readonly) uint32_t numLoadMetadataCallbacks;
+@end
+
+@implementation LoadMetadataRemoteObject
+
+- (bool)hasMetadataForPid:(pid_t)pid
+{
+    return _pidLoadMetadatas.contains(pid);
+}
+
+- (OptionSet<WebCore::LoadMetadata>)metadataForPid:(pid_t)pid
+{
+    RELEASE_ASSERT([self hasMetadataForPid:pid]);
+
+    return OptionSet<WebCore::LoadMetadata>::fromRaw(_pidLoadMetadatas.get(pid));
+}
+
+- (void)loadMetadata:(LoadMetadataType)value withPID:(uint64_t)pid
+{
+    _pidLoadMetadatas.set(pid, value);
+    _numLoadMetadataCallbacks++;
+
+    NSLog(@"LoadMedata test received LoadMetadata: %d with running PID: %lld", value, pid);
+}
+
+@end
+
+static RetainPtr<TestWKWebView> loadMetadataTestConfiguration(const TestWebKitAPI::HTTPServer* plaintextServer, const TestWebKitAPI::HTTPServer* secureServer = nullptr, bool useSiteIsolation = false)
+{
+    NSString * const testPlugInClassName = @"LoadMetadataPlugin";
+
+    RetainPtr<WKWebViewConfiguration> configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
+
+    [configuration preferences].javaScriptCanOpenWindowsAutomatically = YES;
+
+    if (useSiteIsolation) {
+        auto preferences = [configuration preferences];
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            if ([feature.key isEqualToString:@"SiteIsolationEnabled"]) {
+                [preferences _setEnabled:YES forFeature:feature];
+                break;
+            }
+        }
+    }
+
+    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+
+    if (plaintextServer)
+        [storeConfiguration setHTTPProxy:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", plaintextServer->port()]]];
+
+    if (secureServer)
+        [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", secureServer->port()]]];
+
+    [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get()]);
+
+    if (secureServer) {
+        auto navigationDelegate = [TestNavigationDelegate new];
+        [navigationDelegate allowAnyTLSCertificate];
+        [webView setNavigationDelegate: navigationDelegate];
+    }
+
+    return webView;
+}
+
+enum class ExpectedMetadata : bool { Secure, Insecure };
+static void runAndCheckLoadMetadata(RetainPtr<WKWebView> webView, NSString *url, ExpectedMetadata expectedMetadata)
+{
+    RetainPtr<LoadMetadataRemoteObject> object = adoptNS([[LoadMetadataRemoteObject alloc] init]);
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(LoadMetadataProtocol)];
+    [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return [object numLoadMetadataCallbacks] == 1;
+    });
+
+    pid_t webViewPid = [webView _webProcessIdentifier];
+    OptionSet<WebCore::LoadMetadata> metadata = [object metadataForPid:webViewPid];
+
+    if (expectedMetadata == ExpectedMetadata::Insecure)
+        EXPECT_TRUE(metadata.contains(WebCore::LoadMetadata::Insecure));
+    else
+        EXPECT_FALSE(metadata.contains(WebCore::LoadMetadata::Insecure));
+}
+
+static void runAndCheckLoadMetadataForFrames(RetainPtr<TestWKWebView> webView, NSString *url)
+{
+    RetainPtr<LoadMetadataRemoteObject> object = adoptNS([[LoadMetadataRemoteObject alloc] init]);
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(LoadMetadataProtocol)];
+    [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return [object numLoadMetadataCallbacks] == 2;
+    });
+
+    auto mainFrame = [webView mainFrame];
+    EXPECT_EQ(1u, mainFrame.childFrames.count);
+
+    auto childFrame = mainFrame.childFrames.firstObject;
+
+    pid_t mainFramePid = mainFrame.info._processIdentifier;
+    pid_t childFramePid = childFrame.info._processIdentifier;
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return [object hasMetadataForPid:mainFramePid] && [object hasMetadataForPid:childFramePid];
+    });
+
+    EXPECT_TRUE([object metadataForPid:mainFramePid].contains(WebCore::LoadMetadata::Insecure));
+    EXPECT_TRUE([object metadataForPid:childFramePid].contains(WebCore::LoadMetadata::Insecure));
+}
+
+enum class ExpectCreated : bool { No, Yes };
+static void runAndCheckLoadMetadataForViews(RetainPtr<TestWKWebView> webView, NSString *url, ExpectCreated expectCreated = ExpectCreated::Yes, uint8_t expectMetadataCallbackCount = 2)
+{
+    RetainPtr<LoadMetadataRemoteObject> object = adoptNS([[LoadMetadataRemoteObject alloc] init]);
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(LoadMetadataProtocol)];
+    [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+    RELEASE_ASSERT(!webView.get().UIDelegate);
+
+    __block auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+
+    __block auto navigationDelegate = [webView navigationDelegate];
+
+    __block pid_t mainWebViewPid = 0;
+    __block RetainPtr<WKWebView> createdWebView;
+
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        createdWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+
+        mainWebViewPid = [webView _webProcessIdentifier];
+
+        createdWebView.get().UIDelegate = uiDelegate.get();
+        createdWebView.get().navigationDelegate = navigationDelegate;
+
+        [[createdWebView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+        return createdWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "success!");
+
+    if (expectCreated == ExpectCreated::Yes) {
+        EXPECT_FALSE(!createdWebView);
+        EXPECT_NE(mainWebViewPid, 0);
+
+        pid_t createdWebViewPid = [createdWebView _webProcessIdentifier];
+        EXPECT_NE(createdWebViewPid, 0);
+
+        TestWebKitAPI::Util::waitFor([&] {
+            return [object numLoadMetadataCallbacks] == expectMetadataCallbackCount;
+        });
+
+        EXPECT_TRUE([object metadataForPid:mainWebViewPid].contains(WebCore::LoadMetadata::Insecure));
+        EXPECT_TRUE([object metadataForPid:createdWebViewPid].contains(WebCore::LoadMetadata::Insecure));
+
+    } else {
+        EXPECT_TRUE(!createdWebView);
+        EXPECT_EQ(mainWebViewPid, 0);
+
+        mainWebViewPid = [webView _webProcessIdentifier];
+        EXPECT_NE(mainWebViewPid, 0);
+
+        TestWebKitAPI::Util::waitFor([&] {
+            return [object numLoadMetadataCallbacks] == expectMetadataCallbackCount;
+        });
+
+        EXPECT_TRUE([object metadataForPid:mainWebViewPid].contains(WebCore::LoadMetadata::Insecure));
+    }
+}
+
+#define TEST_WITH_AND_WITHOUT_SITE_ISOLATION(test_name) \
+TEST(LoadMetadata, test_name) \
+{ \
+    run##test_name(false); \
+} \
+\
+TEST(LoadMetadata, test_name##WithSiteIsolation) \
+{ \
+    run##test_name(true); \
+}
+
+static void runInsecureLoad(bool useSiteIsolation)
+{
+    TestWebKitAPI::HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('success!')</script>"_s } },
+    });
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, nullptr, useSiteIsolation);
+
+    runAndCheckLoadMetadata(webView, @"http://insecure.example.internal/", ExpectedMetadata::Insecure);
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureLoad)
+
+static void runSecureLoad(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(nullptr, &secureServer, useSiteIsolation);
+
+    runAndCheckLoadMetadata(webView, @"https://secure.example.internal/", ExpectedMetadata::Secure);
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(SecureLoad)
+
+static void runSameSiteHTTPSUpgrade(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.co.uk/"_s, { 302, { { "Location"_s, "https://secure.example.co.uk/"_s } }, emptyString() } } });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    runAndCheckLoadMetadata(webView, @"http://insecure.example.co.uk/", ExpectedMetadata::Secure);
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(SameSiteHTTPSUpgrade)
+
+static void runInsecureEmbeddingInsecure(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<iframe src='http://insecure.different.internal/'></iframe>"_s } },
+        { "http://insecure.different.internal/"_s, { "<script>alert('success!')</script>"_s } }
+    });
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, nullptr, useSiteIsolation);
+
+    runAndCheckLoadMetadataForFrames(webView, @"http://insecure.example.internal/");
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureEmbeddingInsecure)
+
+static void runInsecureEmbeddingSecure(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<iframe src='https://secure.different.internal/'></iframe>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    runAndCheckLoadMetadataForFrames(webView, @"http://insecure.example.internal/");
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureEmbeddingSecure)
+
+static void runInsecureOpeningSecure(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.open('https://secure.different.internal/'); }</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    runAndCheckLoadMetadataForViews(webView, @"http://insecure.example.internal/");
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureOpeningSecure)
+
+static void runInsecureOpeningSecureTargetSelf(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.open('https://secure.different.internal/', '_self', 'noopener'); }</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    runAndCheckLoadMetadataForViews(webView, @"http://insecure.example.internal/", ExpectCreated::No);
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureOpeningSecureTargetSelf)
+
+static void runInsecureOpeningSecureNoOpener(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.open('https://secure.different.internal/', '_blank', 'noopener'); }</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    runAndCheckLoadMetadataForViews(webView, @"http://insecure.example.internal/");
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureOpeningSecureNoOpener)
+
+static void runInsecureLocationRedirectsSecure(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>window.onload = function() { window.location = 'https://secure.different.internal/'; }</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    runAndCheckLoadMetadataForViews(webView, @"http://insecure.example.internal/", ExpectCreated::No);
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureLocationRedirectsSecure)
+
+static void runInsecureThenClickInitiatedNavigation(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<a id='testLink' href='https://secure.different.internal/'>Link</a>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    RetainPtr<LoadMetadataRemoteObject> object = adoptNS([[LoadMetadataRemoteObject alloc] init]);
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(LoadMetadataProtocol)];
+    [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+    __block auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    __block RetainPtr<WKWebView> createdWebView;
+
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        createdWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+
+        createdWebView.get().UIDelegate = uiDelegate.get();
+        createdWebView.get().navigationDelegate = navigationDelegate.get();
+
+        [[createdWebView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+        return createdWebView.get();
+    };
+
+    NSString *url = @"http://insecure.example.internal/";
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+
+    Util::waitFor([&] {
+        return [object numLoadMetadataCallbacks] == 1;
+    });
+
+    pid_t initialProcessPid = [webView _webProcessIdentifier];
+
+    EXPECT_TRUE([object metadataForPid:initialProcessPid].contains(WebCore::LoadMetadata::Insecure));
+
+    // Running Javascript simulates a user gesture so the navigation should escape the LoadMetadata in the new process
+
+    [webView clickOnElementID:@"testLink"];
+
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "success!");
+
+    Util::waitFor([&] {
+        return [object numLoadMetadataCallbacks] == 2;
+    });
+
+    pid_t createdProcessPid = [webView _webProcessIdentifier];
+    EXPECT_TRUE(initialProcessPid != createdProcessPid);
+
+    EXPECT_TRUE([object hasMetadataForPid:createdProcessPid]);
+    EXPECT_FALSE([object metadataForPid:createdProcessPid].contains(WebCore::LoadMetadata::Insecure));
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureThenClickInitiatedNavigation)
+
+static void runInsecureThenNavigatedToSecure(bool useSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "Hello"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('success!')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = loadMetadataTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    RetainPtr<LoadMetadataRemoteObject> object = adoptNS([[LoadMetadataRemoteObject alloc] init]);
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(LoadMetadataProtocol)];
+    [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+    __block auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    __block RetainPtr<WKWebView> createdWebView;
+
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        createdWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+
+        createdWebView.get().UIDelegate = uiDelegate.get();
+        createdWebView.get().navigationDelegate = navigationDelegate.get();
+
+        [[createdWebView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
+
+        return createdWebView.get();
+    };
+
+    NSString *url = @"http://insecure.example.internal/";
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+
+    Util::waitFor([&] {
+        return [object numLoadMetadataCallbacks] == 1;
+    });
+
+    pid_t initialProcessPid = [webView _webProcessIdentifier];
+
+    EXPECT_TRUE([object metadataForPid:initialProcessPid].contains(WebCore::LoadMetadata::Insecure));
+
+    // Performing an app initiated new request should break out of any previous LoadMetadata.
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://secure.different.internal/"]]];
+
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "success!");
+
+    Util::waitFor([&] {
+        return [object numLoadMetadataCallbacks] == 2;
+    });
+
+    pid_t createdProcessPid = [webView _webProcessIdentifier];
+    EXPECT_TRUE(initialProcessPid != createdProcessPid);
+
+    EXPECT_TRUE([object hasMetadataForPid:createdProcessPid]);
+    EXPECT_FALSE([object metadataForPid:createdProcessPid].contains(WebCore::LoadMetadata::Insecure));
+}
+
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(InsecureThenNavigatedToSecure)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadMetadataPlugin.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadMetadataPlugin.mm
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.n
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "LoadMetadataProtocol.h"
+#import "PlatformUtilities.h"
+#import <WebCore/LoadMetadata.h>
+#import <WebKit/WKWebProcessPlugIn.h>
+#import <WebKit/WKWebProcessPlugInBrowserContextController.h>
+#import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
+#import <WebKit/WKWebProcessPlugInFrame.h>
+#import <WebKit/WKWebProcessPlugInFramePrivate.h>
+#import <WebKit/WKWebProcessPlugInLoadDelegate.h>
+#import <WebKit/WKWebProcessPlugInScriptWorld.h>
+#import <WebKit/_WKRemoteObjectInterface.h>
+#import <WebKit/_WKRemoteObjectRegistry.h>
+#import <wtf/ProcessID.h>
+#import <wtf/RetainPtr.h>
+
+@interface LoadMetadataPlugin : NSObject <WKWebProcessPlugIn, WKWebProcessPlugInLoadDelegate>
+@end
+
+@implementation LoadMetadataPlugin {
+    id<LoadMetadataProtocol> _remoteObject;
+}
+
+- (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
+{
+    [browserContextController setLoadDelegate:self];
+}
+
+- (void)webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController *)controller frame:(WKWebProcessPlugInFrame *)frame didFinishLoadForResource:(uint64_t)resource
+{
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(LoadMetadataProtocol)];
+    _remoteObject = [[controller _remoteObjectRegistry] remoteObjectProxyWithInterface:interface];
+
+    OptionSet<WebCore::LoadMetadata> metadata;
+
+    if (frame._hadInsecureLoad)
+        metadata.add(WebCore::LoadMetadata::Insecure);
+
+    [_remoteObject loadMetadata:metadata.toRaw() withPID:getCurrentProcessID()];
+}
+
+@end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadMetadataProtocol.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadMetadataProtocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKWebProcessPlugInFrame.h>
+#import <WebCore/LoadMetadata.h>
+#import <WebKit/WKFoundation.h>
 
-@class JSContext;
-@class JSValue;
-@class WKWebProcessPlugInBrowserContextController;
+using LoadMetadataType = std::underlying_type_t<WebCore::LoadMetadata>;
 
-@interface WKWebProcessPlugInFrame (WKPrivate)
+@protocol LoadMetadataProtocol <NSObject>
 
-+ (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle;
-+ (instancetype)lookUpFrameFromJSContext:(JSContext *)context;
-+ (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value;
-
-@property (nonatomic, readonly) WKWebProcessPlugInBrowserContextController *_browserContextController;
-
-@property (nonatomic, readonly) BOOL _hasCustomContentProvider;
-@property (nonatomic, readonly) NSArray *_certificateChain;
-@property (nonatomic, readonly) SecTrustRef _serverTrust;
-@property (nonatomic, readonly) NSURL *_provisionalURL;
-@property (nonatomic, readonly) NSString *_securityOrigin;
-@property (nonatomic, readonly) BOOL _hadInsecureLoad;
-
-@property (nonatomic, readonly) WKWebProcessPlugInFrame *_parentFrame;
+- (void)loadMetadata:(LoadMetadataType)value withPID:(uint64_t)pid;
 
 @end


### PR DESCRIPTION
#### c8ba1311eba400997d41ccc7822d98c6760df7cc
<pre>
Introduce LoadMetadata for recording information relating to page loads.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8ba1311eba400997d41ccc7822d98c6760df7cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28397 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124237 "Hash c8ba1311 for PR 49887 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70121 "Hash c8ba1311 for PR 49887 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8f9eecf-9177-4c86-a6f7-ef88be87a35e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46343 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/124237 "Hash c8ba1311 for PR 49887 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/70121 "Hash c8ba1311 for PR 49887 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/048b13d0-a3d5-4497-b927-5c1d97767de6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121035 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30630 "7 new passes 2 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105880 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/124237 "Hash c8ba1311 for PR 49887 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40631d51-7322-47a6-b853-1e143f56ca50) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29698 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23996 "Found 1 new test failure: http/tests/navigation/window-open-redirect-and-remove-opener.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67902 "Hash c8ba1311 for PR 49887 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110194 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100055 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24174 "Found 1 new test failure: http/tests/navigation/window-open-redirect-and-remove-opener.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127314 "Hash c8ba1311 for PR 49887 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116593 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44986 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33903 "Found 1 new test failure: http/tests/navigation/window-open-redirect-and-remove-opener.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/127314 "Hash c8ba1311 for PR 49887 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45347 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/127314 "Hash c8ba1311 for PR 49887 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43471 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21458 "Found 1 new test failure: http/tests/navigation/window-open-redirect-and-remove-opener.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41431 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44858 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50532 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145291 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44318 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37378 "Found 1 new JSC binary failure: testapi, Found 19696 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47663 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->