### PR TITLE
Disable WasmMemoryToBufferAPI on 32-bit

### DIFF
--- a/JSTests/wasm/js-api/memory-toFixedLengthBuffer.js
+++ b/JSTests/wasm/js-api/memory-toFixedLengthBuffer.js
@@ -1,3 +1,4 @@
+//@ skip if $addressBits <= 32
 //@ requireOptions("--useWasmMemoryToBufferAPIs=true")
 
 import { eq as assertEq, throws as assertThrows } from "../assert.js";
@@ -92,4 +93,12 @@ function assertSharedFixedLengthBufferOfPageSize(pageCount, buffer) {
     memory.grow(1);
     assertEq(buffer4, memory.buffer);
     assertSharedFixedLengthBufferOfPageSize(3, buffer3);
+}
+
+// Non-shared memory with no user-specified maximum
+
+{
+    let memory = new WebAssembly.Memory({ initial: 0 });
+    let buffer = memory.toFixedLengthBuffer();
+    assertEq(buffer.maxByteLength, pageSize * 65536);
 }

--- a/JSTests/wasm/js-api/memory-toResizableBuffer.js
+++ b/JSTests/wasm/js-api/memory-toResizableBuffer.js
@@ -1,3 +1,4 @@
+//@ skip if $addressBits <= 32
 //@ requireOptions("--useWasmMemoryToBufferAPIs=true")
 
 import { eq as assertEq, throws as assertThrows } from "../assert.js";

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1367,6 +1367,10 @@ void Options::assertOptionsAreCoherent()
         coherent = false;
         dataLog("INCOHERENT OPTIONS: can't restrict pointer tagging to pacibsp and use posix signals");
     }
+    if (is32Bit() && useWasmMemoryToBufferAPIs()) {
+        coherent = false;
+        dataLog("INCOHERENT OPTIONS: useWasmMemoryToBufferAPIs requires a 4GB buffer, currently unfeasible in 32-bit JSC\n");
+    }
 
     if (!coherent)
         CRASH();


### PR DESCRIPTION
#### 2a38769d01a9a3298825b80953cd35f9e1e8cee2
<pre>
Disable WasmMemoryToBufferAPI on 32-bit
https://bugs.webkit.org/show_bug.cgi?id=297968

Reviewed by NOBODY (OOPS!).

This PR prevents JSC from running in 32-bit when using the option
--useWasmMemoryToBufferAPIs=true, and disables the tests for 32-bit if this
feature is required.

useWasmMemoryToBufferAPIs enables resizable memory buffer, but the spec [0]
defines that the max buffer length should be 4GB, but we can&apos;t create a 4GB
buffer in 32-bit JSC, the max size for arrays is 4GB - 1 byte.

[0] <a href="https://webassembly.github.io/threads/js-api/index.html#create-a-resizable-memory-buffer">https://webassembly.github.io/threads/js-api/index.html#create-a-resizable-memory-buffer</a>

* JSTests/wasm/js-api/memory-toFixedLengthBuffer.js:
(assertSharedFixedLengthBufferOfPageSize):
* JSTests/wasm/js-api/memory-toResizableBuffer.js:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::assertOptionsAreCoherent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a38769d01a9a3298825b80953cd35f9e1e8cee2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70302 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89744 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59384 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68081 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110370 "Found 14 new JSC stress test failures: wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.default-wasm, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-aggressive-inline, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-bbq, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-bbq-no-consts, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-collect-continuously, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-eager, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-eager-jettison, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-graph-reg-alloc, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-no-cjit, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-no-jit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100199 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127490 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116767 "Found 14 new JSC stress test failures: wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.default-wasm, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-aggressive-inline, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-bbq, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-bbq-no-consts, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-collect-continuously, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-eager, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-eager-jettison, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-graph-reg-alloc, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-no-cjit, wasm.yaml/wasm/js-api/memory-toFixedLengthBuffer.js.wasm-no-jit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98428 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98214 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41636 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45031 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50707 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145465 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44493 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37424 "Found 1 new JSC binary failure: testapi, Found 19687 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->