### PR TITLE
Change JITOperationAnnotation's initialization to not rely on (void*) casts on function pointers.

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationValidation.h
+++ b/Source/JavaScriptCore/assembler/JITOperationValidation.h
@@ -49,6 +49,18 @@
 
 namespace JSC {
 
+#ifndef JIT_OPERATION_VALIDATION_FUNCTOR
+#define JIT_OPERATION_VALIDATION_FUNCTOR Functor
+#endif
+
+template<typename Functor>
+struct JITOperationAnnotationInitializer {
+    Functor* operation;
+#if ENABLE(JIT_OPERATION_VALIDATION)
+    JIT_OPERATION_VALIDATION_FUNCTOR* operationWithValidation;
+#endif
+};
+
 struct JITOperationAnnotation {
     void* operation;
 #if ENABLE(JIT_OPERATION_VALIDATION)


### PR DESCRIPTION
#### 60998b950370a44226388bd0d02de1ea4b6ed090
<pre>
Change JITOperationAnnotation&apos;s initialization to not rely on (void*) casts on function pointers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297941">https://bugs.webkit.org/show_bug.cgi?id=297941</a>
<a href="https://rdar.apple.com/158233829">rdar://158233829</a>

Reviewed by Yusuke Suzuki.

Apparently, C++ does not allow this since C++11.  See <a href="https://github.com/llvm/llvm-project/pull/150557.">https://github.com/llvm/llvm-project/pull/150557.</a>

Instead, we&apos;ll introduce a JITOperationAnnotationInitializer template class that will be used to
initialize the const annotation records with the operation function pointers.  As long as the size and
shape of JITOperationAnnotationInitializer is identical to JITOperationAnnotation, then we can do the
initialization using JITOperationAnnotationInitializer, and read the function pointer bits using
JITOperationAnnotation.

No test needed as there&apos;s no behavior change.  This patch merely changes how we express a data structure
just to placate the compiler.  Even the data structure layout is identical.  If it builds, the patch is
good.

* Source/JavaScriptCore/assembler/JITOperationValidation.h:
* Source/WTF/wtf/PlatformCallingConventions.h:

Canonical link: <a href="https://commits.webkit.org/299281@main">https://commits.webkit.org/299281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22138c8a9a55be75b8b09d384f5057b10904aa46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70522 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5a94f40-d0ac-44f3-b70b-b99e62e37ae1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2bf6fc36-77b3-473e-a515-5ff05983386e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70401 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/23ba7f4a-aee9-42d6-b47e-ada55b8daa8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68298 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110581 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127701 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116977 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34232 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98366 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21771 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18875 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50918 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145673 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44703 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37462 "Found 1 new JSC binary failure: testapi, Found 18581 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48050 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->