### PR TITLE
Rename the key-pair elements returned in the gcryptGenerateX25519Keys method

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2811,10 +2811,6 @@ imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_cbc.https.any.h
 webkit.org/b/280672 imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any.html [ Crash ]
 webkit.org/b/280672 imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any.worker.html [ Crash ]
 
-# Not possible to generate an -expected.txt file because the test compares the generated keys, which are different every run.
-webkit.org/b/297683 imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any.html [ Failure ]
-webkit.org/b/297683 imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any.worker.html [ Failure ]
-
 webkit.org/b/150806 imported/w3c/web-platform-tests/xhr/send-timeout-events.htm [ Failure Pass ]
 
 webkit.org/b/202736 [ Release ] http/wpt/cache-storage/quota-third-party.https.html [ Failure Pass ]

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
@@ -100,13 +100,13 @@ static std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> gcryptGenerate
     // private key is just 32 random bytes
     PAL::GCrypt::Handle<gcry_mpi_t> mpi(gcry_mpi_new(256));
     gcry_mpi_randomize(mpi, 256, GCRY_STRONG_RANDOM);
-    auto q = mpiData(mpi);
-    if (!q) [[unlikely]]
+    auto d = mpiData(mpi);
+    if (!d) [[unlikely]]
         return std::nullopt;
 
     // public key being X25519(a, 9), as defined in [RFC7748], section 6.1.
-    auto d = GCrypt::RFC7748::X25519(*q, GCrypt::RFC7748::c_X25519BasePointU);
-    if (!d) [[unlikely]]
+    auto q = GCrypt::RFC7748::X25519(*d, GCrypt::RFC7748::c_X25519BasePointU);
+    if (!q) [[unlikely]]
         return std::nullopt;
 
     return std::make_pair(WTFMove(*q), WTFMove(*d));


### PR DESCRIPTION
#### 33777aff18f133fb902b6f6b08438fe36f2bbeaa
<pre>
Rename the key-pair elements returned in the gcryptGenerateX25519Keys method
<a href="https://bugs.webkit.org/show_bug.cgi?id=289693">https://bugs.webkit.org/show_bug.cgi?id=289693</a>

Reviewed by Carlos Garcia Campos.

The gcryptGenerateX25519Keys method returns a std::pair of KeyMaterial variables
which should contain the public and private key. The caller expects the first
element to be the public key.

We were returning the data in the wrong order, so among other issues, it caused
that the public key generated by the JWK export of the private key doesn&apos;t match
the original key-pair&apos;s public key material.

This change fixes the issue by switching the variable names used to hold the
private and public key pair. This is also more consistent with the nomenclature
used in the Ed25519 generateKey() method..

Regarding tests, this change make the successes_X25519.https.any.html tests to
pass, so updating also the platform-specific TestExpectations file.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp:
(WebCore::gcryptGenerateX25519Keys):

Canonical link: <a href="https://commits.webkit.org/299198@main">https://commits.webkit.org/299198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3a0e18f1fc0bc7dedc666eebc6d818547070334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89713 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59350 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106008 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70209 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24126 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127459 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98397 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24964 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43581 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21574 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41594 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50675 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->