### PR TITLE
Fix GLIB JSC build related to undefined-var-template

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -27,8 +27,11 @@
 #ifndef JSCallbackObject_h
 #define JSCallbackObject_h
 
-#if JSC_OBJC_API_ENABLED
+#if JSC_OBJC_API_ENABLED || defined(JSC_GLIB_API_ENABLED)
 #include "JSAPIWrapperObject.h"
+#endif
+#if defined(JSC_GLIB_API_ENABLED)
+#include "JSAPIWrapperGlobalObject.h"
 #endif
 #include "JSObjectRef.h"
 #include "JSValueRef.h"
@@ -254,7 +257,11 @@ void JSCallbackObject<Parent>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 template<> const ClassInfo JSCallbackObject<JSGlobalObject>::s_info;
 template<> const ClassInfo JSCallbackObject<JSNonFinalObject>::s_info;
 
-#if JSC_OBJC_API_ENABLED
+#if defined(JSC_GLIB_API_ENABLED)
+template<> const ClassInfo JSCallbackObject<JSAPIWrapperGlobalObject>::s_info;
+#endif
+
+#if JSC_OBJC_API_ENABLED || defined(JSC_GLIB_API_ENABLED)
 template<> const ClassInfo JSCallbackObject<JSAPIWrapperObject>::s_info;
 #endif
 


### PR DESCRIPTION
#### a237a34233070f215ca42e17c9312e83cf810f08
<pre>
Fix GLIB JSC build related to undefined-var-template
<a href="https://bugs.webkit.org/show_bug.cgi?id=297955">https://bugs.webkit.org/show_bug.cgi?id=297955</a>
<a href="https://rdar.apple.com/159270200">rdar://159270200</a>

Reviewed by Yusuke Suzuki.

Attempts to avoid the undefined-var-template warnings by ensuring
all definitions are declared with the correct ifdef permutations.

* Source/JavaScriptCore/API/JSCallbackObject.h:

Canonical link: <a href="https://commits.webkit.org/299310@main">https://commits.webkit.org/299310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84371821a2e8461f7745c2cf59ae32a1dfa2c253

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70538 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7543f51f-70bb-47df-9f99-fcdf5f496622) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89924 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59499 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1469e5fb-173b-406c-8c11-5bc93e3f1496) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70404 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf331a7f-e56b-4595-97e7-32e86cf59e0d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68310 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110597 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127717 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116993 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98369 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25019 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41884 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50934 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145689 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44719 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37466 "Found 1 new JSC binary failure: testapi, Found 18612 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->