### PR TITLE
Web Inspector: Styles: Lazily create completion suggestions view

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetTextField.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetTextField.js
@@ -30,14 +30,7 @@ WI.SpreadsheetTextField = class SpreadsheetTextField
         this._delegate = delegate;
         this._element = element;
         this._pendingValue = null;
-
         this._completionProvider = completionProvider || null;
-        if (this._completionProvider) {
-            this._suggestionHintElement = document.createElement("span");
-            this._suggestionHintElement.contentEditable = false;
-            this._suggestionHintElement.classList.add("completion-hint");
-            this._suggestionsView = new WI.CompletionSuggestionsView(this, {preventBlur: true});
-        }
 
         this._element.classList.add("spreadsheet-text-field");
 
@@ -89,7 +82,7 @@ WI.SpreadsheetTextField = class SpreadsheetTextField
 
     get suggestionHint()
     {
-        return this._suggestionHintElement.textContent;
+        return this._suggestionHintElement?.textContent || "";
     }
 
     set suggestionHint(value)
@@ -114,6 +107,13 @@ WI.SpreadsheetTextField = class SpreadsheetTextField
 
         if (this._delegate && typeof this._delegate.spreadsheetTextFieldWillStartEditing === "function")
             this._delegate.spreadsheetTextFieldWillStartEditing(this);
+
+        if (this._completionProvider && !this._suggestionsView) {
+            this._suggestionHintElement = document.createElement("span");
+            this._suggestionHintElement.contentEditable = false;
+            this._suggestionHintElement.classList.add("completion-hint");
+            this._suggestionsView = new WI.CompletionSuggestionsView(this, {preventBlur: true});
+        }
 
         this._editing = true;
         this._valueBeforeEditing = this.value;
@@ -147,7 +147,7 @@ WI.SpreadsheetTextField = class SpreadsheetTextField
 
     discardCompletion()
     {
-        if (!this._completionProvider)
+        if (!this._completionProvider || !this._suggestionsView)
             return;
 
         this._suggestionsView.hide();


### PR DESCRIPTION
#### 645fdf3e81568d4e0e8a0bd7994fa4aa14179e5b
<pre>
Web Inspector: Styles: Lazily create completion suggestions view
<a href="https://bugs.webkit.org/show_bug.cgi?id=297911">https://bugs.webkit.org/show_bug.cgi?id=297911</a>
<a href="https://rdar.apple.com/159196049">rdar://159196049</a>

Reviewed by Devin Rousso and BJ Burg.

Initialize the completion suggestions view and suggestion hint element
only when first entering edit mode to avoid creating unused objects.

`WI.SpreadsheetTextField.prototype.discardCompletion()` is the only
method that can get called without ever entering edit mode. It happens via:
`WI.SpreadsheetStyleProperty.prototype.detach()` -&gt; `WI.SpreadsheetTextField.prototype.detach()`

* Source/WebInspectorUI/UserInterface/Views/SpreadsheetTextField.js:
(WI.SpreadsheetTextField):
(WI.SpreadsheetTextField.prototype.get suggestionHint):
(WI.SpreadsheetTextField.prototype.startEditing):
(WI.SpreadsheetTextField.prototype.discardCompletion):

Canonical link: <a href="https://commits.webkit.org/299221@main">https://commits.webkit.org/299221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc5606acc776a324b5230fd681a9b41d049df8cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/118282 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/37962 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/28605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124444 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/70331 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/38657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/46544 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/124444 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/70331 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/121235 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/38657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/28605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124444 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/38657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/28605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/68108 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/38657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/28605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/45188 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/46544 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/45551 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/28605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24972 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/28605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41664 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/45058 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/50734 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/44520 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/47865 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/46208 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->