### PR TITLE
Begin mass migration from TestRunner.idl to testRunnerJS

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html
@@ -148,9 +148,9 @@
             internals.setMockWebAuthenticationConfiguration({ local: { userVerification: "yes", acceptAttestation: false } });
             testRunner.addTestKeyToKeychain(privateKeyBase64, testRpId, testUserEntityBundleBase64);
         }
-        return promiseRejects(t, "UnknownError", navigator.credentials.create(options), "Couldn't create private key.").then(() => {
+        return promiseRejects(t, "UnknownError", navigator.credentials.create(options), "Couldn't create private key.").then(async () => {
             if (window.testRunner)
-                assert_true(testRunner.keyExistsInKeychain(testRpId, credentialIDBase64));
+                assert_true(await testRunner.keyExistsInKeychain(testRpId, credentialIDBase64));
                 testRunner.cleanUpKeychain(testRpId, credentialIDBase64);
         });
     }, "PublicKeyCredential's [[create]] not deleting old credential in a mock local authenticator.");

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
@@ -5,11 +5,11 @@
 <script src="./resources/util.js"></script>
 <script src="./resources/cbor.js"></script>
 <script>
-    function checkResult(credential, credentialID, isUV = true, isUP = true)
+    async function checkResult(credential, credentialID, isUV = true, isUP = true)
     {
         // Check keychain
         if (window.testRunner) {
-            assert_true(testRunner.keyExistsInKeychain(testRpId, base64encode(credentialID)));
+            assert_true(await testRunner.keyExistsInKeychain(testRpId, base64encode(credentialID)));
             testRunner.cleanUpKeychain(testRpId, base64encode(credentialID));
         }
 
@@ -323,9 +323,9 @@
         if (window.internals)
             testRunner.addTestKeyToKeychain(anotherPrivateKeyBase64, testRpId, base64encode(CBOR.encode({ "id": Base64URL.parse(userhandleBase64), "name": userhandleBase64 })));
 
-        return navigator.credentials.create(options).then(credential => {
+        return navigator.credentials.create(options).then(async (credential) => {
             checkResult(credential, credentialID, true);
-            assert_false(testRunner.keyExistsInKeychain(testRpId, base64encode(anotherCredentialID)));
+            assert_false(await testRunner.keyExistsInKeychain(testRpId, base64encode(anotherCredentialID)));
         });
     }, "PublicKeyCredential's [[create]] with duplicate credential in a mock local authenticator.");
 
@@ -365,9 +365,9 @@
         if (window.internals)
             testRunner.addTestKeyToKeychain(anotherPrivateKeyBase64, testRpId, base64encode(CBOR.encode({ "id": Base64URL.parse(userhandleBase64), "name": userhandleBase64 })));
 
-        return navigator.credentials.create(options).then(credential => {
+        return navigator.credentials.create(options).then(async (credential) => {
             checkResult(credential, credentialID, true);
-            assert_false(testRunner.keyExistsInKeychain(testRpId, base64encode(anotherCredentialID)));
+            assert_false(await testRunner.keyExistsInKeychain(testRpId, base64encode(anotherCredentialID)));
         });
     }, "PublicKeyCredential's [[create]] with duplicate credential in a mock local authenticator. 2");
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -384,8 +384,6 @@ interface TestRunner {
 
     undefined removeAllSessionCredentials(object callback);
 
-    undefined getApplicationManifestThen(object callback);
-
     undefined installFakeHelvetica(DOMString configuration);
 
     undefined addMockCameraDevice(DOMString persistentId, DOMString label, optional object properties);
@@ -418,7 +416,6 @@ interface TestRunner {
     // WebAuthn
     undefined addTestKeyToKeychain(DOMString privateKeyBase64, DOMString attrLabel, DOMString applicationTagBase64);
     undefined cleanUpKeychain(DOMString attrLabel, optional DOMString applicationLabelBase64);
-    boolean keyExistsInKeychain(DOMString attrLabel, DOMString applicationLabelBase64);
 
     undefined clearMemoryCache();
 
@@ -450,11 +447,6 @@ interface TestRunner {
     undefined getAndClearReportedWindowProxyAccessDomains(object callback);
     Promise<undefined> flushConsoleLogs();
     Promise<undefined> updatePresentation();
-
-    undefined scrollDuringEnterFullscreen();
-    undefined waitBeforeFinishingFullscreenExit();
-    undefined finishFullscreenExit();
-    undefined requestExitFullscreenFromUIProcess();
 
     Promise<undefined> setObscuredContentInsets(double top, double right, double bottom, double left);
     Promise<undefined> setPageScaleFactor(unrestricted double scaleFactor, long x, long y);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1795,11 +1795,6 @@ void TestRunner::setOriginQuotaRatioEnabled(bool enabled)
     postSynchronousPageMessage("SetOriginQuotaRatioEnabled", enabled);
 }
 
-void TestRunner::getApplicationManifestThen(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "GetApplicationManifest", callback);
-}
-
 void TestRunner::installFakeHelvetica(JSStringRef configuration)
 {
     WTR::installFakeHelvetica(toWK(configuration).get());
@@ -1839,14 +1834,6 @@ void TestRunner::cleanUpKeychain(JSStringRef attrLabel, JSStringRef applicationL
         return;
     }
     postSynchronousMessage("CleanUpKeychain", createWKDictionary({
-        { "AttrLabel", toWK(attrLabel) },
-        { "ApplicationLabel", toWK(applicationLabelBase64) },
-    }));
-}
-
-bool TestRunner::keyExistsInKeychain(JSStringRef attrLabel, JSStringRef applicationLabelBase64)
-{
-    return postSynchronousMessageReturningBoolean("KeyExistsInKeychain", createWKDictionary({
         { "AttrLabel", toWK(attrLabel) },
         { "ApplicationLabel", toWK(applicationLabelBase64) },
     }));
@@ -2039,26 +2026,6 @@ void TestRunner::flushConsoleLogs(JSContextRef context, JSValueRef callback)
 void TestRunner::updatePresentation(JSContextRef context, JSValueRef callback)
 {
     postMessageWithAsyncReply(context, "UpdatePresentation", callback);
-}
-
-void TestRunner::waitBeforeFinishingFullscreenExit()
-{
-    postPageMessage("WaitBeforeFinishingFullscreenExit");
-}
-
-void TestRunner::scrollDuringEnterFullscreen()
-{
-    postPageMessage("ScrollDuringEnterFullscreen");
-}
-
-void TestRunner::finishFullscreenExit()
-{
-    postPageMessage("FinishFullscreenExit");
-}
-
-void TestRunner::requestExitFullscreenFromUIProcess()
-{
-    postPageMessage("RequestExitFullscreenFromUIProcess");
 }
 
 void TestRunner::setPageScaleFactor(JSContextRef context, double scaleFactor, long x, long y, JSValueRef callback)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -485,8 +485,6 @@ public:
     void setUseSeparateServiceWorkerProcess(bool);
 
     void removeAllSessionCredentials(JSContextRef, JSValueRef);
-    
-    void getApplicationManifestThen(JSContextRef, JSValueRef);
 
     void installFakeHelvetica(JSStringRef configuration);
 
@@ -522,7 +520,6 @@ public:
     // FIXME(189876)
     void addTestKeyToKeychain(JSStringRef privateKeyBase64, JSStringRef attrLabel, JSStringRef applicationTagBase64);
     void cleanUpKeychain(JSStringRef attrLabel, JSStringRef applicationLabelBase64);
-    bool keyExistsInKeychain(JSStringRef attrLabel, JSStringRef applicationLabelBase64);
 
     unsigned long serverTrustEvaluationCallbackCallsCount();
 
@@ -551,10 +548,6 @@ public:
 
     void flushConsoleLogs(JSContextRef, JSValueRef callback);
     void updatePresentation(JSContextRef, JSValueRef callback);
-    void scrollDuringEnterFullscreen();
-    void waitBeforeFinishingFullscreenExit();
-    void finishFullscreenExit();
-    void requestExitFullscreenFromUIProcess();
 
     // Reporting API
     void generateTestReport(JSContextRef, JSStringRef message, JSStringRef group);

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -200,7 +200,7 @@ public:
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
     void scrollDuringEnterFullscreen() { m_scrollDuringEnterFullscreen = true; }
     void finishFullscreenExit();
-    void requestExitFullscreenFromUIProcess(WKPageRef);
+    void requestExitFullscreenFromUIProcess();
 
     static void willEnterFullScreen(WKPageRef, WKCompletionListenerRef, const void*);
     void willEnterFullScreen(WKPageRef, WKCompletionListenerRef);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -683,26 +683,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "WaitBeforeFinishingFullscreenExit")) {
-        TestController::singleton().waitBeforeFinishingFullscreenExit();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "ScrollDuringEnterFullscreen")) {
-        TestController::singleton().scrollDuringEnterFullscreen();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "FinishFullscreenExit")) {
-        TestController::singleton().finishFullscreenExit();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "RequestExitFullscreenFromUIProcess")) {
-        TestController::singleton().requestExitFullscreenFromUIProcess(TestController::singleton().mainWebView()->page());
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "ShowWebInspector")) {
         WKPageShowWebInspectorForTesting(TestController::singleton().mainWebView()->page());
         return;
@@ -1296,14 +1276,6 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         auto applicationLabelWK = stringValue(testDictionary, "ApplicationLabel");
         TestController::singleton().cleanUpKeychain(toWTFString(attrLabelWK), applicationLabelWK ? toWTFString(applicationLabelWK) : String());
         return nullptr;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "KeyExistsInKeychain")) {
-        auto testDictionary = dictionaryValue(messageBody);
-        auto attrLabelWK = stringValue(testDictionary, "AttrLabel");
-        auto applicationLabelWK = stringValue(testDictionary, "ApplicationLabel");
-        bool keyExistsInKeychain = TestController::singleton().keyExistsInKeychain(toWTFString(attrLabelWK), toWTFString(applicationLabelWK));
-        return adoptWK(WKBooleanCreate(keyExistsInKeychain));
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "ServerTrustEvaluationCallbackCallsCount"))


### PR DESCRIPTION
#### d50d95fe9f0eaf7059a1dcb5636745027899b6d5
<pre>
Begin mass migration from TestRunner.idl to testRunnerJS
<a href="https://bugs.webkit.org/show_bug.cgi?id=297973">https://bugs.webkit.org/show_bug.cgi?id=297973</a>
<a href="https://rdar.apple.com/159291124">rdar://159291124</a>

Reviewed by Tim Horton.

There are 3 classes of simple things to migrate.  This begins their migration.
1. Notifications implemented with postPageMessage can migrate to just calling post.
2. Synchronous queries implemented with postSynchronousMessage can migrate to being
   asynchronous queries by adding await to the tests that use them.
3. Asynchronous ueries implemented with postMessageWithAsyncReply can migrate to either
   using post and have the test await the result, or if the callback parameter model
   is to be kept then we can make a little wrapper in testRunnerJS that awaits the
   result of post then calls the callback with it.

This gains implementation experience of some primitives needed to migrate other
applications off of the injected bundle by migrating WebKitTestRunner off the
injected bundle.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::getApplicationManifestThen): Deleted.
(WTR::TestRunner::keyExistsInKeychain): Deleted.
(WTR::TestRunner::waitBeforeFinishingFullscreenExit): Deleted.
(WTR::TestRunner::scrollDuringEnterFullscreen): Deleted.
(WTR::TestRunner::finishFullscreenExit): Deleted.
(WTR::TestRunner::requestExitFullscreenFromUIProcess): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::requestExitFullscreenFromUIProcess):
(WTR::adoptAndCallCompletionHandler):
(WTR::if):
(WTR::CompletionHandler&lt;void):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/299219@main">https://commits.webkit.org/299219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b3c9ef444f33ffe7e3a4a9ea3a1fdb736f65a85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70318 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d419e465-9e04-4999-9f4c-24d5d87afb27) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89756 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34e128af-c38e-4cf6-b439-8909b322d6e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106042 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70249 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c1c6677-dc14-4f60-a4aa-333873a8db59) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127505 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34059 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98225 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43616 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41652 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18847 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45046 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50722 "Build is in progress. Recent messages:") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44508 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47853 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->