### PR TITLE
REGRESSION (299129@main): ASSERTION FAILED: !auditTokens.isEmpty() in WebKit::providePresentingApplicationPID

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -178,6 +178,20 @@ namespace WebKit {
 using namespace WebCore;
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
+
+#if PLATFORM(IOS_FAMILY)
+static void providePresentingApplicationPID(GPUConnectionToWebProcess& process, WebCore::PageIdentifier pageIdentifier)
+{
+#if ENABLE(EXTENSION_CAPABILITIES)
+    if (process.sharedPreferencesForWebProcessValue().mediaCapabilityGrantsEnabled)
+        return;
+#endif
+
+    ASSERT(process.presentingApplicationPID(pageIdentifier));
+    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(process.presentingApplicationPID(pageIdentifier));
+}
+#endif
+
 class GPUProxyForCapture final : public UserMediaCaptureManagerProxy::ConnectionProxy {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(GPUProxyForCapture);
 public:
@@ -240,8 +254,7 @@ private:
             process->startCapturingAudio();
 #if PLATFORM(IOS_FAMILY)
         else if (type == CaptureDevice::DeviceType::Camera) {
-            ASSERT(process->presentingApplicationPID(pageIdentifier));
-            MediaSessionHelper::sharedHelper().providePresentingApplicationPID(process->presentingApplicationPID(pageIdentifier));
+            providePresentingApplicationPID(*process, pageIdentifier);
 #if HAVE(AVCAPTUREDEVICEROTATIONCOORDINATOR)
             AVVideoCaptureSource::setUseAVCaptureDeviceRotationCoordinatorAPI(process->sharedPreferencesForWebProcess() && process->sharedPreferencesForWebProcess()->useAVCaptureDeviceRotationCoordinatorAPI);
 #endif


### PR DESCRIPTION
#### ca5e2cc9a290c8c3fcd035b3acad6e271faa5d51
<pre>
REGRESSION (299129@main): ASSERTION FAILED: !auditTokens.isEmpty() in WebKit::providePresentingApplicationPID
<a href="https://bugs.webkit.org/show_bug.cgi?id=297948">https://bugs.webkit.org/show_bug.cgi?id=297948</a>
<a href="https://rdar.apple.com/159248067">rdar://159248067</a>

Reviewed by Youenn Fablet.

299129@main changed how PIDToInheritApplicationStateFrom is determined in the GPU process, but
failed to account for WKWebView clients that don&apos;t set a presentingApplicationAuditToken (which is
most clients, including Safari). For these clients, ASSERT(!auditTokens.isEmpty()) in
WebKit::providePresentingApplicationPID would fail. While there was not an assertion failure, it
was also unnecessary to set a PIDToInheritApplicationStateFrom prior to starting camera capture
when media capability grants are enabled.

Addressed this by reverting to pre-299129@main behavior for clients that do not set a
presentingApplicationAuditToken.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::providePresentingApplicationPID):
  Do not set a PIDToInheritApplicationStateFrom when media capability grants are enabled.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::providePresentingApplicationPID):
  Do not set a PIDToInheritApplicationStateFrom when media capability grants are enabled, otherwise
  fall back to the UI process&apos; PID when the client has not set presentingApplicationAuditToken.

Canonical link: <a href="https://commits.webkit.org/299212@main">https://commits.webkit.org/299212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee02d96659f25f529bcee4ae781384eabab63172

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70303 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89745 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70238 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68082 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127491 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98427 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98213 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43608 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41637 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45032 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50708 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44494 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47839 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46182 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->