### PR TITLE
Race condition between module script execution and FrameLoader's document completion check.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7087,7 +7087,6 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-e
 
 # -- Navigation API -- #
 
-imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html [ Timeout ]
 webkit.org/b/297477 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html [ Timeout Pass Failure ]
 
 # These cross-window needs --allowed-host=www1.localhost, so tested manually.

--- a/LayoutTests/http/wpt/dom/inline-module-script-timing-expected.txt
+++ b/LayoutTests/http/wpt/dom/inline-module-script-timing-expected.txt
@@ -1,0 +1,9 @@
+CONSOLE MESSAGE: in classic script => document.readyState = loading
+CONSOLE MESSAGE: [module script] in module script => document.readyState = interactive
+CONSOLE MESSAGE: [module script] in promise_test => document.readyState = interactive
+CONSOLE MESSAGE: [module script] in Promise() created
+CONSOLE MESSAGE: [module script] in window.onload
+This timing is critical to run with wpt testharness.js
+
+PASS DOM loading state verification (module script)
+

--- a/LayoutTests/http/wpt/dom/inline-module-script-timing.html
+++ b/LayoutTests/http/wpt/dom/inline-module-script-timing.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+
+// existence of this classic script is the key to this test failing.
+console.log(`in classic script => document.readyState = ${document.readyState}`);
+
+</script>
+
+This timing is critical to run with wpt testharness.js
+
+<script type="module">
+
+console.log(`[module script] in module script => document.readyState = ${document.readyState}`);
+promise_test(async t => {
+  console.log(`[module script] in promise_test => document.readyState = ${document.readyState}`);
+  t.step(() => {
+    assert_equals(document.readyState, "interactive", "readyState should be 'interactive' (after DOMContentLoaded, before load)");
+  });
+
+  await new Promise((resolve) => {
+    console.log(`[module script] in Promise() created`);
+    window.addEventListener('load', () => {
+      console.log(`[module script] in window.onload`);
+      t.step_timeout(resolve, 0);
+    });
+  });
+
+  t.step(() => {
+    assert_equals(document.readyState, "complete", "After Promise resolution (module), readyState should be 'complete'");
+  });
+}, "DOM loading state verification (module script)");
+
+</script>

--- a/LayoutTests/http/wpt/dom/inline-module-script-with-imports-expected.txt
+++ b/LayoutTests/http/wpt/dom/inline-module-script-with-imports-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: in classic script => document.readyState = loading
+CONSOLE MESSAGE: delayed-module.js loading...
+CONSOLE MESSAGE: delayed-module.js loaded with value: delayed-value
+CONSOLE MESSAGE: [module script with import] in module script => document.readyState = interactive
+CONSOLE MESSAGE: [module script with import] imported value = delayed-value
+CONSOLE MESSAGE: [module script with import] in promise_test => document.readyState = interactive
+CONSOLE MESSAGE: [module script with import] in window.onload => document.readyState = complete
+This timing test verifies that inline module scripts with imports block readyState completion
+
+PASS Inline module script with imports blocks readyState completion until imports are loaded
+

--- a/LayoutTests/http/wpt/dom/inline-module-script-with-imports.html
+++ b/LayoutTests/http/wpt/dom/inline-module-script-with-imports.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+
+// existence of this classic script is the key to this test failing.
+console.log(`in classic script => document.readyState = ${document.readyState}`);
+
+</script>
+
+This timing test verifies that inline module scripts with imports block readyState completion
+
+<script type="module">
+
+import { delayedExport } from './resources/delayed-module.js';
+
+console.log(`[module script with import] in module script => document.readyState = ${document.readyState}`);
+console.log(`[module script with import] imported value = ${delayedExport}`);
+
+promise_test(async t => {
+  console.log(`[module script with import] in promise_test => document.readyState = ${document.readyState}`);
+  t.step(() => {
+    assert_equals(document.readyState, "interactive", "readyState should be 'interactive' during module execution");
+    assert_equals(delayedExport, "delayed-value", "Import should be resolved before module execution");
+  });
+
+  // Track when load event fires
+  let loadEventFired = false;
+  let loadEventReadyState = null;
+
+  window.addEventListener('load', () => {
+    loadEventFired = true;
+    loadEventReadyState = document.readyState;
+    console.log(`[module script with import] in window.onload => document.readyState = ${document.readyState}`);
+  });
+
+  // Wait a bit to ensure load event has time to fire
+  await new Promise(resolve => t.step_timeout(resolve, 50));
+
+  t.step(() => {
+    assert_true(loadEventFired, "Load event should have fired");
+    assert_equals(loadEventReadyState, "complete", "readyState should be 'complete' when load event fires");
+    assert_equals(document.readyState, "complete", "readyState should be 'complete' after load event");
+  });
+}, "Inline module script with imports blocks readyState completion until imports are loaded");
+
+</script>

--- a/LayoutTests/http/wpt/dom/resources/delayed-module.js
+++ b/LayoutTests/http/wpt/dom/resources/delayed-module.js
@@ -1,0 +1,8 @@
+// This module simulates a delayed import that might take time to load
+// to test that document readyState waits for all imports to complete
+
+console.log('delayed-module.js loading...');
+
+export const delayedExport = "delayed-value";
+
+console.log(`delayed-module.js loaded with value: ${delayedExport}`);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Module script queueing a microtask then throwing an exception assert_array_equals: lengths differ, expected array ["step-2.2-1", "step-2.2-2", "microtask-2.2", "global-error"] length 4, got ["step-2.2-1", "step-2.2-2", "global-error"] length 3
+PASS Module script queueing a microtask then throwing an exception
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+PASS A traversal that redirects from same-origin to cross-origin fires the navigate event
 

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -67,6 +67,7 @@ public:
 
     bool isEmpty() const { return m_microtaskQueue.isEmpty(); }
     bool hasMicrotasksForFullyActiveDocument() const;
+    bool isPerformingCheckpoint() const { return m_performingMicrotaskCheckpoint; }
 
     static void runJSMicrotask(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&);
 


### PR DESCRIPTION
#### f1e55dd8fe6fdc38c20c3409672b89f021417819
<pre>
Race condition between module script execution and FrameLoader&apos;s document completion check.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297939">https://bugs.webkit.org/show_bug.cgi?id=297939</a>
<a href="https://rdar.apple.com/159112160">rdar://159112160</a>

Reviewed by Alex Christensen.

Module scripts that create microtasks were seeing inconsistent document.readyState values, the
module script itself saw &quot;interactive&quot; but Promise callbacks saw &quot;complete&quot;. This happened
because FrameLoader::finishedParsing() was being called during microtask checkpoint execution.

The fix detects when attemptToRunDeferredScriptsAndEnd() is called during a microtask checkpoint
and defers the end() call using the regular task queue, ensuring finishedParsing() runs after
all microtasks complete.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/dom/inline-module-script-timing-expected.txt: Added.
* LayoutTests/http/wpt/dom/inline-module-script-timing.html: Added.
* LayoutTests/http/wpt/dom/inline-module-script-with-imports-expected.txt: Added.
* LayoutTests/http/wpt/dom/inline-module-script-with-imports.html: Added.
* LayoutTests/http/wpt/dom/resources/delayed-module.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt:
* Source/WebCore/dom/Microtasks.h:
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::notifyFinished):

Canonical link: <a href="https://commits.webkit.org/299282@main">https://commits.webkit.org/299282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6abe777e0ef0308bf307f97715a92df90a36b8d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70517 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18d030f6-e66d-49c1-add3-031358a6fe69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89903 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/538758f1-a165-4cbf-8442-40d60365dfb9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70388 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a8555c5-e789-4569-ae15-4299b67837b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24327 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68286 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127696 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98570 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21765 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48045 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46385 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->