### PR TITLE
Align SVGStyleElement's type and media attributes with HTML

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-media-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-media-expected.txt
@@ -1,0 +1,3 @@
+
+PASS media attribute on SVG <style> elements should reflect correctly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-media.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-media.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Media - SVG Style element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg>
+<style id=style1></style>
+<style id=style2 media="foo"></style>
+</svg>
+
+<script>
+  test(() => {
+    assert_equals(style1.media, "", "missing media reflects as empty string IDL attribute on the style element");
+    assert_equals(style2.media, "foo", "media reflects correctly IDL attribute on the style element");
+  }, "media attribute on SVG <style> elements should reflect correctly");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-type-expected.txt
@@ -1,0 +1,3 @@
+
+PASS type attribute on SVG <style> elements should reflect correctly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-type.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-type.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Type - SVG Style element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg>
+  <style id=style1></style>
+  <style id=style2 type="random/type"></style>
+</svg>
+
+<script>
+    test(() => {
+        assert_equals(style1.type, "", "missing type reflects as empty string IDL attribute on the style element");
+        assert_equals(style2.type, "random/type", "type reflects correctly IDL attribute on the style element");
+    }, "type attribute on SVG <style> elements should reflect correctly");
+</script>

--- a/LayoutTests/svg/dom/style-reflect-expected.txt
+++ b/LayoutTests/svg/dom/style-reflect-expected.txt
@@ -3,8 +3,8 @@ This test checks that the type, media and title properties on an SVGStyleElement
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS style.type is "text/css"
-PASS style.media is "all"
+PASS style.type is ""
+PASS style.media is ""
 PASS style.title is ""
 PASS style.type is "text/x-something-else"
 PASS style.media is "print"

--- a/LayoutTests/svg/dom/style-reflect.html
+++ b/LayoutTests/svg/dom/style-reflect.html
@@ -11,8 +11,8 @@ description("This test checks that the type, media and title properties on an SV
 
 var style = document.createElementNS("http://www.w3.org/2000/svg", "style");
 
-shouldBeEqualToString("style.type", "text/css");
-shouldBeEqualToString("style.media", "all");
+shouldBeEqualToString("style.type", "");
+shouldBeEqualToString("style.media", "");
 shouldBeEqualToString("style.title", "");
 
 style.type = "text/x-something-else";

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -66,28 +66,6 @@ void SVGStyleElement::setDisabled(bool setDisabled)
         styleSheet->setDisabled(setDisabled);
 }
 
-const AtomString& SVGStyleElement::type() const
-{
-    auto& typeValue = getAttribute(SVGNames::typeAttr);
-    return typeValue.isNull() ? cssContentTypeAtom() : typeValue;
-}
-
-void SVGStyleElement::setType(const AtomString& type)
-{
-    setAttribute(SVGNames::typeAttr, type);
-}
-
-const AtomString& SVGStyleElement::media() const
-{
-    auto& value = attributeWithoutSynchronization(SVGNames::mediaAttr);
-    return value.isNull() ? allAtom() : value;
-}
-
-void SVGStyleElement::setMedia(const AtomString& media)
-{
-    setAttributeWithoutSynchronization(SVGNames::mediaAttr, media);
-}
-
 String SVGStyleElement::title() const
 {
     return attributeWithoutSynchronization(SVGNames::titleAttr);

--- a/Source/WebCore/svg/SVGStyleElement.h
+++ b/Source/WebCore/svg/SVGStyleElement.h
@@ -38,12 +38,6 @@ public:
 
     bool disabled() const;
     void setDisabled(bool);
-                          
-    const AtomString& type() const;
-    void setType(const AtomString&);
-
-    const AtomString& media() const;
-    void setMedia(const AtomString&);
 
 private:
     SVGStyleElement(const QualifiedName&, Document&, bool createdByParser);

--- a/Source/WebCore/svg/SVGStyleElement.idl
+++ b/Source/WebCore/svg/SVGStyleElement.idl
@@ -28,8 +28,8 @@
     Exposed=Window
 ] interface SVGStyleElement : SVGElement {
      attribute boolean disabled;
-     attribute [AtomString] DOMString type;
-     attribute [AtomString] DOMString media;
+     [Reflect] attribute DOMString type;
+     [Reflect] attribute DOMString media;
      [Reflect] attribute DOMString title;
 };
 


### PR DESCRIPTION
#### f57fc5519fb7a164fca041a0f6206ab9909a7d1b
<pre>
Align SVGStyleElement&apos;s type and media attributes with HTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=297909">https://bugs.webkit.org/show_bug.cgi?id=297909</a>

Reviewed by Tim Nguyen.

See <a href="https://github.com/w3c/svgwg/pull/1001">https://github.com/w3c/svgwg/pull/1001</a>

This aligns SVGStyleElement type and media to use pure attribute reflection which matches how HTMLStyleElement works.

This aligns WebKit with Firefox/Gecko.

Canonical link: <a href="https://commits.webkit.org/299252@main">https://commits.webkit.org/299252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9514a78ec686a0a231c5a61f9f9f98bddce104

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89714 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59355 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24124 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68052 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98399 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98186 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24988 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41595 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50676 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->