### PR TITLE
[JSC] Add fast path for iteration on Set

### DIFF
--- a/JSTests/microbenchmarks/iterator-prototype-forEach-set.js
+++ b/JSTests/microbenchmarks/iterator-prototype-forEach-set.js
@@ -1,0 +1,15 @@
+function test(setIter, cb) {
+    return Iterator.prototype.forEach.call(setIter, cb);
+}
+
+const set = new Set();
+for (let i = 0; i < 12; i++) {
+    set.add(i);
+}
+
+let r = [];
+for (let i = 0; i < 1e4; i++) {
+    test(set.values(), function () {
+        r.push(i);
+    });
+}

--- a/JSTests/microbenchmarks/iterator-prototype-toArray-set.js
+++ b/JSTests/microbenchmarks/iterator-prototype-toArray-set.js
@@ -1,0 +1,13 @@
+function test(setIter) {
+    return Iterator.prototype.toArray.call(setIter);
+}
+
+const set = new Set();
+for (let i = 0; i < 12; i++) {
+    set.add(i);
+}
+
+let r;
+for (let i = 0; i < 1e4; i++) {
+    r = test(set.values());
+}

--- a/JSTests/stress/aggregate-error-constructor-broken-set.js
+++ b/JSTests/stress/aggregate-error-constructor-broken-set.js
@@ -1,0 +1,49 @@
+function test(set) {
+    return new AggregateError(set);
+}
+
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+{
+    const set = new Set([1, 2, 3, 4, 5]);
+    let count = 10;
+    set[Symbol.iterator] = () => {
+        return {
+            next() {
+                if (count++ > 12)
+                    return { value: count, done: true };
+                return { value: count, done: false };
+            }
+        }
+    };
+    const e = test(set);
+    shouldBe(e.errors.length, 3);
+    shouldBe(e.errors[0], 11);
+    shouldBe(e.errors[1], 12);
+    shouldBe(e.errors[2], 13);
+}
+
+{
+    const set = new Set([1, 2, 3, 4, 5]);
+    let count = 10;
+    // break the watchpoint
+    Set.prototype[Symbol.iterator] = () => {
+        return {
+            next() {
+                if (count++ > 12)
+                    return { value: count, done: true };
+                return { value: count, done: false };
+            }
+        }
+    };
+    const e = test(set);
+    shouldBe(e.errors.length, 3);
+    shouldBe(e.errors[0], 11);
+    shouldBe(e.errors[1], 12);
+    shouldBe(e.errors[2], 13);
+}
+

--- a/JSTests/stress/iterator-prototype-forEach-set.js
+++ b/JSTests/stress/iterator-prototype-forEach-set.js
@@ -1,0 +1,38 @@
+function test(setIterator, cb) {
+    return Iterator.prototype.forEach.call(setIterator, cb);
+}
+
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+{
+    const set = new Set([1, 2, 3, 4, 5]);
+    let called = 0;
+    const values = [];
+    const indices = [];
+    const cb = (v, i) => {
+        called++;
+        values.push(v);
+        indices.push(i);
+    };
+    test(set.values(), cb);
+
+    shouldBe(values.length, 5);
+    shouldBe(values[0], 1);
+    shouldBe(values[1], 2);
+    shouldBe(values[2], 3);
+    shouldBe(values[3], 4);
+    shouldBe(values[4], 5);
+
+    shouldBe(indices.length, 5);
+    shouldBe(indices[0], 0);
+    shouldBe(indices[1], 1);
+    shouldBe(indices[2], 2);
+    shouldBe(indices[3], 3);
+    shouldBe(indices[4], 4);
+
+    shouldBe(called, 5);
+}

--- a/JSTests/stress/iterator-prototype-toArray-broken-set-iterator.js
+++ b/JSTests/stress/iterator-prototype-toArray-broken-set-iterator.js
@@ -1,0 +1,42 @@
+function test(setIter) {
+    return Iterator.prototype.toArray.call(setIter);
+}
+
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+{
+    const set = new Set([1, 2, 3, 4, 5]);
+    const setIterator = set.values();
+    let count = 0;
+    setIterator.next = () => {
+        if (count++ > 2)
+            return { value: 1, done: true };
+        return { value: 1, done: false };
+    };
+    const arr = test(setIterator);
+    shouldBe(arr.length, 3);
+    shouldBe(arr[0], 1);
+    shouldBe(arr[1], 1);
+    shouldBe(arr[2], 1);
+}
+
+{
+    const set = new Set([1, 2, 3, 4, 5]);
+    const setIteratorPrototype = Object.getPrototypeOf(new Set().values());
+    let count = 0;
+    // break the watchpoint
+    setIteratorPrototype.next = () => {
+        if (count++ > 2)
+            return { value: 1, done: true };
+        return { value: 1, done: false };
+    };
+    const arr = test(set.values());
+    shouldBe(arr.length, 3);
+    shouldBe(arr[0], 1);
+    shouldBe(arr[1], 1);
+    shouldBe(arr[2], 1);
+}

--- a/JSTests/stress/iterator-prototype-toArray-set.js
+++ b/JSTests/stress/iterator-prototype-toArray-set.js
@@ -1,0 +1,32 @@
+function test(setIterator) {
+    return Iterator.prototype.toArray.call(setIterator);
+}
+
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+{
+    const set = new Set([1, 2, 3, 4, 5]);
+    const arr = test(set.values());
+    shouldBe(arr.length, 5);
+    shouldBe(arr[0], 1);
+    shouldBe(arr[1], 2);
+    shouldBe(arr[2], 3);
+    shouldBe(arr[3], 4);
+    shouldBe(arr[4], 5);
+}
+
+{
+    const set = new Set([1, 2, 3, 4, 5]);
+    const setIter = set.values();
+    setIter.next();
+    const arr = test(setIter);
+    shouldBe(arr.length, 4);
+    shouldBe(arr[0], 2);
+    shouldBe(arr[1], 3);
+    shouldBe(arr[2], 4);
+    shouldBe(arr[3], 5);
+}

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1214,6 +1214,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSSetInlines.h
     runtime/JSSetIterator.h
     runtime/JSSetIteratorInlines.h
+    runtime/SetIteratorPrototype.h
+    runtime/SetIteratorPrototypeInlines.h
     runtime/JSSourceCode.h
     runtime/JSSourceCodeInlines.h
     runtime/JSString.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -866,7 +866,7 @@
 		276B389B2A71D1A900252F4E /* ShadowRealmObjectInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38952A71D1A800252F4E /* ShadowRealmObjectInlines.h */; };
 		276B389C2A71D1A900252F4E /* SetPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38962A71D1A800252F4E /* SetPrototypeInlines.h */; };
 		276B389D2A71D1A900252F4E /* SetConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38972A71D1A800252F4E /* SetConstructorInlines.h */; };
-		276B389E2A71D1A900252F4E /* SetIteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38982A71D1A800252F4E /* SetIteratorPrototypeInlines.h */; };
+		276B389E2A71D1A900252F4E /* SetIteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38982A71D1A800252F4E /* SetIteratorPrototypeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		276B389F2A71D1A900252F4E /* WeakMapConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38992A71D1A800252F4E /* WeakMapConstructorInlines.h */; };
 		276B38A32A71D1B600252F4E /* RegExpPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38A02A71D1B600252F4E /* RegExpPrototypeInlines.h */; };
 		276B38A42A71D1B600252F4E /* RegExpConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38A12A71D1B600252F4E /* RegExpConstructorInlines.h */; };
@@ -1680,7 +1680,7 @@
 		A78A9779179738B8009DF744 /* DFGJITFinalizer.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A9771179738B8009DF744 /* DFGJITFinalizer.h */; };
 		A78A977B179738B8009DF744 /* DFGPlan.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A9773179738B8009DF744 /* DFGPlan.h */; };
 		A78A9781179738D5009DF744 /* FTLJITFinalizer.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A977E179738D5009DF744 /* FTLJITFinalizer.h */; };
-		A790DD6E182F499700588807 /* SetIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A790DD68182F499700588807 /* SetIteratorPrototype.h */; };
+		A790DD6E182F499700588807 /* SetIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A790DD68182F499700588807 /* SetIteratorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A790DD70182F499700588807 /* JSSetIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A790DD6A182F499700588807 /* JSSetIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A79D3ED9C5064DD0A8466A3A /* ModuleScopeData.h in Headers */ = {isa = PBXBuildFile; fileRef = 000BEAF0DF604481AF6AB68C /* ModuleScopeData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A7A8AF3517ADB5F3005AB174 /* ArrayBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2617ADB5F3005AB174 /* ArrayBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/JavaScriptCore/runtime/JSSet.h
+++ b/Source/JavaScriptCore/runtime/JSSet.h
@@ -57,7 +57,7 @@ public:
     }
 
     static bool isAddFastAndNonObservable(Structure*);
-    bool isIteratorProtocolFastAndNonObservable();
+    JS_EXPORT_PRIVATE bool isIteratorProtocolFastAndNonObservable();
     JSSet* clone(JSGlobalObject*, VM&, Structure*);
 
 private:

--- a/Source/JavaScriptCore/runtime/SetIteratorPrototype.h
+++ b/Source/JavaScriptCore/runtime/SetIteratorPrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/SetIteratorPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/SetIteratorPrototypeInlines.h
@@ -25,9 +25,29 @@
 
 #pragma once
 
-#include "SetIteratorPrototype.h"
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/JSSetIterator.h>
+#include <JavaScriptCore/SetIteratorPrototype.h>
 
 namespace JSC {
+
+ALWAYS_INLINE bool setIteratorProtocolIsFastAndNonObservable(VM& vm, JSSetIterator* setIterator)
+{
+    JSGlobalObject* globalObject = setIterator->globalObject();
+
+    if (!globalObject->isSetPrototypeIteratorProtocolFastAndNonObservable())
+        return false;
+
+    if (setIterator->getPrototypeDirect() != globalObject->setIteratorPrototype())
+        return false;
+
+    if (setIterator->hasCustomProperties()) {
+        if (setIterator->getDirectOffset(vm, vm.propertyNames->next) != invalidOffset)
+            return false;
+    }
+
+    return true;
+}
 
 inline Structure* SetIteratorPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {


### PR DESCRIPTION
#### 5dcc399282a60b9241b2cf3054ffcad6b5ac825b
<pre>
[JSC] Add fast path for iteration on Set
<a href="https://bugs.webkit.org/show_bug.cgi?id=297952">https://bugs.webkit.org/show_bug.cgi?id=297952</a>

Reviewed by Yusuke Suzuki.

This patch adds a fast path for Set (and SetIterator) to `forEachInIteratorProtocol`
and `forEachInIterable`. These functions are used in `Iterator.prototype.toArray`,
`Iterator.prototype.forEach`, and constructors like `AggregateError` and more.

This makes iteration over Sets about 5x faster.

                                        TipOfTree                  Patched

iterator-prototype-toArray-set        4.8285+-0.1564     ^      0.9608+-0.0151        ^ definitely 5.0257x faster
iterator-prototype-forEach-set        4.7728+-0.1237     ^      0.9953+-0.0693        ^ definitely 4.7954x faster

* JSTests/microbenchmarks/iterator-prototype-forEach-set.js: Added.
(test):
(set add):
(const.set new):
* JSTests/microbenchmarks/iterator-prototype-toArray-set.js: Added.
(test):
* JSTests/stress/aggregate-error-constructor-broken-set.js: Added.
(set shouldBe):
(set Symbol):
(const.set new):
* JSTests/stress/iterator-prototype-forEach-set.js: Added.
(test):
(shouldBe):
(throw.new.Error.const.set new):
* JSTests/stress/iterator-prototype-toArray-broken-set-iterator.js: Added.
(test):
(shouldBe):
(throw.new.Error.const.setIterator.set values):
(const.set new):
* JSTests/stress/iterator-prototype-toArray-set.js: Added.
(test):
(shouldBe):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInSetStorage):
(JSC::forEachInIterable):
(JSC::forEachInIteratorProtocol):
* Source/JavaScriptCore/runtime/JSSet.h:
* Source/JavaScriptCore/runtime/SetIteratorPrototype.h:
* Source/JavaScriptCore/runtime/SetIteratorPrototypeInlines.h:
(JSC::setIteratorProtocolIsFastAndNonObservable):

Canonical link: <a href="https://commits.webkit.org/299358@main">https://commits.webkit.org/299358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77b9190033d9c1611a25a5af6b603eb9dbca6417

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70264 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89711 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59349 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24121 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68048 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110334 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127456 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116733 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41591 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50672 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145433 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44458 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37414 "Found 1 new JSC binary failure: testapi, Found 19713 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug724121.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->