### PR TITLE
Web Inspector: Searching on certain text fails to find matches

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1516,6 +1516,7 @@ localizedStrings["Search Resource Content"] = "Search Resource Content";
 localizedStrings["Search Tab Name"] = "Search";
 /* Title of Search Tab with keyboard shortcut */
 localizedStrings["Search Tab Title"] = "Search (%s)";
+localizedStrings["Search:"] = "Search:";
 /* Settings tab label for search related settings */
 localizedStrings["Search: @ Settings"] = "Search:";
 localizedStrings["Searching %s"] = "Searching %s";
@@ -1881,6 +1882,7 @@ localizedStrings["Use case sensitive autocomplete"] = "Use case sensitive autoco
 localizedStrings["Use default media styles"] = "Use default media styles";
 localizedStrings["Use fuzzy matching for CSS code completion"] = "Use fuzzy matching for CSS code completion";
 localizedStrings["Use mock capture devices"] = "Use mock capture devices";
+localizedStrings["Use strict word boundary checks for glob pattern matching"] = "Use strict word boundary checks for glob pattern matching";
 localizedStrings["User Agent"] = "User Agent";
 localizedStrings["User Agent Style Sheet"] = "User Agent Style Sheet";
 localizedStrings["User Style Sheet"] = "User Style Sheet";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -243,6 +243,7 @@ WI.settings = {
     experimentalShowCaseSensitiveAutocomplete: new WI.Setting("experimental-show-case-sensitive-auto-complete", false),
     experimentalLimitSourceCodeHighlighting: new WI.Setting("engineering-limit-source-code-highlighting", false),
     experimentalUseFuzzyMatchingForCSSCodeCompletion: new WI.Setting("experimental-use-fuzzy-matching-for-css-code-completion", true),
+    experimentalUseStrictCheckForGlobMatching: new WI.Setting("experimental-use-strict-check-for-glob-matching", false),
 
     // Protocol
     protocolLogAsText: new WI.Setting("protocol-log-as-text", false),

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -1599,12 +1599,14 @@ function simpleGlobStringToRegExp(globString, regExpFlags)
         // Replace all unescaped asterisks with ".*".
         regexString = regexString.replace(unescapedAsteriskRegex, "$1.*");
 
-        // Match edge boundaries when there is an asterisk to better meet the expectations
-        // of the user. When someone types "*.js" they don't expect "foo.json" to match. They
-        // would only expect that if they type "*.js*". We use \b (instead of ^ and $) to allow
-        // matches inside paths or URLs, so "ba*.js" will match "foo/bar.js" but not "boo/bbar.js".
-        // When there isn't an asterisk the regexString is just a substring search.
-        regexString = "\\b" + regexString + "\\b";
+        if (WI.settings.experimentalUseStrictCheckForGlobMatching.value) {
+            // Match edge boundaries when there is an asterisk to better meet the expectations
+            // of the user. When someone types "*.js" they don't expect "foo.json" to match. They
+            // would only expect that if they type "*.js*". We use \b (instead of ^ and $) to allow
+            // matches inside paths or URLs, so "ba*.js" will match "foo/bar.js" but not "boo/bbar.js".
+            // When there isn't an asterisk the regexString is just a substring search.
+            regexString = "\\b" + regexString + "\\b";
+        }
     }
 
     return new RegExp(regexString, regExpFlags);

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -437,6 +437,11 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
 
         experimentalSettingsView.addSeparator();
 
+        let searchGroup = experimentalSettingsView.addGroup(WI.UIString("Search:"));
+        searchGroup.addSetting(WI.settings.experimentalUseStrictCheckForGlobMatching, WI.UIString("Use strict word boundary checks for glob pattern matching"));
+
+        experimentalSettingsView.addSeparator();
+
         let diagnosticsGroup = experimentalSettingsView.addGroup(WI.UIString("Diagnostics:", "Diagnostics: @ Experimental Settings", "Category label for experimental settings related to Web Inspector diagnostics."));
         diagnosticsGroup.addSetting(WI.settings.experimentalAllowInspectingInspector, WI.UIString("Allow Inspecting Web Inspector", "Allow Inspecting Web Inspector @ Experimental Settings", "Label for setting that allows the user to inspect the Web Inspector user interface."));
         experimentalSettingsView.addSeparator();


### PR DESCRIPTION
#### 2e4f4c0f2e596749509d4f3d9d3768bbac632719
<pre>
Web Inspector: Searching on certain text fails to find matches
<a href="https://bugs.webkit.org/show_bug.cgi?id=297790">https://bugs.webkit.org/show_bug.cgi?id=297790</a>
<a href="https://rdar.apple.com/159272725">rdar://159272725</a>

Reviewed by Devin Rousso.

Web Inspector performs a search for a query against multiple backend endpoints to find matches:
- `DOMAgent.performSearch()`
- `PageAgent.searchInResources()`
- `DebuggerAgent.searchInContent()`
- `PageAgent.searchInResource()`

The frontend applies a regex of the same query on the text line matches returned by the backend.
It does this to highlight the search query in the results sidebar.

The frontend regex is slightly different than the one on the backend.

The frontend regex generated by:
`WI.SearchUtilities.searchRegExpForString()` -&gt; `WI.SearchUtilities._regExpForString()` -&gt; `simpleGlobStringToRegExp()`
considers an unescaped asterisk (*) a glob matching pattern and wraps the regex with \b (word boundary)
mostly to satisfy the user experience of matching against filenames.

The backend regex does not make this distinction:
`ContentSearchUtilities::createRegularExpressionForString()`.

But * in a CSS selector means something else. There are patterns where valid CSS selectors
are not bounded by word characters, like `* :not(.foo)`. This fails the frontend regex check in
`WI.SearchSidebarPanel.prototype.performSearch()` -&gt; `forEach()` which then ignores
the valid matches returned by the backend (which does not employ the glob matching pattern).

The fact that frontend and backend use different regexes is a bug in itself.

This patch guards the current glob pattern matching behavior with strict word boundaries
behind a new experimental setting (disabled by default) so the two regexes match by default.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:

Canonical link: <a href="https://commits.webkit.org/299541@main">https://commits.webkit.org/299541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94f0ff56ffe824bd6905a3ea7a169bac60e9ab2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71263 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/daddb21a-65db-4635-b3e6-4eda48dcf567) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90551 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59911 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/932638a9-c991-4eb2-be7d-2ffc7e64dae5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70961 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8daa142b-036c-4a7b-a067-d1bac1f5e7a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24967 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69076 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128441 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99109 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44364 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42686 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45977 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51657 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45444 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48792 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47134 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->