### PR TITLE
REGRESSION (298383@main): Clicking inside text selection does not reset the selection if the coordinates of the event location are not whole

### DIFF
--- a/LayoutTests/fast/events/selection-clear-on-click-fractional-coordinates-expected.txt
+++ b/LayoutTests/fast/events/selection-clear-on-click-fractional-coordinates-expected.txt
@@ -1,0 +1,1 @@
+PASS: Selection was properly cleared on click with fractional coordinates.

--- a/LayoutTests/fast/events/selection-clear-on-click-fractional-coordinates.html
+++ b/LayoutTests/fast/events/selection-clear-on-click-fractional-coordinates.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        #testtext {
+            margin: 0px;
+            overflow: hidden;
+            display: block;
+            font-size: 20px;
+            line-height: 30px;
+            width: 400px;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+    <p id="testtext">This is a test paragraph with some text that we will select and then click on at a point inside the
+        selection with real, non-integer coordinates to verify that the selection is properly cleared. This is a test
+        paragraph with some text that we will select and then click on at a point inside the selection with real,
+        non-integer coordinates to verify that the selection is properly cleared.</p>
+    <div id="console" style="margin-top:100px;"></div>
+    <script>
+        function log(message) {
+            document.getElementById('console').textContent = message;
+        }
+
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function runTest() {
+            if (!window.testRunner || !window.eventSender) {
+                log('This test requires WebKitTestRunner.');
+                return;
+            }
+
+            const testElement = document.getElementById('testtext');
+
+            const startX = testElement.offsetLeft + 1;
+            const startY = testElement.offsetTop + 1;
+            const endX = testElement.offsetLeft + testElement.offsetWidth - 1;
+            const endY = testElement.offsetTop + testElement.offsetHeight - 1;
+
+            eventSender.mouseMoveTo(startX, startY);
+            eventSender.mouseDown();
+            eventSender.mouseMoveTo(endX, endY);
+            eventSender.mouseUp();
+
+            const selection = window.getSelection();
+            if (selection.rangeCount === 0 || selection.isCollapsed) {
+                log('FAIL: Could not create initial selection');
+                return;
+            }
+
+            const clickX = testElement.offsetLeft + testElement.offsetWidth / 2 + 0.7;
+            const clickY = testElement.offsetTop + testElement.offsetHeight / 2 + 0.3;
+
+            document.addEventListener('selectionchange', function (event) {
+                if (event.pageX == Math.floor(event.pageX) && event.pageY == Math.floor(event.pageY))
+                    log('FAIL: Unable to move the mouse to a fractional coordinate.')
+
+                const finalSelection = window.getSelection();
+                if (finalSelection.isCollapsed)
+                    log('PASS: Selection was properly cleared on click with fractional coordinates.');
+                else
+                    log('FAIL: Selection was not cleared on click with fractional coordinates.');
+
+                testElement.remove();
+                testRunner.notifyDone();
+            });
+
+            eventSender.mouseMoveTo(clickX, clickY);
+            eventSender.mouseDown();
+            eventSender.mouseUp();
+        }
+
+        window.addEventListener('load', runTest);
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked-expected.txt
@@ -9,5 +9,5 @@ Click left mouse button again.
 Test passes if the proper behavior of the events is observed.
 
 
-FAIL mouse Test pointerevent coordinates when pointer is locked assert_equals: clientX expected 146 but got 275
+FAIL mouse Test pointerevent coordinates when pointer is locked assert_equals: clientX expected 146.375 but got 275.375
 

--- a/LayoutTests/media/modern-media-controls/slider/slider-value.html
+++ b/LayoutTests/media/modern-media-controls/slider/slider-value.html
@@ -47,13 +47,13 @@ function dragSlider(fromPx, toPx) {
     const minX = bounds.left + KNOB_WIDTH / 2;
     const centerY = bounds.top + bounds.height / 2;
 
-    eventSender.mouseMoveTo(minX + fromPx, centerY);
+    eventSender.mouseMoveTo(Math.floor(minX + fromPx), Math.floor(centerY));
     eventSender.mouseDown();
 
     const delta = toPx - fromPx;
     const iterations = Math.abs(delta);
     for (let i = 1; i <= iterations; ++i)
-        eventSender.mouseMoveTo(minX + fromPx + i * Math.sign(delta), centerY);
+        eventSender.mouseMoveTo(Math.floor(minX + fromPx + i * Math.sign(delta)), Math.floor(centerY));
 
     eventSender.mouseUp();
 }

--- a/LayoutTests/media/modern-media-controls/volume-support/volume-support-click.html
+++ b/LayoutTests/media/modern-media-controls/volume-support/volume-support-click.html
@@ -34,12 +34,12 @@ shouldBecomeEqual("media.paused", "false", () => {
 
         // Controls are now visible, let's hover over the mute button to make the volume control visible.
         const muteButtonBounds = muteButtonElement.getBoundingClientRect();
-        eventSender.mouseMoveTo(muteButtonBounds.left + muteButtonBounds.width / 2, muteButtonBounds.top + muteButtonBounds.height / 2);
+        eventSender.mouseMoveTo(Math.floor(muteButtonBounds.left + muteButtonBounds.width / 2), Math.floor(muteButtonBounds.top + muteButtonBounds.height / 2));
 
         shouldBecomeEqual("!!volumeSliderElement.getBoundingClientRect().width", "true", () => {
             // Volume slider is visible, let's click in the middle of it.
             const volumeSliderBounds = volumeSliderElement.getBoundingClientRect();
-            eventSender.mouseMoveTo(volumeSliderBounds.left + volumeSliderBounds.width / 2, volumeSliderBounds.top + volumeSliderBounds.height / 2);
+            eventSender.mouseMoveTo(Math.floor(volumeSliderBounds.left + volumeSliderBounds.width / 2), Math.floor(volumeSliderBounds.top + volumeSliderBounds.height / 2));
             eventSender.mouseDown();
             eventSender.mouseUp();
 

--- a/LayoutTests/media/modern-media-controls/volume-support/volume-support-drag.html
+++ b/LayoutTests/media/modern-media-controls/volume-support/volume-support-drag.html
@@ -52,8 +52,10 @@ media.addEventListener("play", () => {
             debug("Before starting to drag the volume slider, the media should be muted still");
             shouldBeTrue("media.muted");
 
-            eventSender.mouseMoveTo(centerX, dragStartY);
+            eventSender.mouseMoveTo(Math.floor(centerX), Math.floor(dragStartY));
             eventSender.mouseDown();
+
+            document.body.style.backgroundColor = "red";
 
             debug("");
             debug("We initiated a volume slider drag, the media should no longer be muted and the volume set");
@@ -62,7 +64,7 @@ media.addEventListener("play", () => {
                 // and instead get 0.51 since the slider will only increment on whole pixels.
                 shouldBecomeEqual("media.volume", "0.51", () => {
                     for (let i = 1; i <= iterations; ++i)
-                        eventSender.mouseMoveTo(bounds.left + bounds.width / 2, dragStartY + i * Math.sign(delta));
+                        eventSender.mouseMoveTo(Math.floor(bounds.left + bounds.width / 2), Math.floor(dragStartY + i * Math.sign(delta)));
 
                     eventSender.mouseUp();
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8231,6 +8231,9 @@ webkit.org/b/294931 ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-ua
 
 webkit.org/b/289010 imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html [ Failure ]
 
+# Clicking/tapping within a selection on iOS is not supposed to clear the selection.
+fast/events/selection-clear-on-click-fractional-coordinates.html [ Skip ]
+
 # webkit.org/b/297599 [ iOS ] 6x http/tests/iframe-monitor (layout-tests) tests are constantly timing out 
 http/tests/iframe-monitor/workers/shared-worker.html [ Timeout ]
 http/tests/iframe-monitor/workers/service-worker.html [ Timeout ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3218,6 +3218,9 @@ dom/xsl/lockdown-mode [ Skip ]
 http/tests/lockdown-mode [ Skip ]
 js/dom/lockdown-mode [ Skip ]
 
+# The decimal portion of the coordinates changes slightly between runs
+webkit.org/b/297993 imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked.html [ Skip ]
+
 webkit.org/b/289382 fast/canvas/offscreen-no-script-context-crash.html [ Skip ]
 
 webkit.org/b/297861 fullscreen/fullscreen-document-gc-crash.html [ Failure ]

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1247,7 +1247,7 @@ bool EventHandler::handleMouseReleaseEvent(const MouseEventWithHitTestResults& e
     // editing, place the caret.
     if (m_mouseDownWasSingleClickInSelection && m_selectionInitiationState != ExtendedSelection
 #if ENABLE(DRAG_SUPPORT)
-            && m_dragStartPosition == event.event().position()
+            && m_dragStartPosition == flooredIntPoint(event.event().position())
 #endif
             && frame->selection().isRange()
             && event.event().button() != MouseButton::Right) {

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
@@ -30,10 +30,10 @@ dictionary MonitorWheelEventsOptions {
 interface EventSendingController {
     undefined mouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
     undefined mouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
-    undefined mouseMoveTo(long x, long y, optional DOMString pointerType);
+    undefined mouseMoveTo(double x, double y, optional DOMString pointerType);
     Promise<undefined> asyncMouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
     Promise<undefined> asyncMouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
-    Promise<undefined> asyncMouseMoveTo(long x, long y, optional DOMString pointerType);
+    Promise<undefined> asyncMouseMoveTo(double x, double y, optional DOMString pointerType);
     undefined mouseForceClick();
     undefined startAndCancelMouseForceClick();
     undefined mouseForceDown();

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -222,7 +222,7 @@ void EventSendingController::mouseUp(JSContextRef context, int button, JSValueRe
     postSynchronousPageMessage("EventSender", createMouseMessageBody(MouseUp, button, parseModifierArray(context, modifierArray), pointerType));
 }
 
-void EventSendingController::mouseMoveTo(int x, int y, JSStringRef pointerType)
+void EventSendingController::mouseMoveTo(double x, double y, JSStringRef pointerType)
 {
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "MouseMoveTo");
@@ -249,7 +249,7 @@ void EventSendingController::asyncMouseUp(JSContextRef context, int button, JSVa
     postMessageWithAsyncReply(context, "EventSender", createMouseMessageBody(MouseUp, button, parseModifierArray(context, modifierArray), pointerType), completionHandler);
 }
 
-void EventSendingController::asyncMouseMoveTo(JSContextRef context, int x, int y, JSStringRef pointerType, JSValueRef completionHandler)
+void EventSendingController::asyncMouseMoveTo(JSContextRef context, double x, double y, JSStringRef pointerType, JSValueRef completionHandler)
 {
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "MouseMoveTo");

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
@@ -50,10 +50,10 @@ public:
 
     void mouseDown(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType);
     void mouseUp(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType);
-    void mouseMoveTo(int x, int y, JSStringRef pointerType);
+    void mouseMoveTo(double x, double y, JSStringRef pointerType);
     void asyncMouseDown(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType, JSValueRef completionHandler);
     void asyncMouseUp(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType, JSValueRef completionHandler);
-    void asyncMouseMoveTo(JSContextRef, int x, int y, JSStringRef pointerType, JSValueRef completionHandler);
+    void asyncMouseMoveTo(JSContextRef, double x, double y, JSStringRef pointerType, JSValueRef completionHandler);
     void mouseForceClick();
     void startAndCancelMouseForceClick();
     void mouseForceDown();


### PR DESCRIPTION
#### d9e0ecd72c3523ae29516cf3aa865554435b32b4
<pre>
REGRESSION (298383@main): Clicking inside text selection does not reset the selection if the coordinates of the event location are not whole
<a href="https://bugs.webkit.org/show_bug.cgi?id=297930">https://bugs.webkit.org/show_bug.cgi?id=297930</a>
<a href="https://rdar.apple.com/159141822">rdar://159141822</a>

Reviewed by Abrar Rahman Protyasha.

When a mouse release event occurs inside a text selection, we clear the selection if
the mouse hasn&apos;t moved since the last mouse press event. However, starting in
298383@main, the location of the last mouse press event stored in m_dragStartPosition
was always floored, while the mouse release event location was not. This resulted in
the selection failing to clear unless the x and y coordinates of the release event were
both whole. Fix this by flooring both values during the comparison.

Added support for moving the mouse to non-integral coordinates in WKTR so that this
behavior can be tested in new layout test `selection-clear-on-click-fractional-coordinates.html`.

* LayoutTests/fast/events/selection-clear-on-click-fractional-coordinates-expected.txt: Added.
* LayoutTests/fast/events/selection-clear-on-click-fractional-coordinates.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_coordinates_when_locked-expected.txt:
* LayoutTests/media/modern-media-controls/slider/slider-value.html:
* LayoutTests/media/modern-media-controls/volume-support/volume-support-click.html:
* LayoutTests/media/modern-media-controls/volume-support/volume-support-drag.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMouseReleaseEvent):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::mouseMoveTo):
(WTR::EventSendingController::asyncMouseMoveTo):
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h:

Canonical link: <a href="https://commits.webkit.org/299237@main">https://commits.webkit.org/299237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e664ddfb1d768e2f6107cbc95d26b47315a3bdf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70374 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d38ac1ee-e668-4ab6-88b5-6757ce50716a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cff89c3-429c-4124-a52b-af30c75c4982) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70283 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/071c995e-3127-423d-8f20-6b8825f3b5eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24200 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68148 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127557 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98468 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98254 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21645 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41704 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50774 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44561 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->