### PR TITLE
Implement closedby=any for dialog

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6293,6 +6293,10 @@ webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activatio
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html [ Skip ]
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html?dialog [ Skip ]
 
+# This test times out because closedby attribute is not fully implemented.
+webkit.org/b/284592 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases.html [ Skip ]
+webkit.org/b/284592 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby.html [ Skip ]
+
 # uncategorized dialog element failures
 webkit.org/b/286022 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-close-via-attribute.tentative.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -3623,7 +3623,7 @@ PASS HTMLDialogElement interface: existence and properties of interface prototyp
 PASS HTMLDialogElement interface: existence and properties of interface prototype object's @@unscopables property
 PASS HTMLDialogElement interface: attribute open
 PASS HTMLDialogElement interface: attribute returnValue
-FAIL HTMLDialogElement interface: attribute closedBy assert_true: The prototype object must have a property "closedBy" expected true got false
+PASS HTMLDialogElement interface: attribute closedBy
 PASS HTMLDialogElement interface: operation show()
 PASS HTMLDialogElement interface: operation showModal()
 PASS HTMLDialogElement interface: operation close(optional DOMString)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-bounds-clicking-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-bounds-clicking-expected.txt
@@ -3,14 +3,14 @@ PASS Dialog show will not light dismiss if clicked inside of the dialog bounds
 PASS Dialog show will not light dismiss if clicked inside of the dialog bounds (bottom right)
 PASS Dialog show will not light dismiss if clicked inside the overflowing div bounds (center)
 PASS Dialog show will not light dismiss if clicked inside the overflowing div bounds (bottom right)
-FAIL Dialog show light dismisses when clicked outside of the bounds of both the dialog and the div assert_false: Dialog should be closed after clicking 250px-250px expected false got true
-FAIL Dialog show light dismisses when clicked outside of the bounds of the dialog - where the Y direction is in-line with the div still assert_false: Dialog should be closed after clicking 150px-1px expected false got true
-FAIL Dialog show light dismisses when clicked outside of the bounds of the dialog - where the X direction is in-line with the div still assert_false: Dialog should be closed after clicking 1px-150px expected false got true
-FAIL Dialog showModal will not light dismiss if clicked inside of the dialog bounds promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
-FAIL Dialog showModal will not light dismiss if clicked inside of the dialog bounds (bottom right) promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
-FAIL Dialog showModal will not light dismiss if clicked inside the overflowing div bounds (center) promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
-FAIL Dialog showModal will not light dismiss if clicked inside the overflowing div bounds (bottom right) promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
-FAIL Dialog showModal light dismisses when clicked outside of the bounds of both the dialog and the div promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
-FAIL Dialog showModal light dismisses when clicked outside of the bounds of the dialog - where the Y direction is in-line with the div still promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
-FAIL Dialog showModal light dismisses when clicked outside of the bounds of the dialog - where the X direction is in-line with the div still promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+PASS Dialog show light dismisses when clicked outside of the bounds of both the dialog and the div
+PASS Dialog show light dismisses when clicked outside of the bounds of the dialog - where the Y direction is in-line with the div still
+PASS Dialog show light dismisses when clicked outside of the bounds of the dialog - where the X direction is in-line with the div still
+PASS Dialog showModal will not light dismiss if clicked inside of the dialog bounds
+PASS Dialog showModal will not light dismiss if clicked inside of the dialog bounds (bottom right)
+PASS Dialog showModal will not light dismiss if clicked inside the overflowing div bounds (center)
+PASS Dialog showModal will not light dismiss if clicked inside the overflowing div bounds (bottom right)
+PASS Dialog showModal light dismisses when clicked outside of the bounds of both the dialog and the div
+PASS Dialog showModal light dismisses when clicked outside of the bounds of the dialog - where the Y direction is in-line with the div still
+PASS Dialog showModal light dismisses when clicked outside of the bounds of the dialog - where the X direction is in-line with the div still
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-closedby-complex-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-closedby-complex-expected.txt
@@ -1,43 +1,43 @@
 Unrelated
 
-FAIL clicking outside all with modeless dialogA and modeless dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
+PASS clicking outside all with modeless dialogA and modeless dialogB, normal DOM nesting
 PASS clicking popoverB with modeless dialogA and modeless dialogB, normal DOM nesting
 PASS clicking dialogB with modeless dialogA and modeless dialogB, normal DOM nesting
-FAIL clicking popoverA with modeless dialogA and modeless dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modeless dialogA and modeless dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking outside all with modeless dialogA and modal dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modeless dialogA and modeless dialogB, normal DOM nesting
+PASS clicking dialogA with modeless dialogA and modeless dialogB, normal DOM nesting
+PASS clicking outside all with modeless dialogA and modal dialogB, normal DOM nesting
 PASS clicking popoverB with modeless dialogA and modal dialogB, normal DOM nesting
 PASS clicking dialogB with modeless dialogA and modal dialogB, normal DOM nesting
-FAIL clicking popoverA with modeless dialogA and modal dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modeless dialogA and modal dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking outside all with modal dialogA and modeless dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modeless dialogA and modal dialogB, normal DOM nesting
+PASS clicking dialogA with modeless dialogA and modal dialogB, normal DOM nesting
+PASS clicking outside all with modal dialogA and modeless dialogB, normal DOM nesting
 PASS clicking popoverB with modal dialogA and modeless dialogB, normal DOM nesting
 PASS clicking dialogB with modal dialogA and modeless dialogB, normal DOM nesting
-FAIL clicking popoverA with modal dialogA and modeless dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modal dialogA and modeless dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking outside all with modal dialogA and modal dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modal dialogA and modeless dialogB, normal DOM nesting
+PASS clicking dialogA with modal dialogA and modeless dialogB, normal DOM nesting
+PASS clicking outside all with modal dialogA and modal dialogB, normal DOM nesting
 PASS clicking popoverB with modal dialogA and modal dialogB, normal DOM nesting
 PASS clicking dialogB with modal dialogA and modal dialogB, normal DOM nesting
-FAIL clicking popoverA with modal dialogA and modal dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modal dialogA and modal dialogB, normal DOM nesting assert_equals: dialogB should be closed expected false but got true
-FAIL clicking outside all with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modal dialogA and modal dialogB, normal DOM nesting
+PASS clicking dialogA with modal dialogA and modal dialogB, normal DOM nesting
+PASS clicking outside all with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots
 PASS clicking popoverB with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots
 PASS clicking dialogB with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots
-FAIL clicking popoverA with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
-FAIL clicking outside all with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots
+PASS clicking dialogA with modeless dialogA and modeless dialogB, same structure, but with shadow DOM slots
+PASS clicking outside all with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots
 PASS clicking popoverB with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots
 PASS clicking dialogB with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots
-FAIL clicking popoverA with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
-FAIL clicking outside all with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots
+PASS clicking dialogA with modeless dialogA and modal dialogB, same structure, but with shadow DOM slots
+PASS clicking outside all with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots
 PASS clicking popoverB with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots
 PASS clicking dialogB with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots
-FAIL clicking popoverA with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
-FAIL clicking outside all with modal dialogA and modal dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots
+PASS clicking dialogA with modal dialogA and modeless dialogB, same structure, but with shadow DOM slots
+PASS clicking outside all with modal dialogA and modal dialogB, same structure, but with shadow DOM slots
 PASS clicking popoverB with modal dialogA and modal dialogB, same structure, but with shadow DOM slots
 PASS clicking dialogB with modal dialogA and modal dialogB, same structure, but with shadow DOM slots
-FAIL clicking popoverA with modal dialogA and modal dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
-FAIL clicking dialogA with modal dialogA and modal dialogB, same structure, but with shadow DOM slots assert_equals: dialogB should be closed expected false but got true
+PASS clicking popoverA with modal dialogA and modal dialogB, same structure, but with shadow DOM slots
+PASS clicking dialogA with modal dialogA and modal dialogB, same structure, but with shadow DOM slots
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-closedby-simple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-closedby-simple-expected.txt
@@ -5,5 +5,5 @@ FAIL Dialog closedby=closerequest parent, popover child assert_true: dialog shou
 FAIL Dialog closedby=none parent, popover child assert_true: dialog should stay open for first ESC expected true got false
 FAIL Popover parent, dialog closedby=any child assert_true: popover should stay open for first ESC expected true got false
 FAIL Popover parent, dialog closedby=closerequest child assert_true: popover should stay open for first ESC expected true got false
-FAIL Popover parent, dialog closedby=none child assert_true: popover should stay open for first ESC expected true got false
+FAIL Popover parent, dialog closedby=none child assert_equals: dialog should close after first ESC, if closedby!=none expected true but got false
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -3627,7 +3627,7 @@ PASS HTMLDialogElement interface: existence and properties of interface prototyp
 PASS HTMLDialogElement interface: existence and properties of interface prototype object's @@unscopables property
 PASS HTMLDialogElement interface: attribute open
 PASS HTMLDialogElement interface: attribute returnValue
-FAIL HTMLDialogElement interface: attribute closedBy assert_true: The prototype object must have a property "closedBy" expected true got false
+PASS HTMLDialogElement interface: attribute closedBy
 PASS HTMLDialogElement interface: operation show()
 PASS HTMLDialogElement interface: operation showModal()
 PASS HTMLDialogElement interface: operation close(optional DOMString)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4058,6 +4058,7 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 # Close Watcher tests rely on sending escape keys from test_driver which doesn't work on iOS webkit.org/b/274832
 webkit.org/b/274832 imported/w3c/web-platform-tests/close-watcher/esc-key [ Skip ]
 webkit.org/b/274832 imported/w3c/web-platform-tests/close-watcher/user-activation [ Skip ]
+webkit.org/b/274832 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-show-stacked.html [ Skip ]
 
 # iOS user agent styles are preventing these from passing for <input type=search>
 webkit.org/b/241095 imported/w3c/web-platform-tests/css/css-ui/appearance-textfield-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -3623,7 +3623,7 @@ PASS HTMLDialogElement interface: existence and properties of interface prototyp
 PASS HTMLDialogElement interface: existence and properties of interface prototype object's @@unscopables property
 PASS HTMLDialogElement interface: attribute open
 PASS HTMLDialogElement interface: attribute returnValue
-FAIL HTMLDialogElement interface: attribute closedBy assert_true: The prototype object must have a property "closedBy" expected true got false
+PASS HTMLDialogElement interface: attribute closedBy
 PASS HTMLDialogElement interface: operation show()
 PASS HTMLDialogElement interface: operation showModal()
 PASS HTMLDialogElement interface: operation close(optional DOMString)

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-bounds-clicking-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-bounds-clicking-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Dialog show will not light dismiss if clicked inside of the dialog bounds
+PASS Dialog show will not light dismiss if clicked inside of the dialog bounds (bottom right)
+PASS Dialog show will not light dismiss if clicked inside the overflowing div bounds (center)
+PASS Dialog show will not light dismiss if clicked inside the overflowing div bounds (bottom right)
+FAIL Dialog show light dismisses when clicked outside of the bounds of both the dialog and the div assert_false: Dialog should be closed after clicking 250px-250px expected false got true
+FAIL Dialog show light dismisses when clicked outside of the bounds of the dialog - where the Y direction is in-line with the div still assert_false: Dialog should be closed after clicking 150px-1px expected false got true
+FAIL Dialog show light dismisses when clicked outside of the bounds of the dialog - where the X direction is in-line with the div still assert_false: Dialog should be closed after clicking 1px-150px expected false got true
+FAIL Dialog showModal will not light dismiss if clicked inside of the dialog bounds promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+FAIL Dialog showModal will not light dismiss if clicked inside of the dialog bounds (bottom right) promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+FAIL Dialog showModal will not light dismiss if clicked inside the overflowing div bounds (center) promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+FAIL Dialog showModal will not light dismiss if clicked inside the overflowing div bounds (bottom right) promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+FAIL Dialog showModal light dismisses when clicked outside of the bounds of both the dialog and the div promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+FAIL Dialog showModal light dismisses when clicked outside of the bounds of the dialog - where the Y direction is in-line with the div still promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+FAIL Dialog showModal light dismisses when clicked outside of the bounds of the dialog - where the X direction is in-line with the div still promise_test: Unhandled rejection with value: object "InvalidStateError: Cannot call showModal() on an open non-modal dialog."
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source-expected.txt
@@ -1,9 +1,9 @@
-show modal light dismiss
+show modal light dismiss dialog  close  request close
 
 PASS ToggleEvent.source on <dialog> elements: dialog.showModal().
 PASS ToggleEvent.source on <dialog> elements: command button.
 PASS ToggleEvent.source on <dialog> elements: open with showModal, close with button.
 PASS ToggleEvent.soruce on <dialog> elements: open with button, close with dialog.close().
 PASS ToggleEvent.source on <dialog> elements: open with showModal, close with request-close button.
-PASS ToggleEvent.source on <dialog> elements: open with button, close with light dismiss.
+FAIL ToggleEvent.source on <dialog> elements: open with button, close with light dismiss. assert_true: A closing beforetoggle event should have been fired. expected true got false
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1850,6 +1850,20 @@ CloseWatcherEnabled:
     WebCore:
       default: false
 
+ClosedbyAttributeEnabled:
+  type: bool
+  status: testable
+  category: html
+  humanReadableName: "HTML closedby attribute"
+  humanReadableDescription: "Enable HTML closedby attribute support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ColorFilterEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -75,6 +75,7 @@
 #include "DOMAudioSession.h"
 #include "DOMCSSPaintWorklet.h"
 #include "DOMImplementation.h"
+#include "DOMRect.h"
 #include "DOMTimer.h"
 #include "DateComponents.h"
 #include "DebugPageOverlays.h"
@@ -10892,6 +10893,34 @@ HTMLElement* Document::topmostAutoPopover() const
     return m_autoPopoverList.last().ptr();
 }
 
+RefPtr<HTMLDialogElement> Document::nearestClickedDialog(const PointerEvent& event, Node& target) const
+{
+    RefPtr currentNode = dynamicDowncast<Element>(target);
+    RefPtr dialog = dynamicDowncast<HTMLDialogElement>(currentNode);
+
+    if (dialog) {
+        Ref dialogRect = dialog->getBoundingClientRect();
+        auto insideBounds = event.clientX() >= dialogRect->left()
+            && event.clientX() < dialogRect->right()
+            && event.clientY() >= dialogRect->top()
+            && event.clientY() < dialogRect->bottom();
+        if (dialog->isOpen() && dialog->isModal() && !insideBounds)
+            return nullptr;
+    }
+
+    do {
+        if (dialog && dialog->isOpen())
+            return dialog;
+
+        currentNode = currentNode->parentElementInComposedTree();
+        if (!currentNode)
+            break;
+        dialog = dynamicDowncast<HTMLDialogElement>(*currentNode);
+    } while (currentNode);
+
+    return nullptr;
+}
+
 // https://html.spec.whatwg.org/#hide-all-popovers-until
 void Document::hideAllPopoversUntil(HTMLElement* endpoint, FocusPreviousElement focusPreviousElement, FireEvents fireEvents)
 {
@@ -10995,6 +11024,41 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
     if (m_popoverPointerDownTarget == popoverToAvoidHiding.get())
         hideAllPopoversUntil(popoverToAvoidHiding.get(), FocusPreviousElement::No, FireEvents::Yes);
     m_popoverPointerDownTarget = nullptr;
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-light-dismiss
+void Document::handleDialogLightDismiss(const PointerEvent& event, Node& target)
+{
+    ASSERT(event.isTrusted());
+
+    if (m_openDialogsList.isEmpty())
+        return;
+
+    RefPtr ancestor = nearestClickedDialog(event, target);
+
+    if (event.type() == eventNames().pointerdownEvent) {
+        m_dialogPointerDownTarget = ancestor.get();
+        return;
+    }
+
+    ASSERT(event.type() == eventNames().pointerupEvent);
+
+    bool sameTarget = ancestor.get() == m_dialogPointerDownTarget;
+
+    m_dialogPointerDownTarget = nullptr;
+
+    if (!sameTarget)
+        return;
+
+    RefPtr topMostDialog = m_openDialogsList.last().ptr();
+
+    if (ancestor == topMostDialog)
+        return;
+
+    if (topMostDialog->computedClosedByState() != ClosedByState::Any)
+        return;
+
+    topMostDialog->requestClose(nullString());
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1872,11 +1872,15 @@ public:
 
     const ListHashSet<Ref<HTMLElement>>& autoPopoverList() const LIFETIME_BOUND { return m_autoPopoverList; }
 
+    ListHashSet<Ref<HTMLDialogElement>>& openDialogsList() { return m_openDialogsList; }
+
     HTMLDialogElement* activeModalDialog() const;
     HTMLElement* NODELETE topmostAutoPopover() const;
+    RefPtr<HTMLDialogElement> nearestClickedDialog(const PointerEvent&, Node&) const;
 
     void hideAllPopoversUntil(HTMLElement*, FocusPreviousElement, FireEvents);
     void handlePopoverLightDismiss(const PointerEvent&, Node&);
+    void handleDialogLightDismiss(const PointerEvent&, Node&);
     bool needsPointerEventHandlingForPopover() const { return !m_autoPopoverList.isEmpty(); }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -2606,8 +2610,10 @@ private:
 
     ListHashSet<Ref<Element>> m_topLayerElements;
     ListHashSet<Ref<HTMLElement>> m_autoPopoverList;
+    ListHashSet<Ref<HTMLDialogElement>> m_openDialogsList;
 
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_popoverPointerDownTarget;
+    WeakPtr<HTMLDialogElement, WeakPtrImplWithEventTargetData> m_dialogPointerDownTarget;
 
 #if ENABLE(WEB_RTC)
     RefPtr<RTCNetworkManager> m_rtcNetworkManager;

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -104,6 +104,7 @@ cite
 class
 classid
 clear
+closedby
 code
 codebase
 codetype

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "HTMLDialogElement.h"
 
+#include "CommonAtomStrings.h"
 #include "ContainerNodeInlines.h"
 #include "CSSSelector.h"
 #include "DocumentPage.h"
@@ -55,6 +56,46 @@ using namespace HTMLNames;
 HTMLDialogElement::HTMLDialogElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document)
 {
+}
+
+const AtomString& HTMLDialogElement::closedBy() const
+{
+    switch (computedClosedByState()) {
+    case ClosedByState::None:
+        return noneAtom();
+    case ClosedByState::CloseRequest:
+        return closerequestAtom();
+    case ClosedByState::Any:
+        return anyAtom();
+    default:
+        ASSERT_NOT_REACHED();
+        return nullAtom();
+    }
+}
+
+ClosedByState HTMLDialogElement::closedByState() const
+{
+    if (!hasAttributeWithoutSynchronization(HTMLNames::closedbyAttr))
+        return ClosedByState::Auto;
+
+    auto value = attributeWithoutSynchronization(HTMLNames::closedbyAttr);
+    if (value == noneAtom())
+        return ClosedByState::None;
+    if (value == closerequestAtom())
+        return ClosedByState::CloseRequest;
+    if (value == anyAtom())
+        return ClosedByState::Any;
+
+    return ClosedByState::Auto;
+}
+
+ClosedByState HTMLDialogElement::computedClosedByState() const
+{
+    ClosedByState result = closedByState();
+    if (result == ClosedByState::Auto)
+        return m_isModal ? ClosedByState::CloseRequest : ClosedByState::None;
+
+    return result;
 }
 
 ExceptionOr<void> HTMLDialogElement::show()
@@ -289,20 +330,72 @@ bool HTMLDialogElement::supportsFocus() const
     return true;
 }
 
+Node::NeedsPostConnectionSteps HTMLDialogElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+{
+    HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
+    if (!insertionType.connectedToDocument)
+        return NeedsPostConnectionSteps::No;
+    Ref document = this->document();
+    if (document->settings().closedbyAttributeEnabled())
+        return NeedsPostConnectionSteps::Yes;
+
+    return NeedsPostConnectionSteps::No;
+}
+
+void HTMLDialogElement::postConnectionSteps()
+{
+    HTMLElement::postConnectionSteps();
+    Ref document = this->document();
+    ASSERT(document->settings().closedbyAttributeEnabled());
+    if (!document->isFullyActive())
+        return;
+    if (isOpen() && isConnected())
+        setupSteps();
+}
+
 void HTMLDialogElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
+    if (document().settings().closedbyAttributeEnabled() && isOpen())
+        cleanupSteps();
     setIsModal(false);
 }
 
 void HTMLDialogElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+    Ref document = this->document();
     if (name == openAttr) {
         auto isOpen = !newValue.isNull();
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Open, isOpen);
         m_isOpen = isOpen;
+
+        if (document->settings().closedbyAttributeEnabled()) {
+            if (!document->isFullyActive())
+                return;
+            if (newValue.isNull() && !oldValue.isNull())
+                cleanupSteps();
+            if (!isConnected())
+                return;
+            if (!newValue.isNull() && oldValue.isNull())
+                setupSteps();
+        }
     }
+}
+
+void HTMLDialogElement::setupSteps()
+{
+    ASSERT(isOpen());
+    ASSERT(isConnected());
+    Ref document = this->document();
+    ASSERT(!document->openDialogsList().contains(this));
+    document->openDialogsList().add(*this);
+}
+
+void HTMLDialogElement::cleanupSteps()
+{
+    Ref document = this->document();
+    document->openDialogsList().remove(*this);
 }
 
 void HTMLDialogElement::setIsModal(bool newValue)

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -30,6 +30,13 @@
 
 namespace WebCore {
 
+enum class ClosedByState : uint8_t {
+    Auto,
+    None,
+    CloseRequest,
+    Any,
+};
+
 class HTMLDialogElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLDialogElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDialogElement);
@@ -40,6 +47,10 @@ public:
 
     const String& returnValue() const LIFETIME_BOUND { return m_returnValue; }
     void setReturnValue(String&& value) { m_returnValue = WTF::move(value); }
+
+    ClosedByState closedByState() const;
+    ClosedByState computedClosedByState() const;
+    const AtomString& closedBy() const;
 
     ExceptionOr<void> show();
     ExceptionOr<void> showModal(Element* = nullptr);
@@ -64,7 +75,13 @@ private:
     void setIsModal(bool newValue);
     bool supportsFocus() const final;
 
+    NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
+    void postConnectionSteps() final;
+
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+
+    void setupSteps();
+    void cleanupSteps();
 
     String m_returnValue;
     bool m_isModal { false };

--- a/Source/WebCore/html/HTMLDialogElement.idl
+++ b/Source/WebCore/html/HTMLDialogElement.idl
@@ -28,6 +28,7 @@
 ] interface HTMLDialogElement : HTMLElement {
     [CEReactions=Needed, Reflect] attribute boolean open;
     attribute DOMString returnValue;
+    [CEReactions=Needed, ReflectSetter, EnabledBySetting=ClosedbyAttributeEnabled] attribute [AtomString] DOMString closedBy;
     [CEReactions=Needed] undefined show();
     [CEReactions=Needed] undefined showModal();
     [CEReactions=Needed] undefined close(optional DOMString returnValue);

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -40,6 +40,7 @@
 #include "Page.h"
 #include "PointerEvent.h"
 #include "Quirks.h"
+#include "Settings.h"
 #include <algorithm>
 #include <ranges>
 #include <wtf/CheckedArithmetic.h>
@@ -495,6 +496,8 @@ void PointerCaptureController::pointerEventWillBeDispatched(const PointerEvent& 
         setPointerCapture(&element, event.pointerId());
     }
     element.document().handlePopoverLightDismiss(event, element);
+    if (element.document().settings().closedbyAttributeEnabled())
+        element.document().handleDialogLightDismiss(event, element);
 }
 
 auto PointerCaptureController::ensureCapturingDataForPointerEvent(const PointerEvent& event) -> Ref<CapturingData>

--- a/Source/WebCore/platform/CommonAtomStrings.h
+++ b/Source/WebCore/platform/CommonAtomStrings.h
@@ -33,11 +33,13 @@ namespace WebCore {
 #define WEBCORE_COMMON_ATOM_STRINGS_FOR_EACH_KEYWORD(macro) \
     macro(all, "all") \
     macro(alternative, "alternative") \
+    macro(any, "any") \
     macro(applicationXHTMLContentType, "application/xhtml+xml") \
     macro(applicationXMLContentType, "application/xml") \
     macro(applicationOctetStream, "application/octet-stream") \
     macro(auto, "auto") \
-    macro(captions, "captions") \
+    macro(captions, "captions")                             \
+    macro(closerequest, "closerequest") \
     macro(commentary, "commentary") \
     macro(cssContentType, "text/css") \
     macro(eager, "eager") \


### PR DESCRIPTION
#### ef0549626737a337f21297e9e0ddb2922b695e70
<pre>
Implement closedby=any for dialog
<a href="https://bugs.webkit.org/show_bug.cgi?id=297954">https://bugs.webkit.org/show_bug.cgi?id=297954</a>

Reviewed by Anne van Kesteren.

This adds an implementation for the closedby attribute&apos;s &quot;any&quot; value,
specifically covering the light dismiss behaviour.

Further additions will be needed to handle the close watcher aspect
of this attribute (e.g. none and closerequest values)

Canonical link: <a href="https://commits.webkit.org/309558@main">https://commits.webkit.org/309558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33a32a3f8e8a9fbcab352eb30957773cdca6da4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104463 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116600 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15765 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7601 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143011 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162228 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11826 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5353 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124607 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124795 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33858 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80000 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11990 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182636 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87482 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46615 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->