### PR TITLE
[Bidi Copy/Paste] Preserve writing direction when pasting multi-paragraph bidi text

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-rtl-paragraph-twice-expected.html
+++ b/LayoutTests/editing/pasteboard/paste-rtl-paragraph-twice-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+div[contenteditable] {
+    border: 1px solid orange;
+    padding: 1em;
+    outline: none;
+}
+</style>
+</head>
+<body>
+    <div dir="rtl" contenteditable id="destination" spellcheck="false" autocorrect="off">
+        <div>الإنجليزي مثل<strong>الإنجليزي مثل “hello world” يُكتب من اليسار إلى</strong>الاتجاهين</div>
+        <div>الإنجليزي مثل<strong>الإنجليزي مثل “hello world” يُكتب من اليسار إلى</strong>الاتجاهين</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/paste-rtl-paragraph-twice.html
+++ b/LayoutTests/editing/pasteboard/paste-rtl-paragraph-twice.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true BidiContentAwarePasteEnabled=true ] -->
+<html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+div[contenteditable] {
+    border: 1px solid orange;
+    padding: 1em;
+    outline: none;
+}
+
+.rtl {
+    direction: rtl;
+    margin: 1em;
+}
+
+button {
+    font-size: 20px;
+}
+</style>
+<script>
+window.testRunner?.waitUntilDone();
+
+addEventListener("load", async () => {
+    const source = document.getElementById("source");
+    const copyButton = document.querySelector("button");
+    copyButton.addEventListener("click", () => {
+        getSelection().selectAllChildren(source);
+        document.execCommand("Copy");
+    });
+
+    await UIHelper.activateElement(copyButton);
+    await UIHelper.ensurePresentationUpdate();
+    const destination = document.getElementById("destination");
+    getSelection().selectAllChildren(destination);
+    document.execCommand("Paste");
+    await UIHelper.ensurePresentationUpdate();
+    document.execCommand("InsertParagraph");
+    await UIHelper.ensurePresentationUpdate();
+    document.execCommand("Paste");
+    await UIHelper.ensurePresentationUpdate();
+
+    getSelection().removeAllRanges();
+    document.getElementById("removeAfterTest").remove();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="rtl" id="removeAfterTest">
+        <p id="source">الإنجليزي مثل<strong>الإنجليزي مثل “hello world” يُكتب من اليسار إلى</strong>الاتجاهين</p>
+        <button>Click to copy</button>
+    </div>
+    <div contenteditable id="destination" spellcheck="false" autocorrect="off"></div>
+</body>
+</html>


### PR DESCRIPTION
#### 1663444ffb8cc963ae9fed19c2c430c3f4074926
<pre>
[Bidi Copy/Paste] Preserve writing direction when pasting multi-paragraph bidi text
<a href="https://bugs.webkit.org/show_bug.cgi?id=297923">https://bugs.webkit.org/show_bug.cgi?id=297923</a>
<a href="https://rdar.apple.com/152236717">rdar://152236717</a>

Reviewed by Abrar Rahman Protyasha.

Make the heuristics in `updateDirectionForStartOfInsertedContentIfNeeded` more aggressive, in the
case where the inserted content range spans multiple paragraphs (e.g. a paragraph separator,
followed by text); instead of only applying the paragraph direction fixup (based on the pasted
text&apos;s base writing direction or the paragraph&apos;s `dir`) to the first paragraph, we apply it to all
pasted paragraphs.

Note that the use of `baseTextDirection` (i.e. `ubidi_getBaseDirection`) is consistent with the
platform for now, but in the future (and on Cocoa platforms), we&apos;d want to adopt
`CFAttributedStringGetStatisticalWritingDirections` to more accurately determine whether a pasted
string of plain text (with no explicit `dir`) should be handled as RTL or LTR.

* LayoutTests/editing/pasteboard/paste-rtl-paragraph-twice-expected.html: Added.
* LayoutTests/editing/pasteboard/paste-rtl-paragraph-twice.html: Added.

Add a layout test to exercise this change (the second paste would otherwise result in the second
paragraph ending up as LTR rather than RTL).

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::updateDirectionForStartOfInsertedContentIfNeeded):

See above.

Canonical link: <a href="https://commits.webkit.org/299176@main">https://commits.webkit.org/299176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c9d8ec43c7120c0d2fdfc12b85c344a4c640ee2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70180 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14cca56b-e7ac-4ec5-927e-df46e0fe67fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89650 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc62b637-f143-42d7-b829-2dd5de3e7b77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70143 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2951350-71e7-4e54-8818-f437cfc6171c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24042 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127372 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98330 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24950 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21501 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50589 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->