### PR TITLE
Refactoring TextDecorationLine to fit in 5 bits

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -189,6 +189,7 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_inheritedFlags.visibility = static_cast<unsigned>(initialVisibility());
     m_inheritedFlags.textAlign = static_cast<unsigned>(initialTextAlign());
     m_inheritedFlags.textTransform = initialTextTransform().toRaw();
+    m_inheritedFlags.textDecorationLineInEffect = initialTextDecorationLine().toRaw();
     m_inheritedFlags.cursorType = static_cast<unsigned>(initialCursor().predefined);
 #if ENABLE(CURSOR_VISIBILITY)
     m_inheritedFlags.cursorVisibility = static_cast<unsigned>(initialCursorVisibility());
@@ -214,6 +215,7 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.position = static_cast<unsigned>(initialPosition());
     m_nonInheritedFlags.unicodeBidi = static_cast<unsigned>(initialUnicodeBidi());
     m_nonInheritedFlags.floating = static_cast<unsigned>(initialFloating());
+    m_nonInheritedFlags.textDecorationLine = initialTextDecorationLine().toRaw();
     m_nonInheritedFlags.usesViewportUnits = false;
     m_nonInheritedFlags.usesContainerUnits = false;
     m_nonInheritedFlags.useTreeCountingFunctions = false;
@@ -392,6 +394,7 @@ inline void RenderStyle::NonInheritedFlags::copyNonInheritedFrom(const NonInheri
     position = other.position;
     unicodeBidi = other.unicodeBidi;
     floating = other.floating;
+    textDecorationLine = other.textDecorationLine;
     usesViewportUnits = other.usesViewportUnits;
     usesContainerUnits = other.usesContainerUnits;
     useTreeCountingFunctions = other.useTreeCountingFunctions;
@@ -723,23 +726,20 @@ inline bool RenderStyle::changeAffectsVisualOverflow(const RenderStyle& other) c
     };
 
     auto textDecorationsDiffer = [&]() {
+        if (m_inheritedFlags.textDecorationLineInEffect != other.m_inheritedFlags.textDecorationLineInEffect)
+            return true;
+
         if (m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr() && m_nonInheritedData->rareData.ptr() != other.m_nonInheritedData->rareData.ptr()) {
             if (m_nonInheritedData->rareData->textDecorationStyle != other.m_nonInheritedData->rareData->textDecorationStyle
                 || m_nonInheritedData->rareData->textDecorationThickness != other.m_nonInheritedData->rareData->textDecorationThickness)
                 return true;
         }
 
-        if (m_inheritedData->textDecorationLineInEffect != other.m_inheritedData->textDecorationLineInEffect)
-            return true;
-        if (m_nonInheritedData->miscData->textDecorationLine != other.m_nonInheritedData->miscData->textDecorationLine)
-            return true;
-
         if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr()) {
             if (m_rareInheritedData->textUnderlineOffset != other.m_rareInheritedData->textUnderlineOffset
                 || m_rareInheritedData->textUnderlinePosition != other.m_rareInheritedData->textUnderlinePosition)
                     return true;
         }
-
 
         return false;
     };
@@ -1247,8 +1247,7 @@ static bool miscDataChangeRequiresRepaint(const StyleMiscNonInheritedData& first
 {
     if (first.userDrag != second.userDrag
         || first.objectFit != second.objectFit
-        || first.objectPosition != second.objectPosition
-        || first.textDecorationLine != second.textDecorationLine)
+        || first.objectPosition != second.objectPosition)
         return true;
 
     return false;
@@ -1355,11 +1354,6 @@ bool RenderStyle::changeRequiresRepaint(const RenderStyle& other, OptionSet<Styl
         }
     }
 
-    if (m_inheritedData.ptr() != other.m_inheritedData.ptr()) {
-        if (m_inheritedData->textDecorationLineInEffect != other.m_inheritedData->textDecorationLineInEffect)
-            return true;
-    }
-
     if (m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr()) {
         if (m_nonInheritedData->miscData.ptr() != other.m_nonInheritedData->miscData.ptr()
             && miscDataChangeRequiresRepaint(*m_nonInheritedData->miscData, *other.m_nonInheritedData->miscData, changedContextSensitiveProperties))
@@ -1385,12 +1379,11 @@ bool RenderStyle::changeRequiresRepaintIfText(const RenderStyle& other, OptionSe
     // FIXME: Does this code need to consider currentColorDiffers? webkit.org/b/266833
     if (m_inheritedData->color != other.m_inheritedData->color)
         return true;
-    if (m_inheritedData->textDecorationLineInEffect != other.m_inheritedData->textDecorationLineInEffect)
-        return true;
 
     // Note that we may reach this function with mutated text-decoration values (e.g. thickness), when visual overflow recompute is not required.
     // see RenderStyle::changeAffectsVisualOverflow
-    if (m_nonInheritedData->miscData->textDecorationLine != other.m_nonInheritedData->miscData->textDecorationLine)
+    if (m_inheritedFlags.textDecorationLineInEffect != other.m_inheritedFlags.textDecorationLineInEffect
+        || m_nonInheritedFlags.textDecorationLine != other.m_nonInheritedFlags.textDecorationLine)
         return true;
 
     if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr()) {
@@ -1546,6 +1539,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTextAlign);
         if (first.textTransform != second.textTransform)
             changingProperties.m_properties.set(CSSPropertyTextTransform);
+        if (first.textDecorationLineInEffect != second.textDecorationLineInEffect)
+            changingProperties.m_properties.set(CSSPropertyTextDecorationLine);
         if (first.cursorType != second.cursorType)
             changingProperties.m_properties.set(CSSPropertyCursor);
         if (first.whiteSpaceCollapse != second.whiteSpaceCollapse)
@@ -1595,6 +1590,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyDisplay);
         if (first.floating != second.floating)
             changingProperties.m_properties.set(CSSPropertyFloat);
+        if (first.textDecorationLine != second.textDecorationLine)
+            changingProperties.m_properties.set(CSSPropertyTextDecorationLine);
 
         // Non animated styles are followings.
         // originalDisplay
@@ -1846,8 +1843,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyAppearance);
         if (first.tableLayout != second.tableLayout)
             changingProperties.m_properties.set(CSSPropertyTableLayout);
-        if (first.textDecorationLine != second.textDecorationLine)
-            changingProperties.m_properties.set(CSSPropertyTextDecorationLine);
 
         if (first.transform.ptr() != second.transform.ptr())
             conservativelyCollectChangedAnimatablePropertiesViaTransformData(*first.transform, *second.transform);
@@ -2082,9 +2077,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
 
         if (first.color != second.color || first.visitedLinkColor != second.visitedLinkColor)
             changingProperties.m_properties.set(CSSPropertyColor);
-
-        if (first.textDecorationLineInEffect != second.textDecorationLineInEffect)
-            changingProperties.m_properties.set(CSSPropertyTextDecorationLine);
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaRareInheritedData = [&](auto& first, auto& second) {
@@ -3794,6 +3786,8 @@ void RenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const NonIn
     LOG_IF_DIFFERENT(usesContainerUnits);
     LOG_IF_DIFFERENT(useTreeCountingFunctions);
 
+    LOG_IF_DIFFERENT_WITH_CAST(Style::TextDecorationLine, textDecorationLine);
+
     LOG_IF_DIFFERENT(hasExplicitlyInheritedProperties);
     LOG_IF_DIFFERENT(disallowsFastPathInheritance);
 
@@ -3819,6 +3813,7 @@ void RenderStyle::InheritedFlags::dumpDifferences(TextStream& ts, const Inherite
     LOG_IF_DIFFERENT_WITH_CAST(TextWrapStyle, textWrapStyle);
 
     LOG_RAW_OPTIONSET_IF_DIFFERENT(TextTransform, textTransform);
+    LOG_IF_DIFFERENT_WITH_CAST(Style::TextDecorationLine, textDecorationLineInEffect);
 
     LOG_IF_DIFFERENT_WITH_CAST(PointerEvents, pointerEvents);
     LOG_IF_DIFFERENT_WITH_CAST(Visibility, visibility);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -29,6 +29,7 @@
 #include <WebCore/BoxExtents.h>
 #include <WebCore/PseudoElementIdentifier.h>
 #include <WebCore/StylePrimitiveNumeric+Forward.h>
+#include <WebCore/StyleTextDecorationLine.h>
 #include <WebCore/WritingMode.h>
 #include <unicode/utypes.h>
 #include <wtf/CheckedRef.h>
@@ -348,7 +349,6 @@ struct ShapeMargin;
 struct ShapeOutside;
 struct StrokeMiterlimit;
 struct StrokeWidth;
-struct TextDecorationLine;
 struct TextDecorationThickness;
 struct TextEmphasisStyle;
 struct TextIndent;
@@ -402,6 +402,7 @@ using WebkitBorderSpacing = Length<CSS::Nonnegative>;
 }
 
 constexpr auto PublicPseudoIDBits = 17;
+constexpr auto TextDecorationLineBits = 5;
 constexpr auto TextTransformBits = 5;
 constexpr auto PseudoElementTypeBits = 5;
 
@@ -728,8 +729,8 @@ public:
     inline TextAlignLast textAlignLast() const;
     inline TextGroupAlign textGroupAlign() const;
     inline OptionSet<TextTransform> textTransform() const;
-    inline const Style::TextDecorationLine& textDecorationLineInEffect() const;
-    inline const Style::TextDecorationLine& textDecorationLine() const;
+    inline Style::TextDecorationLine textDecorationLineInEffect() const;
+    inline Style::TextDecorationLine textDecorationLine() const;
     inline TextDecorationStyle textDecorationStyle() const;
     inline TextDecorationSkipInk textDecorationSkipInk() const;
     inline OptionSet<TextUnderlinePosition> textUnderlinePosition() const;
@@ -2418,6 +2419,7 @@ private:
         PREFERRED_TYPE(bool) unsigned isLink : 1;
         PREFERRED_TYPE(PseudoId) unsigned pseudoElementType : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
+        PREFERRED_TYPE(Style::TextDecorationLine) unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
 
         // If you add more style bits here, you will also need to update RenderStyle::NonInheritedFlags::copyNonInheritedFrom().
     };
@@ -2439,6 +2441,7 @@ private:
         PREFERRED_TYPE(TextWrapStyle) unsigned char textWrapStyle : 2;
         PREFERRED_TYPE(OptionSet<TextTransform>) unsigned char textTransform : TextTransformBits;
         unsigned char : 1; // byte alignment
+        PREFERRED_TYPE(Style::TextDecorationLine) unsigned char textDecorationLineInEffect : TextDecorationLineBits;
 
         // Cursors and Visibility = 13 bits aligned onto 4 bits + 1 byte + 1 bit
         PREFERRED_TYPE(PointerEvents) unsigned char pointerEvents : 4;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -755,11 +755,11 @@ inline TextAlignLast RenderStyle::textAlignLast() const { return static_cast<Tex
 inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }
 inline TextCombine RenderStyle::textCombine() const { return static_cast<TextCombine>(m_rareInheritedData->textCombine); }
 inline const Style::Color& RenderStyle::textDecorationColor() const { return m_nonInheritedData->rareData->textDecorationColor; }
-inline const Style::TextDecorationLine& RenderStyle::textDecorationLine() const { return m_nonInheritedData->miscData->textDecorationLine; }
+inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return m_nonInheritedFlags.textDecorationLine; }
 inline TextDecorationSkipInk RenderStyle::textDecorationSkipInk() const { return static_cast<TextDecorationSkipInk>(m_rareInheritedData->textDecorationSkipInk); }
 inline TextDecorationStyle RenderStyle::textDecorationStyle() const { return static_cast<TextDecorationStyle>(m_nonInheritedData->rareData->textDecorationStyle); }
 inline const Style::TextDecorationThickness& RenderStyle::textDecorationThickness() const { return m_nonInheritedData->rareData->textDecorationThickness; }
-inline const Style::TextDecorationLine& RenderStyle::textDecorationLineInEffect() const { return m_inheritedData->textDecorationLineInEffect; }
+inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return m_inheritedFlags.textDecorationLineInEffect; }
 inline const Style::Color& RenderStyle::textEmphasisColor() const { return m_rareInheritedData->textEmphasisColor; }
 inline const Style::TextEmphasisStyle& RenderStyle::textEmphasisStyle() const { return m_rareInheritedData->textEmphasisStyle; }
 inline OptionSet<TextEmphasisPosition> RenderStyle::textEmphasisPosition() const { return OptionSet<TextEmphasisPosition>::fromRaw(m_rareInheritedData->textEmphasisPosition); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -46,7 +46,7 @@ namespace WebCore {
 
 template<typename T, typename U> inline bool compareEqual(const T& a, const U& b) { return a == b; }
 
-inline void RenderStyle::addToTextDecorationLineInEffect(const Style::TextDecorationLine& value) { m_inheritedData.access().textDecorationLineInEffect.addOrReplaceIfNotNone(value); }
+inline void RenderStyle::addToTextDecorationLineInEffect(const Style::TextDecorationLine& value) { m_inheritedFlags.textDecorationLineInEffect = textDecorationLineInEffect().addOrReplaceIfNotNone(value); }
 inline void RenderStyle::clearAnimations() { m_nonInheritedData.access().miscData.access().animations = nullptr; }
 inline void RenderStyle::clearBackgroundLayers() { m_nonInheritedData.access().backgroundData.access().background = FillLayer::create(FillLayerType::Background); }
 inline void RenderStyle::clearMaskLayers() { m_nonInheritedData.access().miscData.access().mask = FillLayer::create(FillLayerType::Mask); }
@@ -300,11 +300,11 @@ inline void RenderStyle::setTextAlignLast(TextAlignLast value) { SET(m_rareInher
 inline void RenderStyle::setTextBoxTrim(TextBoxTrim value) { SET_NESTED(m_nonInheritedData, rareData, textBoxTrim, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextCombine(TextCombine value) { SET(m_rareInheritedData, textCombine, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, rareData, textDecorationColor, WTFMove(color)); }
-inline void RenderStyle::setTextDecorationLine(Style::TextDecorationLine&& value) { SET_NESTED(m_nonInheritedData, miscData, textDecorationLine, WTFMove(value)); }
+inline void RenderStyle::setTextDecorationLine(Style::TextDecorationLine&& value) { m_nonInheritedFlags.textDecorationLine = value.toRaw(); }
 inline void RenderStyle::setTextDecorationSkipInk(TextDecorationSkipInk skipInk) { SET(m_rareInheritedData, textDecorationSkipInk, static_cast<unsigned>(skipInk)); }
 inline void RenderStyle::setTextDecorationStyle(TextDecorationStyle value) { SET_NESTED(m_nonInheritedData, rareData, textDecorationStyle, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationThickness(Style::TextDecorationThickness&& textDecorationThickness) { SET_NESTED(m_nonInheritedData, rareData, textDecorationThickness, WTFMove(textDecorationThickness)); }
-inline void RenderStyle::setTextDecorationLineInEffect(Style::TextDecorationLine&& value) { SET(m_inheritedData, textDecorationLineInEffect, WTFMove(value)); }
+inline void RenderStyle::setTextDecorationLineInEffect(Style::TextDecorationLine&& value) { m_inheritedFlags.textDecorationLineInEffect = value.toRaw(); }
 inline void RenderStyle::setTextEmphasisColor(Style::Color&& c) { SET(m_rareInheritedData, textEmphasisColor, WTFMove(c)); }
 inline void RenderStyle::setTextEmphasisStyle(Style::TextEmphasisStyle&& style) { SET(m_rareInheritedData, textEmphasisStyle, style); }
 inline void RenderStyle::setTextEmphasisPosition(OptionSet<TextEmphasisPosition> position) { SET(m_rareInheritedData, textEmphasisPosition, static_cast<unsigned>(position.toRaw())); }

--- a/Source/WebCore/rendering/style/StyleInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleInheritedData.cpp
@@ -41,7 +41,6 @@ StyleInheritedData::StyleInheritedData()
     , fontData(StyleFontData::create())
     , color(RenderStyle::initialColor())
     , visitedLinkColor(RenderStyle::initialColor())
-    , textDecorationLineInEffect(RenderStyle::initialTextDecorationLineInEffect())
 {
 }
 
@@ -56,7 +55,6 @@ inline StyleInheritedData::StyleInheritedData(const StyleInheritedData& o)
     , fontData(o.fontData)
     , color(o.color)
     , visitedLinkColor(o.visitedLinkColor)
-    , textDecorationLineInEffect(o.textDecorationLineInEffect)
 {
     ASSERT(o == *this, "StyleInheritedData should be properly copied.");
 }
@@ -87,8 +85,7 @@ bool StyleInheritedData::nonFastPathInheritedEqual(const StyleInheritedData& oth
 #endif
         && fontData == other.fontData
         && borderHorizontalSpacing == other.borderHorizontalSpacing
-        && borderVerticalSpacing == other.borderVerticalSpacing
-        && textDecorationLineInEffect == other.textDecorationLineInEffect;
+        && borderVerticalSpacing == other.borderVerticalSpacing;
 }
 
 void StyleInheritedData::fastPathInheritFrom(const StyleInheritedData& inheritParent)
@@ -112,7 +109,6 @@ void StyleInheritedData::dumpDifferences(TextStream& ts, const StyleInheritedDat
 
     LOG_IF_DIFFERENT(color);
     LOG_IF_DIFFERENT(visitedLinkColor);
-    LOG_IF_DIFFERENT(textDecorationLineInEffect);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/StyleInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleInheritedData.h
@@ -28,7 +28,6 @@
 #include <WebCore/Length.h>
 #include <WebCore/StyleColor.h>
 #include <WebCore/StyleFontData.h>
-#include <WebCore/StyleTextDecorationLine.h>
 #include <WebCore/StyleWebKitBorderSpacing.h>
 #include <wtf/DataRef.h>
 
@@ -66,8 +65,6 @@ public:
     DataRef<StyleFontData> fontData;
     Color color;
     Color visitedLinkColor;
-
-    Style::TextDecorationLine textDecorationLineInEffect;
 
 private:
     StyleInheritedData();

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -35,7 +35,6 @@
 #include "StyleFlexibleBoxData.h"
 #include "StyleMultiColData.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
-#include "StyleTextDecorationLine.h"
 #include "StyleTransformData.h"
 #include "StyleVisitedLinkColorData.h"
 #include <wtf/PointerComparison.h>
@@ -64,7 +63,6 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData()
     , justifySelf(RenderStyle::initialSelfAlignment())
     , objectPosition(RenderStyle::initialObjectPosition())
     , order(RenderStyle::initialOrder())
-    , textDecorationLine(RenderStyle::initialTextDecorationLine())
     , tableLayout(static_cast<unsigned>(RenderStyle::initialTableLayout()))
     , appearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
     , usedAppearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
@@ -98,7 +96,6 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData(const StyleMiscNonInherited
     , justifySelf(o.justifySelf)
     , objectPosition(o.objectPosition)
     , order(o.order)
-    , textDecorationLine(o.textDecorationLine)
     , hasAttrContent(o.hasAttrContent)
     , hasDisplayAffectedByAnimations(o.hasDisplayAffectedByAnimations)
 #if ENABLE(DARK_MODE_CSS)
@@ -146,7 +143,6 @@ bool StyleMiscNonInheritedData::operator==(const StyleMiscNonInheritedData& o) c
         && justifySelf == o.justifySelf
         && objectPosition == o.objectPosition
         && order == o.order
-        && textDecorationLine == o.textDecorationLine
         && hasAttrContent == o.hasAttrContent
         && hasDisplayAffectedByAnimations == o.hasDisplayAffectedByAnimations
 #if ENABLE(DARK_MODE_CSS)
@@ -199,7 +195,6 @@ void StyleMiscNonInheritedData::dumpDifferences(TextStream& ts, const StyleMiscN
     LOG_IF_DIFFERENT(justifySelf);
     LOG_IF_DIFFERENT(objectPosition);
     LOG_IF_DIFFERENT(order);
-    LOG_IF_DIFFERENT(textDecorationLine);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasAttrContent);
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasDisplayAffectedByAnimations);

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -36,7 +36,6 @@
 #include <WebCore/StyleOpacity.h>
 #include <WebCore/StyleOrder.h>
 #include <WebCore/StyleSelfAlignmentData.h>
-#include <WebCore/StyleTextDecorationLine.h>
 #include <memory>
 #include <wtf/DataRef.h>
 #include <wtf/FixedVector.h>
@@ -99,7 +98,6 @@ public:
     StyleSelfAlignmentData justifySelf;
     Style::ObjectPosition objectPosition;
     Style::Order order;
-    Style::TextDecorationLine textDecorationLine;
 
     PREFERRED_TYPE(bool) unsigned hasAttrContent : 1 { false };
     PREFERRED_TYPE(bool) unsigned hasDisplayAffectedByAnimations : 1 { false };

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
@@ -28,39 +28,75 @@
 #include "RenderStyleConstants.h"
 #include "StyleValueTypes.h"
 #include <wtf/OptionSet.h>
-#include <wtf/Variant.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
-struct TextDecorationLine;
 
 // text-decoration-line = none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error
 // https://www.w3.org/TR/css-text-decor-4/#text-decoration-line-property
+
+// We are representing TextDecorationLine in 5 bits.
+// 1 bit is used for defining the Type (SingleValue or Flags)
+// 4 bits are used for defining the Value
+// Values for SingleValue: None, SpellingError, GrammarError
+// Values for Flags: Any combination of Underline, Overline, LineThrough, Blink
+// Therefore, we are packing its content with the following layout:
+// Bits 7-5 : Reserved
+// Bit 4    : Type (SingleValue or Flags)
+// Bits 3-0 : When Type=1 (Underline=0x1, Overline=0x2, LineThrough=0x4, Blink=0x8)
+//          : When Type=0 (None = 0, SpellingError = 1, GrammarError = 2)
 struct TextDecorationLine {
-    TextDecorationLine(CSS::Keyword::None keyword)
-        : m_value { keyword }
+    enum class Type : uint8_t {
+        SingleValue   = 0,
+        Flags         = 1 << 4
+    };
+
+    static constexpr uint8_t TypeMask = 1 << 4; // 0001 0000
+    static constexpr uint8_t ValuesMask = 0x0F;
+
+    // Values when Type is SingleValue
+    enum class SingleValue : uint8_t {
+        None  = 0,
+        SpellingError,
+        GrammarError
+    };
+
+    // Values when Type is Flags
+    static constexpr uint8_t UnderlineBit   = static_cast<uint8_t>(TextDecorationLineFlags::Underline);
+    static constexpr uint8_t OverlineBit    = static_cast<uint8_t>(TextDecorationLineFlags::Overline);
+    static constexpr uint8_t LineThroughBit = static_cast<uint8_t>(TextDecorationLineFlags::LineThrough);
+    static constexpr uint8_t BlinkBit       = static_cast<uint8_t>(TextDecorationLineFlags::Blink);
+
+    static constexpr uint8_t SingleValueNone          = static_cast<uint8_t>(Type::SingleValue) | static_cast<uint8_t>(SingleValue::None);
+    static constexpr uint8_t SingleValueSpellingError = static_cast<uint8_t>(Type::SingleValue) | static_cast<uint8_t>(SingleValue::SpellingError);
+    static constexpr uint8_t SingleValueGrammarError  = static_cast<uint8_t>(Type::SingleValue) | static_cast<uint8_t>(SingleValue::GrammarError);
+
+    TextDecorationLine() = default;
+
+    TextDecorationLine(uint8_t rawValue)
+        : m_packed(rawValue)
     {
     }
 
-    TextDecorationLine(CSS::Keyword::SpellingError keyword)
-        : m_value { keyword }
+    TextDecorationLine(CSS::Keyword::None)
+        : m_packed(SingleValueNone)
     {
     }
 
-    TextDecorationLine(CSS::Keyword::GrammarError keyword)
-        : m_value { keyword }
+    TextDecorationLine(CSS::Keyword::SpellingError)
+        : m_packed(SingleValueSpellingError)
+    {
+    }
+
+    TextDecorationLine(CSS::Keyword::GrammarError)
+        : m_packed(SingleValueGrammarError)
     {
     }
 
     TextDecorationLine(OptionSet<TextDecorationLineFlags> flags)
-        : m_value { flags }
+        : m_packed(flags.isEmpty() ? SingleValueNone : packFlags(flags))
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value)) {
-            if (flags->isEmpty())
-                m_value = CSS::Keyword::None { };
-        } else
-            ASSERT_NOT_REACHED();
     }
 
     TextDecorationLine(TextDecorationLineFlags flag)
@@ -68,76 +104,145 @@ struct TextDecorationLine {
     {
     }
 
-    constexpr bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(m_value); }
-    bool isSpellingError() const { return WTF::holdsAlternative<CSS::Keyword::SpellingError>(m_value); }
-    bool isGrammarError() const { return WTF::holdsAlternative<CSS::Keyword::GrammarError>(m_value); }
-    bool isFlags() const { return WTF::holdsAlternative<OptionSet<TextDecorationLineFlags>>(m_value); }
+    inline Type type() const { return static_cast<Type>(m_packed & TypeMask); }
+    bool isNone() const { return m_packed == SingleValueNone; }
+    bool isSpellingError() const { return m_packed == SingleValueSpellingError; }
+    bool isGrammarError() const { return m_packed == SingleValueGrammarError; }
+    bool isFlags() const { return type() == Type::Flags; }
 
     bool hasUnderline() const
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value))
-            return flags->contains(TextDecorationLineFlags::Underline);
-        return false;
+        return (isFlags()) && (m_packed & UnderlineBit);
     }
 
     bool hasOverline() const
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value))
-            return flags->contains(TextDecorationLineFlags::Overline);
-        return false;
+        return (isFlags()) && (m_packed & OverlineBit);
     }
 
     bool hasLineThrough() const
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value))
-            return flags->contains(TextDecorationLineFlags::LineThrough);
-        return false;
+        return (isFlags()) && (m_packed & LineThroughBit);
     }
 
     bool hasBlink() const
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value))
-            return flags->contains(TextDecorationLineFlags::Blink);
-        return false;
+        return (isFlags()) && (m_packed & BlinkBit);
     }
 
     bool containsAny(OptionSet<TextDecorationLineFlags> options) const
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value))
-            return flags->containsAny(options);
-        return false;
+        if (!isFlags())
+            return false;
+        return (m_packed & packFlags(options));
     }
 
     bool contains(TextDecorationLineFlags option) const
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value))
-            return flags->contains(option);
-        return false;
+        if (!isFlags())
+            return false;
+        return (m_packed & packFlagValue(option));
     }
 
     void remove(TextDecorationLineFlags option)
     {
-        if (auto* flags = std::get_if<OptionSet<TextDecorationLineFlags>>(&m_value)) {
-            flags->remove(option);
-            if (flags->isEmpty())
-                m_value = CSS::Keyword::None { };
+        if (type() == Type::Flags) {
+            m_packed &= ~packFlagValue(option);
+            // If none flags are set we should represent this as Type::None
+            if (!(m_packed & ValuesMask))
+                setNone();
         }
     }
 
-    void addOrReplaceIfNotNone(const TextDecorationLine& value);
+    uint8_t addOrReplaceIfNotNone(const TextDecorationLine& value);
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
-        return WTF::switchOn(m_value, std::forward<F>(f)...);
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        switch (type()) {
+        case Type::Flags:
+            return visitor(unpackFlags());
+        case Type::SingleValue: {
+            if (isNone())
+                return visitor(CSS::Keyword::None { });
+            if (isSpellingError())
+                return visitor(CSS::Keyword::SpellingError { });
+            ASSERT(isGrammarError());
+            return visitor(CSS::Keyword::GrammarError { });
+            }
+        }
+        ASSERT_NOT_REACHED();
+        return visitor(CSS::Keyword::None { });
+    }
+
+    void setNone() { m_packed = SingleValueNone; }
+    void setSpellingError() { m_packed = SingleValueSpellingError; }
+    void setGrammarError() { m_packed = SingleValueGrammarError; }
+    void setFlags(OptionSet<TextDecorationLineFlags> flags)
+    {
+        if (isFlags())
+            m_packed |= packFlags(flags);
+        else
+            m_packed = packFlags(flags);
     }
 
     constexpr explicit operator bool() const { return !isNone(); }
-    bool operator==(const TextDecorationLine&) const = default;
+    bool operator==(const TextDecorationLine& other) const { return m_packed == other.m_packed; }
+
+    uint8_t toRaw() const { return m_packed; }
+    static constexpr uint8_t packFlags(OptionSet<TextDecorationLineFlags> flags)
+    {
+        uint8_t result = static_cast<uint8_t>(Type::Flags);
+        if (flags.contains(TextDecorationLineFlags::Underline))
+            result |= UnderlineBit;
+        if (flags.contains(TextDecorationLineFlags::Overline))
+            result |= OverlineBit;
+        if (flags.contains(TextDecorationLineFlags::LineThrough))
+            result |= LineThroughBit;
+        if (flags.contains(TextDecorationLineFlags::Blink))
+            result |= BlinkBit;
+        return result;
+    }
 
 private:
-    Variant<CSS::Keyword::None, CSS::Keyword::SpellingError, CSS::Keyword::GrammarError, OptionSet<TextDecorationLineFlags>> m_value;
-};
+    // Returns only the value bits, not to be confused with "toRaw", which returns the whole packed raw representation
+    inline uint8_t rawValue() const { return m_packed & ValuesMask; }
 
+    // Note that this function packs only the 'Value' bit, ignoring the Type. This is useful for bitwise operations.
+    static constexpr uint8_t packFlagValue(TextDecorationLineFlags flag)
+    {
+        switch (flag) {
+        case TextDecorationLineFlags::Underline:
+            return UnderlineBit;
+        case TextDecorationLineFlags::Overline:
+            return OverlineBit;
+        case TextDecorationLineFlags::LineThrough:
+            return LineThroughBit;
+        case TextDecorationLineFlags::Blink:
+            return BlinkBit;
+        }
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+
+    OptionSet<TextDecorationLineFlags> unpackFlags() const
+    {
+        ASSERT(isFlags());
+        OptionSet<TextDecorationLineFlags> flags;
+        if (m_packed & UnderlineBit)
+            flags.add(TextDecorationLineFlags::Underline);
+        if (m_packed & OverlineBit)
+            flags.add(TextDecorationLineFlags::Overline);
+        if (m_packed & LineThroughBit)
+            flags.add(TextDecorationLineFlags::LineThrough);
+        if (m_packed & BlinkBit)
+            flags.add(TextDecorationLineFlags::Blink);
+        return flags;
+    }
+
+    uint8_t m_packed { 0 };
+};
 
 // MARK: - Conversion
 


### PR DESCRIPTION
#### 02d04382a054cfe1edcb38c58ba1c1d7795eeefb
<pre>
Refactoring TextDecorationLine to fit in 5 bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=297940">https://bugs.webkit.org/show_bug.cgi?id=297940</a>
<a href="https://rdar.apple.com/159236131">rdar://159236131</a>

Reviewed by Sammy Gill.

At <a href="https://commits.webkit.org/299142@main">https://commits.webkit.org/299142@main</a> we have refactored TextDecorationLine
into a strong type. However, it increased its size to 2 bytes and it had to be
moved out from RenderStyle Flags.

We have now refactored it, packing its content within 5 bits, so we can move
it back to RenderStyle flags where it used to be.

We are representing TextDecorationLine in 5 bits.
1 bit is used for defining the Type (SingleValue or Flags)
4 bits are used for defining the Value
Values for SingleValue: None, SpellingError, GrammarError
Values for Flags: Any combination of Underline, Overline, LineThrough, Blink
Therefore, we are packing its content with the following layout:
Bits 7-5: Reserved
Bit 4: Type (SingleValue or Flags)
Bits 3-0: When Type=1 (Underline=0x1, Overline=0x2, LineThrough=0x4, Blink=0x8)
         : When Type=0 (None = 0, SpellingError = 1, GrammarError = 2)

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
(WebCore::RenderStyle::NonInheritedFlags::copyNonInheritedFrom):
(WebCore::RenderStyle::changeAffectsVisualOverflow const):
(WebCore::miscDataChangeRequiresRepaint):
(WebCore::RenderStyle::changeRequiresRepaint const):
(WebCore::RenderStyle::changeRequiresRepaintIfText const):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
(WebCore::RenderStyle::NonInheritedFlags::dumpDifferences const):
(WebCore::RenderStyle::InheritedFlags::dumpDifferences const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::textDecorationLine const):
(WebCore::RenderStyle::textDecorationLineInEffect const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::addToTextDecorationLineInEffect):
(WebCore::RenderStyle::setTextDecorationLine):
(WebCore::RenderStyle::setTextDecorationLineInEffect):
* Source/WebCore/rendering/style/StyleInheritedData.cpp:
(WebCore::StyleInheritedData::StyleInheritedData):
(WebCore::StyleInheritedData::nonFastPathInheritedEqual const):
(WebCore::StyleInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleInheritedData.h:
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp:
(WebCore::StyleMiscNonInheritedData::StyleMiscNonInheritedData):
(WebCore::StyleMiscNonInheritedData::operator== const):
(WebCore::StyleMiscNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp:
(WebCore::Style::TextDecorationLine::addOrReplaceIfNotNone):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h:
(WebCore::Style::TextDecorationLine::TextDecorationLine):
(WebCore::Style::TextDecorationLine::type const):
(WebCore::Style::TextDecorationLine::isNone const):
(WebCore::Style::TextDecorationLine::isSpellingError const):
(WebCore::Style::TextDecorationLine::isGrammarError const):
(WebCore::Style::TextDecorationLine::isFlags const):
(WebCore::Style::TextDecorationLine::hasUnderline const):
(WebCore::Style::TextDecorationLine::hasOverline const):
(WebCore::Style::TextDecorationLine::hasLineThrough const):
(WebCore::Style::TextDecorationLine::hasBlink const):
(WebCore::Style::TextDecorationLine::containsAny const):
(WebCore::Style::TextDecorationLine::contains const):
(WebCore::Style::TextDecorationLine::remove):
(WebCore::Style::TextDecorationLine::switchOn const):
(WebCore::Style::TextDecorationLine::toRaw const):
(WebCore::Style::TextDecorationLine::operator== const):
(WebCore::Style::TextDecorationLine::rawValue const):
(WebCore::Style::TextDecorationLine::packFlags):
(WebCore::Style::TextDecorationLine::packFlag):
(WebCore::Style::TextDecorationLine::unpackFlags const):

Canonical link: <a href="https://commits.webkit.org/299294@main">https://commits.webkit.org/299294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/052d8c9271bf975041d93101802119913746c4f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124705 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/70592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f21edfb-c6cb-4758-b59b-dd4492f50fe3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89968 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/70592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc052dd5-9a9f-4b45-bd41-5841789b756c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121486 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/30995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70472 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/552ee652-39b6-4dfc-8725-31004137a20e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24389 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68364 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/100434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/24580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45440 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102499 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25009 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/43823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50988 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/44773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->