### PR TITLE
[WebRTC] Allow AV1 streams to contain timing info when hardware decoding on apple silicon

### DIFF
--- a/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
@@ -147,6 +147,22 @@ static std::optional<std::pair<std::span<const uint8_t>, std::span<const uint8_t
     return { };
 }
 
+struct ParsedDecoderModel {
+    std::optional<size_t> buffer_delay_length_minus_1;
+    std::optional<size_t> num_units_in_decoding_tick;
+    std::optional<size_t> buffer_removal_time_length_minus_1;
+    std::optional<size_t> frame_presentation_time_length_minus_1;
+};
+
+struct ParsedTimingInfo {
+    std::optional<size_t> num_units_in_display_tick;
+    std::optional<size_t> time_scale;
+    std::optional<size_t> equal_picture_interval;
+    std::optional<size_t> num_ticks_per_picture_minus_1;
+    std::optional<size_t> decoder_model_info_present_flag;
+    std::optional<ParsedDecoderModel> decoder_model;
+};
+
 struct ParsedSequenceHeaderParameters {
     int32_t height { 0 };
     int32_t width { 0 };
@@ -158,6 +174,57 @@ struct ParsedSequenceHeaderParameters {
     uint8_t twelve_bit { 0 };
     uint8_t chroma_type { 0 };
 };
+
+static size_t parseUlvc(BitReader *reader)
+{
+    int leading_zeros = 0;
+    while (leading_zeros < 32) {
+        std::optional<size_t> done = reader->read(1);
+        if (done && *done)
+            break;
+        ++leading_zeros;
+    }
+
+    if (leading_zeros >= 32)
+        return UINT32_MAX;
+
+    const size_t base = (1u << leading_zeros) - 1;
+
+    if (!leading_zeros)
+        return 0;
+
+    std::optional<size_t> value = reader->read(leading_zeros);
+    if (value && *value)
+        return base + *value;
+
+    return 0;
+}
+
+static std::optional<ParsedTimingInfo> parseTimingInfo(BitReader *reader)
+{
+    ParsedTimingInfo timingInfo;
+
+    timingInfo.num_units_in_display_tick = reader->read(32);
+    timingInfo.time_scale = reader->read(32);
+    timingInfo.equal_picture_interval = reader->read(1);
+
+    if (timingInfo.equal_picture_interval && *timingInfo.equal_picture_interval)
+        timingInfo.num_ticks_per_picture_minus_1 = parseUlvc(reader);
+
+    timingInfo.decoder_model_info_present_flag = reader->read(1);
+    if (timingInfo.decoder_model_info_present_flag && *timingInfo.decoder_model_info_present_flag) {
+        ParsedDecoderModel decoderModel;
+
+        decoderModel.buffer_delay_length_minus_1 = reader->read(5);
+        decoderModel.num_units_in_decoding_tick = reader->read(32);
+        decoderModel.buffer_removal_time_length_minus_1 = reader->read(5);
+        decoderModel.frame_presentation_time_length_minus_1 = reader->read(5);
+
+        timingInfo.decoder_model = decoderModel;
+    }
+
+    return timingInfo;
+}
 
 static std::optional<ParsedSequenceHeaderParameters> parseSequenceHeaderOBU(std::span<const uint8_t> data)
 {
@@ -181,6 +248,7 @@ static std::optional<ParsedSequenceHeaderParameters> parseSequenceHeaderOBU(std:
     value = bitReader.read(1);
     if (!value)
         return { };
+
     // We only support hdr still picture = 0 for now.
     if (*value)
         return { };
@@ -193,9 +261,12 @@ static std::optional<ParsedSequenceHeaderParameters> parseSequenceHeaderOBU(std:
     value = bitReader.read(1);
     if (!value)
         return { };
-    // We only support no timing info for now.
+
+    // Parse timing_info if present
+    std::optional<ParsedTimingInfo> timingInfo;
     if (*value)
-        return { };
+        timingInfo = parseTimingInfo(&bitReader);
+
 
     // Read one bit, display mode
     value = bitReader.read(1);
@@ -206,26 +277,44 @@ static std::optional<ParsedSequenceHeaderParameters> parseSequenceHeaderOBU(std:
     value = bitReader.read(5);
     if (!value)
         return { };
-    // We only support operating_points_cnt_minus_1 = 0 for now.
-    if (*value)
-        return { };
 
-    // Read 12 bits, operating_point_idc
-    value = bitReader.read(12);
-    if (!value)
-        return { };
-
-    // Read 5 bits, level
-    value = bitReader.read(5);
-    if (!value)
-        return { };
-    parameters.level = *value;
-
-    // If level >= 4.0, read one bit
-    if (parameters.level > 7) {
-        value = bitReader.read(1);
+    uint8_t loops = *value;
+    // Parse through the operating points
+    for (uint8_t i = 0; i <= loops; i++) {
+        // Read 12 bits, operating_point_idc
+        value = bitReader.read(12);
         if (!value)
             return { };
+
+        // Read 5 bits, level
+        value = bitReader.read(5);
+        if (!value)
+            return { };
+        parameters.level = *value;
+
+        // If level >= 4.0, read one bit
+        if (parameters.level > 7) {
+            value = bitReader.read(1);
+            if (!value)
+                return { };
+        }
+
+        if (timingInfo && *(*timingInfo).decoder_model_info_present_flag) {
+            value = bitReader.read(1);
+            if (!value)
+                return { };
+
+            if (*value) {
+                // Parse operating_parameters_info(i)
+                auto n = (*(*(*timingInfo).decoder_model).buffer_delay_length_minus_1) + 1;
+                // decoder_buffer_delay f(n)
+                value = bitReader.read(n);
+                // encoder_buffer_delay f(n)
+                value = bitReader.read(n);
+                // low_delay_mode_flag
+                value = bitReader.read(1);
+            }
+        }
     }
 
     // Read width num bits


### PR DESCRIPTION
#### 357974e5a1819a47abce548f522ef0ba8552b288
<pre>
Allow AV1 streams to contain timing info when hardware decoding on apple silicon
<a href="https://bugs.webkit.org/show_bug.cgi?id=297962">https://bugs.webkit.org/show_bug.cgi?id=297962</a>

Unreviewed

* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(parseUlvc): parsing of variable length fields
(parseTimingInfo): parsing timing info
(parseSequenceHeaderOBU): use parseTimingInfo instead of bailing
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/498617d102cebd664574705d4cfa3587fd4256bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125193 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90305 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59810 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70813 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24798 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68846 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128230 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98968 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98748 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22208 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42472 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45767 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51445 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->