### PR TITLE
[UnifiedPDF] VoiceOver does not recognize the password form

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1241,6 +1241,11 @@ bool PluginView::pluginDelegatesScrollingToMainFrame() const
     return m_plugin->delegatesScrollingToMainFrame();
 }
 
+bool PluginView::isPresentingLockedContent() const
+{
+    return m_isInitialized && m_plugin->isLocked();
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -169,6 +169,8 @@ public:
 
     bool pluginDelegatesScrollingToMainFrame() const;
 
+    bool isPresentingLockedContent() const;
+
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);
     virtual ~PluginView();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1463,6 +1463,29 @@ void WebPage::processSystemDidWake() const
         manager->processSystemDidWake();
 }
 
+NSObject *WebPage::accessibilityObjectForMainFramePlugin()
+{
+#if ENABLE(PDF_PLUGIN)
+    if (!m_page)
+        return nil;
+
+    if (RefPtr pluginView = mainFramePlugIn())
+        return pluginView->accessibilityObject();
+#endif
+
+    return nil;
+}
+
+bool WebPage::shouldFallbackToWebContentAXObjectForMainFramePlugin() const
+{
+#if ENABLE(PDF_PLUGIN)
+    RefPtr pluginView = mainFramePlugIn();
+    return pluginView && pluginView->isPresentingLockedContent();
+#else
+    return false;
+#endif
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1245,6 +1245,7 @@ public:
     void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&);
 #endif
     NSObject *accessibilityObjectForMainFramePlugin();
+    bool shouldFallbackToWebContentAXObjectForMainFramePlugin() const;
     const WebCore::FloatPoint& accessibilityPosition() const { return m_accessibilityPosition; }
 
     void setTextAsync(const String&);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -708,16 +708,6 @@ void WebPage::getSelectionContext(CompletionHandler<void(const String&, const St
 
     completionHandler(selectedText, textBefore, textAfter);
 }
-
-NSObject *WebPage::accessibilityObjectForMainFramePlugin()
-{
-#if ENABLE(PDF_PLUGIN)
-    if (RefPtr pluginView = mainFramePlugIn())
-        return pluginView->accessibilityObject();
-#endif
-
-    return nil;
-}
     
 void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint offset)
 {

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -82,4 +82,5 @@ class AXIsolatedTree;
 - (WebCore::LocalFrame *)focusedLocalFrame;
 - (NSUInteger)remoteTokenHash;
 
+- (BOOL)shouldFallbackToWebContentAXObjectForMainFramePlugin;
 @end

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -89,6 +89,12 @@ namespace ax = WebCore::Accessibility;
     return axPlugin.autorelease();
 }
 
+- (BOOL)shouldFallbackToWebContentAXObjectForMainFramePlugin
+{
+    RefPtr page = m_page.get();
+    return page && page->shouldFallbackToWebContentAXObjectForMainFramePlugin();
+}
+
 // Called directly by Accessibility framework.
 - (id)accessibilityRootObjectWrapper
 {
@@ -111,7 +117,7 @@ namespace ax = WebCore::Accessibility;
         if (!WebCore::AXObjectCache::accessibilityEnabled())
             [protectedSelf enableAccessibilityForAllProcesses];
 
-        if (protectedSelf.get()->m_hasMainFramePlugin) {
+        if (protectedSelf->m_hasMainFramePlugin) {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
             // Even though we want to serve the PDF plugin tree for main-frame plugins, we still need to make sure the isolated tree
             // is built, so that when text annotations are created on-the-fly as users focus on text fields,
@@ -120,7 +126,8 @@ namespace ax = WebCore::Accessibility;
             if (auto cache = protectedSelf.get().axObjectCache)
                 cache->buildIsolatedTreeIfNeeded();
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-            return protectedSelf.get().accessibilityPluginObject;
+            if (![protectedSelf shouldFallbackToWebContentAXObjectForMainFramePlugin])
+                return [protectedSelf accessibilityPluginObject];
         }
 
         if (auto cache = protectedSelf.get().axObjectCache) {

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -221,17 +221,6 @@ void WebPage::handleAcceptedCandidate(WebCore::TextCheckingResult acceptedCandid
         frame->protectedEditor()->handleAcceptedCandidate(acceptedCandidate);
 }
 
-NSObject *WebPage::accessibilityObjectForMainFramePlugin()
-{
-    if (!m_page)
-        return nil;
-    
-    if (RefPtr pluginView = mainFramePlugIn())
-        return pluginView->accessibilityObject();
-
-    return nil;
-}
-
 static String commandNameForSelectorName(const String& selectorName)
 {
     // Map selectors into Editor command names.


### PR DESCRIPTION
#### 0d359e074687d590e5888bf9beb8d0fe5d4986b4
<pre>
[UnifiedPDF] VoiceOver does not recognize the password form
<a href="https://bugs.webkit.org/show_bug.cgi?id=297895">https://bugs.webkit.org/show_bug.cgi?id=297895</a>
<a href="https://rdar.apple.com/155907450">rdar://155907450</a>

Reviewed by Tyler Wilcock.

When WebPage reports the presence of a main frame plugin, we
unconditionally reach for the AX object wrapper corresponding to the
plugin. This has the undesired effect of stealing AX away from general
web content, which is usually fine except when said web content is
presented over a plugin, as is the case for the password form for locked
documents.

In this patch, we teach WKAccessibilityWebPageObject that it may be
necessary to disregard the plugin AX object even when a main frame
plugin is present. We go with this approach over teaching the plugin&apos;s
AX object (WKAccessibilityPDFDocumentObject) about the password
annotations because (a) the concept of an active annotation is still not
platform agnostic and (b) it would introduce an unfortunate coordinate
transformation spaghetti inside the accessibility object since it will
have to undo some transformations performed on the hit test point.

More details in-line.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::presentingLockedContent const):

Helper query that forwards PDFPluginBase::isLocked().

* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::accessibilityObjectForMainFramePlugin):

This method has the same definition on all Cocoa platforms, so we
deduplicate.

(WebKit::WebPage::fallbackToWebContentAXObjectForMainFramePlugin const):

Introduce a query that allows our AX wrapper object finding logic to
look at web content, rather than the plugin&apos;s bespoke object. You could
imagine this being necessary for multiple conditions, but the only one
it abstracts away for now is the presence of a password form (i.e. if
the document is locked)

* Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm:
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):

Multiple changes:
- Lift a clarifying comment from the macOS method definition about
  coordinate transformations for the plugin.
- Respect fallbackToWebContentAXObjectForMainFramePlugin and perform
  coordinate conversions regardless of main frame plugin presence as
  needed.
- Refactor the code so there is only one terminal call to hitTest:.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::accessibilityObjectForMainFramePlugin): Deleted.

Deduplicated this.

* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase fallbackToWebContentAXObjectForMainFramePlugin]):

Just forward WebPage::fallbackToWebContentAXObjectForMainFramePlugin().
Makes callsites a bit easier to read.

(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]):

Respect fallbackToWebContentAXObjectForMainFramePlugin and return
general web content AX cache object when appropriate.

* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):

Same added logic and refactor as the iOS method definition.

* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::accessibilityObjectForMainFramePlugin): Deleted.

Deduplicated this.

Canonical link: <a href="https://commits.webkit.org/299180@main">https://commits.webkit.org/299180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66dceefd7075ffe0ad5abfa3ce0603a136d530ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70205 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0874203-ef2f-4905-84dd-1dfa67816195) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89670 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/784110cf-0eec-4460-b431-9069bb4cee66) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70163 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4fbb078-a1fd-4a5b-bd3d-f8289961e5f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29760 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67988 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98348 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98137 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43529 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44400 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->