### PR TITLE
Rename `tagHistory` in `CSSSelector`

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -135,7 +135,7 @@ public:
     // Selectors are kept in an array by CSSSelectorList.
     // The next component of the selector is the next item in the array.
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    const CSSSelector* tagHistory() const { return m_isLastInTagHistory ? nullptr : this + 1; }
+    const CSSSelector* precedingInComplexSelector() const { return m_isLastInComplexSelector ? nullptr : this + 1; }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     const CSSSelector* firstInCompound() const;
@@ -174,8 +174,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     Match match() const { return static_cast<Match>(m_match); }
 
     bool isLastInSelectorList() const { return m_isLastInSelectorList; }
-    bool isFirstInTagHistory() const { return m_isFirstInTagHistory; }
-    bool isLastInTagHistory() const { return m_isLastInTagHistory; }
+    bool isFirstInComplexSelector() const { return m_isFirstInComplexSelector; }
+    bool isLastInComplexSelector() const { return m_isLastInComplexSelector; }
 
     // FIXME: This should ideally be private, but StyleRule uses it.
     void setLastInSelectorList() { m_isLastInSelectorList = true; }
@@ -217,8 +217,8 @@ private:
     mutable unsigned m_pseudoType : 8 { 0 }; // PseudoType.
     // 17 bits
     unsigned m_isLastInSelectorList : 1 { false };
-    unsigned m_isFirstInTagHistory : 1 { true };
-    unsigned m_isLastInTagHistory : 1 { true };
+    unsigned m_isFirstInComplexSelector : 1 { true };
+    unsigned m_isLastInComplexSelector : 1 { true };
     unsigned m_hasRareData : 1 { false };
     unsigned m_isForPage : 1 { false };
     unsigned m_tagIsForNamespaceRule : 1 { false };

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -83,7 +83,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const_iterator& operator++()
         {
             // Skip subparts of compound selectors.
-            while (!m_ptr->isLastInTagHistory())
+            while (!m_ptr->isLastInComplexSelector())
                 ++m_ptr;
             m_ptr = m_ptr->isLastInSelectorList() ? nullptr : m_ptr + 1;
             return *this;
@@ -115,7 +115,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     CSSSelectorList& operator=(CSSSelectorList&&) = default;
 
 private:
-    // End of a multipart selector is indicated by m_isLastInTagHistory bit in the last item.
+    // End of a multipart selector is indicated by m_isLastInComplexSelector bit in the last item.
     // End of the array is indicated by m_isLastInSelectorList bit in the last item.
     UniqueArray<CSSSelector> m_selectorArray;
 };

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -362,7 +362,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
     auto relation = context.selector->relation();
 
     // Prepare next selector
-    const CSSSelector* leftSelector = context.selector->tagHistory();
+    const CSSSelector* leftSelector = context.selector->precedingInComplexSelector();
     if (!leftSelector) {
         if (context.mustMatchHostPseudoClass && !context.matchedHostPseudoClass)
             return MatchResult::fails(Match::SelectorFailsCompletely);
@@ -668,7 +668,7 @@ static bool canMatchHoverOrActiveInQuirksMode(const SelectorChecker::LocalContex
     if (context.inFunctionalPseudoClass)
         return true;
 
-    for (const CSSSelector* selector = context.firstSelectorOfTheFragment; selector; selector = selector->tagHistory()) {
+    for (const CSSSelector* selector = context.firstSelectorOfTheFragment; selector; selector = selector->precedingInComplexSelector()) {
         switch (selector->match()) {
         case CSSSelector::Match::Tag:
             if (selector->tagQName() != anyQName())
@@ -1638,7 +1638,7 @@ unsigned SelectorChecker::determineLinkMatchType(const CSSSelector* selector)
 
     // Statically determine if this selector will match a link in visited, unvisited or any state, or never.
     // :visited never matches other elements than the innermost link element.
-    for (; selector; selector = selector->tagHistory()) {
+    for (; selector; selector = selector->precedingInComplexSelector()) {
         if (selector->match() == CSSSelector::Match::PseudoClass) {
             switch (selector->pseudoClass()) {
             case CSSSelector::PseudoClass::Link:

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -185,12 +185,12 @@ void SelectorFilter::collectSelectorHashes(CollectedSelectorHashes& collectedHas
 {
     auto [selector, relation, skipOverSubselectors] = [&] {
         if (includeRightmost == IncludeRightmost::No)
-            return std::tuple { rightmostSelector.tagHistory(), rightmostSelector.relation(), true };
+            return std::tuple { rightmostSelector.precedingInComplexSelector(), rightmostSelector.relation(), true };
 
         return std::tuple { &rightmostSelector, CSSSelector::Relation::Subselector, false };
     }();
 
-    for (; selector; selector = selector->tagHistory()) {
+    for (; selector; selector = selector->precedingInComplexSelector()) {
         // Only collect identifiers that match ancestors.
         switch (relation) {
         case CSSSelector::Relation::Subselector:

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -332,7 +332,7 @@ Vector<Ref<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorCompo
 
     for (auto& selector : selectorList()) {
         Vector<const CSSSelector*, 8> componentsInThisSelector;
-        for (const CSSSelector* component = &selector; component; component = component->tagHistory())
+        for (const CSSSelector* component = &selector; component; component = component->precedingInComplexSelector())
             componentsInThisSelector.append(component);
 
         if (componentsInThisSelector.size() + componentsSinceLastSplit.size() > maxCount && !componentsSinceLastSplit.isEmpty()) {

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -287,7 +287,7 @@ CSSSelectorList CSSParser::parsePageSelector(CSSParserTokenRange range, StyleShe
                 return { };
         }
         if (!typeSelector.isNull())
-            selector->prependTagSelector(QualifiedName(nullAtom(), typeSelector, styleSheet->defaultNamespace()));
+            selector->appendTagInComplexSelector(QualifiedName(nullAtom(), typeSelector, styleSheet->defaultNamespace()));
     }
 
     selector->setForPage();

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -102,19 +102,19 @@ MutableCSSSelector::MutableCSSSelector(const QualifiedName& tagQName)
 MutableCSSSelector::MutableCSSSelector(const CSSSelector& selector)
     : m_selector(makeUnique<CSSSelector>(selector))
 {
-    if (auto next = selector.tagHistory())
-        m_tagHistory = makeUnique<MutableCSSSelector>(*next);
+    if (auto preceding = selector.precedingInComplexSelector())
+        m_precedingInComplexSelector = makeUnique<MutableCSSSelector>(*preceding);
 }
 
 
 MutableCSSSelector::~MutableCSSSelector()
 {
-    if (!m_tagHistory)
+    if (!m_precedingInComplexSelector)
         return;
     Vector<std::unique_ptr<MutableCSSSelector>, 16> toDelete;
-    std::unique_ptr<MutableCSSSelector> selector = WTFMove(m_tagHistory);
+    std::unique_ptr<MutableCSSSelector> selector = WTFMove(m_precedingInComplexSelector);
     while (true) {
-        std::unique_ptr<MutableCSSSelector> next = WTFMove(selector->m_tagHistory);
+        std::unique_ptr<MutableCSSSelector> next = WTFMove(selector->m_precedingInComplexSelector);
         toDelete.append(WTFMove(selector));
         if (!next)
             break;
@@ -147,7 +147,7 @@ void MutableCSSSelector::setSelectorList(std::unique_ptr<CSSSelectorList> select
 const MutableCSSSelector* MutableCSSSelector::leftmostSimpleSelector() const
 {
     auto selector = this;
-    while (auto next = selector->tagHistory())
+    while (auto next = selector->precedingInComplexSelector())
         selector = next;
     return selector;
 }
@@ -155,7 +155,7 @@ const MutableCSSSelector* MutableCSSSelector::leftmostSimpleSelector() const
 MutableCSSSelector* MutableCSSSelector::leftmostSimpleSelector()
 {
     auto selector = this;
-    while (auto next = selector->tagHistory())
+    while (auto next = selector->precedingInComplexSelector())
         selector = next;
     return selector;
 }
@@ -167,7 +167,7 @@ bool MutableCSSSelector::hasExplicitNestingParent() const
         if (selector->selector()->hasExplicitNestingParent())
             return true;
 
-        selector = selector->tagHistory();
+        selector = selector->precedingInComplexSelector();
     }
     return false;
 }
@@ -179,7 +179,7 @@ bool MutableCSSSelector::hasExplicitPseudoClassScope() const
         if (selector->selector()->hasExplicitPseudoClassScope())
             return true;
 
-        selector = selector->tagHistory();
+        selector = selector->precedingInComplexSelector();
     }
     return false;
 }
@@ -190,7 +190,7 @@ static bool selectorListMatchesPseudoElement(const CSSSelectorList* selectorList
         return false;
 
     for (auto& subSelector : *selectorList) {
-        for (const CSSSelector* selector = &subSelector; selector; selector = selector->tagHistory()) {
+        for (const CSSSelector* selector = &subSelector; selector; selector = selector->precedingInComplexSelector()) {
             if (selector->matchesPseudoElement())
                 return true;
             if (const CSSSelectorList* subselectorList = selector->selectorList()) {
@@ -207,44 +207,46 @@ bool MutableCSSSelector::matchesPseudoElement() const
     return m_selector->matchesPseudoElement() || selectorListMatchesPseudoElement(m_selector->selectorList());
 }
 
-void MutableCSSSelector::appendTagHistory(CSSSelector::Relation relation, std::unique_ptr<MutableCSSSelector> selector)
+void MutableCSSSelector::prependInComplexSelector(CSSSelector::Relation relation, std::unique_ptr<MutableCSSSelector> selector)
 {
-    auto* end = this;
-    while (end->tagHistory())
-        end = end->tagHistory();
+    auto* first = this;
+    while (first->precedingInComplexSelector())
+        first = first->precedingInComplexSelector();
 
-    end->setRelation(relation);
-    end->setTagHistory(WTFMove(selector));
+    first->setRelation(relation);
+    first->setPrecedingInComplexSelector(WTFMove(selector));
 }
 
-void MutableCSSSelector::appendTagHistoryAsRelative(std::unique_ptr<MutableCSSSelector> selector)
+void MutableCSSSelector::prependInComplexSelectorAsRelative(std::unique_ptr<MutableCSSSelector> selector)
 {
-    auto lastSelector = leftmostSimpleSelector()->selector();
-    ASSERT(lastSelector);
+    auto firstSelector = leftmostSimpleSelector()->selector();
+    ASSERT(firstSelector);
 
     // Relation is Descendant by default.
-    auto relation = lastSelector->relation();
+    auto relation = firstSelector->relation();
     if (relation == CSSSelector::Relation::Subselector)
         relation = CSSSelector::Relation::DescendantSpace;
 
-    appendTagHistory(relation, WTFMove(selector));
+    prependInComplexSelector(relation, WTFMove(selector));
 }
 
-void MutableCSSSelector::prependTagSelector(const QualifiedName& tagQName, bool tagIsForNamespaceRule)
+void MutableCSSSelector::appendTagInComplexSelector(const QualifiedName& tagQName, bool tagIsForNamespaceRule)
 {
-    auto second = makeUnique<MutableCSSSelector>();
-    second->m_selector = WTFMove(m_selector);
-    second->m_tagHistory = WTFMove(m_tagHistory);
-    m_tagHistory = WTFMove(second);
+    // Make the current last selector the second to last.
+    auto currentLast = makeUnique<MutableCSSSelector>();
+    currentLast->m_selector = WTFMove(m_selector);
+    currentLast->m_precedingInComplexSelector = WTFMove(m_precedingInComplexSelector);
+    m_precedingInComplexSelector = WTFMove(currentLast);
 
+    // Change the last selector to be the tag selector.
     m_selector = makeUnique<CSSSelector>(tagQName, tagIsForNamespaceRule);
     m_selector->setRelation(CSSSelector::Relation::Subselector);
 }
 
-std::unique_ptr<MutableCSSSelector> MutableCSSSelector::releaseTagHistory()
+std::unique_ptr<MutableCSSSelector> MutableCSSSelector::releaseFromComplexSelector()
 {
     setRelation(CSSSelector::Relation::Subselector);
-    return WTFMove(m_tagHistory);
+    return WTFMove(m_precedingInComplexSelector);
 }
 
 bool MutableCSSSelector::startsWithExplicitCombinator() const

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -91,19 +91,19 @@ public:
     // special case, since it will be covered by this function once again.
     bool needsImplicitShadowCombinatorForMatching() const;
 
-    MutableCSSSelector* tagHistory() const { return m_tagHistory.get(); }
+    MutableCSSSelector* precedingInComplexSelector() const { return m_precedingInComplexSelector.get(); }
     MutableCSSSelector* leftmostSimpleSelector();
     const MutableCSSSelector* leftmostSimpleSelector() const;
     bool startsWithExplicitCombinator() const;
-    void setTagHistory(std::unique_ptr<MutableCSSSelector> selector) { m_tagHistory = WTFMove(selector); }
-    void appendTagHistory(CSSSelector::Relation, std::unique_ptr<MutableCSSSelector>);
-    void appendTagHistoryAsRelative(std::unique_ptr<MutableCSSSelector>);
-    void prependTagSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
-    std::unique_ptr<MutableCSSSelector> releaseTagHistory();
+    void setPrecedingInComplexSelector(std::unique_ptr<MutableCSSSelector> selector) { m_precedingInComplexSelector = WTFMove(selector); }
+    void prependInComplexSelector(CSSSelector::Relation, std::unique_ptr<MutableCSSSelector>);
+    void prependInComplexSelectorAsRelative(std::unique_ptr<MutableCSSSelector>);
+    void appendTagInComplexSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
+    std::unique_ptr<MutableCSSSelector> releaseFromComplexSelector();
 
 private:
     std::unique_ptr<CSSSelector> m_selector;
-    std::unique_ptr<MutableCSSSelector> m_tagHistory;
+    std::unique_ptr<MutableCSSSelector> m_precedingInComplexSelector;
 };
 
 // FIXME: WebKitUnknown is listed below as otherwise @supports does the wrong thing, but there ought

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1418,7 +1418,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
     bool isRightmostOrAdjacent = positionInRootFragments != FragmentPositionInRootFragments::Other;
     FunctionType functionType = FunctionType::SimpleSelectorChecker;
     SelectorFragment* fragment = nullptr;
-    for (const CSSSelector* selector = rootSelector; selector; selector = selector->tagHistory()) {
+    for (const CSSSelector* selector = rootSelector; selector; selector = selector->precedingInComplexSelector()) {
         if (!fragment) {
             selectorFragments.append(SelectorFragment());
             fragment = &selectorFragments.last();
@@ -1550,7 +1550,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
         if (relation == CSSSelector::Relation::Subselector)
             continue;
 
-        if ((relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant) && !selector->isLastInTagHistory())
+        if ((relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant) && !selector->isLastInComplexSelector())
             return FunctionType::CannotCompile;
 
         if (relation == CSSSelector::Relation::ShadowSlotted)

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -70,7 +70,7 @@ auto HasSelectorFilter::makeKey(const CSSSelector& hasSelector) -> Key
 {
     SelectorFilter::CollectedSelectorHashes hashes;
     bool hasHoverInCompound = false;
-    for (auto* simpleSelector = &hasSelector; simpleSelector; simpleSelector = simpleSelector->tagHistory()) {
+    for (auto* simpleSelector = &hasSelector; simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
         if (simpleSelector->match() == CSSSelector::Match::PseudoClass && simpleSelector->pseudoClass() == CSSSelector::PseudoClass::Hover)
             hasHoverInCompound = true;
         SelectorFilter::collectSimpleSelectorHash(hashes, *simpleSelector);

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -93,7 +93,7 @@ void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isF
 
 static bool checkPageSelectorComponents(const CSSSelector* selector, bool isLeftPage, bool isFirstPage, const String& pageName)
 {
-    for (const CSSSelector* component = selector; component; component = component->tagHistory()) {
+    for (const CSSSelector* component = selector; component; component = component->precedingInComplexSelector()) {
         if (component->match() == CSSSelector::Match::Tag) {
             const AtomString& localName = component->tagQName().localName();
             if (localName != starAtom() && localName != pageName)

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -62,7 +62,7 @@ static_assert(sizeof(RuleData) == sizeof(SameSizeAsRuleData), "RuleData should s
 
 static inline MatchBasedOnRuleHash computeMatchBasedOnRuleHash(const CSSSelector& selector)
 {
-    if (selector.tagHistory())
+    if (selector.precedingInComplexSelector())
         return MatchBasedOnRuleHash::None;
 
     if (selector.match() == CSSSelector::Match::Tag) {
@@ -100,14 +100,14 @@ static bool selectorCanMatchPseudoElement(const CSSSelector& rootSelector)
             }
         }
 
-        selector = selector->tagHistory();
+        selector = selector->precedingInComplexSelector();
     } while (selector);
     return false;
 }
 
 static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* selector)
 {
-    for (const CSSSelector* component = selector; component; component = component->tagHistory()) {
+    for (const CSSSelector* component = selector; component; component = component->precedingInComplexSelector()) {
 #if ENABLE(VIDEO)
         // Property allow-list for `::cue`:
         if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && component->value() == UserAgentParts::cue())

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -211,7 +211,7 @@ static MatchElement computeNextHasPseudoClassMatchElement(MatchElement matchElem
 MatchElement computeHasPseudoClassMatchElement(const CSSSelector& hasSelector)
 {
     auto hasMatchElement = MatchElement::Subject;
-    for (auto* simpleSelector = &hasSelector; simpleSelector->tagHistory(); simpleSelector = simpleSelector->tagHistory())
+    for (auto* simpleSelector = &hasSelector; simpleSelector->precedingInComplexSelector(); simpleSelector = simpleSelector->precedingInComplexSelector())
         hasMatchElement = computeNextMatchElement(hasMatchElement, simpleSelector->relation());
 
     switch (hasMatchElement) {
@@ -347,7 +347,7 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
             }
         }
 
-        if (!selector->tagHistory())
+        if (!selector->precedingInComplexSelector())
             break;
 
         matchElement = [&] {
@@ -359,7 +359,7 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
         if (isScopeBreaking(matchElement))
             doesBreakScope = DoesBreakScope::Yes;
 
-        selector = selector->tagHistory();
+        selector = selector->precedingInComplexSelector();
     };
 
     return doesBreakScope;
@@ -385,7 +385,7 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
     AtomString attributeName;
     AtomString className;
     AtomString tagName;
-    for (auto* simpleSelector = selector.firstInCompound(); simpleSelector; simpleSelector = simpleSelector->tagHistory()) {
+    for (auto* simpleSelector = selector.firstInCompound(); simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
         if (simpleSelector->match() == CSSSelector::Match::Id)
             return makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Id, simpleSelector->value());
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -111,12 +111,12 @@ static bool isHostSelectorMatchingInShadowTree(const CSSSelector& startSelector)
 
     bool hasOnlyOneCompound = true;
     bool hasHostInLastCompound = false;
-    for (auto* selector = &startSelector; selector; selector = selector->tagHistory()) {
+    for (auto* selector = &startSelector; selector; selector = selector->precedingInComplexSelector()) {
         if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Host)
             hasHostInLastCompound = true;
         if (isHostSelectorMatchingInShadowTreeInSelectorList(selector->selectorList()))
             return true;
-        if (selector->tagHistory() && selector->relation() != CSSSelector::Relation::Subselector) {
+        if (selector->precedingInComplexSelector() && selector->relation() != CSSSelector::Relation::Subselector) {
             hasOnlyOneCompound = false;
             hasHostInLastCompound = false;
         }
@@ -277,7 +277,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         // We only process the subject (rightmost compound selector).
         if (selector->relation() != CSSSelector::Relation::Subselector)
             break;
-        selector = selector->tagHistory();
+        selector = selector->precedingInComplexSelector();
     } while (selector);
 
     if (!m_hasHostPseudoClassRulesMatchingInShadowTree)
@@ -308,7 +308,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         // FIXME: Custom pseudo elements are handled by the shadow tree's selector filter. It doesn't know about the main DOM.
         ruleData.disableSelectorFiltering();
 
-        auto* nextSelector = customPseudoElementSelector->tagHistory();
+        auto* nextSelector = customPseudoElementSelector->precedingInComplexSelector();
         if (nextSelector && nextSelector->match() == CSSSelector::Match::PseudoElement && nextSelector->pseudoElement() == CSSSelector::PseudoElement::Part) {
             // Handle selectors like ::part(foo)::placeholder with the part codepath.
             m_partPseudoElementRules.append(ruleData);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -826,7 +826,7 @@ static CSSSelectorList viewTransitionSelector(CSSSelector::PseudoElement element
     groupSelector->setValue(selectorName);
     groupSelector->setArgumentList({ { name } });
 
-    selectorList.first()->appendTagHistory(CSSSelector::Relation::Subselector, WTFMove(groupSelector));
+    selectorList.first()->prependInComplexSelector(CSSSelector::Relation::Subselector, WTFMove(groupSelector));
 
     return CSSSelectorList(WTFMove(selectorList));
 }


### PR DESCRIPTION
#### 0cc8d008055b8590212df7c71ded13924187a1a5
<pre>
Rename `tagHistory` in `CSSSelector`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297912">https://bugs.webkit.org/show_bug.cgi?id=297912</a>
<a href="https://rdar.apple.com/159200563">rdar://159200563</a>

Reviewed by Antti Koivisto.

The tag history is actually a linked list of simple selectors within a complex selector. Make that explicit.

m_tagHistory -&gt; m_precedingInComplexSelector
tagHistory() -&gt; precedingInComplexSelector()
setTagHistory() -&gt; setPrecedingInComplexSelector()
appendTagHistory() -&gt; prependInComplexSelector()
appendTagHistoryAsRelative() -&gt; prependInComplexSelectorAsRelative()
prependTagSelector() -&gt; appendTagInComplexSelector()
releaseTagHistory() -&gt; releaseFromComplexSelector()

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::selectorSpecificity):
(WebCore::CSSSelector::specificityForPage const):
(WebCore::CSSSelector::firstInCompound const):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::visitSimpleSelectors const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::precedingInComplexSelector const):
(WebCore::CSSSelector::isFirstInComplexSelector const):
(WebCore::CSSSelector::isLastInComplexSelector const):
(WebCore::CSSSelector::tagHistory const): Deleted.
(WebCore::CSSSelector::isFirstInTagHistory const): Deleted.
(WebCore::CSSSelector::isLastInTagHistory const): Deleted.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::makeCopyingSimpleSelector):
(WebCore::CSSSelectorList::makeCopyingComplexSelector):
(WebCore::CSSSelectorList::listSize const):
(WebCore::forEachTagSelector):
(WebCore::CSSSelectorList::hasOnlyNestingSelector const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::const_iterator::operator++):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::determineLinkMatchType):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSelectorHashes):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::splitIntoMultipleRulesWithMaximumSelectorComponentCount const):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parsePageSelector):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::appendImplicitSelectorPseudoClassScopeIfNeeded):
(WebCore::appendImplicitSelectorNestingParentIfNeeded):
(WebCore::CSSSelectorParser::consumeComplexSelector):
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
(WebCore::CSSSelectorParser::consumeCompoundSelector):
(WebCore::CSSSelectorParser::prependTypeSelectorIfNeeded):
(WebCore::CSSSelectorParser::splitCompoundAtImplicitShadowCrossingCombinator):
(WebCore::CSSSelectorParser::containsUnknownWebKitPseudoElements):
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::MutableCSSSelector):
(WebCore::MutableCSSSelector::~MutableCSSSelector):
(WebCore::MutableCSSSelector::leftmostSimpleSelector const):
(WebCore::MutableCSSSelector::leftmostSimpleSelector):
(WebCore::MutableCSSSelector::hasExplicitNestingParent const):
(WebCore::MutableCSSSelector::hasExplicitPseudoClassScope const):
(WebCore::selectorListMatchesPseudoElement):
(WebCore::MutableCSSSelector::insertInComplexSelector):
(WebCore::MutableCSSSelector::prependInComplexSelector):
(WebCore::MutableCSSSelector::prependInComplexSelectorAsRelative):
(WebCore::MutableCSSSelector::appendTagInComplexSelector):
(WebCore::MutableCSSSelector::releaseFromComplexSelector):
(WebCore::MutableCSSSelector::insertTagHistory): Deleted.
(WebCore::MutableCSSSelector::appendTagHistory): Deleted.
(WebCore::MutableCSSSelector::appendTagHistoryAsRelative): Deleted.
(WebCore::MutableCSSSelector::prependTagSelector): Deleted.
(WebCore::MutableCSSSelector::releaseTagHistory): Deleted.
* Source/WebCore/css/parser/MutableCSSSelector.h:
(WebCore::MutableCSSSelector::precedingInComplexSelector const):
(WebCore::MutableCSSSelector::setPrecedingInComplexSelector):
(WebCore::MutableCSSSelector::clearPrecedingInComplexSelector):
(WebCore::MutableCSSSelector::tagHistory const): Deleted.
(WebCore::MutableCSSSelector::setTagHistory): Deleted.
(WebCore::MutableCSSSelector::clearTagHistory): Deleted.
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::isSingleTagNameSelector):
(WebCore::isSingleClassNameSelector):
(WebCore::isSingleAttributeExactSelector):
(WebCore::findIdMatchingType):
(WebCore::SelectorDataList::SelectorDataList):
(WebCore::selectorForIdLookup):
(WebCore::filterRootById):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::makeKey):
* Source/WebCore/style/PageRuleCollector.cpp:
(WebCore::Style::checkPageSelectorComponents):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::computeMatchBasedOnRuleHash):
(WebCore::Style::selectorCanMatchPseudoElement):
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeHasPseudoClassMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::makePseudoClassInvalidationKey):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::isHostSelectorMatchingInShadowTree):
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::viewTransitionSelector):

Canonical link: <a href="https://commits.webkit.org/299193@main">https://commits.webkit.org/299193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d46589a344f05e002306e436e373449115816437

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118220 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70261 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/942eab48-5fd2-4b09-a5a9-a94a4fa9713d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89709 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/894efe11-ea12-4748-8a2d-bb311418ec11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36383052-e424-458e-b234-c7f14fa8db97) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24115 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68045 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127453 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98394 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41588 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50669 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44455 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->