### PR TITLE
fast/images/image-map-outline-with-paint-root-offset.html is flakey

### DIFF
--- a/LayoutTests/fast/images/image-map-outline-with-paint-root-offset.html
+++ b/LayoutTests/fast/images/image-map-outline-with-paint-root-offset.html
@@ -12,14 +12,50 @@
 }
 </style>
 <script>
-window.onload = function() {
+function waitForElementReady(id) {
+    return new Promise((resolve) => {
+        const element = document.getElementById(id);
+        if (element) {
+            if (element.tagName === 'IMG' && (!element.complete || !element.src)) {
+                element.addEventListener('load', () => {
+                    resolve();
+                });
+                return;
+            }
+            resolve();
+            return;
+        }
+
+        const observer = new MutationObserver((mutations, obs) => {
+            const currentElement = document.getElementById(id);
+            if (currentElement && currentElement.complete !== false) {
+                obs.disconnect();
+                resolve();
+            }
+        });
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+          attributes: true
+        });
+    });
+}
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+window.onload = async function() {
+    await waitForElementReady("image");
+    await waitForElementReady("area");
     document.getElementById("area").focus();
+    if (window.testRunner)
+        testRunner.notifyDone();
 }
 </script>
 </head>
 <body>
 <div class=paintroot>
-  <img src="./resources/green.jpg" width=50 height=50 usemap="#map"/>
+  <img src="./resources/green.jpg" id=image width=50 height=50 usemap="#map"/>
   <map name="map"><area id=area shape="rectangle" coords="5, 5, 25, 25" href="#"></map>
 </div>
 </body>


### PR DESCRIPTION
#### fbc1feb9e6607de2673b622dcbd0e9b6513d950a
<pre>
fast/images/image-map-outline-with-paint-root-offset.html is flakey
<a href="https://bugs.webkit.org/show_bug.cgi?id=297928">https://bugs.webkit.org/show_bug.cgi?id=297928</a>
<a href="https://rdar.apple.com/159221489">rdar://159221489</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/images/image-map-outline-with-paint-root-offset.html:
Resolve flakiness by waiting for the image and area elements to load.

Canonical link: <a href="https://commits.webkit.org/299276@main">https://commits.webkit.org/299276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34a40442135f68bebfe7a27979b05cb54f62ace3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70240 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/faf8fd15-2ae8-4bee-aa9a-4b4629fac8b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89693 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fac8ee95-d64a-4267-b61e-d8fd4745ffd5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70189 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1bfd253-725b-46c0-b19c-55f8cc519162) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24098 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68025 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127432 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98378 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98162 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21546 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41568 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18871 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44975 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47780 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->