### PR TITLE
[WebXR][OpenXR] Add input support

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -297,6 +297,8 @@ UIProcess/gtk/WebTextCheckerClient.cpp
 UIProcess/soup/WebProcessPoolSoup.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRInput.cpp
+UIProcess/XR/openxr/OpenXRInputSource.cpp
 UIProcess/XR/openxr/OpenXRLayer.cpp
 UIProcess/XR/openxr/OpenXRSwapchain.cpp
 UIProcess/XR/openxr/PlatformXROpenXR.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -268,6 +268,8 @@ UIProcess/wpe/WebPasteboardProxyWPE.cpp
 UIProcess/wpe/WebPreferencesWPE.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRInput.cpp
+UIProcess/XR/openxr/OpenXRInputSource.cpp
 UIProcess/XR/openxr/OpenXRLayer.cpp
 UIProcess/XR/openxr/OpenXRSwapchain.cpp
 UIProcess/XR/openxr/PlatformXROpenXR.cpp

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
@@ -52,8 +52,8 @@ class OpenXRExtensions final {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRExtensions);
     WTF_MAKE_NONCOPYABLE(OpenXRExtensions);
 public:
-    static std::unique_ptr<OpenXRExtensions> create();
-    OpenXRExtensions(Vector<XrExtensionProperties>&&);
+    static OpenXRExtensions& singleton();
+
     ~OpenXRExtensions();
 
     bool loadMethods(XrInstance);
@@ -61,6 +61,8 @@ public:
     const OpenXRExtensionMethods& methods() const { return *m_methods; }
 
 private:
+    friend class NeverDestroyed<OpenXRExtensions>;
+    OpenXRExtensions();
     Vector<XrExtensionProperties> m_extensions;
     std::unique_ptr<OpenXRExtensionMethods> m_methods;
 };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInput.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInput.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "OpenXRInput.h"
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+#include "OpenXRInputSource.h"
+#include <openxr/openxr.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRInput);
+
+std::unique_ptr<OpenXRInput> OpenXRInput::create(XrInstance instance, XrSession session)
+{
+    auto input = std::unique_ptr<OpenXRInput>(new OpenXRInput(instance, session));
+    if (XR_FAILED(input->initialize()))
+        return nullptr;
+    return input;
+}
+
+OpenXRInput::OpenXRInput(XrInstance instance, XrSession session)
+    : m_instance(instance)
+    , m_session(session)
+{
+}
+
+OpenXRInput::~OpenXRInput() = default;
+
+XrResult OpenXRInput::initialize()
+{
+    for (auto handedness : { PlatformXR::XRHandedness::Left, PlatformXR::XRHandedness::Right }) {
+        m_handleIndex++;
+        if (auto inputSource = OpenXRInputSource::create(m_instance, m_session, handedness, m_handleIndex))
+            m_inputSources.append(makeUniqueRefFromNonNullUniquePtr(WTFMove(inputSource)));
+    }
+
+    OpenXRInputSource::SuggestedBindings bindings;
+    Vector<XrActionSet> actionSets;
+    actionSets.reserveInitialCapacity(m_inputSources.size());
+    for (const auto& inputSource : m_inputSources) {
+        inputSource->suggestBindings(bindings);
+        actionSets.append(inputSource->actionSet());
+    }
+
+    for (const auto& binding : bindings) {
+        auto suggestedBinding = createOpenXRStruct<XrInteractionProfileSuggestedBinding, XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING>();
+        if (XR_FAILED(xrStringToPath(m_instance, binding.key, &suggestedBinding.interactionProfile)))
+            continue;
+        suggestedBinding.countSuggestedBindings = binding.value.size();
+        suggestedBinding.suggestedBindings = binding.value.span().data();
+        CHECK_XRCMD(xrSuggestInteractionProfileBindings(m_instance, &suggestedBinding));
+    }
+
+    auto attachInfo = createOpenXRStruct<XrSessionActionSetsAttachInfo, XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO>();
+    attachInfo.countActionSets = actionSets.size();
+    attachInfo.actionSets = actionSets.span().data();
+    return CHECK_XRCMD(xrAttachSessionActionSets(m_session, &attachInfo));
+}
+
+Vector<PlatformXR::FrameData::InputSource> OpenXRInput::collectInputSources(const XrFrameState& frameState, XrSpace space) const
+{
+    Vector<XrActiveActionSet> actionSets;
+    actionSets.reserveInitialCapacity(m_inputSources.size());
+    for (const auto& input : m_inputSources)
+        actionSets.append(XrActiveActionSet { input->actionSet(), XR_NULL_PATH });
+
+    auto syncInfo = createOpenXRStruct<XrActionsSyncInfo, XR_TYPE_ACTIONS_SYNC_INFO>();
+    syncInfo.countActiveActionSets = actionSets.size();
+    syncInfo.activeActionSets = actionSets.span().data();
+    CHECK_XRCMD(xrSyncActions(m_session, &syncInfo));
+
+    Vector<PlatformXR::FrameData::InputSource> result;
+    result.reserveInitialCapacity(m_inputSources.size());
+    for (auto& input : m_inputSources) {
+        if (auto data = input->collectInputSource(space, frameState))
+            result.append(*data);
+    }
+
+    return result;
+}
+
+void OpenXRInput::updateInteractionProfile()
+{
+    for (auto& input : m_inputSources)
+        input->updateInteractionProfile();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInput.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInput.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include "OpenXRInputMappings.h"
+#include "OpenXRUtils.h"
+
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebKit {
+
+class OpenXRInputSource;
+
+class OpenXRInput {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRInput);
+    WTF_MAKE_NONCOPYABLE(OpenXRInput);
+public:
+    static std::unique_ptr<OpenXRInput> create(XrInstance, XrSession);
+    ~OpenXRInput();
+
+    Vector<PlatformXR::FrameData::InputSource> collectInputSources(const XrFrameState&, XrSpace) const;
+    void updateInteractionProfile();
+
+private:
+    OpenXRInput(XrInstance, XrSession);
+    XrResult initialize();
+
+    XrInstance m_instance { XR_NULL_HANDLE };
+    XrSession m_session { XR_NULL_HANDLE };
+    Vector<UniqueRef<OpenXRInputSource>> m_inputSources;
+    PlatformXR::InputSourceHandle m_handleIndex { 0 };
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include <array>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+using OpenXRProfileId = ASCIILiteral;
+using OpenXRButtonPath = ASCIILiteral;
+
+enum class OpenXRButtonType {
+    Trigger,
+    Squeeze,
+    Touchpad,
+    Thumbstick,
+    Thumbrest,
+    ButtonA,
+    ButtonB
+};
+
+constexpr std::array<OpenXRButtonType, 7> openXRButtonTypes {
+    OpenXRButtonType::Trigger, OpenXRButtonType::Squeeze, OpenXRButtonType::Touchpad, OpenXRButtonType::Thumbstick, OpenXRButtonType::Thumbrest,
+    OpenXRButtonType::ButtonA, OpenXRButtonType::ButtonB
+};
+
+constexpr ASCIILiteral s_pathSelect { "/input/select"_s };
+constexpr ASCIILiteral s_pathPinchExt { "/input/pinch_ext"_s };
+constexpr ASCIILiteral s_pathGraspExt { "/input/grasp_ext"_s };
+
+constexpr ASCIILiteral s_pathActionClick { "/click"_s };
+constexpr ASCIILiteral s_pathActionTouch { "/touch"_s };
+constexpr ASCIILiteral s_pathActionValue { "/value"_s };
+
+inline String buttonTypeToString(OpenXRButtonType type)
+{
+    switch (type) {
+    case OpenXRButtonType::Trigger: return "trigger"_s;
+    case OpenXRButtonType::Squeeze: return "squeeze"_s;
+    case OpenXRButtonType::Touchpad: return "touchpad"_s;
+    case OpenXRButtonType::Thumbstick: return "thumbstick"_s;
+    case OpenXRButtonType::Thumbrest: return "thumbrest"_s;
+    case OpenXRButtonType::ButtonA: return "buttona"_s;
+    case OpenXRButtonType::ButtonB: return "buttonb"_s;
+
+    default:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+}
+
+enum OpenXRButtonFlags {
+    Click = 1u << 0,
+    Touch = 1u << 1,
+    Value  = 1u << 2,
+};
+
+enum class OpenXRHandFlags {
+    Left = 1u << 0,
+    Right = 1u << 1,
+    Both = Left | Right
+};
+
+struct OpenXRButton {
+    OpenXRButtonType type;
+    OpenXRButtonPath path;
+    OpenXRButtonFlags flags;
+    OpenXRHandFlags hand;
+};
+
+enum class OpenXRAxisType {
+    Touchpad,
+    Thumbstick
+};
+
+constexpr std::array<OpenXRAxisType, 2> openXRAxisTypes {
+    OpenXRAxisType::Touchpad, OpenXRAxisType::Thumbstick
+};
+
+inline String axisTypetoString(OpenXRAxisType type)
+{
+    switch (type) {
+    case OpenXRAxisType::Touchpad: return "touchpad"_s;
+    case OpenXRAxisType::Thumbstick: return "thumbstick"_s;
+    default:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+}
+
+struct OpenXRAxis {
+    OpenXRAxisType type;
+    OpenXRButtonPath path;
+};
+
+struct OpenXRInteractionProfile {
+    ASCIILiteral path;
+    std::span<const OpenXRProfileId> profileIds;
+    std::span<const OpenXRButton> buttons;
+    std::span<const OpenXRAxis> axes;
+};
+
+constexpr std::array<OpenXRProfileId, 3> handInteractionProfileIds { "generic-hand-select-grasp", "generic-hand-select", "generic-hand" };
+constexpr std::array<OpenXRButton, 2> handInteractionProfileButtons {
+    OpenXRButton { .type = OpenXRButtonType::Trigger, .path = s_pathPinchExt, .flags = OpenXRButtonFlags::Value, .hand = OpenXRHandFlags::Both },
+    OpenXRButton { .type = OpenXRButtonType::Squeeze, .path = s_pathGraspExt, .flags = OpenXRButtonFlags::Value, .hand = OpenXRHandFlags::Both },
+};
+
+constexpr OpenXRInteractionProfile handInteractionProfile {
+    "/interaction_profiles/ext/hand_interaction_ext"_s,
+    handInteractionProfileIds,
+    handInteractionProfileButtons,
+    { }
+};
+
+// Default fallback when there isn't a specific controller binding.
+constexpr std::array<ASCIILiteral, 1> khrSimpleProfileIds { "generic-button"_s };
+
+constexpr std::array<OpenXRButton, 1> khrSimpleButtons {
+    OpenXRButton { .type = OpenXRButtonType::Trigger, .path = s_pathSelect, .flags = OpenXRButtonFlags::Click, .hand = OpenXRHandFlags::Both }
+};
+
+constexpr OpenXRInteractionProfile khrSimpleControllerProfile {
+    "/interaction_profiles/khr/simple_controller"_s,
+    khrSimpleProfileIds,
+    khrSimpleButtons,
+    { }
+};
+
+constexpr std::array<OpenXRInteractionProfile, 2> openXRInteractionProfiles { handInteractionProfile, khrSimpleControllerProfile };
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
@@ -1,0 +1,403 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "OpenXRInputSource.h"
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include "OpenXRExtensions.h"
+#include "OpenXRUtils.h"
+#include <openxr/openxr.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/MakeString.h>
+
+constexpr auto s_userHandPath { "/user/hand/"_s };
+constexpr auto s_inputGripPath { "/input/grip/pose"_s };
+constexpr auto s_inputAimPath { "/input/aim/pose"_s };
+constexpr auto s_inputPinchPath { "/input/pinch_ext/pose"_s };
+constexpr auto s_inputPokePath { "/input/poke_ext/pose"_s };
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRInputSource);
+
+std::unique_ptr<OpenXRInputSource> OpenXRInputSource::create(XrInstance instance, XrSession session, PlatformXR::XRHandedness handedness, PlatformXR::InputSourceHandle handle)
+{
+    auto input = std::unique_ptr<OpenXRInputSource>(new OpenXRInputSource(instance, session, handedness, handle));
+    if (XR_FAILED(input->initialize()))
+        return nullptr;
+    return input;
+}
+
+OpenXRInputSource::OpenXRInputSource(XrInstance instance, XrSession session, PlatformXR::XRHandedness handedness, PlatformXR::InputSourceHandle handle)
+    : m_instance(instance)
+    , m_session(session)
+    , m_handedness(handedness)
+    , m_handle(handle)
+{
+}
+
+OpenXRInputSource::~OpenXRInputSource()
+{
+    if (m_actionSet != XR_NULL_HANDLE)
+        xrDestroyActionSet(m_actionSet);
+    if (m_gripSpace != XR_NULL_HANDLE)
+        xrDestroySpace(m_gripSpace);
+    if (m_pointerSpace != XR_NULL_HANDLE)
+        xrDestroySpace(m_pointerSpace);
+}
+
+XrResult OpenXRInputSource::initialize()
+{
+    String handednessName = handednessToString(m_handedness);
+    m_subactionPathName = makeString(s_userHandPath, handednessName);
+    RETURN_RESULT_IF_FAILED(xrStringToPath(m_instance, m_subactionPathName.utf8().data(), &m_subactionPath));
+
+    auto prefix = makeString("input_"_s, handednessName);
+    auto actionSetName = makeString(prefix, "_action_set"_s);
+    auto createInfo = createOpenXRStruct<XrActionSetCreateInfo, XR_TYPE_ACTION_SET_CREATE_INFO>();
+    std::strncpy(createInfo.actionSetName, actionSetName.utf8().data(), XR_MAX_ACTION_SET_NAME_SIZE - 1);
+    std::strncpy(createInfo.localizedActionSetName, actionSetName.utf8().data(), XR_MAX_ACTION_SET_NAME_SIZE - 1);
+
+    RETURN_RESULT_IF_FAILED(xrCreateActionSet(m_instance, &createInfo, &m_actionSet));
+
+    RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_grip"_s), m_gripAction));
+    RETURN_RESULT_IF_FAILED(createActionSpace(m_gripAction, m_gripSpace));
+    RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_pointer"_s), m_pointerAction));
+    RETURN_RESULT_IF_FAILED(createActionSpace(m_pointerAction, m_pointerSpace));
+
+#if defined(XR_EXT_hand_interaction)
+    if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME)) {
+        RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_pinch_ext"_s), m_pinchPoseAction));
+        RETURN_RESULT_IF_FAILED(createActionSpace(m_pinchPoseAction, m_pinchSpace), m_instance);
+        RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_poke_ext"_s), m_pokePoseAction));
+        RETURN_RESULT_IF_FAILED(createActionSpace(m_pokePoseAction, m_pokeSpace), m_instance);
+    }
+#endif
+
+    for (auto buttonType : openXRButtonTypes) {
+        OpenXRButtonActions actions;
+        createButtonActions(buttonType, prefix, actions);
+        m_buttonActions.add(buttonType, actions);
+    }
+
+    for (auto axisType : openXRAxisTypes) {
+        XrAction axisAction = XR_NULL_HANDLE;
+        auto name = makeString(prefix, "_axis_"_s, axisTypetoString(axisType));
+        RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_VECTOR2F_INPUT, name, axisAction), false);
+        m_axisActions.add(axisType, axisAction);
+    }
+
+    return XR_SUCCESS;
+}
+
+XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
+{
+    auto isBindingForHand = [hand = m_handedness](OpenXRHandFlags buttonHand) {
+        switch (buttonHand) {
+        case OpenXRHandFlags::Both:
+            return true;
+        case OpenXRHandFlags::Left:
+            return hand == PlatformXR::XRHandedness::Left;
+        case OpenXRHandFlags::Right:
+            return hand == PlatformXR::XRHandedness::Right;
+        default:
+            ASSERT_NOT_REACHED_WITH_MESSAGE("Unknown OpenXRHandFlags");
+            return false;
+        }
+    };
+
+    for (const auto& profile : openXRInteractionProfiles) {
+        CHECK_XRCMD(createBinding(profile.path, m_gripAction, makeString(m_subactionPathName, s_inputGripPath), bindings));
+        CHECK_XRCMD(createBinding(profile.path, m_pointerAction, makeString(m_subactionPathName, s_inputAimPath), bindings));
+
+#if defined(XR_EXT_hand_interaction)
+        if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME)) {
+            RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_pinchPoseAction, makeString(m_subactionPathName, s_inputPinchPath), bindings));
+            RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_pokePoseAction, makeString(m_subactionPathName, s_inputPokePath), bindings));
+        }
+#endif
+
+        for (const auto& button : profile.buttons) {
+            if (!isBindingForHand(button.hand))
+                continue;
+
+            const auto& actions = m_buttonActions.get(button.type);
+            if (button.flags & OpenXRButtonFlags::Click) {
+                ASSERT(actions.press != XR_NULL_HANDLE);
+                CHECK_XRCMD(createBinding(profile.path, actions.press, makeString(m_subactionPathName, button.path, s_pathActionClick), bindings));
+            }
+            if (button.flags & OpenXRButtonFlags::Touch) {
+                ASSERT(actions.touch != XR_NULL_HANDLE);
+                CHECK_XRCMD(createBinding(profile.path, actions.touch, makeString(m_subactionPathName, button.path, s_pathActionTouch), bindings));
+            }
+            if (button.flags & OpenXRButtonFlags::Value) {
+                ASSERT(actions.value != XR_NULL_HANDLE);
+                CHECK_XRCMD(createBinding(profile.path, actions.value, makeString(m_subactionPathName, button.path, s_pathActionValue), bindings));
+            }
+        }
+
+        for (const auto& axis : profile.axes) {
+            auto action = m_axisActions.get(axis.type);
+            ASSERT(action != XR_NULL_HANDLE);
+            CHECK_XRCMD(createBinding(profile.path, action, makeString(m_subactionPathName, unsafeSpan(axis.path)), bindings));
+        }
+    }
+
+    return XR_SUCCESS;
+}
+
+std::optional<PlatformXR::FrameData::InputSource> OpenXRInputSource::collectInputSource(XrSpace localSpace, const XrFrameState& frameState) const
+{
+    PlatformXR::FrameData::InputSource data;
+    data.handedness = m_handedness;
+    data.handle = m_handle;
+    data.targetRayMode = PlatformXR::XRTargetRayMode::TrackedPointer;
+    data.profiles = m_profiles;
+
+    getPose(m_pointerSpace, localSpace, frameState, data.pointerOrigin);
+    PlatformXR::FrameData::InputSourcePose gripPose;
+    if (XR_SUCCEEDED(getPose(m_gripSpace, localSpace, frameState, gripPose)))
+        data.gripOrigin = gripPose;
+
+    Vector<std::optional<PlatformXR::FrameData::InputSourceButton>, openXRButtonTypes.size()> buttons;
+    for (auto type : openXRButtonTypes) {
+        if (auto button = collectButton(type); button.has_value())
+            buttons.append(button);
+    }
+
+    // Trigger is mandatory in xr-standard mapping.
+    if (buttons.isEmpty() || !buttons.first().has_value())
+        return std::nullopt;
+
+    for (size_t i = 0; i < buttons.size(); ++i) {
+        if (buttons[i]) {
+            data.buttons.append(*buttons[i]);
+            continue;
+        }
+        // Add placeholder if there are more valid buttons in the list.
+        for (size_t j = i + 1; j < buttons.size(); ++j) {
+            if (buttons[j]) {
+                data.buttons.append({ });
+                break;
+            }
+        }
+    }
+
+    Vector<std::optional<XrVector2f>, openXRAxisTypes.size()> axes;
+    for (auto type : openXRAxisTypes)
+        axes.append(collectAxis(type));
+
+    for (size_t i = 0; i < axes.size(); ++i) {
+        if (axes[i]) {
+            data.axes.append(axes[i]->x);
+            data.axes.append(axes[i]->y);
+            continue;
+        }
+        // Add placeholder if there are more valid axes in the list.
+        for (size_t j = i + 1; j < buttons.size(); ++j) {
+            if (axes[j]) {
+                data.axes.append(0.0f);
+                data.axes.append(0.0f);
+                break;
+            }
+        }
+    }
+
+    return data;
+}
+
+XrResult OpenXRInputSource::updateInteractionProfile()
+{
+    auto state = createOpenXRStruct<XrInteractionProfileState, XR_TYPE_INTERACTION_PROFILE_STATE>();
+    RETURN_RESULT_IF_FAILED(xrGetCurrentInteractionProfile(m_session, m_subactionPath, &state));
+
+    constexpr uint32_t bufferSize = 100;
+    char buffer[bufferSize];
+    uint32_t writtenCount = 0;
+    RETURN_RESULT_IF_FAILED(xrPathToString(m_instance, state.interactionProfile, bufferSize, &writtenCount, buffer));
+
+    m_profiles.clear();
+    for (auto& profile : openXRInteractionProfiles) {
+        if (equalSpans(profile.path.span(), unsafeSpan(buffer))) {
+            LOG(XR, "Input source %s using interaction profile %s", m_subactionPathName.utf8().data(), profile.path.span().data());
+            for (const auto& id : profile.profileIds)
+                m_profiles.append(String::fromUTF8(id));
+            break;
+        }
+    }
+
+    return XR_SUCCESS;
+}
+
+
+XrResult OpenXRInputSource::createActionSpace(XrAction action, XrSpace& space) const
+{
+    auto createInfo =  createOpenXRStruct<XrActionSpaceCreateInfo, XR_TYPE_ACTION_SPACE_CREATE_INFO>();
+    createInfo.action = action;
+    createInfo.subactionPath = m_subactionPath;
+    createInfo.poseInActionSpace = { };
+    createInfo.poseInActionSpace.orientation.w = 1.0f;
+
+    return xrCreateActionSpace(m_session, &createInfo, &space);
+}
+
+XrResult OpenXRInputSource::createAction(XrActionType actionType, const String& name, XrAction& action) const
+{
+    auto createInfo =  createOpenXRStruct<XrActionCreateInfo, XR_TYPE_ACTION_CREATE_INFO>();
+    createInfo.actionType = actionType;
+    createInfo.countSubactionPaths = 1;
+    createInfo.subactionPaths = &m_subactionPath;
+    std::strncpy(createInfo.actionName, name.utf8().data(), XR_MAX_ACTION_SET_NAME_SIZE - 1);
+    std::strncpy(createInfo.localizedActionName, name.utf8().data(), XR_MAX_ACTION_SET_NAME_SIZE - 1);
+
+    return xrCreateAction(m_actionSet, &createInfo, &action);
+}
+
+XrResult OpenXRInputSource::createButtonActions(OpenXRButtonType type, const String& prefix, OpenXRButtonActions& actions) const
+{
+    auto name = makeString(prefix, "_button_"_s, buttonTypeToString(type));
+
+    RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_BOOLEAN_INPUT, makeString(name, "_press"_s), actions.press));
+    RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_BOOLEAN_INPUT, makeString(name, "_touch"_s), actions.touch));
+    RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_FLOAT_INPUT, makeString(name, "_value"_s), actions.value));
+
+    return XR_SUCCESS;
+}
+
+XrResult OpenXRInputSource::createBinding(const char* profilePath, XrAction action, const String& bindingPath, SuggestedBindings& bindings) const
+{
+    ASSERT(profilePath != XR_NULL_PATH);
+    ASSERT(action != XR_NULL_HANDLE);
+    ASSERT(!bindingPath.isEmpty());
+
+    XrPath path = XR_NULL_PATH;
+    RETURN_RESULT_IF_FAILED(xrStringToPath(m_instance, bindingPath.utf8().data(), &path));
+
+    XrActionSuggestedBinding binding { action, path };
+    if (auto it = bindings.find(profilePath); it != bindings.end())
+        it->value.append(binding);
+    else
+        bindings.add(profilePath, Vector<XrActionSuggestedBinding> { binding });
+
+    return XR_SUCCESS;
+}
+
+XrResult OpenXRInputSource::getPose(XrSpace space, XrSpace baseSpace, const XrFrameState& frameState, PlatformXR::FrameData::InputSourcePose& pose) const
+{
+    auto location = createOpenXRStruct<XrSpaceLocation, XR_TYPE_SPACE_LOCATION>();
+    RETURN_RESULT_IF_FAILED(xrLocateSpace(space, baseSpace, frameState.predictedDisplayTime, &location), m_instance);
+
+    if (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT)
+        pose.pose = XrPosefToPose(location.pose);
+    pose.isPositionEmulated = !(location.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT);
+
+    return XR_SUCCESS;
+}
+
+std::optional<PlatformXR::FrameData::InputSourceButton> OpenXRInputSource::collectButton(OpenXRButtonType buttonType) const
+{
+    auto it = m_buttonActions.find(buttonType);
+    if (it == m_buttonActions.end())
+        return std::nullopt;
+
+    PlatformXR::FrameData::InputSourceButton result;
+    bool hasValue = false;
+    auto& actions = it->value;
+
+    auto queryActionState = [this, &hasValue](XrAction action, auto& value, auto defaultValue) {
+        if (action != XR_NULL_HANDLE && XR_SUCCEEDED(this->getActionState(action, &value)))
+            hasValue = true;
+        else
+            value = defaultValue;
+    };
+
+    queryActionState(actions.press, result.pressed, false);
+    queryActionState(actions.touch, result.touched, result.pressed);
+    queryActionState(actions.value, result.pressedValue, result.pressed ? 1.0 : 0.0);
+    // When using hand interaction profiles, press and touch are not valid paths, so use the value for everything.
+    if (result.pressedValue > 0.0f)
+        result.pressed = result.touched = true;
+
+    return hasValue ?  std::make_optional(result) : std::nullopt;
+}
+
+std::optional<XrVector2f> OpenXRInputSource::collectAxis(OpenXRAxisType axisType) const
+{
+    auto it = m_axisActions.find(axisType);
+    if (it == m_axisActions.end())
+        return std::nullopt;
+
+    XrVector2f axis;
+    if (XR_FAILED(getActionState(it->value, &axis)))
+        return std::nullopt;
+
+    return axis;
+}
+
+XrResult OpenXRInputSource::getActionState(XrAction action, bool* value) const
+{
+    ASSERT(value);
+    ASSERT(action != XR_NULL_HANDLE);
+
+    auto state = createOpenXRStruct<XrActionStateBoolean, XR_TYPE_ACTION_STATE_BOOLEAN>();
+    auto info = createOpenXRStruct<XrActionStateGetInfo, XR_TYPE_ACTION_STATE_GET_INFO>();
+    info.action = action;
+
+    RETURN_RESULT_IF_FAILED(xrGetActionStateBoolean(m_session, &info, &state));
+    *value = state.currentState;
+
+    return XR_SUCCESS;
+}
+
+XrResult OpenXRInputSource::getActionState(XrAction action, float* value) const
+{
+    ASSERT(value);
+    ASSERT(action != XR_NULL_HANDLE);
+
+    auto state = createOpenXRStruct<XrActionStateFloat, XR_TYPE_ACTION_STATE_FLOAT>();
+    auto info = createOpenXRStruct<XrActionStateGetInfo, XR_TYPE_ACTION_STATE_GET_INFO>();
+    info.action = action;
+
+    RETURN_RESULT_IF_FAILED(xrGetActionStateFloat(m_session, &info, &state));
+    *value = state.currentState;
+
+    return XR_SUCCESS;
+}
+
+XrResult OpenXRInputSource::getActionState(XrAction action, XrVector2f* value) const
+{
+    ASSERT(value);
+    ASSERT(action != XR_NULL_HANDLE);
+
+    auto state = createOpenXRStruct<XrActionStateVector2f, XR_TYPE_ACTION_STATE_VECTOR2F>();
+    auto info = createOpenXRStruct<XrActionStateGetInfo, XR_TYPE_ACTION_STATE_GET_INFO>();
+    info.action = action;
+
+    RETURN_RESULT_IF_FAILED(xrGetActionStateVector2f(m_session, &info, &state));
+    *value = state.currentState;
+
+    return XR_SUCCESS;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include "OpenXRInputMappings.h"
+#include "OpenXRUtils.h"
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebKit {
+
+class OpenXRInputSource {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRInputSource);
+    WTF_MAKE_NONCOPYABLE(OpenXRInputSource);
+public:
+    using SuggestedBindings = HashMap<const char*, Vector<XrActionSuggestedBinding>>;
+    static std::unique_ptr<OpenXRInputSource> create(XrInstance, XrSession, PlatformXR::XRHandedness, PlatformXR::InputSourceHandle);
+    ~OpenXRInputSource();
+
+    XrResult suggestBindings(SuggestedBindings&) const;
+    std::optional<PlatformXR::FrameData::InputSource> collectInputSource(XrSpace, const XrFrameState&) const;
+    XrActionSet actionSet() const { return m_actionSet; }
+    XrResult updateInteractionProfile();
+
+private:
+    OpenXRInputSource(XrInstance, XrSession, PlatformXR::XRHandedness, PlatformXR::InputSourceHandle);
+
+    struct OpenXRButtonActions {
+        XrAction press { XR_NULL_HANDLE };
+        XrAction touch { XR_NULL_HANDLE };
+        XrAction value { XR_NULL_HANDLE };
+    };
+
+    XrResult initialize();
+    XrResult createAction(XrActionType, const String& name, XrAction&) const;
+    XrResult createActionSpace(XrAction, XrSpace&) const;
+    XrResult createBinding(const char* profilePath, XrAction, const String& bindingPath, SuggestedBindings&) const;
+    XrResult createButtonActions(OpenXRButtonType, const String& prefix, OpenXRButtonActions&) const;
+
+    XrResult getPose(XrSpace, XrSpace, const XrFrameState&, PlatformXR::FrameData::InputSourcePose&) const;
+    std::optional<PlatformXR::FrameData::InputSourceButton> collectButton(OpenXRButtonType) const;
+    std::optional<XrVector2f> collectAxis(OpenXRAxisType) const;
+    XrResult getActionState(XrAction, bool*) const;
+    XrResult getActionState(XrAction, float*) const;
+    XrResult getActionState(XrAction, XrVector2f*) const;
+
+    XrInstance m_instance { XR_NULL_HANDLE };
+    XrSession m_session { XR_NULL_HANDLE };
+    PlatformXR::XRHandedness m_handedness { PlatformXR::XRHandedness::Left };
+    PlatformXR::InputSourceHandle m_handle { 0 };
+    String m_subactionPathName;
+    XrPath m_subactionPath { XR_NULL_PATH };
+    XrActionSet m_actionSet { XR_NULL_HANDLE };
+    XrAction m_gripAction { XR_NULL_HANDLE };
+    XrSpace m_gripSpace { XR_NULL_HANDLE };
+    XrAction m_pointerAction { XR_NULL_HANDLE };
+    XrSpace m_pointerSpace { XR_NULL_HANDLE };
+    XrAction m_pinchPoseAction { XR_NULL_HANDLE };
+    XrSpace m_pinchSpace { XR_NULL_HANDLE };
+    XrAction m_pokePoseAction { XR_NULL_HANDLE };
+    XrSpace m_pokeSpace { XR_NULL_HANDLE };
+    using OpenXRButtonActionsMap = HashMap<OpenXRButtonType, OpenXRButtonActions, IntHash<OpenXRButtonType>, WTF::StrongEnumHashTraits<OpenXRButtonType>>;
+    OpenXRButtonActionsMap m_buttonActions;
+    using OpenXRAxesMap = HashMap<OpenXRAxisType, XrAction, IntHash<OpenXRAxisType>, WTF::StrongEnumHashTraits<OpenXRAxisType>>;
+    OpenXRAxesMap m_axisActions;
+    Vector<String> m_profiles;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h
@@ -71,6 +71,15 @@ inline XrResult checkXrResult(XrResult res, const char* originator = nullptr, co
 
 #define CHECK_XRCMD(cmd) checkXrResult(cmd, #cmd, FILE_AND_LINE);
 
+#define RETURN_RESULT_IF_FAILED(call, ...) \
+{ \
+    auto xrResult = call; \
+    if (XR_FAILED(xrResult)) { \
+        LOG(XR, "%s %s: %s\n", __func__, #call, toString(xrResult)); \
+        return xrResult; \
+    } \
+}
+
 inline PlatformXR::FrameData::Pose XrIdentityPose()
 {
     return { { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 0.0f, 1.0f } };
@@ -85,6 +94,20 @@ inline PlatformXR::FrameData::View XrViewToView(XrView view)
 {
     return { XrPosefToPose(view.pose), PlatformXR::FrameData::Fov { std::abs(view.fov.angleUp), std::abs(view.fov.angleDown), std::abs(view.fov.angleLeft), std::abs(view.fov.angleRight) } };
 }
+
+inline ASCIILiteral handednessToString(PlatformXR::XRHandedness handedness)
+{
+    switch (handedness) {
+    case PlatformXR::XRHandedness::Left:
+        return "left"_s;
+    case PlatformXR::XRHandedness::Right:
+        return "right"_s;
+    default:
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+}
+
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -37,6 +37,7 @@ class GLDisplay;
 
 namespace WebKit {
 
+class OpenXRInput;
 class OpenXRLayer;
 class OpenXRSwapchain;
 
@@ -94,7 +95,6 @@ private:
     XrInstance m_instance { XR_NULL_HANDLE };
     XrSystemId m_systemId { XR_NULL_SYSTEM_ID };
     State m_state;
-    std::unique_ptr<OpenXRExtensions> m_extensions;
     Vector<XrViewConfigurationView> m_viewConfigurationViews;
     XrViewConfigurationType m_currentViewConfiguration;
     XrEnvironmentBlendMode m_vrBlendMode;
@@ -104,6 +104,7 @@ private:
 #if USE(GBM)
     mutable RefPtr<WebCore::GBMDevice> m_gbmDevice;
 #endif
+    std::unique_ptr<OpenXRInput> m_input;
 
     XrSession m_session { XR_NULL_HANDLE };
     XrSessionState m_sessionState { XR_SESSION_STATE_UNKNOWN };


### PR DESCRIPTION
#### befb287e6ce7defbdcb7253a94f51a8a262a59d9
<pre>
[WebXR][OpenXR] Add input support
<a href="https://bugs.webkit.org/show_bug.cgi?id=297951">https://bugs.webkit.org/show_bug.cgi?id=297951</a>

Reviewed by Carlos Garcia Campos.

This implements the OpenXR machinery required to retrieve the
available input methods for WebXR sessions as long as the
information associated to them, like poses, status of buttons,
axes, etc...

The OpenXR coordinator just need to instance an OpenXRInput object
and then ask it to collect the input sources information on every
frame. The OpenXRInput object in turn instances as many OpenXRInputSources
as required, typically two (one for each hand). Those input sources
are the ones that finally query the state of the defined input actions.

In order to have all the interaction profiles information in a single place
a OpenXRInputMappings header file was created. That would store all the
information about the supported interaction profiles and their suggested
bindings for the different hardware components they support. So far we
define two supported profiles, the hand interaction profile (useful for
hand tracking only devices) and the generic simple profile from Khronos
which must be supported by all OpenXR runtimes.

These changes required converting the OpenXRExtensions object into a
singleton as it needs to be accessed by the OpenXRInputSources as well
(to check the availability of extensions).

* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp:
(WebKit::OpenXRExtensions::singleton):
(WebKit::OpenXRExtensions::OpenXRExtensions):
(WebKit::OpenXRExtensions::create): Deleted.
* Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRInput.cpp: Added.
(WebKit::OpenXRInput::create):
(WebKit::OpenXRInput::OpenXRInput):
(WebKit::OpenXRInput::initialize):
(WebKit::OpenXRInput::collectInputSources const):
(WebKit::OpenXRInput::updateInteractionProfile):
* Source/WebKit/UIProcess/XR/openxr/OpenXRInput.h: Added.
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h: Added.
(WebKit::buttonTypeToString):
(WebKit::axisTypetoString):
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp: Added.
(WebKit::OpenXRInputSource::create):
(WebKit::OpenXRInputSource::OpenXRInputSource):
(WebKit::OpenXRInputSource::~OpenXRInputSource):
(WebKit::OpenXRInputSource::initialize):
(WebKit::OpenXRInputSource::suggestBindings const):
(WebKit::OpenXRInputSource::collectInputSource const):
(WebKit::OpenXRInputSource::updateInteractionProfile):
(WebKit::OpenXRInputSource::createActionSpace const):
(WebKit::OpenXRInputSource::createAction const):
(WebKit::OpenXRInputSource::createButtonActions const):
(WebKit::OpenXRInputSource::createBinding const):
(WebKit::OpenXRInputSource::getPose const):
(WebKit::OpenXRInputSource::collectButton const):
(WebKit::OpenXRInputSource::collectAxis const):
(WebKit::OpenXRInputSource::getActionState const):
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h: Added.
(WebKit::OpenXRInputSource::actionSet const):
* Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h:
(WebKit::handednessToString):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::getPrimaryDeviceInfo):
(WebKit::OpenXRCoordinator::startSession):
(WebKit::OpenXRCoordinator::createInstance):
(WebKit::OpenXRCoordinator::initializeDevice):
(WebKit::OpenXRCoordinator::tryInitializeGraphicsBinding):
(WebKit::OpenXRCoordinator::createSessionIfNeeded):
(WebKit::OpenXRCoordinator::cleanupSessionAndAssociatedResources):
(WebKit::OpenXRCoordinator::handleSessionStateChange):
(WebKit::OpenXRCoordinator::pollEvents):
(WebKit::OpenXRCoordinator::populateFrameData):
(WebKit::OpenXRCoordinator::createReferenceSpacesIfNeeded):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/299200@main">https://commits.webkit.org/299200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6291e8c63281f1787b7039308e91f05997858f2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70284 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38612 "Hash 6291e8c6 for PR 49924 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89726 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121190 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/38612 "Hash 6291e8c6 for PR 49924 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70219 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/38612 "Hash 6291e8c6 for PR 49924 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68063 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/38612 "Hash 6291e8c6 for PR 49924 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34034 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24962 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41613 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50689 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44475 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->