### PR TITLE
Introduce AudioVideoRenderer class.

### DIFF
--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -55,6 +55,7 @@ public:
 #define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { (thisPtr)->logger() }->logAlwaysVerbose((thisPtr)->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { (thisPtr)->logger() }->errorVerbose((thisPtr)->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { (thisPtr)->logger() }->infoVerbose((thisPtr)->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define DEBUG_LOG_WITH_THIS(thisPtr, ...)      Ref { (thisPtr)->logger() }->debugVerbose((thisPtr)->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 #else
 #define ALWAYS_LOG(...)     Ref { logger() }->logAlways(logChannel(), __VA_ARGS__)
 #define ERROR_LOG(...)      Ref { logger() }->error(logChannel(), __VA_ARGS__)
@@ -65,6 +66,7 @@ public:
 #define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { (thisPtr)->logger() }->logAlways((thisPtr)->logChannel(), __VA_ARGS__)
 #define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { (thisPtr)->logger() }->error((thisPtr)->logChannel(), __VA_ARGS__)
 #define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { (thisPtr)->logger() }->info((thisPtr)->logChannel(), __VA_ARGS__)
+#define DEBUG_LOG_WITH_THIS(thisPtr, ...)      Ref { (thisPtr)->logger() }->debug((thisPtr)->logChannel(), __VA_ARGS__)
 #endif
 
 #define WILL_LOG(_level_)   Ref { logger() }->willLog(logChannel(), _level_)
@@ -85,6 +87,7 @@ public:
 #define ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)  if (RefPtr logger = thisPtr->loggerPtr()) ALWAYS_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
 #define ERROR_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)   if (RefPtr logger = thisPtr->loggerPtr()) ERROR_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
 #define INFO_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)    if (RefPtr logger = thisPtr->loggerPtr()) INFO_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
+#define DEBUG_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)    if (RefPtr logger = thisPtr->loggerPtr()) DEBUG_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
 
 #if defined(__OBJC__)
 #define OBJC_LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(__PRETTY_FUNCTION__, self.logIdentifier)
@@ -123,10 +126,12 @@ public:
 #define ALWAYS_LOG_WITH_THIS(thisPtr, channelName, ...)   do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
 #define ERROR_LOG_WITH_THIS(thisPtr, channelName, ...)    do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
 #define INFO_LOG_WITH_THIS(thisPtr, channelName, ...)     do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
+#define DEBUG_LOG_WITH_THIS(thisPtr, channelName, ...)    do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
 
 #define ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, channelName, ...)  do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
 #define ERROR_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, channelName, ...)   do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
 #define INFO_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, channelName, ...)    do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
+#define DEBUG_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, channelName, ...)   do { UNUSED_PARAM(thisPtr); UNUSED_PARAM(channelName); } while (0)
 
 #define ALWAYS_LOG_IF(condition, ...)     ((void)0)
 #define ERROR_LOG_IF(condition, ...)      ((void)0)

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2456,6 +2456,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/AnimationFrameRate.h
     platform/graphics/AudioTrackPrivate.h
     platform/graphics/AudioTrackPrivateClient.h
+    platform/graphics/AudioVideoRenderer.h
     platform/graphics/BifurcatedGraphicsContext.h
     platform/graphics/BitmapImage.h
     platform/graphics/ByteArrayPixelBuffer.h

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -631,6 +631,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/angle/ANGLEUtilities.h
 
     platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+    platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
     platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
     platform/graphics/avfoundation/SampleBufferDisplayLayer.h
     platform/graphics/avfoundation/WebMediaSessionManagerMac.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -353,6 +353,7 @@ platform/gamepad/mac/StadiaHIDGamepad.cpp
 platform/graphics/MediaPlaybackTargetPicker.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm @no-unify
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm @no-unify
+platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
 platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
 platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -132,6 +132,8 @@ public:
         object->setObject("pts"_s, presentationTime().toJSONObject());
         object->setObject("dts"_s, decodeTime().toJSONObject());
         object->setObject("duration"_s, duration().toJSONObject());
+        object->setBoolean("isSync"_s, isSync());
+        object->setBoolean("isNonDisplaying"_s, isNonDisplaying());
         object->setInteger("flags"_s, static_cast<unsigned>(flags()));
         object->setObject("presentationSize"_s, presentationSize().toJSONObject());
 

--- a/Source/WebCore/platform/PlatformMediaError.cpp
+++ b/Source/WebCore/platform/PlatformMediaError.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 String convertEnumerationToString(PlatformMediaError enumerationValue)
 {
-    static std::array<const NeverDestroyed<String>, 13> values {
+    static std::array<const NeverDestroyed<String>, 16> values {
         MAKE_STATIC_STRING_IMPL("AppendError"),
         MAKE_STATIC_STRING_IMPL("ClientDisconnected"),
         MAKE_STATIC_STRING_IMPL("BufferRemoved"),
@@ -46,6 +46,9 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
         MAKE_STATIC_STRING_IMPL("NotSupportedError"),
         MAKE_STATIC_STRING_IMPL("NetworkError"),
         MAKE_STATIC_STRING_IMPL("NotReady"),
+        MAKE_STATIC_STRING_IMPL("AudioDecodingError"),
+        MAKE_STATIC_STRING_IMPL("VideoDecodingError"),
+        MAKE_STATIC_STRING_IMPL("RequiresFlushToResume"),
     };
     static_assert(!static_cast<size_t>(PlatformMediaError::AppendError), "PlatformMediaError::AppendError is not 0 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::ClientDisconnected) == 1, "PlatformMediaError::ClientDisconnected is not 1 as expected");
@@ -60,6 +63,9 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
     static_assert(static_cast<size_t>(PlatformMediaError::NotSupportedError) == 10, "PlatformMediaError::NotSupportedError is not 10 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::NetworkError) == 11, "PlatformMediaError::NetworkError is not 11 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::NotReady) == 12, "PlatformMediaError::NotReady is not 12 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::AudioDecodingError) == 13, "PlatformMediaError::AudioDecodingError is not 13 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::VideoDecodingError) == 14, "PlatformMediaError::VideoDecodingError is not 14 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::RequiresFlushToResume) == 15, "PlatformMediaError::RequiresFlushToResume is not 15 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/PlatformMediaError.h
+++ b/Source/WebCore/platform/PlatformMediaError.h
@@ -43,7 +43,10 @@ enum class PlatformMediaError : uint8_t {
     DecoderCreationError,
     NotSupportedError,
     NetworkError,
-    NotReady
+    NotReady,
+    AudioDecodingError,
+    VideoDecodingError,
+    RequiresFlushToResume,
 };
 
 using MediaPromise = NativePromise<void, PlatformMediaError>;

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MediaPlayerEnums.h"
+#include "MediaPromiseTypes.h"
+#include "MediaSample.h"
+#include "PlatformLayer.h"
+#include "VideoPlaybackQualityMetrics.h"
+#include "VideoTarget.h"
+#include <optional>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/MediaTime.h>
+#include <wtf/NativePromise.h>
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+class FloatRect;
+class LayoutRect;
+class PlatformDynamicRangeLimit;
+class ProcessIdentity;
+class TextTrackRepresentation;
+class VideoFrame;
+
+class AudioInterface {
+public:
+    virtual ~AudioInterface() = default;
+    virtual void setVolume(float) = 0;
+    virtual void setMuted(bool) = 0;
+    virtual void setPreservesPitch(bool) { }
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+    virtual void setOutputDeviceId(const String&) { }
+#endif
+};
+
+class VideoInterface {
+public:
+    virtual ~VideoInterface() = default;
+    virtual void setIsVisible(bool) = 0;
+    virtual void setPresentationSize(const IntSize&) = 0;
+    virtual void setShouldMaintainAspectRatio(bool) { }
+    virtual void acceleratedRenderingStateChanged(bool) { }
+    virtual void contentBoxRectChanged(const LayoutRect&) { }
+    virtual void notifyFirstFrameAvailable(Function<void()>&&) { }
+    virtual void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&) { }
+    virtual void notifyWhenRequiresFlushToResume(Function<void()>&&) { }
+    virtual void notifyRenderingModeChanged(Function<void()>&&) { }
+    virtual void setMinimumUpcomingPresentationTime(const MediaTime&) { }
+    virtual void setShouldDisableHDR(bool) { };
+    virtual void setPlatformDynamicRangeLimit(const PlatformDynamicRangeLimit&) { };
+    virtual void setResourceOwner(const ProcessIdentity&) { }
+    virtual void flushAndRemoveImage() { };
+    virtual RefPtr<VideoFrame> currentVideoFrame() const = 0;
+    virtual std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() = 0;
+    virtual PlatformLayerContainer platformVideoLayer() const { return nullptr; }
+};
+
+class VideoFullscreenInterface {
+public:
+    virtual ~VideoFullscreenInterface() = default;
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    virtual void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&&) { }
+    virtual void setVideoFullscreenFrame(const FloatRect&) { }
+    virtual Ref<GenericPromise> setVideoTarget(const PlatformVideoTarget&) { return GenericPromise::createAndReject(); }
+    virtual void isInFullscreenOrPictureInPictureChanged(bool) { }
+#endif
+    virtual void setTextTrackRepresentation(TextTrackRepresentation*) { }
+    virtual void syncTextTrackBounds() { }
+};
+
+class SynchronizerInterface {
+public:
+    virtual ~SynchronizerInterface() = default;
+    virtual void play() = 0;
+    virtual void pause() = 0;
+    virtual bool paused() const = 0;
+    virtual void setRate(double) = 0;
+    virtual double effectiveRate() const = 0;
+    virtual void prepareToSeek() { }
+    virtual Ref<MediaTimePromise> seekTo(const MediaTime&) = 0;
+};
+
+enum class SamplesRendererTrackIdentifierType { };
+using SamplesRendererTrackIdentifier = AtomicObjectIdentifier<SamplesRendererTrackIdentifierType>;
+
+class TracksRendererManager {
+public:
+    using TrackType = TrackInfo::TrackType;
+    using TrackIdentifier = SamplesRendererTrackIdentifier;
+
+    virtual ~TracksRendererManager() = default;
+
+    virtual TrackIdentifier addTrack(TrackType) = 0;
+    virtual void removeTrack(TrackIdentifier) = 0;
+
+    virtual void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime> = std::nullopt) = 0;
+    virtual bool isReadyForMoreSamples(TrackIdentifier) = 0;
+    virtual void requestMediaDataWhenReady(TrackIdentifier, Function<void(TrackIdentifier)>&&) = 0;
+    virtual void stopRequestingMediaData(TrackIdentifier) = 0;
+
+    virtual bool timeIsProgressing() const = 0;
+    virtual MediaTime currentTime() const = 0;
+    virtual void setDuration(MediaTime) { }
+    virtual void notifyDurationReached(Function<void(const MediaTime&)>&&) = 0;
+
+    virtual void flush() = 0;
+    virtual void flushTrack(TrackIdentifier) = 0;
+
+    virtual void notifyWhenErrorOccurs(Function<void(PlatformMediaError)>&&) = 0;
+
+    using SoundStageSize = MediaPlayerSoundStageSize;
+    virtual void setSpatialTrackingInfo(bool /* prefersSpatialAudioExperience */, SoundStageSize, const String& /* sceneIdentifier */, const String& /* defaultLabel */, const String& /* label */) { }
+};
+
+class AudioVideoRenderer : public AudioInterface, public VideoInterface, public VideoFullscreenInterface, public SynchronizerInterface, public TracksRendererManager, public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
+public:
+    virtual ~AudioVideoRenderer() = default;
+};
+
+}

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -922,7 +922,7 @@ void MediaPlayer::updateVideoFullscreenInlineImage()
     protectedPrivate()->updateVideoFullscreenInlineImage();
 }
 
-void MediaPlayer::setVideoFullscreenFrame(FloatRect frame)
+void MediaPlayer::setVideoFullscreenFrame(const FloatRect& frame)
 {
     protectedPrivate()->setVideoFullscreenFrame(frame);
 }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -398,7 +398,7 @@ public:
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RetainPtr<PlatformLayer> createVideoFullscreenLayer();
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler = [] { });
-    void setVideoFullscreenFrame(FloatRect);
+    void setVideoFullscreenFrame(const FloatRect&);
     void updateVideoFullscreenInlineImage();
     using MediaPlayerEnums::VideoGravity;
     void setVideoFullscreenGravity(VideoGravity);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -87,7 +87,7 @@ public:
     virtual RetainPtr<PlatformLayer> createVideoFullscreenLayer() { return nullptr; }
     virtual void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) { completionHandler(); }
     virtual void updateVideoFullscreenInlineImage() { }
-    virtual void setVideoFullscreenFrame(FloatRect) { }
+    virtual void setVideoFullscreenFrame(const FloatRect&) { }
     virtual void setVideoFullscreenGravity(MediaPlayer::VideoGravity) { }
     virtual void setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode) { }
     virtual void videoFullscreenStandbyChanged() { }

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AudioVideoRenderer.h"
+#include "PlatformDynamicRangeLimit.h"
+#include "ProcessIdentity.h"
+#include "WebAVSampleBufferListener.h"
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/HashMap.h>
+#include <wtf/LoggerHelper.h>
+#include <wtf/NativePromise.h>
+#include <wtf/StdUnorderedMap.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+OBJC_CLASS AVSampleBufferAudioRenderer;
+OBJC_CLASS AVSampleBufferDisplayLayer;
+OBJC_CLASS AVSampleBufferRenderSynchronizer;
+OBJC_CLASS AVSampleBufferVideoRenderer;
+OBJC_PROTOCOL(WebSampleBufferVideoRendering);
+
+namespace WebCore {
+
+class PixelBufferConformerCV;
+class VideoLayerManagerObjC;
+class VideoMediaSampleRenderer;
+
+class AudioVideoRendererAVFObjC
+    : public AudioVideoRenderer
+    , public WebAVSampleBufferListenerClient
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioVideoRendererAVFObjC>
+    , private LoggerHelper {
+    WTF_MAKE_TZONE_ALLOCATED(AudioVideoRendererAVFObjC);
+public:
+    static Ref<AudioVideoRendererAVFObjC> create(const Logger& logger, uint64_t logIdentifier) { return adoptRef(*new AudioVideoRendererAVFObjC(logger, logIdentifier)); }
+
+    ~AudioVideoRendererAVFObjC();
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
+
+    // TracksRendererInterface
+    TrackIdentifier addTrack(TrackType) final;
+    void removeTrack(TrackIdentifier) final;
+
+    void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime>) final;
+    bool isReadyForMoreSamples(TrackIdentifier) final;
+    void requestMediaDataWhenReady(TrackIdentifier, Function<void(TrackIdentifier)>&&) final;
+    void stopRequestingMediaData(TrackIdentifier) final;
+
+    bool timeIsProgressing() const final;
+    MediaTime currentTime() const final;
+
+    void flush() final;
+    void flushTrack(TrackIdentifier) final;
+
+    void notifyWhenErrorOccurs(Function<void(PlatformMediaError)>&&) final;
+
+    // SynchronizerInterface
+    void play() final;
+    void pause() final;
+    bool paused() const final;
+    void setRate(double) final;
+    double effectiveRate() const final;
+    void setDuration(MediaTime) final;
+    void notifyDurationReached(Function<void(const MediaTime&)>&&) final;
+    void prepareToSeek() final;
+    Ref<MediaTimePromise> seekTo(const MediaTime&) final;
+
+    // AudioInterface
+    void setVolume(float) final;
+    void setMuted(bool) final;
+    void setPreservesPitch(bool) final;
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+    void setOutputDeviceId(const String&) final;
+    void setOutputDeviceIdOnRenderer(AVSampleBufferAudioRenderer *);
+#endif
+
+    // VideoInterface
+    void setIsVisible(bool);
+    void setPresentationSize(const IntSize&) final;
+    void setShouldMaintainAspectRatio(bool) final;
+    void acceleratedRenderingStateChanged(bool) final;
+    void contentBoxRectChanged(const LayoutRect&) final;
+    void notifyFirstFrameAvailable(Function<void()>&&) final;
+    void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&) final;
+    void notifyWhenRequiresFlushToResume(Function<void()>&&) final;
+    void notifyRenderingModeChanged(Function<void()>&&) final;
+    void setMinimumUpcomingPresentationTime(const MediaTime&) final;
+    void setShouldDisableHDR(bool) final;
+    void setPlatformDynamicRangeLimit(const PlatformDynamicRangeLimit&) final;
+    void setResourceOwner(const ProcessIdentity& resourceOwner) final { m_resourceOwner = resourceOwner; }
+    RefPtr<VideoFrame> currentVideoFrame() const final;
+    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
+    PlatformLayerContainer platformVideoLayer() const final;
+
+    // VideoFullscreenInterface
+    void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&&) final;
+    void setVideoFullscreenFrame(const FloatRect&) final;
+    void setTextTrackRepresentation(TextTrackRepresentation*) final;
+    void syncTextTrackBounds() final;
+    Ref<GenericPromise> setVideoTarget(const PlatformVideoTarget&) final;
+    void isInFullscreenOrPictureInPictureChanged(bool) final;
+
+private:
+    AudioVideoRendererAVFObjC(const Logger&, uint64_t);
+
+    bool seeking() const;
+    MediaTime clampTimeToLastSeekTime(const MediaTime&) const;
+    void maybeCompleteSeek();
+    bool shouldBePlaying() const;
+
+    std::optional<TrackType> typeOf(TrackIdentifier) const;
+
+    void addAudioRenderer(TrackIdentifier);
+    void removeAudioRenderer(TrackIdentifier);
+    void destroyAudioRenderers();
+    void destroyAudioRenderer(RetainPtr<AVSampleBufferAudioRenderer>);
+    RetainPtr<AVSampleBufferAudioRenderer> audioRendererFor(TrackIdentifier) const;
+    void applyOnAudioRenderers(NOESCAPE Function<void(AVSampleBufferAudioRenderer *)>&&) const;
+
+    Ref<GenericPromise> updateDisplayLayerIfNeeded();
+    bool shouldEnsureLayerOrVideoRenderer() const;
+    WebSampleBufferVideoRendering *layerOrVideoRenderer() const;
+    Ref<GenericPromise> ensureLayerOrVideoRenderer();
+    void ensureLayer();
+    void destroyLayer();
+    void destroyVideoLayerIfNeeded();
+    void ensureVideoRenderer();
+    void destroyVideoRenderer();
+    Ref<GenericPromise> setVideoRenderer(WebSampleBufferVideoRendering *);
+    void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
+    Ref<GenericPromise> stageVideoRenderer(WebSampleBufferVideoRendering *);
+
+    enum class AcceleratedVideoMode: uint8_t {
+        Layer = 0,
+        VideoRenderer,
+    };
+    AcceleratedVideoMode acceleratedVideoMode() const;
+
+    void notifyError(PlatformMediaError);
+    // WebAVSampleBufferListenerClient
+    void audioRendererDidReceiveError(AVSampleBufferAudioRenderer *, NSError *) final;
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    void setSpatialTrackingInfo(bool prefersSpatialAudioExperience, SoundStageSize, const String& sceneIdentifier, const String& defaultLabel, const String& label) final;
+    void updateSpatialTrackingLabel();
+#endif
+
+    bool isEnabledVideoTrackId(TrackIdentifier) const;
+    bool hasSelectedVideo() const;
+    void flushVideo();
+    void flushAudio();
+    void flushAudioTrack(TrackIdentifier);
+
+    void cancelSeekingPromiseIfNeeded();
+
+    RefPtr<VideoMediaSampleRenderer> protectedVideoRenderer() const;
+
+    // Logger
+    const Logger& logger() const final { return m_logger.get(); }
+    Ref<const Logger> protectedLogger() const { return logger(); }
+    ASCIILiteral logClassName() const final { return "AudioVideoRendererAVFObjC"_s; }
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
+    WTFLogChannel& logChannel() const final;
+
+    enum SeekState {
+        Preparing,
+        RequiresFlush,
+        Seeking,
+        WaitingForAvailableFame,
+        SeekCompleted,
+    };
+
+    String toString(TrackIdentifier) const;
+    String toString(SeekState) const;
+
+    const Ref<const Logger> m_logger;
+    const uint64_t m_logIdentifier;
+    const UniqueRef<VideoLayerManagerObjC> m_videoLayerManager;
+    const RetainPtr<AVSampleBufferRenderSynchronizer> m_synchronizer;
+    const Ref<WebAVSampleBufferListener> m_listener;
+
+    Function<void(PlatformMediaError)> m_errorCallback;
+    Function<void(const MediaTime&)> m_durationReachedCallback;
+    Function<void()> m_firstFrameAvailableCallback;
+    Function<void(const MediaTime&, double)> m_hasAvailableVideoFrameCallback;
+    Function<void()> m_notifyWhenRequiresFlushToResume;
+    Function<void()> m_renderingModeChangedCallback;
+
+    RetainPtr<id> m_durationObserver;
+    bool m_isPlaying { false };
+    double m_rate { 1 };
+
+    float m_volume { 1 };
+    bool m_muted { false };
+    bool m_preservePitch { true };
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+    String m_audioOutputDeviceId;
+#endif
+
+    // Seek Logic
+    MediaTime m_lastSeekTime;
+    SeekState m_seekState { SeekCompleted };
+    std::optional<MediaTimePromise::Producer> m_seekPromise;
+    RetainPtr<id> m_timeJumpedObserver;
+    bool m_isSynchronizerSeeking { false };
+    bool m_hasAvailableVideoFrame { false };
+
+    HashMap<TrackIdentifier, TrackType> m_trackTypes;
+    HashMap<TrackIdentifier, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
+    bool m_readyToRequestVideoData { true };
+    bool m_readyToRequestAudioData { true };
+    RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
+    RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;
+    RefPtr<VideoMediaSampleRenderer> m_videoRenderer;
+    bool m_renderingCanBeAccelerated { false };
+    bool m_visible { false };
+    IntSize m_presentationSize;
+    bool m_shouldMaintainAspectRatio { true };
+    std::optional<TrackIdentifier> m_enabledVideoTrackId;
+    bool m_shouldDisableHDR { false };
+    PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValueForVideos() };
+    ProcessIdentity m_resourceOwner;
+
+    std::unique_ptr<PixelBufferConformerCV> m_rgbConformer;
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    bool m_prefersSpatialAudioExperience { false };
+    SoundStageSize m_soundStage { SoundStageSize::Auto };
+    String m_sceneIdentifier;
+    String m_defaultSpatialTrackingLabel;
+    String m_spatialTrackingLabel;
+#endif
+
+    bool m_needsDestroyVideoLayer { false };
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    RetainPtr<FigVideoTargetRef> m_videoTarget;
+#endif
+};
+
+}

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -1,0 +1,1260 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "AudioVideoRendererAVFObjC.h"
+
+#import "AudioMediaStreamTrackRenderer.h"
+#import "LayoutRect.h"
+#import "Logging.h"
+#import "PixelBufferConformerCV.h"
+#import "PlatformDynamicRangeLimitCocoa.h"
+#import "SpatialAudioExperienceHelper.h"
+#import "TextTrackRepresentation.h"
+#import "VideoFrameCV.h"
+#import "VideoLayerManagerObjC.h"
+#import "VideoMediaSampleRenderer.h"
+#import "WebSampleBufferVideoRendering.h"
+
+#import <AVFoundation/AVFoundation.h>
+#import <pal/avfoundation/MediaTimeAVFoundation.h>
+#import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/BlockObjCExceptions.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/MainThread.h>
+#import <wtf/SoftLinking.h>
+#import <wtf/TZoneMallocInlines.h>
+#import <wtf/WeakPtr.h>
+#import <wtf/WorkQueue.h>
+
+#pragma mark - Soft Linking
+#import "CoreVideoSoftLink.h"
+#import "VideoToolboxSoftLink.h"
+#import <pal/cf/CoreMediaSoftLink.h>
+#import <pal/cocoa/AVFoundationSoftLink.h>
+
+@interface AVSampleBufferDisplayLayer (Staging_100128644)
+@property (assign, nonatomic) BOOL preventsAutomaticBackgroundingDuringVideoPlayback;
+@end
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioVideoRendererAVFObjC);
+
+AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogger, uint64_t logSiteIdentifier)
+    : m_logger(originalLogger)
+    , m_logIdentifier(logSiteIdentifier)
+    , m_videoLayerManager(makeUniqueRef<VideoLayerManagerObjC>(originalLogger, logSiteIdentifier))
+    , m_synchronizer([adoptNS(PAL::allocAVSampleBufferRenderSynchronizerInstance()) init])
+    , m_listener(WebAVSampleBufferListener::create(*this))
+{
+    // addPeriodicTimeObserverForInterval: throws an exception if you pass a non-numeric CMTime, so just use
+    // an arbitrarily large time value of once an hour:
+    __block WeakPtr weakThis { *this };
+    // False positive webkit.org/b/298037
+    SUPPRESS_UNRETAINED_ARG m_timeJumpedObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::toCMTime(MediaTime::createWithDouble(3600)) queue:dispatch_get_main_queue() usingBlock:^(CMTime time) {
+#if LOG_DISABLED
+        UNUSED_PARAM(time);
+#endif
+        if (!weakThis)
+            return;
+
+        auto clampedTime = CMTIME_IS_NUMERIC(time) ? clampTimeToLastSeekTime(PAL::toMediaTime(time)) : MediaTime::zeroTime();
+        ALWAYS_LOG(LOGIDENTIFIER, "synchronizer fired: time clamped = ", clampedTime, ", seeking = ", m_isSynchronizerSeeking);
+
+        m_isSynchronizerSeeking = false;
+        maybeCompleteSeek();
+    }];
+    [m_synchronizer setRate:0];
+}
+
+AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC()
+{
+    cancelSeekingPromiseIfNeeded();
+
+    if (m_durationObserver)
+        [m_synchronizer removeTimeObserver:m_durationObserver.get()];
+    if (m_timeJumpedObserver)
+        [m_synchronizer removeTimeObserver:m_timeJumpedObserver.get()];
+
+    destroyLayer();
+    destroyAudioRenderers();
+    m_listener->invalidate();
+}
+
+TracksRendererManager::TrackIdentifier AudioVideoRendererAVFObjC::addTrack(TrackType type)
+{
+    auto identifier = TrackIdentifier::generate();
+    m_trackTypes.add(identifier, type);
+
+    switch (type) {
+    case TrackType::Video:
+        m_enabledVideoTrackId = identifier;
+        updateDisplayLayerIfNeeded();
+        break;
+    case TrackType::Audio:
+        addAudioRenderer(identifier);
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+    return identifier;
+}
+
+void AudioVideoRendererAVFObjC::removeTrack(TrackIdentifier trackId)
+{
+    auto type = typeOf(trackId);
+    if (!type)
+        return;
+
+    switch (*type) {
+    case TrackType::Video:
+        if (isEnabledVideoTrackId(trackId)) {
+            m_enabledVideoTrackId.reset();
+            if (RefPtr videoRenderer = m_videoRenderer)
+                videoRenderer->stopRequestingMediaData();
+        }
+        break;
+    case TrackType::Audio:
+        removeAudioRenderer(trackId);
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    m_trackTypes.remove(trackId);
+}
+
+void AudioVideoRendererAVFObjC::enqueueSample(TrackIdentifier trackId, Ref<MediaSample>&& sample, std::optional<MediaTime> minimumUpcomingTime)
+{
+    auto type = typeOf(trackId);
+    if (!type)
+        return;
+
+    switch (*type) {
+    case TrackType::Video:
+        ASSERT(m_videoRenderer);
+        if (RefPtr videoRenderer = m_videoRenderer; videoRenderer && isEnabledVideoTrackId(trackId))
+            videoRenderer->enqueueSample(sample, minimumUpcomingTime.value_or(sample->presentationTime()));
+        break;
+    case TrackType::Audio:
+        if (RetainPtr audioRenderer = audioRendererFor(trackId)) {
+            RetainPtr cmSampleBuffer = sample->platformSample().sample.cmSampleBuffer;
+            [audioRenderer enqueueSampleBuffer:cmSampleBuffer.get()];
+        }
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+bool AudioVideoRendererAVFObjC::isReadyForMoreSamples(TrackIdentifier trackId)
+{
+    auto type = typeOf(trackId);
+    if (!type)
+        return false;
+
+    switch (*type) {
+    case TrackType::Video:
+        return isEnabledVideoTrackId(trackId) && protectedVideoRenderer()->isReadyForMoreMediaData();
+    case TrackType::Audio:
+        if (RetainPtr audioRenderer = audioRendererFor(trackId))
+            return [audioRenderer isReadyForMoreMediaData];
+        return false;
+    default:
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+}
+
+void AudioVideoRendererAVFObjC::requestMediaDataWhenReady(TrackIdentifier trackId, Function<void(TrackIdentifier)>&& callback)
+{
+    auto type = typeOf(trackId);
+    if (!type)
+        return;
+
+    DEBUG_LOG(LOGIDENTIFIER, "trackId: ", toString(trackId), " isEnabledVideoTrackId: ", isEnabledVideoTrackId(trackId));
+
+    switch (*type) {
+    case TrackType::Video:
+        ASSERT(m_videoRenderer);
+        if (RefPtr videoRenderer = m_videoRenderer) {
+            videoRenderer->requestMediaDataWhenReady([trackId, weakThis = WeakPtr { *this }, callback = WTFMove(callback)]() mutable {
+                if (RefPtr protectedThis = weakThis.get()) {
+                    if (protectedThis->m_readyToRequestVideoData)
+                        callback(trackId);
+                    else
+                        DEBUG_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "Not ready to request video data, ignoring");
+                }
+            });
+        }
+        break;
+    case TrackType::Audio:
+        if (RetainPtr audioRenderer = audioRendererFor(trackId)) {
+            auto handler = makeBlockPtr([trackId, weakThis = WeakPtr { *this }, callback = WTFMove(callback)]() mutable {
+                if (RefPtr protectedThis = weakThis.get()) {
+                    if (protectedThis->m_readyToRequestAudioData)
+                        callback(trackId);
+                    else
+                        DEBUG_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "Not ready to request audio data, ignoring");
+                }
+            });
+            // False positive webkit.org/b/298037
+            SUPPRESS_UNRETAINED_ARG [audioRenderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:handler.get()];
+        }
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+void AudioVideoRendererAVFObjC::stopRequestingMediaData(TrackIdentifier trackId)
+{
+    auto type = typeOf(trackId);
+    if (!type)
+        return;
+
+    switch (*type) {
+    case TrackType::Video:
+        if (RefPtr videoRenderer = m_videoRenderer; videoRenderer && isEnabledVideoTrackId(trackId))
+            videoRenderer->stopRequestingMediaData();
+        break;
+    case TrackType::Audio:
+        if (RetainPtr audioRenderer = audioRendererFor(trackId))
+            [audioRenderer stopRequestingMediaData];
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+void AudioVideoRendererAVFObjC::flush()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    cancelSeekingPromiseIfNeeded();
+    if (m_seekState == RequiresFlush)
+        m_seekState = Seeking;
+    else {
+        m_seekState = SeekCompleted;
+        m_isSynchronizerSeeking = false;
+    }
+
+    flushVideo();
+    flushAudio();
+}
+
+void AudioVideoRendererAVFObjC::flushTrack(TrackIdentifier trackId)
+{
+    DEBUG_LOG(LOGIDENTIFIER, toString(trackId));
+
+    auto type = typeOf(trackId);
+    if (!type)
+        return;
+
+    switch (*type) {
+    case TrackType::Video:
+        if (isEnabledVideoTrackId(trackId))
+            flushVideo();
+        break;
+    case TrackType::Audio:
+        flushAudioTrack(trackId);
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+void AudioVideoRendererAVFObjC::notifyWhenErrorOccurs(Function<void(PlatformMediaError)>&& callback)
+{
+    m_errorCallback = WTFMove(callback);
+}
+
+// Synchronizer interface
+void AudioVideoRendererAVFObjC::play()
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "m_rate: ", m_rate, " seeking: ", seeking());
+    m_isPlaying = true;
+    if (!seeking())
+        [m_synchronizer setRate:m_rate];
+}
+
+void AudioVideoRendererAVFObjC::pause()
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "m_rate: ", m_rate);
+    m_isPlaying = false;
+    [m_synchronizer setRate:0];
+}
+
+bool AudioVideoRendererAVFObjC::paused() const
+{
+    return !m_isPlaying;
+}
+
+bool AudioVideoRendererAVFObjC::timeIsProgressing() const
+{
+    return m_isPlaying && [m_synchronizer rate];
+}
+
+MediaTime AudioVideoRendererAVFObjC::currentTime() const
+{
+    if (seeking())
+        return m_lastSeekTime;
+
+    // False positive see webkit.org/b/298024
+    SUPPRESS_UNRETAINED_ARG MediaTime synchronizerTime = clampTimeToLastSeekTime(PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase])));
+    if (synchronizerTime < MediaTime::zeroTime())
+        return MediaTime::zeroTime();
+
+    return synchronizerTime;
+}
+
+void AudioVideoRendererAVFObjC::setRate(double rate)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "m_rate: ", rate);
+
+    if (m_rate == rate)
+        return;
+    m_rate = rate;
+    if (shouldBePlaying())
+        [m_synchronizer setRate:m_rate];
+}
+
+double AudioVideoRendererAVFObjC::effectiveRate() const
+{
+    // False positive see webkit.org/b/298024
+    SUPPRESS_UNRETAINED_ARG return PAL::CMTimebaseGetRate([m_synchronizer timebase]);
+}
+
+void AudioVideoRendererAVFObjC::setDuration(MediaTime duration)
+{
+    if (m_durationObserver)
+        [m_synchronizer removeTimeObserver:m_durationObserver.get()];
+
+    NSArray* times = @[[NSValue valueWithCMTime:PAL::toCMTime(duration)]];
+
+    auto logSiteIdentifier = LOGIDENTIFIER;
+    DEBUG_LOG(logSiteIdentifier, duration);
+    UNUSED_PARAM(logSiteIdentifier);
+
+    // False positive webkit.org/b/298037
+    SUPPRESS_UNRETAINED_ARG m_durationObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[weakThis = WeakPtr { *this }, duration, logSiteIdentifier] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        MediaTime now = protectedThis->currentTime();
+        ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
+
+        protectedThis->pause();
+        if (now < duration) {
+            ERROR_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "ERROR: boundary time observer called before duration");
+            [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(duration)];
+        }
+        if (protectedThis->m_durationReachedCallback)
+            protectedThis->m_durationReachedCallback(now);
+    }];
+}
+
+void AudioVideoRendererAVFObjC::notifyDurationReached(Function<void(const MediaTime&)>&& callback)
+{
+    m_durationReachedCallback = WTFMove(callback);
+}
+
+void AudioVideoRendererAVFObjC::prepareToSeek()
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "state: ", toString(m_seekState));
+
+    cancelSeekingPromiseIfNeeded();
+    m_seekState = Preparing;
+    [m_synchronizer setRate:0];
+}
+
+Ref<MediaTimePromise> AudioVideoRendererAVFObjC::seekTo(const MediaTime& seekTime)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, seekTime, "state: ", toString(m_seekState), " m_isSynchronizerSeeking: ", m_isSynchronizerSeeking, " m_hasAvailableVideoFrame: ", m_hasAvailableVideoFrame);
+
+    cancelSeekingPromiseIfNeeded();
+    if (m_seekState == RequiresFlush)
+        return MediaTimePromise::createAndReject(PlatformMediaError::RequiresFlushToResume);
+
+    m_lastSeekTime = seekTime;
+
+    MediaTime synchronizerTime = PAL::toMediaTime([m_synchronizer currentTime]);
+
+    bool isSynchronizerSeeking = m_isSynchronizerSeeking || std::abs((synchronizerTime - seekTime).toMicroseconds()) > 1000;
+
+    if (!isSynchronizerSeeking) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Synchroniser doesn't require seeking current: ", synchronizerTime, " seeking: ", seekTime);
+        // In cases where the destination seek time matches too closely the synchronizer's existing time
+        // no time jumped notification will be issued. In this case, just notify the MediaPlayer that
+        // the seek completed successfully.
+        m_seekPromise.emplace();
+        Ref promise = m_seekPromise->promise();
+        maybeCompleteSeek();
+        return promise;
+    }
+
+    m_isSynchronizerSeeking = isSynchronizerSeeking;
+    [m_synchronizer setRate:0 time:PAL::toCMTime(seekTime)];
+
+    if (m_seekState == SeekCompleted || m_seekState == Preparing) {
+        m_seekState = RequiresFlush;
+        m_readyToRequestAudioData = false;
+        m_readyToRequestVideoData = false;
+        ALWAYS_LOG(LOGIDENTIFIER, "Requesting Flush");
+        return MediaTimePromise::createAndReject(PlatformMediaError::RequiresFlushToResume);
+    }
+
+    m_seekState = Seeking;
+
+    m_seekPromise.emplace();
+    return m_seekPromise->promise();
+}
+
+void AudioVideoRendererAVFObjC::setVolume(float volume)
+{
+    m_volume = volume;
+    applyOnAudioRenderers([&](auto* renderer) {
+        [renderer setVolume:volume];
+    });
+}
+
+void AudioVideoRendererAVFObjC::setMuted(bool muted)
+{
+    m_muted = muted;
+    applyOnAudioRenderers([&](auto* renderer) {
+        [renderer setMuted:muted];
+    });
+}
+
+void AudioVideoRendererAVFObjC::setPreservesPitch(bool preservePitch)
+{
+    m_preservePitch = preservePitch;
+    applyOnAudioRenderers([&](auto* renderer) {
+        // False positive see webkit.org/b/298035
+        SUPPRESS_UNRETAINED_ARG [renderer setAudioTimePitchAlgorithm:preservePitch ? AVAudioTimePitchAlgorithmSpectral : AVAudioTimePitchAlgorithmVarispeed];
+    });
+}
+
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+void AudioVideoRendererAVFObjC::setOutputDeviceId(const String& outputDeviceId)
+{
+    m_audioOutputDeviceId = outputDeviceId;
+    if (!outputDeviceId)
+        return;
+    applyOnAudioRenderers([&](auto* renderer) {
+        setOutputDeviceIdOnRenderer(renderer);
+    });
+}
+
+void AudioVideoRendererAVFObjC::setOutputDeviceIdOnRenderer(AVSampleBufferAudioRenderer *renderer)
+{
+    if (m_audioOutputDeviceId.isEmpty() || m_audioOutputDeviceId == AudioMediaStreamTrackRenderer::defaultDeviceID()) {
+        // FIXME(rdar://155986053): Remove the @try/@catch when this exception is resolved.
+        @try {
+            [renderer setAudioOutputDeviceUniqueID:nil];
+        } @catch(NSException *exception) {
+            ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferAudioRenderer setAudioOutputDeviceUniqueID:] threw an exception: ", exception.name, ", reason : ", exception.reason);
+        }
+    } else
+        [renderer setAudioOutputDeviceUniqueID:m_audioOutputDeviceId.createNSString().get()];
+}
+#endif
+
+void AudioVideoRendererAVFObjC::setIsVisible(bool visible)
+{
+    if (m_visible == visible)
+        return;
+    m_visible = visible;
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    updateSpatialTrackingLabel();
+#endif
+}
+
+void AudioVideoRendererAVFObjC::setPresentationSize(const IntSize& newSize)
+{
+    m_presentationSize = newSize;
+    updateDisplayLayerIfNeeded();
+}
+
+void AudioVideoRendererAVFObjC::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)
+{
+    if (m_shouldMaintainAspectRatio == shouldMaintainAspectRatio)
+        return;
+
+    m_shouldMaintainAspectRatio = shouldMaintainAspectRatio;
+    if (!m_sampleBufferDisplayLayer)
+        return;
+
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:0];
+    [CATransaction setDisableActions:YES];
+
+    // False positive see webkit.org/b/298035
+    SUPPRESS_UNRETAINED_ARG [m_sampleBufferDisplayLayer setVideoGravity: (m_shouldMaintainAspectRatio ? AVLayerVideoGravityResizeAspect : AVLayerVideoGravityResize)];
+
+    [CATransaction commit];
+}
+
+void AudioVideoRendererAVFObjC::acceleratedRenderingStateChanged(bool isAccelerated)
+{
+    m_renderingCanBeAccelerated = isAccelerated;
+    if (isAccelerated)
+        updateDisplayLayerIfNeeded();
+}
+
+void AudioVideoRendererAVFObjC::contentBoxRectChanged(const LayoutRect& newRect)
+{
+    if (!layerOrVideoRenderer() && !newRect.isEmpty())
+        updateDisplayLayerIfNeeded();
+}
+
+void AudioVideoRendererAVFObjC::notifyFirstFrameAvailable(Function<void()>&& callback)
+{
+    m_firstFrameAvailableCallback = WTFMove(callback);
+}
+
+void AudioVideoRendererAVFObjC::notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&& callback)
+{
+    m_hasAvailableVideoFrameCallback = WTFMove(callback);
+    RefPtr videoRenderer = m_videoRenderer;
+    if (m_hasAvailableVideoFrameCallback && videoRenderer) {
+        videoRenderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_hasAvailableVideoFrameCallback)
+                protectedThis->m_hasAvailableVideoFrameCallback(presentationTime, displayTime);
+        });
+    }
+}
+
+void AudioVideoRendererAVFObjC::notifyWhenRequiresFlushToResume(Function<void()>&& callback)
+{
+    m_notifyWhenRequiresFlushToResume = WTFMove(callback);
+}
+
+void AudioVideoRendererAVFObjC::notifyRenderingModeChanged(Function<void()>&& callback)
+{
+    m_renderingModeChangedCallback = WTFMove(callback);
+}
+
+void AudioVideoRendererAVFObjC::setMinimumUpcomingPresentationTime(const MediaTime&)
+{
+    // TODO: need to pass it to the videoRenderer. Not needed yet for webm or when decompression session is always in use
+    ASSERT_NOT_REACHED();
+}
+
+void AudioVideoRendererAVFObjC::setShouldDisableHDR(bool shouldDisable)
+{
+    m_shouldDisableHDR = shouldDisable;
+    if (![m_sampleBufferDisplayLayer respondsToSelector:@selector(setToneMapToStandardDynamicRange:)])
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, shouldDisable);
+    [m_sampleBufferDisplayLayer setToneMapToStandardDynamicRange:shouldDisable];
+}
+
+void AudioVideoRendererAVFObjC::setPlatformDynamicRangeLimit(const PlatformDynamicRangeLimit& platformDynamicRangeLimit)
+{
+    m_dynamicRangeLimit = platformDynamicRangeLimit;
+
+    if (!m_sampleBufferDisplayLayer)
+        return;
+
+    setLayerDynamicRangeLimit(m_sampleBufferDisplayLayer.get(), platformDynamicRangeLimit);
+}
+
+RefPtr<VideoFrame> AudioVideoRendererAVFObjC::currentVideoFrame() const
+{
+    RefPtr videoRenderer = m_videoRenderer;
+    if (!videoRenderer)
+        return nullptr;
+
+    auto entry = videoRenderer->copyDisplayedPixelBuffer();
+    if (!entry.pixelBuffer)
+        return nullptr;
+
+    return VideoFrameCV::create(entry.presentationTimeStamp, false, VideoFrame::Rotation::None, entry.pixelBuffer.get());
+}
+
+std::optional<VideoPlaybackQualityMetrics> AudioVideoRendererAVFObjC::videoPlaybackQualityMetrics()
+{
+    RefPtr videoRenderer = m_videoRenderer;
+    if (!videoRenderer)
+        return std::nullopt;
+
+    return VideoPlaybackQualityMetrics {
+        videoRenderer->totalVideoFrames(),
+        videoRenderer->droppedVideoFrames(),
+        videoRenderer->corruptedVideoFrames(),
+        videoRenderer->totalFrameDelay().toDouble(),
+        videoRenderer->totalDisplayedFrames()
+    };
+}
+
+PlatformLayerContainer AudioVideoRendererAVFObjC::platformVideoLayer() const
+{
+    if (!m_videoRenderer)
+        return nullptr;
+    return m_videoLayerManager->videoInlineLayer();
+}
+
+void AudioVideoRendererAVFObjC::setVideoFullscreenLayer(PlatformLayer *videoFullscreenLayer, WTF::Function<void()>&& completionHandler)
+{
+    RefPtr videoFrame = currentVideoFrame();
+
+    if (!m_rgbConformer) {
+        auto attributes = @{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) };
+        m_rgbConformer = makeUnique<PixelBufferConformerCV>((__bridge CFDictionaryRef)attributes);
+    }
+    RefPtr<NativeImage> currentFrameImage = videoFrame ? RefPtr { NativeImage::create(m_rgbConformer->createImageFromPixelBuffer(videoFrame->protectedPixelBuffer().get())) } : nullptr;
+    m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), currentFrameImage ? currentFrameImage->platformImage() : nullptr);
+}
+
+void AudioVideoRendererAVFObjC::setVideoFullscreenFrame(const FloatRect& frame)
+{
+    m_videoLayerManager->setVideoFullscreenFrame(frame);
+}
+
+void AudioVideoRendererAVFObjC::setTextTrackRepresentation(TextTrackRepresentation* representation)
+{
+    RetainPtr representationLayer = representation ? representation->platformLayer() : nil;
+    m_videoLayerManager->setTextTrackRepresentationLayer(representationLayer.get());
+}
+
+void AudioVideoRendererAVFObjC::syncTextTrackBounds()
+{
+    m_videoLayerManager->syncTextTrackBounds();
+}
+
+Ref<GenericPromise> AudioVideoRendererAVFObjC::setVideoTarget(const PlatformVideoTarget& videoTarget)
+{
+#if !ENABLE(LINEAR_MEDIA_PLAYER)
+    UNUSED_PARAM(videoTarget);
+    return GenericPromise::createAndReject();
+#else
+    m_videoTarget = videoTarget;
+    return updateDisplayLayerIfNeeded();
+#endif
+}
+
+void AudioVideoRendererAVFObjC::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    ALWAYS_LOG(LOGIDENTIFIER, isInFullscreenOrPictureInPicture);
+    if (acceleratedVideoMode() == AcceleratedVideoMode::VideoRenderer)
+        destroyVideoLayerIfNeeded();
+#else
+    UNUSED_PARAM(isInFullscreenOrPictureInPicture);
+#endif
+}
+
+RetainPtr<AVSampleBufferAudioRenderer> AudioVideoRendererAVFObjC::audioRendererFor(TrackIdentifier trackId) const
+{
+    auto itRenderer = m_audioRenderers.find(trackId);
+    if (itRenderer == m_audioRenderers.end())
+        return nil;
+    return itRenderer->value;
+}
+
+void AudioVideoRendererAVFObjC::applyOnAudioRenderers(NOESCAPE Function<void(AVSampleBufferAudioRenderer *)>&& function) const
+{
+    for (auto& pair : m_audioRenderers) {
+        RetainPtr renderer = pair.value;
+        function(renderer.get());
+    }
+}
+
+void AudioVideoRendererAVFObjC::addAudioRenderer(TrackIdentifier trackId)
+{
+    ASSERT(!m_audioRenderers.contains(trackId));
+
+    RetainPtr renderer = [adoptNS(PAL::allocAVSampleBufferAudioRendererInstance()) init];
+
+    if (!renderer) {
+        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferAudioRenderer init] returned nil! bailing!");
+        ASSERT_NOT_REACHED();
+
+        notifyError(PlatformMediaError::AudioDecodingError);
+        return;
+    }
+
+    [renderer setMuted:m_muted];
+    [renderer setVolume:m_volume];
+    // False positive see webkit.org/b/298035
+    SUPPRESS_UNRETAINED_ARG [renderer setAudioTimePitchAlgorithm:(m_preservePitch ? AVAudioTimePitchAlgorithmSpectral : AVAudioTimePitchAlgorithmVarispeed)];
+
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+    if (!!m_audioOutputDeviceId)
+        setOutputDeviceIdOnRenderer(renderer.get());
+#endif
+
+    @try {
+        [m_synchronizer addRenderer:renderer.get()];
+    } @catch(NSException *exception) {
+        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferRenderSynchronizer addRenderer:] threw an exception: ", exception.name, ", reason : ", exception.reason);
+        ASSERT_NOT_REACHED();
+
+        notifyError(PlatformMediaError::AudioDecodingError);
+        return;
+    }
+
+    m_audioRenderers.set(trackId, renderer);
+    m_listener->beginObservingAudioRenderer(renderer.get());
+}
+
+void AudioVideoRendererAVFObjC::removeAudioRenderer(TrackIdentifier trackId)
+{
+    if (RetainPtr audioRenderer = audioRendererFor(trackId)) {
+        destroyAudioRenderer(audioRenderer);
+        m_audioRenderers.remove(trackId);
+    }
+}
+
+void AudioVideoRendererAVFObjC::destroyAudioRenderer(RetainPtr<AVSampleBufferAudioRenderer> renderer)
+{
+    // False positive see webkit.org/b/298024
+    SUPPRESS_UNRETAINED_ARG CMTime currentTime = PAL::CMTimebaseGetTime([m_synchronizer timebase]);
+    [m_synchronizer removeRenderer:renderer.get() atTime:currentTime completionHandler:nil];
+
+    m_listener->stopObservingAudioRenderer(renderer.get());
+    [renderer flush];
+    [renderer stopRequestingMediaData];
+}
+
+void AudioVideoRendererAVFObjC::destroyAudioRenderers()
+{
+    for (auto& pair : m_audioRenderers) {
+        auto renderer = pair.value;
+        destroyAudioRenderer(renderer);
+    }
+    m_audioRenderers.clear();
+}
+
+bool AudioVideoRendererAVFObjC::seeking() const
+{
+    return m_seekState != SeekCompleted;
+}
+
+MediaTime AudioVideoRendererAVFObjC::clampTimeToLastSeekTime(const MediaTime& time) const
+{
+    if (m_lastSeekTime.isFinite() && time < m_lastSeekTime)
+        return m_lastSeekTime;
+
+    return time;
+}
+
+void AudioVideoRendererAVFObjC::maybeCompleteSeek()
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "state: ", toString(m_seekState));
+
+    if (m_seekState == SeekCompleted || !m_seekPromise)
+        return;
+
+    if (m_videoRenderer && !m_hasAvailableVideoFrame) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Waiting for first video frame");
+        m_seekState = WaitingForAvailableFame;
+        return;
+    }
+    m_seekState = Seeking;
+    if (m_isSynchronizerSeeking) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Waiting on synchronizer to complete seeking");
+        return;
+    }
+    m_seekState = SeekCompleted;
+    if (shouldBePlaying())
+        [m_synchronizer setRate:m_rate];
+    else
+        ALWAYS_LOG(LOGIDENTIFIER, "Not resuming playback, shouldBePlaying:false");
+
+    if (auto promise = std::exchange(m_seekPromise, std::nullopt))
+        promise->resolve();
+    ALWAYS_LOG(LOGIDENTIFIER, "seek completed");
+}
+
+bool AudioVideoRendererAVFObjC::shouldBePlaying() const
+{
+    return m_isPlaying && !seeking();
+}
+
+std::optional<TracksRendererManager::TrackType> AudioVideoRendererAVFObjC::typeOf(TrackIdentifier trackId) const
+{
+    if (auto it = m_trackTypes.find(trackId); it != m_trackTypes.end())
+        return it->value;
+    return { };
+}
+
+Ref<GenericPromise> AudioVideoRendererAVFObjC::updateDisplayLayerIfNeeded()
+{
+    if (!m_enabledVideoTrackId)
+        return GenericPromise::createAndResolve();
+
+    if (shouldEnsureLayerOrVideoRenderer())
+        return ensureLayerOrVideoRenderer();
+
+    // Using renderless video renderer.
+    return setVideoRenderer(nil);
+}
+
+bool AudioVideoRendererAVFObjC::shouldEnsureLayerOrVideoRenderer() const
+{
+    return ((m_sampleBufferDisplayLayer && !CGRectIsEmpty([m_sampleBufferDisplayLayer bounds])) || (!m_presentationSize.isEmpty() && m_renderingCanBeAccelerated));
+}
+
+WebSampleBufferVideoRendering *AudioVideoRendererAVFObjC::layerOrVideoRenderer() const
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    switch (acceleratedVideoMode()) {
+    case AcceleratedVideoMode::Layer:
+        return m_sampleBufferDisplayLayer.get();
+    case AcceleratedVideoMode::VideoRenderer:
+        return m_sampleBufferVideoRenderer.get();
+    }
+#else
+    return m_sampleBufferDisplayLayer.get();
+#endif
+}
+
+Ref<GenericPromise> AudioVideoRendererAVFObjC::ensureLayerOrVideoRenderer()
+{
+    switch (acceleratedVideoMode()) {
+    case AcceleratedVideoMode::Layer:
+        ensureLayer();
+        break;
+    case AcceleratedVideoMode::VideoRenderer:
+        ensureVideoRenderer();
+        break;
+    }
+
+    RetainPtr renderer = layerOrVideoRenderer();
+    if (!renderer) {
+        notifyError(PlatformMediaError::DecoderCreationError);
+        return GenericPromise::createAndReject();
+    }
+    RefPtr videoRenderer = m_videoRenderer;
+
+    bool needsRenderingModeChanged = (!videoRenderer && renderer) || (videoRenderer && videoRenderer->renderer() != renderer.get());
+
+    ALWAYS_LOG(LOGIDENTIFIER, acceleratedVideoMode(), ", renderer=", !!renderer);
+
+    Ref promise = setVideoRenderer(renderer.get());
+
+    if (needsRenderingModeChanged && m_renderingModeChangedCallback)
+        m_renderingModeChangedCallback();
+
+    return promise;
+}
+
+void AudioVideoRendererAVFObjC::ensureLayer()
+{
+    if (m_sampleBufferDisplayLayer)
+        return;
+
+    destroyVideoLayerIfNeeded();
+
+    m_sampleBufferDisplayLayer = [adoptNS(PAL::allocAVSampleBufferDisplayLayerInstance()) init];
+    if (!m_sampleBufferDisplayLayer) {
+        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferDisplayLayer init] returned nil! bailing!");
+        return;
+    }
+    [m_sampleBufferDisplayLayer setName:@"AudioVideoRendererAVFObjC AVSampleBufferDisplayLayer"];
+    // False positive see webkit.org/b/298035
+    SUPPRESS_UNRETAINED_ARG [m_sampleBufferDisplayLayer setVideoGravity:(m_shouldMaintainAspectRatio ? AVLayerVideoGravityResizeAspect : AVLayerVideoGravityResize)];
+
+    configureLayerOrVideoRenderer(m_sampleBufferDisplayLayer.get());
+
+    if ([m_sampleBufferDisplayLayer respondsToSelector:@selector(setToneMapToStandardDynamicRange:)])
+        [m_sampleBufferDisplayLayer setToneMapToStandardDynamicRange:m_shouldDisableHDR];
+
+    setLayerDynamicRangeLimit(m_sampleBufferDisplayLayer.get(), m_dynamicRangeLimit);
+
+    m_videoLayerManager->setVideoLayer(m_sampleBufferDisplayLayer.get(), m_presentationSize);
+}
+
+void AudioVideoRendererAVFObjC::destroyLayer()
+{
+    if (!m_sampleBufferDisplayLayer)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    // False positive see webkit.org/b/298024
+    SUPPRESS_UNRETAINED_ARG CMTime currentTime = PAL::CMTimebaseGetTime([m_synchronizer timebase]);
+    [m_synchronizer removeRenderer:m_sampleBufferDisplayLayer.get() atTime:currentTime completionHandler:nil];
+
+    m_videoLayerManager->didDestroyVideoLayer();
+    m_sampleBufferDisplayLayer = nullptr;
+    m_needsDestroyVideoLayer = false;
+}
+
+void AudioVideoRendererAVFObjC::destroyVideoLayerIfNeeded()
+{
+    if (!m_needsDestroyVideoLayer)
+        return;
+    m_needsDestroyVideoLayer = false;
+    m_videoLayerManager->didDestroyVideoLayer();
+}
+
+void AudioVideoRendererAVFObjC::ensureVideoRenderer()
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    if (m_sampleBufferVideoRenderer)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    m_sampleBufferVideoRenderer = [adoptNS(PAL::allocAVSampleBufferVideoRendererInstance()) init];
+    if (!m_sampleBufferVideoRenderer) {
+        ERROR_LOG(LOGIDENTIFIER, "-[VSampleBufferVideoRenderer init] returned nil! bailing!");
+        return;
+    }
+
+    [m_sampleBufferVideoRenderer addVideoTarget:m_videoTarget.get()];
+
+    configureLayerOrVideoRenderer(m_sampleBufferVideoRenderer.get());
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)
+}
+
+void AudioVideoRendererAVFObjC::destroyVideoRenderer()
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    if (!m_sampleBufferVideoRenderer)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    // False positive see webkit.org/b/298024
+    SUPPRESS_UNRETAINED_ARG CMTime currentTime = PAL::CMTimebaseGetTime([m_synchronizer timebase]);
+    [m_synchronizer removeRenderer:m_sampleBufferVideoRenderer.get() atTime:currentTime completionHandler:nil];
+
+    if ([m_sampleBufferVideoRenderer respondsToSelector:@selector(removeAllVideoTargets)])
+        [m_sampleBufferVideoRenderer removeAllVideoTargets];
+    m_sampleBufferVideoRenderer = nullptr;
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)
+}
+
+Ref<GenericPromise> AudioVideoRendererAVFObjC::setVideoRenderer(WebSampleBufferVideoRendering *renderer)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "!!renderer = ", !!renderer);
+
+    if (m_videoRenderer)
+        return stageVideoRenderer(renderer);
+
+    if (!renderer) {
+        destroyLayer();
+        destroyVideoRenderer();
+    }
+
+    RefPtr videoRenderer = VideoMediaSampleRenderer::create(renderer);
+    m_videoRenderer = videoRenderer;
+    videoRenderer->setPreferences(VideoMediaSampleRendererPreference::PrefersDecompressionSession);
+    // False positive see webkit.org/b/298024
+    SUPPRESS_UNRETAINED_ARG videoRenderer->setTimebase([m_synchronizer timebase]);
+    videoRenderer->notifyWhenDecodingErrorOccurred([weakThis = WeakPtr { *this }](NSError *) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->notifyError(PlatformMediaError::VideoDecodingError);
+    });
+    videoRenderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }](const MediaTime&, double) {
+        if (RefPtr protectedThis = weakThis.get()) {
+            protectedThis->m_hasAvailableVideoFrame = true;
+            if (protectedThis->m_firstFrameAvailableCallback)
+                protectedThis->m_firstFrameAvailableCallback();
+            protectedThis->maybeCompleteSeek();
+        }
+    });
+    if (m_hasAvailableVideoFrameCallback) {
+        videoRenderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_hasAvailableVideoFrameCallback)
+                protectedThis->m_hasAvailableVideoFrameCallback(presentationTime, displayTime);
+        });
+    }
+    videoRenderer->notifyWhenVideoRendererRequiresFlushToResumeDecoding([weakThis = WeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            ALWAYS_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "VideoRendererRequiresFlushToResumeDecoding");
+            protectedThis->m_readyToRequestVideoData = false;
+            if (protectedThis->m_notifyWhenRequiresFlushToResume)
+                protectedThis->m_notifyWhenRequiresFlushToResume();
+        }
+    });
+    videoRenderer->setResourceOwner(m_resourceOwner);
+
+    return GenericPromise::createAndResolve();
+}
+
+void AudioVideoRendererAVFObjC::configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *renderer)
+{
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    updateSpatialTrackingLabel();
+#endif
+
+    renderer.preventsDisplaySleepDuringVideoPlayback = NO;
+
+    if ([renderer respondsToSelector:@selector(setPreventsAutomaticBackgroundingDuringVideoPlayback:)])
+        renderer.preventsAutomaticBackgroundingDuringVideoPlayback = NO;
+
+    @try {
+        [m_synchronizer addRenderer:renderer];
+    } @catch(NSException *exception) {
+        ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferRenderSynchronizer addRenderer:] threw an exception: ", exception.name, ", reason : ", exception.reason);
+        ASSERT_NOT_REACHED();
+
+        notifyError(PlatformMediaError::DecoderCreationError);
+        return;
+    }
+}
+
+RefPtr<VideoMediaSampleRenderer> AudioVideoRendererAVFObjC::protectedVideoRenderer() const
+{
+    return m_videoRenderer;
+}
+
+Ref<GenericPromise> AudioVideoRendererAVFObjC::stageVideoRenderer(WebSampleBufferVideoRendering *renderer)
+{
+    ASSERT(m_videoRenderer);
+
+    RefPtr videoRenderer = m_videoRenderer;
+    if (renderer == videoRenderer->renderer())
+        return GenericPromise::createAndResolve();
+
+    ALWAYS_LOG(LOGIDENTIFIER, "renderer: ", !!renderer);
+    ASSERT(!renderer || hasSelectedVideo());
+
+    Vector<RetainPtr<WebSampleBufferVideoRendering>> renderersToExpire { 2u };
+    if (renderer) {
+        switch (acceleratedVideoMode()) {
+        case AcceleratedVideoMode::Layer:
+            renderersToExpire.append(std::exchange(m_sampleBufferVideoRenderer, { }));
+            break;
+        case AcceleratedVideoMode::VideoRenderer:
+            m_needsDestroyVideoLayer = true;
+            renderersToExpire.append(std::exchange(m_sampleBufferDisplayLayer, { }));
+            break;
+        }
+    } else {
+        destroyLayer();
+        destroyVideoRenderer();
+    }
+
+    return videoRenderer->changeRenderer(renderer)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, renderersToExpire = WTFMove(renderersToExpire)]() mutable {
+        RefPtr protectedThis = weakThis.get();
+        for (auto& rendererToExpire : renderersToExpire) {
+            if (!rendererToExpire)
+                continue;
+            if (protectedThis) {
+                // False positive see webkit.org/b/298024
+                SUPPRESS_UNRETAINED_ARG CMTime currentTime = PAL::CMTimebaseGetTime([protectedThis->m_synchronizer timebase]);
+                [protectedThis->m_synchronizer removeRenderer:rendererToExpire.get() atTime:currentTime completionHandler:nil];
+            }
+        }
+        if (protectedThis)
+            return GenericPromise::createAndResolve();
+        return GenericPromise::createAndReject();
+    });
+}
+
+AudioVideoRendererAVFObjC::AcceleratedVideoMode AudioVideoRendererAVFObjC::acceleratedVideoMode() const
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    if (m_videoTarget)
+        return AcceleratedVideoMode::VideoRenderer;
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)
+
+    return AcceleratedVideoMode::Layer;
+}
+
+void AudioVideoRendererAVFObjC::notifyError(PlatformMediaError error)
+{
+    if (m_errorCallback)
+        m_errorCallback(error);
+}
+
+void AudioVideoRendererAVFObjC::audioRendererDidReceiveError(AVSampleBufferAudioRenderer *, NSError *)
+{
+    notifyError(PlatformMediaError::AudioDecodingError);
+}
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+void AudioVideoRendererAVFObjC::setSpatialTrackingInfo(bool prefersSpatialAudioExperience, SoundStageSize soundStage, const String& sceneIdentifier, const String& defaultLabel, const String& label)
+{
+    m_prefersSpatialAudioExperience = prefersSpatialAudioExperience;
+    m_soundStage = soundStage;
+    m_sceneIdentifier = sceneIdentifier;
+    m_defaultSpatialTrackingLabel = defaultLabel;
+    m_spatialTrackingLabel = label;
+
+    updateSpatialTrackingLabel();
+}
+
+void AudioVideoRendererAVFObjC::updateSpatialTrackingLabel()
+{
+    RetainPtr renderer = m_sampleBufferVideoRenderer ? m_sampleBufferVideoRenderer.get() : [m_sampleBufferDisplayLayer sampleBufferRenderer];
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    if (m_prefersSpatialAudioExperience) {
+        RetainPtr experience = createSpatialAudioExperienceWithOptions({
+            .hasLayer = !!renderer,
+            .hasTarget = !!m_videoTarget,
+            .isVisible = m_visible,
+            .soundStageSize = m_soundStage,
+            .sceneIdentifier = m_sceneIdentifier,
+#if HAVE(SPATIAL_TRACKING_LABEL)
+            .spatialTrackingLabel = m_spatialTrackingLabel,
+#endif
+        });
+        [m_synchronizer setIntendedSpatialAudioExperience:experience.get()];
+        return;
+    }
+#endif
+
+    if (!m_spatialTrackingLabel.isNull()) {
+        INFO_LOG(LOGIDENTIFIER, "Explicitly set STSLabel: ", m_spatialTrackingLabel);
+        [renderer setSTSLabel:m_spatialTrackingLabel.createNSString().get()];
+        return;
+    }
+
+    if (renderer && m_visible) {
+        // Let AVSBRS manage setting the spatial tracking label in its video renderer itself.
+        INFO_LOG(LOGIDENTIFIER, "Has visible renderer, set STSLabel: nil");
+        [renderer setSTSLabel:nil];
+        return;
+    }
+
+    if (m_audioRenderers.isEmpty()) {
+        // If there are no audio renderers, there's nothing to do.
+        INFO_LOG(LOGIDENTIFIER, "No audio renderers - no-op");
+        return;
+    }
+
+    // If there is no video renderer, use the default spatial tracking label if available, or
+    // the session's spatial tracking label if not, and set the label directly on each audio
+    // renderer.
+    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
+    RetainPtr<NSString> defaultLabel;
+    if (!m_defaultSpatialTrackingLabel.isNull()) {
+        INFO_LOG(LOGIDENTIFIER, "Default STSLabel: ", m_defaultSpatialTrackingLabel);
+        defaultLabel = m_defaultSpatialTrackingLabel.createNSString();
+    } else {
+        INFO_LOG(LOGIDENTIFIER, "AVAudioSession label: ", session.spatialTrackingLabel);
+        defaultLabel = session.spatialTrackingLabel;
+    }
+    for (auto& pair : m_audioRenderers)
+        [(__bridge AVSampleBufferAudioRenderer *)pair.value.get() setSTSLabel:defaultLabel.get()];
+}
+#endif
+
+bool AudioVideoRendererAVFObjC::isEnabledVideoTrackId(TrackIdentifier trackId) const
+{
+    return m_enabledVideoTrackId == trackId;
+}
+
+bool AudioVideoRendererAVFObjC::hasSelectedVideo() const
+{
+    return !!m_enabledVideoTrackId;
+}
+
+void AudioVideoRendererAVFObjC::flushVideo()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    if (RefPtr videoRenderer = m_videoRenderer)
+        videoRenderer->flush();
+    m_hasAvailableVideoFrame = false;
+    m_readyToRequestVideoData = true;
+}
+
+void AudioVideoRendererAVFObjC::flushAudio()
+{
+    applyOnAudioRenderers([&](auto *renderer) {
+        [renderer flush];
+    });
+    m_readyToRequestAudioData = true;
+}
+
+void AudioVideoRendererAVFObjC::flushAudioTrack(TrackIdentifier trackId)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    RetainPtr audioRenderer = audioRendererFor(trackId);
+    if (!audioRenderer)
+        return;
+    [audioRenderer flush];
+}
+
+void AudioVideoRendererAVFObjC::cancelSeekingPromiseIfNeeded()
+{
+    if (auto promise = std::exchange(m_seekPromise, std::nullopt))
+        promise->reject(PlatformMediaError::Cancelled);
+}
+
+WTFLogChannel& AudioVideoRendererAVFObjC::logChannel() const
+{
+    return LogMedia;
+}
+
+String AudioVideoRendererAVFObjC::toString(TrackIdentifier trackId) const
+{
+    StringBuilder builder;
+
+    builder.append('[');
+    if (auto type = typeOf(trackId)) {
+        switch (*type) {
+        case TrackType::Video:
+            builder.append("video:"_s);
+            break;
+        case TrackType::Audio:
+            builder.append("audio:"_s);
+            break;
+        default:
+            builder.append("unknown:"_s);
+            break;
+        }
+    } else
+        builder.append("NotFound:"_s);
+    builder.append(trackId.loggingString());
+    builder.append(']');
+    return builder.toString();
+}
+
+String AudioVideoRendererAVFObjC::toString(SeekState state) const
+{
+    switch (state) {
+    case Preparing:
+        return "Preparing"_s;
+    case RequiresFlush:
+        return "RequiresFlush"_s;
+    case Seeking:
+        return "Seeking"_s;
+    case WaitingForAvailableFame:
+        return "WaitingForAvailableFame"_s;
+    case SeekCompleted:
+        return "SeekCompleted"_s;
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -180,7 +180,7 @@ private:
     RetainPtr<PlatformLayer> createVideoFullscreenLayer() final;
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) final;
     void updateVideoFullscreenInlineImage() final;
-    void setVideoFullscreenFrame(FloatRect) final;
+    void setVideoFullscreenFrame(const FloatRect&) final;
     void setVideoFullscreenGravity(MediaPlayer::VideoGravity) final;
     void setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode) final;
     void videoFullscreenStandbyChanged() final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1333,7 +1333,7 @@ void MediaPlayerPrivateAVFoundationObjC::setVideoFullscreenLayer(PlatformLayer* 
         completion();
 }
 
-void MediaPlayerPrivateAVFoundationObjC::setVideoFullscreenFrame(FloatRect frame)
+void MediaPlayerPrivateAVFoundationObjC::setVideoFullscreenFrame(const FloatRect& frame)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "width = ", frame.size().width(), ", height = ", frame.size().height());
     m_videoLayerManager->setVideoFullscreenFrame(frame);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -125,7 +125,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RetainPtr<PlatformLayer> createVideoFullscreenLayer() override;
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) override;
-    void setVideoFullscreenFrame(FloatRect) override;
+    void setVideoFullscreenFrame(const FloatRect&) override;
 #endif
 
     void setTextTrackRepresentation(TextTrackRepresentation*) override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1720,7 +1720,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenLayer(PlatformLayer
     m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), lastImage ? lastImage->platformImage() : nullptr);
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenFrame(FloatRect frame)
+void MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenFrame(const FloatRect& frame)
 {
     m_videoLayerManager->setVideoFullscreenFrame(frame);
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -234,7 +234,7 @@ private:
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RetainPtr<PlatformLayer> createVideoFullscreenLayer() override;
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) override;
-    void setVideoFullscreenFrame(FloatRect) override;
+    void setVideoFullscreenFrame(const FloatRect&) override;
 #endif
 
     AudioSourceProvider* audioSourceProvider() final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -873,7 +873,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setVideoFullscreenLayer(PlatformLayer
     m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), m_imagePainter.cgImage ? RefPtr { m_imagePainter.cgImage }->platformImage() : nullptr);
 }
 
-void MediaPlayerPrivateMediaStreamAVFObjC::setVideoFullscreenFrame(FloatRect frame)
+void MediaPlayerPrivateMediaStreamAVFObjC::setVideoFullscreenFrame(const FloatRect& frame)
 {
     m_videoLayerManager->setVideoFullscreenFrame(frame);
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -28,6 +28,7 @@
 #include <wtf/Platform.h>
 #if ENABLE(COCOA_WEBM_PLAYER)
 
+#include <WebCore/AudioVideoRenderer.h>
 #include <WebCore/MediaPlayerPrivate.h>
 #include <WebCore/PlatformLayer.h>
 #include <WebCore/SourceBufferParserWebM.h>
@@ -69,8 +70,7 @@ class SharedBuffer;
 class TextTrackRepresentation;
 class TrackBuffer;
 class VideoFrame;
-class VideoMediaSampleRenderer;
-class VideoLayerManagerObjC;
+class VideoFrameCV;
 class VideoTrackPrivateWebM;
 
 class MediaPlayerPrivateWebM
@@ -96,8 +96,6 @@ private:
     void load(const URL&, const LoadOptions&) final;
     bool needsResourceClient() const;
     bool createResourceClientIfNeeded();
-
-    RefPtr<VideoMediaSampleRenderer> protectedVideoRenderer() const;
 
 #if ENABLE(MEDIA_SOURCE)
     void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) final;
@@ -163,7 +161,7 @@ private:
     bool didLoadingProgress() const final;
 
     RefPtr<NativeImage> nativeImageForCurrentTime() final;
-    bool updateLastPixelBuffer();
+    bool updateLastVideoFrame();
     bool updateLastImage();
     void paint(GraphicsContext&, const FloatRect&) final;
     void paintCurrentFrameInContext(GraphicsContext&, const FloatRect&) final;
@@ -183,11 +181,10 @@ private:
     void setPresentationSize(const IntSize&) final;
     bool supportsAcceleratedRendering() const final { return true; }
     void acceleratedRenderingStateChanged() final;
-    void updateDisplayLayer();
 
     RetainPtr<PlatformLayer> createVideoFullscreenLayer() final;
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) final;
-    void setVideoFullscreenFrame(FloatRect) final;
+    void setVideoFullscreenFrame(const FloatRect&) final;
 
     void setTextTrackRepresentation(TextTrackRepresentation*) final;
     void syncTextTrackBounds() final;
@@ -210,10 +207,9 @@ private:
         Yes
     };
     void reenqueSamples(TrackID, NeedsFlush = NeedsFlush::Yes);
+    void reenqueueMediaForTime(const MediaTime&);
     void reenqueueMediaForTime(TrackBuffer&, TrackID, const MediaTime&, NeedsFlush = NeedsFlush::Yes);
     void notifyClientWhenReadyForMoreSamples(TrackID);
-
-    void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&);
 
     bool isReadyForMoreSamples(TrackID);
     void didBecomeReadyForMoreSamples(TrackID);
@@ -230,45 +226,19 @@ private:
     void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, TrackID);
 
     void flush();
-    void flushIfNeeded();
     void flushTrack(TrackID);
-    void flushVideo();
-    void flushAudio(AVSampleBufferAudioRenderer*);
+    void flushVideoIfNeeded();
 
     void addTrackBuffer(TrackID, RefPtr<MediaDescription>&&);
 
-    bool shouldEnsureLayerOrVideoRenderer() const;
-    void ensureLayer();
-    void destroyLayer();
-    void destroyVideoLayerIfNeeded();
-    void ensureVideoRenderer();
-    void destroyVideoRenderer();
-
-    void ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsRenderingModeChanged);
-    void destroyLayerOrVideoRendererAndCreateRenderlessVideoMediaSampleRenderer();
-    void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
-
-    void addAudioRenderer(TrackID);
-    void removeAudioRenderer(TrackID);
-    void destroyAudioRenderer(RetainPtr<AVSampleBufferAudioRenderer>);
-    void destroyAudioRenderers();
     void clearTracks();
 
-    void configureVideoRenderer(VideoMediaSampleRenderer&);
-    void invalidateVideoRenderer(VideoMediaSampleRenderer&);
-    void setVideoRenderer(WebSampleBufferVideoRendering *);
-    void stageVideoRenderer(WebSampleBufferVideoRendering *);
-
-    void setVideoFrameMetadataGatheringCallbackIfNeeded(VideoMediaSampleRenderer&);
     void startVideoFrameMetadataGathering() final;
     void stopVideoFrameMetadataGathering() final;
     std::optional<VideoFrameMetadata> videoFrameMetadata() final { return std::exchange(m_videoFrameMetadata, { }); }
-    void setResourceOwner(const ProcessIdentity& resourceOwner) final { m_resourceOwner = resourceOwner; }
+    void setResourceOwner(const ProcessIdentity&) final;
 
     void checkNewVideoFrameMetadata(const MediaTime& presentationTime, double displayTime);
-
-    // WebAVSampleBufferListenerParent
-    void audioRendererDidReceiveError(AVSampleBufferAudioRenderer *, NSError *) final;
 
     void setShouldDisableHDR(bool) final;
     void setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit) final;
@@ -300,12 +270,12 @@ private:
     bool supportsLinearMediaPlayer() const final { return true; }
 #endif
 
-    enum class AcceleratedVideoMode: uint8_t {
-        Layer = 0,
-        VideoRenderer,
-    };
-    AcceleratedVideoMode acceleratedVideoMode() const;
+    using TrackIdentifier = TracksRendererManager::TrackIdentifier;
+    TrackIdentifier trackIdentifierFor(TrackID);
+
     void setLayerRequiresFlush();
+    void setAllTracksForReenqueuing();
+    void setTrackForReenqueuing(TrackID);
 
     const Logger& logger() const final { return m_logger.get(); }
     Ref<const Logger> protectedLogger() const { return logger(); }
@@ -324,10 +294,7 @@ private:
     URL m_assetURL;
     MediaPlayer::Preload m_preload { MediaPlayer::Preload::Auto };
     ThreadSafeWeakPtr<MediaPlayer> m_player;
-    RetainPtr<AVSampleBufferRenderSynchronizer> m_synchronizer;
-    RetainPtr<id> m_durationObserver;
-    RetainPtr<CVPixelBufferRef> m_lastPixelBuffer;
-    MediaTime m_lastPixelBufferPresentationTimeStamp;
+    RefPtr<VideoFrameCV> m_lastVideoFrame;
     RefPtr<NativeImage> m_lastImage;
     std::unique_ptr<PixelBufferConformerCV> m_rgbConformer;
     RefPtr<WebMResourceClient> m_resourceClient;
@@ -335,15 +302,12 @@ private:
 
     Vector<RefPtr<VideoTrackPrivateWebM>> m_videoTracks;
     Vector<RefPtr<AudioTrackPrivateWebM>> m_audioTracks;
+    StdUnorderedMap<TrackID, TrackIdentifier> m_trackIdentifiers;
     StdUnorderedMap<TrackID, UniqueRef<TrackBuffer>> m_trackBufferMap;
     StdUnorderedMap<TrackID, bool> m_readyForMoreSamplesMap;
+    StdUnorderedMap<TrackID, bool> m_requestReadyForMoreSamplesSetMap;
     PlatformTimeRanges m_buffered;
 
-    RefPtr<VideoMediaSampleRenderer> m_videoRenderer;
-
-    RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
-    RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;
-    StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
     const Ref<SourceBufferParserWebM> m_parser;
     const Ref<WTF::WorkQueue> m_appendQueue;
 
@@ -356,11 +320,10 @@ private:
 #endif
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
-    const UniqueRef<VideoLayerManagerObjC> m_videoLayerManager;
+
     bool m_isGatheringVideoFrameMetadata { false };
     std::optional<VideoFrameMetadata> m_videoFrameMetadata;
     uint64_t m_lastConvertedSampleCount { 0 };
-    ProcessIdentity m_resourceOwner;
 
     FloatSize m_naturalSize;
     MediaTime m_currentTime;
@@ -386,39 +349,29 @@ private:
     bool m_loadFinished { false };
     bool m_errored { false };
     bool m_processingInitializationSegment { false };
-    const Ref<WebAVSampleBufferListener> m_listener;
 
     // Seek logic support
     void seekToTarget(const SeekTarget&) final;
     bool seeking() const final;
     void seekInternal();
-    Ref<GenericPromise> seekTo(const MediaTime&);
-    void maybeCompleteSeek();
-    MediaTime clampTimeToLastSeekTime(const MediaTime&) const;
+    void cancelPendingSeek();
+    void startSeek(const MediaTime&);
+    void completeSeek(const MediaTime&);
+    Ref<GenericPromise> waitForTimeBuffered(const MediaTime&);
     bool shouldBePlaying() const;
 
     bool m_isPlaying { false };
-    RetainPtr<id> m_timeJumpedObserver;
     Timer m_seekTimer;
     MediaTime m_lastSeekTime;
     std::optional<SeekTarget> m_pendingSeek;
-    enum SeekState {
-        Seeking,
-        WaitingForAvailableFame,
-        SeekCompleted,
-    };
-    SeekState m_seekState { SeekCompleted };
-    std::optional<GenericPromise::Producer> m_seekPromise;
-    bool m_isSynchronizerSeeking { false };
+    std::optional<GenericPromise::Producer> m_waitForTimeBufferedPromise;
+    NativePromiseRequest m_rendererSeekRequest;
+    bool m_seeking { false };
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;
 #endif
-    bool m_needsDestroyVideoLayer { false };
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-    bool m_usingLinearMediaPlayer { false };
-    RetainPtr<FigVideoTargetRef> m_videoTarget;
-#endif
+    const Ref<AudioVideoRenderer> m_renderer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -206,6 +206,7 @@ private:
 
     bool m_notifiedFirstFrameAvailable WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
     bool m_waitingForMoreMediaData WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
+    std::atomic<bool> m_waitingForMoreMediaDataPending { false };
     Function<void()> m_readyForMoreMediaDataFunction WTF_GUARDED_BY_CAPABILITY(mainThread);
     Preferences m_preferences;
     std::optional<uint32_t> m_currentCodec;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1112,7 +1112,7 @@ void MediaPlayerPrivateRemote::updateVideoFullscreenInlineImage()
     connection().send(Messages::RemoteMediaPlayerProxy::UpdateVideoFullscreenInlineImage(), m_id);
 }
 
-void MediaPlayerPrivateRemote::setVideoFullscreenFrame(WebCore::FloatRect rect)
+void MediaPlayerPrivateRemote::setVideoFullscreenFrame(const WebCore::FloatRect& rect)
 {
 #if PLATFORM(COCOA)
     ALWAYS_LOG(LOGIDENTIFIER, "width = ", rect.size().width(), ", height = ", rect.size().height());

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -295,7 +295,7 @@ private:
     PlatformLayerContainer createVideoFullscreenLayer() final;
     void setVideoFullscreenLayer(PlatformLayer*, WTF::Function<void()>&& completionHandler) final;
     void updateVideoFullscreenInlineImage() final;
-    void setVideoFullscreenFrame(WebCore::FloatRect) final;
+    void setVideoFullscreenFrame(const WebCore::FloatRect&) final;
     void setVideoFullscreenGravity(WebCore::MediaPlayer::VideoGravity) final;
     void setVideoFullscreenMode(WebCore::MediaPlayer::VideoFullscreenMode) final;
     void videoFullscreenStandbyChanged() final;


### PR DESCRIPTION
#### 6b4f3c573ce21a3d316a14591a4b2290269e96d1
<pre>
Introduce AudioVideoRenderer class.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297961">https://bugs.webkit.org/show_bug.cgi?id=297961</a>
<a href="https://rdar.apple.com/159279717">rdar://159279717</a>

Reviewed by Eric Carlson.

And make MediaPlayerPrivateWebM use its AVFoundation implementation
AudioVideoRendererAVFObjC.

AudioVideoRenderer abstract the entire interaction with the system framework
required to decode and render a video or MediaSample and handle A/V synchronization.

By using an AudioVideoRenderer a MediaPlayerPrivate is only left to handle
the demuxing of the media file.

By having this new layer separation, we will be able in a future change
to have the MediaPlayerPrivate runs with its demuxer in the Content Process
while the AudioVideoRenderer runs remotely.

For now, there&apos;s no visible functional changes except on visionOS.
This current AudioVideoRendererAVFObjC is only usable on systems where
WebCoreDecompressionSession is preferred to decode MediaSample.

On visionOS the transition between an AVSampleBufferDisplayLayer and
a AVSampleBufferVideoRenderer is fully handled by AudioVideoRenderer rather
than the MediaPlayerPrivate. It no longer requires to perform internal
seeks and re-enqueuing samples.
The same improvement also occurs when the video element will be added/removed
from the DOM, the transition is instantaneous without having to perform
similar sets of operations as we no longer need to switch between an AVSBDL
and a WebCoreDecompressionSession.

Covered by existing tests.

Fullscreen, PiP and docking transitions manually tested on iPad and Vision Pro
as we don&apos;t have automated coverage for those.

* Source/WTF/wtf/LoggerHelper.h: Add DEBUG_LOG_WITH_THIS and DEBUG_LOG_WITH_THIS_IF_POSSIBLE macro.

Canonical link: <a href="https://commits.webkit.org/299373@main">https://commits.webkit.org/299373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/020d90485350017dd5c6f8caeea5415747108379

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70856 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/998595cc-dad0-4101-a076-a9e9f71534c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90161 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c239c30-ade9-4c3f-883e-400bbae1c847) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70666 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13ef06fd-c880-4c62-b330-c64723da1ee5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68642 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110912 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128033 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117308 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98811 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42240 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51249 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146004 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45036 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37549 "Found 1 new JSC binary failure: testapi, Found 18593 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->