### PR TITLE
[Liquid Glass] [iOS] Swipe-back snapshot misaligned after closing sidebar

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -598,6 +598,7 @@ public:
 
     virtual bool isSimulatingCompatibilityPointerTouches() const = 0;
 
+    virtual WebCore::FloatBoxExtent computedObscuredInset() const = 0;
     virtual WebCore::Color contentViewBackgroundColor() = 0;
     virtual WebCore::Color insertionPointColor() = 0;
     virtual bool isScreenBeingCaptured() = 0;

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
@@ -96,6 +96,9 @@ void ViewSnapshotStore::recordSnapshot(WebPageProxy& webPageProxy, WebBackForwar
 #if PLATFORM(MAC)
     snapshot->setVolatile(true);
 #endif
+#if PLATFORM(IOS_FAMILY)
+    snapshot->setComputedObscuredInset(webPageProxy.computedObscuredInset());
+#endif
     snapshot->setRenderTreeSize(webPageProxy.renderTreeSize());
     snapshot->setDeviceScaleFactor(webPageProxy.deviceScaleFactor());
     snapshot->setBackgroundColor(webPageProxy.pageExtendedBackgroundColor());

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/BoxExtents.h>
 #include <WebCore/Color.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/SecurityOriginData.h>
@@ -84,6 +85,9 @@ public:
     void setViewScrollPosition(WebCore::IntPoint scrollPosition) { m_viewScrollPosition = scrollPosition; }
     WebCore::IntPoint viewScrollPosition() const { return m_viewScrollPosition; }
 
+    void setComputedObscuredInset(WebCore::FloatBoxExtent&& inset) { m_computedObscuredInset = WTFMove(inset); }
+    const WebCore::FloatBoxExtent computedObscuredInset() const { return m_computedObscuredInset; }
+
     void setDeviceScaleFactor(float deviceScaleFactor) { m_deviceScaleFactor = deviceScaleFactor; }
     float deviceScaleFactor() const { return m_deviceScaleFactor; }
 
@@ -135,6 +139,7 @@ private:
     float m_deviceScaleFactor;
     WebCore::Color m_backgroundColor;
     WebCore::IntPoint m_viewScrollPosition; // Scroll position at snapshot time. Integral to make comparison reliable.
+    WebCore::FloatBoxExtent m_computedObscuredInset;
     WebCore::SecurityOriginData m_origin;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1114,6 +1114,7 @@ public:
     WebCore::FloatRect unobscuredContentRectRespectingInputViewBounds() const;
     // When visual viewports are enabled, this is the layout viewport rect.
     WebCore::FloatRect layoutViewportRect() const;
+    WebCore::FloatBoxExtent computedObscuredInset() const;
 
     void resendLastVisibleContentRects();
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -330,6 +330,7 @@ private:
 
     bool isSimulatingCompatibilityPointerTouches() const final;
 
+    WebCore::FloatBoxExtent computedObscuredInset() const final;
     WebCore::Color contentViewBackgroundColor() final;
     WebCore::Color insertionPointColor() final;
     bool isScreenBeingCaptured() final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -47,6 +47,7 @@
 #import "RunningBoardServicesSPI.h"
 #import "TapHandlingResult.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "UndoOrRedo.h"
 #import "ViewSnapshotStore.h"
 #import "WKContentView.h"
@@ -1195,6 +1196,11 @@ bool PageClientImpl::isSimulatingCompatibilityPointerTouches() const
 void PageClientImpl::runModalJavaScriptDialog(CompletionHandler<void()>&& callback)
 {
     [contentView() runModalJavaScriptDialog:WTFMove(callback)];
+}
+
+FloatBoxExtent PageClientImpl::computedObscuredInset() const
+{
+    return floatBoxExtent([webView() _computedObscuredInset]);
 }
 
 WebCore::Color PageClientImpl::contentViewBackgroundColor()

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -33,6 +33,9 @@
 namespace WebCore {
 class FloatQuad;
 enum class BoxSide : uint8_t;
+
+template<typename> class RectEdges;
+using FloatBoxExtent = RectEdges<float>;
 }
 
 @interface UIScrollView (WebKitInternal)
@@ -85,6 +88,7 @@ RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *
 UIScrollView *scrollViewForTouches(NSSet<UITouch *> *);
 UIRectEdge uiRectEdgeForSide(WebCore::BoxSide);
 UIEdgeInsets maxEdgeInsets(const UIEdgeInsets&, const UIEdgeInsets&);
+WebCore::FloatBoxExtent floatBoxExtent(const UIEdgeInsets&);
 
 static constexpr auto allUIRectEdges = std::array {
     UIRectEdgeTop,

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -30,6 +30,7 @@
 
 #import "UIKitSPI.h"
 #import <WebCore/BoxSides.h>
+#import <WebCore/FloatConversion.h>
 #import <WebCore/FloatPoint.h>
 #import <WebCore/FloatQuad.h>
 #import <wtf/BlockPtr.h>
@@ -397,6 +398,16 @@ UIEdgeInsets maxEdgeInsets(const UIEdgeInsets& a, const UIEdgeInsets& b)
         std::max<CGFloat>(a.bottom, b.bottom),
         std::max<CGFloat>(a.right, b.right)
     );
+}
+
+WebCore::FloatBoxExtent floatBoxExtent(const UIEdgeInsets& insets)
+{
+    return {
+        WebCore::narrowPrecisionToFloatFromCGFloat(insets.top),
+        WebCore::narrowPrecisionToFloatFromCGFloat(insets.right),
+        WebCore::narrowPrecisionToFloatFromCGFloat(insets.bottom),
+        WebCore::narrowPrecisionToFloatFromCGFloat(insets.left)
+    };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -41,6 +41,7 @@
 #import "RemoteLayerTreeDrawingAreaProxyIOS.h"
 #import "SmartMagnificationController.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "VisibleContentRectUpdateInfo.h"
 #import "WKBrowsingContextGroupPrivate.h"
 #import "WKInspectorHighlightView.h"
@@ -662,11 +663,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_textInteractionWrapper deactivateSelection];
 }
 
-static WebCore::FloatBoxExtent floatBoxExtent(UIEdgeInsets insets)
-{
-    return { WebCore::narrowPrecisionToFloatFromCGFloat(insets.top), WebCore::narrowPrecisionToFloatFromCGFloat(insets.right), WebCore::narrowPrecisionToFloatFromCGFloat(insets.bottom), WebCore::narrowPrecisionToFloatFromCGFloat(insets.left) };
-}
-
 - (CGRect)_computeUnobscuredContentRectRespectingInputViewBounds:(CGRect)unobscuredContentRect inputViewBounds:(CGRect)inputViewBounds
 {
     // The input view bounds are in window coordinates, but the unobscured rect is in content coordinates. Account for this by converting input view bounds to content coordinates.
@@ -708,12 +704,12 @@ static WebCore::FloatBoxExtent floatBoxExtent(UIEdgeInsets insets)
     WebKit::VisibleContentRectUpdateInfo visibleContentRectUpdateInfo(
         visibleContentRect,
         unobscuredContentRect,
-        floatBoxExtent(contentInsets),
+        WebKit::floatBoxExtent(contentInsets),
         unobscuredRectInScrollViewCoordinates,
         unobscuredContentRectRespectingInputViewBounds,
         fixedPositionRectForLayout,
-        floatBoxExtent(obscuredInsets),
-        floatBoxExtent(unobscuredSafeAreaInsets),
+        WebKit::floatBoxExtent(obscuredInsets),
+        WebKit::floatBoxExtent(unobscuredSafeAreaInsets),
         zoomScale,
         viewStability,
         !!_sizeChangedSinceLastVisibleContentRectUpdate,

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1793,6 +1793,14 @@ FloatRect WebPageProxy::layoutViewportRect() const
     return { };
 }
 
+FloatBoxExtent WebPageProxy::computedObscuredInset() const
+{
+    if (RefPtr pageClient = this->pageClient())
+        return pageClient->computedObscuredInset();
+
+    return { };
+}
+
 FloatSize WebPageProxy::viewLayoutSize() const
 {
     return internals().viewportConfigurationViewLayoutSize;


### PR DESCRIPTION
#### c495a3af9e9a28d3b461e151721569785ce1e059
<pre>
[Liquid Glass] [iOS] Swipe-back snapshot misaligned after closing sidebar
<a href="https://bugs.webkit.org/show_bug.cgi?id=297943">https://bugs.webkit.org/show_bug.cgi?id=297943</a>
<a href="https://rdar.apple.com/154122055">rdar://154122055</a>

Reviewed by Abrar Rahman Protyasha.

When swiping back/forward in Safari, a snapshot of the webpage in the back/forward list is shown
only if certain criteria are met (e.g. the size of the web view and the snapshot must match).
However, this size does not account for any obscured insets. Since iOS 26, opening or closing the
sidebar changes the left obscured inset. As such, if we go forward, toggle the sidebar, and then
swipe to go back (or vice versa), we end up showing a snapshot that&apos;s incorrectly sized and offset
relative to the actual unobscured rect.

To fix this, we simply account for changes to obscured content insets in this case, and (if the
change is more than some arbitrary threshold) we avoid using the back/forward snapshot, as if the
size of the web view had changed.

This arbitrary &quot;significant change&quot; threshold exists (as opposed to checking for equality in order
to keep using snapshots in common cases (especially on phone) where the tab bar may have collapsed
or expanded. The mismatch is subtle in these cases, and keeping snapshots visible in this case
matches shipping behavior. In the case of the left sidebar opening or closing, this causes a
difference of a few hundred points, which results in a very noticeable (and jarring) jump when
swiping.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ViewSnapshotStore.cpp:
(WebKit::ViewSnapshotStore::recordSnapshot):
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
(WebKit::ViewSnapshot::setComputedObscuredInset):
(WebKit::ViewSnapshot::computedObscuredInset const):

Add the computed obscured inset as a member on `ViewSnapshot`, so that we can check it (along with
size and scroll position) when determining whether the snapshot is suitable for use.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::computedObscuredInset const):

Add plumbing from `WebPageProxy` -&gt; `PageClient` -&gt; `WKWebView` to grab the computed obscured inset.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(WebKit::floatBoxExtent):

Move this static helper into UIKitUtilities, so that we can use it in `PageClientImplIOS.mm` above.

* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView didUpdateVisibleRect:unobscuredRect:contentInsets:unobscuredRectInScrollViewCoordinates:obscuredInsets:unobscuredSafeAreaInsets:inputViewBounds:scale:minimumScale:viewStability:enclosedInScrollableAncestorView:sendEvenIfUnchanged:]):
(floatBoxExtent): Deleted.
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::computedObscuredInset const):

Canonical link: <a href="https://commits.webkit.org/299185@main">https://commits.webkit.org/299185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eba45f47798f489aa3660348b5e82f2f3163c713

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70218 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abd2e87e-238d-4839-b702-fcf480ecac79) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89676 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59312 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfeec5c8-6dbd-437d-b83d-d7725eaf086b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0facda1-cca0-4f26-8294-7bf77793f08f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29774 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68001 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127410 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98355 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98144 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24955 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21528 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41546 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44413 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->