### PR TITLE
Sync `image-map-processing-model` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-expected.txt
@@ -123,7 +123,7 @@ PASS XHTML img usemap="#hash-id"
 PASS XHTML object usemap="#hash-id"
 PASS XHTML img usemap="#non-map-with-this-name"
 PASS XHTML object usemap="#non-map-with-this-name"
-FAIL XHTML img usemap="#non-map-with-this-id" assert_equals: expected Element node <area shape="rect" coords="0,0,99,50" href="#area-non-map... but got Element node <img src="/images/threecolors.png" usemap="#non-map-with-...
+PASS XHTML img usemap="#non-map-with-this-id"
 PASS XHTML object usemap="#non-map-with-this-id"
 PASS XHTML img usemap="#two-maps-with-this-name"
 PASS XHTML object usemap="#two-maps-with-this-name"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-test-data.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-test-data.html
@@ -54,7 +54,7 @@
 <div data-expect="area-non-map-with-this-id">
  <img src="/images/threecolors.png" usemap="#non-map-with-this-id" id="non-map-with-this-id"/>
  <object data="/images/threecolors.png" usemap="#non-map-with-this-id"></object>
- <map id="non-map-with-this-name">
+ <map id="non-map-with-this-id">
   <area shape="rect" coords="0,0,99,50" href="#area-non-map-with-this-id"/>
  </map>
 </div>


### PR DESCRIPTION
#### 89793b2f1a8a92c577dad3643d50346b12a0feb8
<pre>
Sync `image-map-processing-model` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=297935">https://bugs.webkit.org/show_bug.cgi?id=297935</a>
<a href="https://rdar.apple.com/159227690">rdar://159227690</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/6871b9f5cf0c788fb60676cf4e208d27cd572729">https://github.com/web-platform-tests/wpt/commit/6871b9f5cf0c788fb60676cf4e208d27cd572729</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-test-data.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-expected.txt:

Canonical link: <a href="https://commits.webkit.org/299179@main">https://commits.webkit.org/299179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd67b1420987c44340e7cf717a8955b97d4eb449

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70187 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/412025d0-a867-4a0c-a6fa-ccb1913a7246) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89656 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b396074-e644-44ed-8552-2f932f006297) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70149 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a0247a7-e3c4-44a8-8b9b-2c9b2fb8946f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24051 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67970 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127379 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98335 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21510 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44922 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44382 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->