### PR TITLE
Skip setting content box dimensions.

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-crash-out-of-flow-positioned-element-002-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-crash-out-of-flow-positioned-element-002-expected.txt
@@ -1,0 +1,1 @@
+This test has passed if it didn't crash.

--- a/LayoutTests/fast/css-grid-layout/grid-crash-out-of-flow-positioned-element-002.html
+++ b/LayoutTests/fast/css-grid-layout/grid-crash-out-of-flow-positioned-element-002.html
@@ -1,0 +1,22 @@
+<style>
+    .grid-container {
+        display: grid;
+        position: relative;
+    }
+
+    .other {
+        position: absolute;
+        inset-block: 0px;
+        grid-column: 1;
+        padding-top: 7%;
+    }
+</style>
+<div class="grid-container">
+    <div>
+        <div class="other"></div>
+    </div>
+</div>
+This test has passed if it didn't crash.
+<script>
+    testRunner?.dumpAsText();
+</script>

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -640,10 +640,10 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
     }
 
     boxGeometry.setSpaceForScrollbar(scrollbarSize);
-
-    boxGeometry.setContentBoxWidth(contentLogicalWidthForRenderer(renderBox));
-    boxGeometry.setContentBoxHeight(contentLogicalHeightForRenderer(renderBox));
-
+    if (!renderBox.isOutOfFlowPositioned()) {
+        boxGeometry.setContentBoxWidth(contentLogicalWidthForRenderer(renderBox));
+        boxGeometry.setContentBoxHeight(contentLogicalHeightForRenderer(renderBox));
+    }
     boxGeometry.setVerticalMargin(verticalLogicalMargin(renderBox, availableWidth, writingMode));
     boxGeometry.setHorizontalMargin(inlineMargin);
     boxGeometry.setBorder(border);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -659,7 +659,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
         if (layoutBox.isOutOfFlowPositioned()) {
             ASSERT(renderer.layer());
             auto& layer = *renderer.layer();
-            auto borderBoxLogicalTopLeft = Layout::BoxGeometry::borderBoxRect(logicalGeometry).topLeft();
+            auto borderBoxLogicalTopLeft = Layout::BoxGeometry::borderBoxTopLeft(logicalGeometry);
             auto previousStaticPosition = LayoutPoint { layer.staticInlinePosition(), layer.staticBlockPosition() };
             auto delta = borderBoxLogicalTopLeft - previousStaticPosition;
             auto hasStaticInlinePositioning = layoutBox.style().hasStaticInlinePosition(renderer.isHorizontalWritingMode());


### PR DESCRIPTION
#### dc67a4ae1f10370155d6548776ab1aec73af656b
<pre>
Skip setting content box dimensions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297950">https://bugs.webkit.org/show_bug.cgi?id=297950</a>
<a href="https://rdar.apple.com/157023770">rdar://157023770</a>

Reviewed by Alan Baradlay.

Avoid computing and setting the dimensions of a content box for an out
of flow element during inflow layout.

* LayoutTests/fast/css-grid-layout/grid-crash-out-of-flow-positioned-element-002-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/grid-crash-out-of-flow-positioned-element-002.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateLayoutBoxDimensions):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):

Canonical link: <a href="https://commits.webkit.org/299421@main">https://commits.webkit.org/299421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc8568bee3de06e3bfa448fe449f1af143de0e2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71029 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b34cb0d6-e691-4055-af58-10279527d5b0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90280 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55a65f01-3eaf-445d-81fb-914a972a6576) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70795 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b9491ef-12e6-4598-90ad-97e38a33c3d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24771 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68819 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128206 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98945 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42442 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45743 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51421 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45209 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->