### PR TITLE
Enable format string attributes in Objective-C++ sources

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -111,10 +111,13 @@
 
 #define WTF_PRETTY_FUNCTION __PRETTY_FUNCTION__
 
-#if COMPILER(GCC_COMPATIBLE) && !defined(__OBJC__)
-/* WTF logging functions can process %@ in the format string to log a NSObject* but the printf format attribute
-   emits a warning when %@ is used in the format string.  Until <rdar://problem/5195437> is resolved we can't include
-   the attribute when being used from Objective-C code in case it decides to use %@. */
+#if USE(CF)
+#define WTF_ATTRIBUTE_NSSTRING(formatStringArgument, extraArguments) __attribute__((__format__(__NSString__, formatStringArgument, extraArguments)))
+#else
+#define WTF_ATTRIBUTE_NSSTRING WTF_ATTRIBUTE_PRINTF
+#endif
+
+#if COMPILER(GCC_COMPATIBLE)
 #define WTF_ATTRIBUTE_PRINTF(formatStringArgument, extraArguments) __attribute__((__format__(printf, formatStringArgument, extraArguments)))
 #else
 #define WTF_ATTRIBUTE_PRINTF(formatStringArgument, extraArguments)
@@ -208,18 +211,18 @@ static const WTFLogLevel logLevelError = (WTFLogLevel)1;
 
 WTF_EXPORT_PRIVATE void WTFReportNotImplementedYet(const char* file, int line, const char* function);
 WTF_EXPORT_PRIVATE void WTFReportAssertionFailure(const char* file, int line, const char* function, const char* assertion);
-WTF_EXPORT_PRIVATE void WTFReportAssertionFailureWithMessage(const char* file, int line, const char* function, const char* assertion, const char* format, ...) WTF_ATTRIBUTE_PRINTF(5, 6);
+WTF_EXPORT_PRIVATE void WTFReportAssertionFailureWithMessage(const char* file, int line, const char* function, const char* assertion, const char* format, ...) WTF_ATTRIBUTE_NSSTRING(5, 6);
 WTF_EXPORT_PRIVATE void WTFReportArgumentAssertionFailure(const char* file, int line, const char* function, const char* argName, const char* assertion);
-WTF_EXPORT_PRIVATE void WTFReportFatalError(const char* file, int line, const char* function, const char* format, ...) WTF_ATTRIBUTE_PRINTF(4, 5);
-WTF_EXPORT_PRIVATE void WTFReportError(const char* file, int line, const char* function, const char* format, ...) WTF_ATTRIBUTE_PRINTF(4, 5);
-WTF_EXPORT_PRIVATE void WTFLog(WTFLogChannel*, const char* format, ...) WTF_ATTRIBUTE_PRINTF(2, 3);
-WTF_EXPORT_PRIVATE void WTFLogVerbose(const char* file, int line, const char* function, WTFLogChannel*, const char* format, ...) WTF_ATTRIBUTE_PRINTF(5, 6);
-WTF_EXPORT_PRIVATE void WTFLogAlwaysV(const char* format, va_list) WTF_ATTRIBUTE_PRINTF(1, 0);
-WTF_EXPORT_PRIVATE void WTFLogAlways(const char* format, ...) WTF_ATTRIBUTE_PRINTF(1, 2);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFLogAlwaysAndCrash(const char* format, ...) WTF_ATTRIBUTE_PRINTF(1, 2);
+WTF_EXPORT_PRIVATE void WTFReportFatalError(const char* file, int line, const char* function, const char* format, ...) WTF_ATTRIBUTE_NSSTRING(4, 5);
+WTF_EXPORT_PRIVATE void WTFReportError(const char* file, int line, const char* function, const char* format, ...) WTF_ATTRIBUTE_NSSTRING(4, 5);
+WTF_EXPORT_PRIVATE void WTFLog(WTFLogChannel*, const char* format, ...) WTF_ATTRIBUTE_NSSTRING(2, 3);
+WTF_EXPORT_PRIVATE void WTFLogVerbose(const char* file, int line, const char* function, WTFLogChannel*, const char* format, ...) WTF_ATTRIBUTE_NSSTRING(5, 6);
+WTF_EXPORT_PRIVATE void WTFLogAlwaysV(const char* format, va_list) WTF_ATTRIBUTE_NSSTRING(1, 0);
+WTF_EXPORT_PRIVATE void WTFLogAlways(const char* format, ...) WTF_ATTRIBUTE_NSSTRING(1, 2);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFLogAlwaysAndCrash(const char* format, ...) WTF_ATTRIBUTE_NSSTRING(1, 2);
 WTF_EXPORT_PRIVATE WTFLogChannel* WTFLogChannelByName(WTFLogChannel*[], size_t count, const char*);
 WTF_EXPORT_PRIVATE void WTFInitializeLogChannelStatesFromString(WTFLogChannel*[], size_t count, const char*);
-WTF_EXPORT_PRIVATE void WTFLogWithLevel(WTFLogChannel*, WTFLogLevel, const char* format, ...) WTF_ATTRIBUTE_PRINTF(3, 4);
+WTF_EXPORT_PRIVATE void WTFLogWithLevel(WTFLogChannel*, WTFLogLevel, const char* format, ...) WTF_ATTRIBUTE_NSSTRING(3, 4);
 WTF_EXPORT_PRIVATE void WTFSetLogChannelLevel(WTFLogChannel*, WTFLogLevel);
 WTF_EXPORT_PRIVATE bool WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -72,7 +72,7 @@ private:
     void logJSONPayload(const JSON::Object&);
     void logString(std::span<const String> path, const String&);
     void logObject(std::span<const String> path, Ref<JSON::Object>&&);
-    void logError(const char*, ...);
+    void logError(const char*, ...) WTF_ATTRIBUTE_PRINTF(2, 3);
 
     void logExecutablePath(void);
     void logDYLDSharedCacheInfo(void);

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
@@ -106,7 +106,7 @@ void MultiGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Ev
 {
     auto index = indexForNewlyConnectedDevice();
 
-    LOG(Gamepad, "MultiGamepadProvider adding new platform gamepad to index %i from a %s source", index, gamepad.source());
+    LOG(Gamepad, "MultiGamepadProvider adding new platform gamepad to index %i from a %s source", index, gamepad.source().characters());
 
     ASSERT(m_gamepadVector.size() > index);
 
@@ -120,7 +120,7 @@ void MultiGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Ev
 
 void MultiGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
 {
-    LOG(Gamepad, "MultiGamepadProvider disconnecting gamepad from a %s source", gamepad.source());
+    LOG(Gamepad, "MultiGamepadProvider disconnecting gamepad from a %s source", gamepad.source().characters());
 
     auto gamepadWrapper = m_gamepadMap.take(gamepad);
 

--- a/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
@@ -156,7 +156,7 @@ String keyIdentifierForKeyEvent(WebEvent *event)
     }
     NSString *characters = event.charactersIgnoringModifiers;
     if ([characters length] != 1) {
-        LOG(Events, "received an unexpected number of characters in key event: %u", [characters length]);
+        LOG(Events, "received an unexpected number of characters in key event: %zu", [characters length]);
         return "Unidentified"_s;
     }
     return keyIdentifierForCharCode([characters characterAtIndex:0]);

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -345,13 +345,13 @@ void WebCoreObjCDeallocOnWebThread(Class cls)
     // get the existing release method
     Method releaseMethod = class_getInstanceMethod(cls, releaseSEL);
     if (!releaseMethod) {
-        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocOnWebThread() failed to find %s for %@", releaseSEL, NSStringFromClass(cls));
+        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocOnWebThread() failed to find %s for %@", sel_getName(releaseSEL), NSStringFromClass(cls));
         return;
     }
 
     // add the implementation that ensures release WebThread release/deallocation
     if (!class_addMethod(cls, webThreadReleaseSEL, (IMP)WebCoreObjCDeallocOnWebThreadImpl, method_getTypeEncoding(releaseMethod))) {
-        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocOnWebThread() failed to add %s for %@", webThreadReleaseSEL, NSStringFromClass(cls));
+        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocOnWebThread() failed to add %s for %@", sel_getName(webThreadReleaseSEL), NSStringFromClass(cls));
         return;
     }
 
@@ -371,13 +371,13 @@ void WebCoreObjCDeallocWithWebThreadLock(Class cls)
     // get the existing release method
     Method releaseMethod = class_getInstanceMethod(cls, releaseSEL);
     if (!releaseMethod) {
-        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocWithWebThreadLock() failed to find %s for %@", releaseSEL, NSStringFromClass(cls));
+        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocWithWebThreadLock() failed to find %s for %@", sel_getName(releaseSEL), NSStringFromClass(cls));
         return;
     }
 
     // add the implementation that ensures release WebThreadLock release/deallocation
     if (!class_addMethod(cls, webThreadLockReleaseSEL, (IMP)WebCoreObjCDeallocWithWebThreadLockImpl, method_getTypeEncoding(releaseMethod))) {
-        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocWithWebThreadLock() failed to add %s for %@", webThreadLockReleaseSEL, NSStringFromClass(cls));
+        ASSERT_WITH_MESSAGE(releaseMethod, "WebCoreObjCDeallocWithWebThreadLock() failed to add %s for %@", sel_getName(webThreadLockReleaseSEL), NSStringFromClass(cls));
         return;
     }
 

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -519,7 +519,7 @@ String keyIdentifierForKeyEvent(NSEvent* event)
     
     NSString *s = [event charactersIgnoringModifiers];
     if ([s length] != 1) {
-        LOG(Events, "received an unexpected number of characters in key event: %u", [s length]);
+        LOG(Events, "received an unexpected number of characters in key event: %zu", [s length]);
         return "Unidentified"_s;
     }
     return keyIdentifierForCharCode([s characterAtIndex:0]);

--- a/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
@@ -208,7 +208,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     ASSERT(!isMainThread());
     UNUSED_PARAM(connection);
 
-    LOG(Network, "Handle %p delegate connection:%p canAuthenticateAgainstProtectionSpace:%@://%@:%u realm:%@ method:%@ %@%@", m_handle, connection, [protectionSpace protocol], [protectionSpace host], [protectionSpace port], [protectionSpace realm], [protectionSpace authenticationMethod], [protectionSpace isProxy] ? @"proxy:" : @"", [protectionSpace isProxy] ? [protectionSpace proxyType] : @"");
+    LOG(Network, "Handle %p delegate connection:%p canAuthenticateAgainstProtectionSpace:%@://%@:%zd realm:%@ method:%@ %@%@", m_handle, connection, [protectionSpace protocol], [protectionSpace host], [protectionSpace port], [protectionSpace realm], [protectionSpace authenticationMethod], [protectionSpace isProxy] ? @"proxy:" : @"", [protectionSpace isProxy] ? [protectionSpace proxyType] : @"");
 
     auto protectedSelf = retainPtr(self);
     auto work = [self, protectedSelf, protectionSpace = retainPtr(protectionSpace)] () mutable {
@@ -243,7 +243,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     ASSERT(!isMainThread());
 
-    LOG(Network, "Handle %p delegate connection:%p didReceiveResponse:%p (HTTP status %d, reported MIMEType '%s')", m_handle, connection, r, [r respondsToSelector:@selector(statusCode)] ? [(id)r statusCode] : 0, [[r MIMEType] UTF8String]);
+    LOG(Network, "Handle %p delegate connection:%p didReceiveResponse:%p (HTTP status %zd, reported MIMEType '%s')", m_handle, connection, r, [r respondsToSelector:@selector(statusCode)] ? [(id)r statusCode] : 0, [[r MIMEType] UTF8String]);
 
     auto protectedSelf = retainPtr(self);
     auto work = [self, protectedSelf, r = retainPtr(r), connection = retainPtr(connection)] () mutable {
@@ -314,7 +314,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     UNUSED_PARAM(connection);
     UNUSED_PARAM(bytesWritten);
 
-    LOG(Network, "Handle %p delegate connection:%p didSendBodyData:%d totalBytesWritten:%d totalBytesExpectedToWrite:%d", m_handle, connection, bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
+    LOG(Network, "Handle %p delegate connection:%p didSendBodyData:%zd totalBytesWritten:%zd totalBytesExpectedToWrite:%zd", m_handle, connection, bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
 
     auto work = [self = self, protectedSelf = retainPtr(self), totalBytesWritten = totalBytesWritten, totalBytesExpectedToWrite = totalBytesExpectedToWrite] () mutable {
         if (!m_handle || !m_handle->client())

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -317,7 +317,7 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
         ALLOW_DEPRECATED_DECLARATIONS_END
         id<MTLLibrary> library = [device newLibraryWithSource:@"[[vertex]] float4 vsNop() { return (float4)0; }" options:options error:&error];
         if (error)
-            WTFLogAlways("%@", error); // NOLINT
+            WTFLogAlways("newLibraryWithSource failed: %@", error.localizedDescription); // NOLINT
         m_nopVertexFunction = [library newFunctionWithName:@"vsNop"];
     });
     RELEASE_ASSERT(m_nopVertexFunction);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -616,7 +616,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler
 {
     auto taskIdentifier = task.taskIdentifier;
-    LOG(NetworkSession, "%llu willPerformHTTPRedirection from %s to %s", taskIdentifier, response.URL.absoluteString.UTF8String, request.URL.absoluteString.UTF8String);
+    LOG(NetworkSession, "%zu willPerformHTTPRedirection from %s to %s", taskIdentifier, response.URL.absoluteString.UTF8String, request.URL.absoluteString.UTF8String);
 
     if (RefPtr networkDataTask = [self existingTask:task]) {
         bool shouldIgnoreHSTS = false;
@@ -628,7 +628,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
             if (shouldIgnoreHSTS) {
                 RetainPtr newRequest = downgradeRequest(request);
                 ASSERT([newRequest.get().URL.scheme isEqualToString:@"http"]);
-                LOG(NetworkSession, "%llu Downgraded %s from https to http", taskIdentifier, newRequest.get().URL.absoluteString.UTF8String);
+                LOG(NetworkSession, "%zu Downgraded %s from https to http", taskIdentifier, newRequest.get().URL.absoluteString.UTF8String);
 
                 updateIgnoreStrictTransportSecuritySetting(newRequest, shouldIgnoreHSTS);
                 completionHandler(newRequest.get());
@@ -641,7 +641,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 
         networkDataTask->willPerformHTTPRedirection(WTFMove(resourceResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier, shouldIgnoreHSTS](auto&& request) {
 #if !LOG_DISABLED
-            LOG(NetworkSession, "%llu willPerformHTTPRedirection completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
+            LOG(NetworkSession, "%zu willPerformHTTPRedirection completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
 #else
             UNUSED_PARAM(taskIdentifier);
 #endif
@@ -653,7 +653,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
         WebCore::ResourceResponse resourceResponse(response);
         webSocketTask->willPerformHTTPRedirection(WTFMove(resourceResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier](auto&& request) {
 #if !LOG_DISABLED
-            LOG(NetworkSession, "%llu willPerformHTTPRedirection completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
+            LOG(NetworkSession, "%zu willPerformHTTPRedirection completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
 #else
             UNUSED_PARAM(taskIdentifier);
 #endif
@@ -661,7 +661,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
             completionHandler(nsRequest.get());
         });
     } else {
-        LOG(NetworkSession, "%llu willPerformHTTPRedirection completionHandler (nil)", taskIdentifier);
+        LOG(NetworkSession, "%zu willPerformHTTPRedirection completionHandler (nil)", taskIdentifier);
         completionHandler(nil);
     }
 }
@@ -669,7 +669,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask*)task _schemeUpgraded:(NSURLRequest*)request completionHandler:(void (^)(NSURLRequest*))completionHandler
 {
     auto taskIdentifier = task.taskIdentifier;
-    LOG(NetworkSession, "%llu _schemeUpgraded %s", taskIdentifier, request.URL.absoluteString.UTF8String);
+    LOG(NetworkSession, "%zu _schemeUpgraded %s", taskIdentifier, request.URL.absoluteString.UTF8String);
 
     if (RefPtr networkDataTask = [self existingTask:task]) {
         bool shouldIgnoreHSTS = false;
@@ -680,7 +680,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
             if (shouldIgnoreHSTS) {
                 RetainPtr newRequest = downgradeRequest(request);
                 ASSERT([newRequest.get().URL.scheme isEqualToString:@"http"]);
-                LOG(NetworkSession, "%llu Downgraded %s from https to http", taskIdentifier, newRequest.get().URL.absoluteString.UTF8String);
+                LOG(NetworkSession, "%zu Downgraded %s from https to http", taskIdentifier, newRequest.get().URL.absoluteString.UTF8String);
 
                 updateIgnoreStrictTransportSecuritySetting(newRequest, shouldIgnoreHSTS);
                 completionHandler(newRequest.get());
@@ -694,7 +694,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
         synthesizedResponse.setHTTPHeaderField(WebCore::HTTPHeaderName::AccessControlAllowOrigin, origin.get());
         networkDataTask->willPerformHTTPRedirection(WTFMove(synthesizedResponse), request, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier, shouldIgnoreHSTS](auto&& request) {
 #if !LOG_DISABLED
-            LOG(NetworkSession, "%llu _schemeUpgraded completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
+            LOG(NetworkSession, "%zu _schemeUpgraded completionHandler (%s)", taskIdentifier, request.url().string().utf8().data());
 #else
             UNUSED_PARAM(taskIdentifier);
 #endif
@@ -703,7 +703,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
             completionHandler(nsRequest.get());
         });
     } else {
-        LOG(NetworkSession, "%llu _schemeUpgraded completionHandler (nil)", taskIdentifier);
+        LOG(NetworkSession, "%zu _schemeUpgraded completionHandler (nil)", taskIdentifier);
         completionHandler(nil);
     }
 }
@@ -787,7 +787,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     auto taskIdentifier = task.taskIdentifier;
-    LOG(NetworkSession, "%llu didReceiveChallenge", taskIdentifier);
+    LOG(NetworkSession, "%zu didReceiveChallenge", taskIdentifier);
     
     // Proxy authentication is handled by CFNetwork internally. We can get here if the user cancels
     // CFNetwork authentication dialog, and we shouldn't ask the client to display another one in that case.
@@ -908,7 +908,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-    LOG(NetworkSession, "%llu didCompleteWithError %@", task.taskIdentifier, error);
+    LOG(NetworkSession, "%zu didCompleteWithError %@", task.taskIdentifier, error);
 
     RetainPtr updatedError = error;
     if (updatedError) {
@@ -969,7 +969,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
 {
-    LOG(NetworkSession, "%llu didFinishCollectingMetrics", task.taskIdentifier);
+    LOG(NetworkSession, "%zu didFinishCollectingMetrics", task.taskIdentifier);
     if (auto networkDataTask = [self existingTask:task]) {
         RetainPtr<NSArray<NSURLSessionTaskTransactionMetrics *>> transactionMetrics = metrics.transactionMetrics;
         RetainPtr<NSURLSessionTaskTransactionMetrics> m = transactionMetrics.get().lastObject;
@@ -1096,7 +1096,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
 {
     auto taskIdentifier = dataTask.taskIdentifier;
-    LOG(NetworkSession, "%llu didReceiveResponse", taskIdentifier);
+    LOG(NetworkSession, "%zu didReceiveResponse", taskIdentifier);
     if (auto networkDataTask = [self existingTask:dataTask]) {
         ASSERT(RunLoop::isMain());
 
@@ -1138,14 +1138,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         resourceResponse.setProxyName(WTFMove(proxyName));
         networkDataTask->didReceiveResponse(WTFMove(resourceResponse), negotiatedLegacyTLS, privateRelayed, [completionHandler = makeBlockPtr(completionHandler), taskIdentifier](WebCore::PolicyAction policyAction) {
 #if !LOG_DISABLED
-            LOG(NetworkSession, "%llu didReceiveResponse completionHandler (%s)", taskIdentifier, toString(policyAction).characters());
+            LOG(NetworkSession, "%zu didReceiveResponse completionHandler (%s)", taskIdentifier, toString(policyAction).characters());
 #else
             UNUSED_PARAM(taskIdentifier);
 #endif
             completionHandler(toNSURLSessionResponseDisposition(policyAction));
         });
     } else {
-        LOG(NetworkSession, "%llu didReceiveResponse completionHandler (cancel)", taskIdentifier);
+        LOG(NetworkSession, "%zu didReceiveResponse completionHandler (cancel)", taskIdentifier);
         completionHandler(NSURLSessionResponseCancel);
     }
 }
@@ -2479,7 +2479,7 @@ void NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTime> modif
 
     bool result = [usageFeed performNetworkDomainsActionWithOptions:options reply:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSDictionary *reply, NSError *error) mutable {
         if (error)
-            LOG(NetworkSession, "Error deleting network domain data %" PUBLIC_LOG_STRING, error);
+            RELEASE_LOG_DEBUG(NetworkSession, "Error deleting network domain data %" PUBLIC_LOG_STRING, error.localizedDescription.UTF8String);
 
         completionHandler();
     }).get()];

--- a/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
+++ b/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -228,7 +228,7 @@ bool hasProhibitedUsageStrings()
     for (NSString *prohibitedString : prohibitedStrings) {
         if ([infoDictionary objectForKey:prohibitedString]) {
             String message = adoptNS([[NSString alloc] initWithFormat:@"[In-App Browser Privacy] %@ used prohibited usage string %@.", [[NSBundle mainBundle] bundleIdentifier], prohibitedString]).get();
-            WTFLogAlways(message.utf8().data());
+            WTFLogAlways("%s", message.utf8().data());
             hasProhibitedUsageStrings = true;
             break;
         }

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -350,7 +350,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!makeDataVault())
             return false;
     } else {
-        WTFLogAlways("%s: Sandbox directory couldn't be created: ", getprogname(), safeStrerror(errno).data());
+        WTFLogAlways("%s: Sandbox directory couldn't be created: %s", getprogname(), safeStrerror(errno).data());
         return false;
     }
 #else

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -62,7 +62,7 @@ bool checkSandboxRequirementForType(MediaPermissionType type)
 
         int result = sandbox_check(getpid(), operation, static_cast<enum sandbox_filter_type>(SANDBOX_CHECK_NO_REPORT | SANDBOX_FILTER_NONE));
         if (result == -1)
-            WTFLogAlways("Error checking '%s' sandbox access, errno=%ld", operation, (long)errno);
+            WTFLogAlways("Error checking '%s' sandbox access, errno=%ld", operation.characters(), (long)errno);
         *entitled = !result;
     };
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
@@ -139,7 +139,7 @@
     ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: (authorization = %p, _session = %p)", authorization, _session.get());
     if (error.code)
-        LOG_ERROR("Could not complete AppSSO operation. Error: %d", error.code);
+        LOG_ERROR("Could not complete AppSSO operation. Error: %zd", error.code);
     RefPtr session = _session;
     if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: No session, so returning early.");

--- a/Source/WebKit/UIProcess/Cocoa/WebInspectorPreferenceObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebInspectorPreferenceObserver.mm
@@ -51,10 +51,10 @@
     if (!(self = [super init]))
         return nil;
 
-    RetainPtr sandboxBrokerBundleIdentifier = WebKit::bundleIdentifierForSandboxBroker();
-    m_userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:bridge_cast(sandboxBrokerBundleIdentifier.get())]);
+    RetainPtr sandboxBrokerBundleIdentifier = bridge_cast(WebKit::bundleIdentifierForSandboxBroker());
+    m_userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:sandboxBrokerBundleIdentifier.get()]);
     if (!m_userDefaults) {
-        WTFLogAlways("Could not init user defaults instance for domain %s.", sandboxBrokerBundleIdentifier.get());
+        WTFLogAlways("Could not init user defaults instance for domain %@.", sandboxBrokerBundleIdentifier.get());
         return self;
     }
     [m_userDefaults.get() addObserver:self forKeyPath:@"ShowDevelopMenu" options:NSKeyValueObservingOptionNew context:nil];

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -401,7 +401,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
         exceptionData = { ExceptionCode::AbortError, "Request was cancelled."_s };
         break;
     default:
-        LOG(DigitalCredentials, "The error code was not in the case statement? %d.", error.code);
+        LOG(DigitalCredentials, "The error code was not in the case statement? %zd.", error.code);
         exceptionData = { ExceptionCode::UnknownError, "Some other error."_s };
         RetainPtr debugDescription = error.userInfo[NSDebugDescriptionErrorKey] ?: error.userInfo[NSLocalizedDescriptionKey];
         LOG(DigitalCredentials, "Internal error: %@", debugDescription ? debugDescription.get() : @"Unknown error with no description.");

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -202,7 +202,7 @@ void MediaUsageManagerCocoa::updateMediaUsage(WebCore::MediaSessionIdentifier id
         session->mediaUsageInfo = mediaUsageInfo;
 
     } @catch(NSException *exception) {
-        WTFLogAlways("MediaUsageManagerCocoa::updateMediaUsage caught exception: %@", [[exception reason] UTF8String]);
+        WTFLogAlways("MediaUsageManagerCocoa::updateMediaUsage caught exception: %@", [exception reason]);
     }
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -179,7 +179,7 @@ void LocalAuthenticator::clearAllCredentials()
 
     OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query.get());
     if (status && status != errSecItemNotFound)
-        LOG_ERROR(makeString("Couldn't clear all credential: "_s, status).utf8().data());
+        LOG_ERROR("Couldn't clear all credential: %d", status);
 }
 
 LocalAuthenticator::LocalAuthenticator(Ref<LocalConnection>&& connection)
@@ -764,7 +764,7 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
 
 void LocalAuthenticator::receiveException(ExceptionData&& exception, WebAuthenticationStatus status) const
 {
-    LOG_ERROR(exception.message.utf8().data());
+    LOG_ERROR("%s", exception.message.utf8().data());
 
     // Roll back the just created credential.
     if (m_provisionalCredentialId) {

--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -461,7 +461,7 @@ inline static String pointerType(UITouchType type)
     [_mouseHoverGestureRecognizer setEnabled:NO];
     _pointerLockState.isActive = true;
 
-    LOG(PointerLock, "Pointer lock mouse tracking enabled with GCMouse: %{private}@", [_pointerLockState.currentMouse productCategory]);
+    RELEASE_LOG_DEBUG(PointerLock, "Pointer lock mouse tracking enabled with GCMouse: %" PRIVATE_LOG_STRING, [_pointerLockState.currentMouse productCategory].UTF8String);
 }
 
 - (void)endPointerLockMouseTracking

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -277,7 +277,7 @@ static void pageDidDrawToImage(std::optional<WebCore::ShareableBitmap::Handle>&&
 
     ASSERT(firstPage > 0);
     ASSERT(firstPage <= lastPage);
-    LOG(Printing, "WKPrintingView requesting PDF data for pages %u...%u", firstPage, lastPage);
+    LOG(Printing, "WKPrintingView requesting PDF data for pages %zu...%zu", firstPage, lastPage);
 
     WebKit::PrintInfo printInfo([_printOperation.get() printInfo]);
     // Return to printing mode if we're already back to screen (e.g. due to window resizing).

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5269,7 +5269,7 @@ void WebViewImpl::insertText(id string, NSRange replacementRange)
     ASSERT(isAttributedString || [string isKindOfClass:[NSString class]]);
 
     if (replacementRange.location != NSNotFound)
-        LOG(TextInput, "insertText:\"%@\" replacementRange:(%u, %u)", isAttributedString ? [string string] : string, replacementRange.location, replacementRange.length);
+        LOG(TextInput, "insertText:\"%@\" replacementRange:(%zu, %zu)", isAttributedString ? [string string] : string, replacementRange.location, replacementRange.length);
     else
         LOG(TextInput, "insertText:\"%@\"", isAttributedString ? [string string] : string);
 
@@ -5336,9 +5336,9 @@ void WebViewImpl::selectedRangeWithCompletionHandler(void(^completionHandlerPtr)
 
         NSRange result = editingRangeResult;
         if (result.location == NSNotFound)
-            LOG(TextInput, "    -> selectedRange returned (NSNotFound, %llu)", result.length);
+            LOG(TextInput, "    -> selectedRange returned (NSNotFound, %zu)", result.length);
         else
-            LOG(TextInput, "    -> selectedRange returned (%llu, %llu)", result.location, result.length);
+            LOG(TextInput, "    -> selectedRange returned (%zu, %zu)", result.location, result.length);
         completionHandlerBlock(result);
     });
 }
@@ -5352,9 +5352,9 @@ void WebViewImpl::markedRangeWithCompletionHandler(void(^completionHandlerPtr)(N
         void (^completionHandlerBlock)(NSRange) = (void (^)(NSRange))completionHandler.get();
         NSRange result = editingRangeResult;
         if (result.location == NSNotFound)
-            LOG(TextInput, "    -> markedRange returned (NSNotFound, %llu)", result.length);
+            LOG(TextInput, "    -> markedRange returned (NSNotFound, %zu)", result.length);
         else
-            LOG(TextInput, "    -> markedRange returned (%llu, %llu)", result.location, result.length);
+            LOG(TextInput, "    -> markedRange returned (%zu, %zu)", result.location, result.length);
         completionHandlerBlock(result);
     });
 }
@@ -5370,7 +5370,7 @@ void WebViewImpl::hasMarkedTextWithCompletionHandler(void(^completionHandler)(BO
 
 void WebViewImpl::attributedSubstringForProposedRange(NSRange proposedRange, void(^completionHandler)(NSAttributedString *attrString, NSRange actualRange))
 {
-    LOG(TextInput, "attributedSubstringFromRange:(%u, %u)", proposedRange.location, proposedRange.length);
+    LOG(TextInput, "attributedSubstringFromRange:(%zu, %zu)", proposedRange.location, proposedRange.length);
     m_page->attributedSubstringForCharacterRangeAsync(proposedRange, [completionHandler = makeBlockPtr(completionHandler)](const WebCore::AttributedString& string, const EditingRange& actualRange) {
         auto attributedString = string.nsAttributedString();
         LOG(TextInput, "    -> attributedSubstringFromRange returned %@", attributedString.get());
@@ -5380,7 +5380,7 @@ void WebViewImpl::attributedSubstringForProposedRange(NSRange proposedRange, voi
 
 void WebViewImpl::firstRectForCharacterRange(NSRange range, void(^completionHandler)(NSRect firstRect, NSRange actualRange))
 {
-    LOG(TextInput, "firstRectForCharacterRange:(%u, %u)", range.location, range.length);
+    LOG(TextInput, "firstRectForCharacterRange:(%zu, %zu)", range.location, range.length);
 
     // Just to match NSTextView's behavior. Regression tests cannot detect this;
     // to reproduce, use a test application from http://bugs.webkit.org/show_bug.cgi?id=4682
@@ -5421,7 +5421,7 @@ void WebViewImpl::characterIndexForPoint(NSPoint point, void(^completionHandler)
     m_page->characterIndexForPointAsync(WebCore::IntPoint(point), [completionHandler = makeBlockPtr(completionHandler)](uint64_t result) {
         if (result == notFound)
             result = NSNotFound;
-        LOG(TextInput, "    -> characterIndexForPoint returned %lu", result);
+        LOG(TextInput, "    -> characterIndexForPoint returned %llu", result);
         completionHandler(result);
     });
 }
@@ -5579,7 +5579,7 @@ void WebViewImpl::setMarkedText(id string, NSRange selectedRange, NSRange replac
     BOOL isAttributedString = [string isKindOfClass:[NSAttributedString class]];
     ASSERT(isAttributedString || [string isKindOfClass:[NSString class]]);
 
-    LOG(TextInput, "setMarkedText:\"%@\" selectedRange:(%u, %u) replacementRange:(%u, %u)", string, selectedRange.location, selectedRange.length, replacementRange.location, replacementRange.length);
+    LOG(TextInput, "setMarkedText:\"%@\" selectedRange:(%zu, %zu) replacementRange:(%zu, %zu)", string, selectedRange.location, selectedRange.length, replacementRange.location, replacementRange.length);
 
 #if HAVE(INLINE_PREDICTIONS)
     if (RetainPtr attributedString = dynamic_objc_cast<NSAttributedString>(string)) {

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -223,7 +223,7 @@ void InjectedBundle::extendClassesForParameterCoder(API::Array& classes)
     for (size_t i = 0; i < size; ++i) {
         RefPtr classNameString = classes.at<API::String>(i);
         if (!classNameString) {
-            WTFLogAlways("InjectedBundle::extendClassesForParameterCoder - No class provided as argument %d.\n", i);
+            WTFLogAlways("InjectedBundle::extendClassesForParameterCoder - No class provided as argument %zu.\n", i);
             break;
         }
     

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -154,7 +154,7 @@ void ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL(const URL& 
 {
     // First, create the WebProcess preview.
     m_inlinePreview = adoptNS([allocASVInlinePreviewInstance() initWithFrame:CGRectMake(0, 0, m_size.width(), m_size.height())]);
-    LOG(ModelElement, "ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL() created preview with UUID %s and size %f x %f.", ((String)[m_inlinePreview uuid].UUIDString).utf8().data(), m_size.width(), m_size.height());
+    LOG(ModelElement, "ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL() created preview with UUID %s and size %f x %f.", ((String)[m_inlinePreview uuid].UUIDString).utf8().data(), m_size.width().toDouble(), m_size.height().toDouble());
 
     auto* client = this->client();
     if (!client)
@@ -227,7 +227,7 @@ void ARKitInlinePreviewModelPlayerMac::didCreateRemotePreviewForModelWithURL(con
             return;
         }
 
-        LOG(ModelElement, "ARKitInlinePreviewModelPlayer::didCreateRemotePreviewForModelWithURL() successfully completed load for UUID %s.", [strongSelf->m_inlinePreview uuid]);
+        LOG(ModelElement, "ARKitInlinePreviewModelPlayer::didCreateRemotePreviewForModelWithURL() successfully completed load for UUID %@.", [strongSelf->m_inlinePreview uuid]);
 
         client->didFinishLoading(*strongSelf);
     };

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -6364,7 +6364,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     
     DOMRange *range = [frame _convertNSRangeToDOMRange:theRange];
     if (!range) {
-        LOG(TextInput, "firstRectForCharacterRange:(%u, %u) -> (0, 0, 0, 0)", theRange.location, theRange.length);
+        LOG(TextInput, "firstRectForCharacterRange:(%zu, %zu) -> (0, 0, 0, 0)", theRange.location, theRange.length);
         return NSZeroRect;
     }
     
@@ -6378,7 +6378,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (window)
         resultRect.origin = [window convertRectToScreen:resultRect].origin;
     
-    LOG(TextInput, "firstRectForCharacterRange:(%u, %u) -> (%f, %f, %f, %f)", theRange.location, theRange.length, resultRect.origin.x, resultRect.origin.y, resultRect.size.width, resultRect.size.height);
+    LOG(TextInput, "firstRectForCharacterRange:(%zu, %zu) -> (%f, %f, %f, %f)", theRange.location, theRange.length, resultRect.origin.x, resultRect.origin.y, resultRect.size.width, resultRect.size.height);
     return resultRect;
 }
 
@@ -6394,7 +6394,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
     NSRange result = [[self _frame] _selectedNSRange];
 
-    LOG(TextInput, "selectedRange -> (%u, %u)", result.location, result.length);
+    LOG(TextInput, "selectedRange -> (%zu, %zu)", result.location, result.length);
     return result;
 }
 
@@ -6414,7 +6414,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return NSMakeRange(NSNotFound, 0);
 
     NSRange result = [webFrame _convertToNSRange:*range];
-    LOG(TextInput, "markedRange -> (%u, %u)", result.location, result.length);
+    LOG(TextInput, "markedRange -> (%zu, %zu)", result.location, result.length);
     return result;
 }
 
@@ -6429,12 +6429,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     WebFrame *frame = [self _frame];
     auto* coreFrame = core(frame);
     if (!isTextInput(coreFrame) || isInPasswordField(coreFrame)) {
-        LOG(TextInput, "attributedSubstringFromRange:(%u, %u) -> nil", nsRange.location, nsRange.length);
+        LOG(TextInput, "attributedSubstringFromRange:(%zu, %zu) -> nil", nsRange.location, nsRange.length);
         return nil;
     }
     auto range = [frame _convertToDOMRange:nsRange];
     if (!range) {
-        LOG(TextInput, "attributedSubstringFromRange:(%u, %u) -> nil", nsRange.location, nsRange.length);
+        LOG(TextInput, "attributedSubstringFromRange:(%zu, %zu) -> nil", nsRange.location, nsRange.length);
         return nil;
     }
 
@@ -6448,7 +6448,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         ASSERT([[result string] characterAtIndex:nsRange.length] == '\n' || [[result string] characterAtIndex:nsRange.length] == ' ');
         result = [result attributedSubstringFromRange:NSMakeRange(0, nsRange.length)];
     }
-    LOG(TextInput, "attributedSubstringFromRange:(%u, %u) -> \"%@\"", nsRange.location, nsRange.length, [result string]);
+    LOG(TextInput, "attributedSubstringFromRange:(%zu, %zu) -> \"%@\"", nsRange.location, nsRange.length, [result string]);
     return result.autorelease();
 }
 
@@ -6533,7 +6533,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     BOOL isAttributedString = [string isKindOfClass:[NSAttributedString class]];
     ASSERT(isAttributedString || [string isKindOfClass:[NSString class]]);
 
-    LOG(TextInput, "setMarkedText:\"%@\" selectedRange:(%u, %u)", isAttributedString ? [string string] : string, newSelRange.location, newSelRange.length);
+    LOG(TextInput, "setMarkedText:\"%@\" selectedRange:(%zu, %zu)", isAttributedString ? [string string] : string, newSelRange.location, newSelRange.length);
 #endif
 
     // Use pointer to get parameters passed to us by the caller of interpretKeyEvents.

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -1171,7 +1171,7 @@ IGNORE_WARNINGS_END
                 [itemCopy setTarget:PDFSubviewProxy];
             }
         } else
-            LOG_ERROR("PDF context menu item %@ came with tag %d, so no WebKit tag was applied. This could mean that the item doesn't appear in clients such as Safari.", [itemCopy title], [itemCopy tag]);
+            LOG_ERROR("PDF context menu item %@ came with tag %zd, so no WebKit tag was applied. This could mean that the item doesn't appear in clients such as Safari.", [itemCopy title], [itemCopy tag]);
     }
     
     // Since we might have removed elements supplied by PDFKit, and we want to minimize our hardwired

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -7820,13 +7820,13 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
 
 - (void)addObserver:(NSObject *)anObserver forKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options context:(void *)context
 {
-    LOG (Bindings, "addObserver:%p forKeyPath:%@ options:%x context:%p", anObserver, keyPath, options, context);
+    LOG(Bindings, "addObserver:%p forKeyPath:%@ options:%zx context:%p", anObserver, keyPath, options, context);
     [super addObserver:anObserver forKeyPath:keyPath options:options context:context];
 }
 
 - (void)removeObserver:(NSObject *)anObserver forKeyPath:(NSString *)keyPath
 {
-    LOG (Bindings, "removeObserver:%p forKeyPath:%@", anObserver, keyPath);
+    LOG(Bindings, "removeObserver:%p forKeyPath:%@", anObserver, keyPath);
     [super removeObserver:anObserver forKeyPath:keyPath];
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -444,7 +444,9 @@ static void configureSOAuthorizationWebView(TestWKWebView *webView, TestSOAuthor
 static String generateHtml(const char* templateHtml, const String& substitute, const String& optionalSubstitute1 = emptyString(), const String& optionalSubstitute2 = emptyString())
 {
     StringPrintStream stream;
+    ALLOW_NONLITERAL_FORMAT_BEGIN
     stream.printf(templateHtml, substitute.utf8().data(), optionalSubstitute1.utf8().data(), optionalSubstitute2.utf8().data());
+    ALLOW_NONLITERAL_FORMAT_END
     return stream.toString();
 }
 


### PR DESCRIPTION
#### 1c37850168d747622bc2bab5909a5d5b5bdd8b73
<pre>
Enable format string attributes in Objective-C++ sources
<a href="https://rdar.apple.com/159245047">rdar://159245047</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297946">https://bugs.webkit.org/show_bug.cgi?id=297946</a>

Reviewed by Mike Wyrzykowski, Per Arne Vollan, and Ben Nham.

Clang introduced `__attribute__((__format__(__NSString__, format, va_args)))`
a few years ago, which is a superset of the `printf` format attribute
and supports the `%@` placeholder.

Since the assertion and logging code in WTF all support the `%@`
placeholder, switch them to use the `__NSString__` format attribute on
Apple OSes, then fix all the resulting format warnings.

If no comment below, the change is to fix placeholders and/or parameters.

* Source/WTF/wtf/Assertions.cpp:
- Switch logging methods from WTF_ATTRIBUTE_PRINTF to
  WTF_ATTRIBUTE_NSSTRING.
(WTF::createWithFormatAndArguments):
- Extract `formatSpan` into a variable since it&apos;s used with USE(CF), we
  will want to switch to using that in the future anyway, and because it
  makes clang forget that `format` has an `__NSString__` format
  attribute when passing to functions with a `printf` format attribute.
(WTF::vprintf_stderr_common):
- Ditto of comments for WTF::createWithFormatAndArguments().
- Also disable the -Wformat-nonliteral warnings for the whole function
  like WTF::createWithFormatAndArguments().
* Source/WTF/wtf/Assertions.h:
(WTF_ATTRIBUTE_NSSTRING): Add.
- Declare compiler attribute for __NSString__ format strings with a
  fallback to use WTF_ATTRIBUTE_PRINTF() on non-Apple platforms.
(WTF_ATTRIBUTE_PRINTF):
- Remove hack that disables format string attributes in Objective-C++.
- Switch logging functions to use WTF_ATTRIBUTE_NSSTRING() attribute.
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logError):
- Add missing format string attribute.

* Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm:
(WebCore::keyIdentifierForKeyEvent):
* Source/WebCore/platform/ios/wak/WebCoreThread.mm:
(WebCoreObjCDeallocOnWebThread):
(WebCoreObjCDeallocWithWebThreadLock):
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm:
(WebCore::MultiGamepadProvider::platformGamepadConnected):
(WebCore::MultiGamepadProvider::platformGamepadDisconnected):
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::keyIdentifierForKeyEvent):
* Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm:
(-[WebCoreResourceHandleAsOperationQueueDelegate connection:canAuthenticateAgainstProtectionSpace:]):
(-[WebCoreResourceHandleAsOperationQueueDelegate connection:didReceiveResponse:]):
(-[WebCoreResourceHandleAsOperationQueueDelegate connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:]):

* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
- Use -localizedDescription instead of logging whole `error` object.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:_schemeUpgraded:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:didReceiveChallenge:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:didCompleteWithError:]):
(-[WKNetworkSessionDelegate URLSession:task:didFinishCollectingMetrics:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
(WebKit::NetworkSessionCocoa::removeNetworkWebsiteData):
- Switch LOG() (which doesn&apos;t support the {public} modifier) to
  RELEASE_LOG_DEBUG() (which does support it, and is not enabled by
  default).
* Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm:
(WebKit::hasProhibitedUsageStrings):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::ensureSandboxCacheDirectory):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::checkSandboxRequirementForType):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm:
(-[WKSOAuthorizationDelegate authorization:didCompleteWithError:]):
* Source/WebKit/UIProcess/Cocoa/WebInspectorPreferenceObserver.mm:
(-[WKWebInspectorPreferenceObserver init]):
- Move bridge_cast() to create RetainPtr&lt;NSString&gt;.
- Fix placeholder for `NSString *` argument.
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKDigitalCredentialsPicker handleNSError:]):
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
(WebKit::MediaUsageManagerCocoa::updateMediaUsage):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::clearAllCredentials):
(WebKit::LocalAuthenticator::receiveException const):
* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseInteraction beginPointerLockMouseTracking]):
- Switch to use PRIVATE_LOG_STRING.
- Switch LOG() (which doesn&apos;t support the {private} modifier) to
  RELEASE_LOG_DEBUG() (which does support it, and is not enabled by
  default).
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _preparePDFDataForPrintingOnSecondaryThread]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::insertText):
(WebKit::WebViewImpl::selectedRangeWithCompletionHandler):
(WebKit::WebViewImpl::markedRangeWithCompletionHandler):
(WebKit::WebViewImpl::attributedSubstringForProposedRange):
(WebKit::WebViewImpl::firstRectForCharacterRange):
(WebKit::WebViewImpl::characterIndexForPoint):
(WebKit::WebViewImpl::setMarkedText):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::InjectedBundle::extendClassesForParameterCoder):
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm:
(WebKit::ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL):
(WebKit::ARKitInlinePreviewModelPlayerMac::didCreateRemotePreviewForModelWithURL):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView firstRectForCharacterRange:]):
(-[WebHTMLView ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WebHTMLView attributedSubstringFromRange:]):
(-[WebHTMLView setMarkedText:selectedRange:]):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView _menuItemsFromPDFKitForEvent:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView addObserver:forKeyPath:options:context:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(generateHtml):
- Add ALLOW_NONLITERAL_FORMAT_BEGIN/ALLOW_NONLITERAL_FORMAT_END macros
  to silence nonliteral format warnings.  All of the values passed into
  this function come from `static const char*` globals.

Canonical link: <a href="https://commits.webkit.org/299238@main">https://commits.webkit.org/299238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c28c4106ca4686155c24f37c5f7f80bfd0e2d816

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118331 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70383 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00f6498a-d170-4fde-be0e-a866e70878cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89803 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cb9e9d5-0a32-409d-8d88-ac564862a23c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70292 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dba9d126-e120-419e-bfd0-a50ca1a3ac60) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24213 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68157 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110446 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127566 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116843 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98481 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98268 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41713 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18856 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50783 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145541 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44570 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37439 "Found 1 new JSC binary failure: testapi, Found 19704 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/shift_unshift.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->