### PR TITLE
AX: Ensure native HTML radio buttons on macOS maintain accurate group count when group membership changes

### DIFF
--- a/LayoutTests/accessibility/radio-button-group-dynamic-changes-expected.txt
+++ b/LayoutTests/accessibility/radio-button-group-dynamic-changes-expected.txt
@@ -1,0 +1,21 @@
+This test verifies AX radio group member count is updated for existing members when a new radio button is added to a group.
+
+Verify radio 2a's first linked element is itself:
+PASS: radio2a.linkedUIElementAtIndex(0).isEqual(radio2a) === true
+
+Verify radio 2a has no second linked element:
+PASS: !radio2a.linkedUIElementAtIndex(1) === true
+
+Verify radio2b dynamically added to DOM successfully:
+PASS: !!accessibilityController.accessibleElementById('radio2b') === true
+
+Verify radio 2a's first linked element is itself:
+PASS: radio2a.linkedUIElementAtIndex(0).isEqual(accessibilityController.accessibleElementById('radio2a')) === true
+
+Verify radio 2a's second linked element is now radio 2b:
+PASS: radio2a.linkedUIElementAtIndex(1).isEqual(accessibilityController.accessibleElementById('radio2b')) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/radio-button-group-dynamic-changes.html
+++ b/LayoutTests/accessibility/radio-button-group-dynamic-changes.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+<div id ="content">
+    <input id="radio1" type="radio" name="group1">
+    <input id="radio2" type="radio" name="group1">
+    <input id="radio2a" type="radio" name="group2">
+</div>
+
+<script>
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    var output = "This test verifies AX radio group member count is updated for existing members when a new radio button is added to a group.\n";
+
+    document.getElementById("radio2").addEventListener("change", () => {
+        document.getElementById("radio2a").insertAdjacentHTML(
+            "afterend",
+            '<input id="radio2b" type="radio" name="group2">'
+        );
+    });
+
+    function focusRadio2() {
+        document.getElementById("radio2").checked = false;
+        document.getElementById("radio2").click();
+    }
+    
+    var radio2a = accessibilityController.accessibleElementById("radio2a");
+    
+    output += "\nVerify radio 2a's first linked element is itself: \n";
+    output += expect("radio2a.linkedUIElementAtIndex(0).isEqual(radio2a)", "true");
+    output += "\nVerify radio 2a has no second linked element: \n";
+    output += expect("!radio2a.linkedUIElementAtIndex(1)", "true");
+
+    setTimeout(async function() {
+        await focusRadio2();
+
+        output += "\nVerify radio2b dynamically added to DOM successfully: \n";
+        output += await expectAsync("!!accessibilityController.accessibleElementById('radio2b')", "true");
+
+        output += "\nVerify radio 2a's first linked element is itself: \n";
+        output += await expectAsync("radio2a.linkedUIElementAtIndex(0).isEqual(accessibilityController.accessibleElementById('radio2a'))", "true");
+        output += "\nVerify radio 2a's second linked element is now radio 2b: \n";
+        output += await expectAsync("radio2a.linkedUIElementAtIndex(1).isEqual(accessibilityController.accessibleElementById('radio2b'))", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -955,6 +955,7 @@ webkit.org/b/228915 accessibility/selected-state-changed-notifications.html [ Ti
 # Not supported
 accessibility/embedded-image-description.html [ Skip ]
 accessibility/aria-keyshortcuts.html [ Skip ]
+accessibility/radio-button-group-dynamic-changes.html [ Skip ]
 
 # Not supported. Skipped also in mac-wk1 and win ports.
 accessibility/nested-textareas-value-changed-notifications.html [ Skip ]

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1090,8 +1090,8 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::PreventKeyboardDOMEventDispatch:
         stream << "PreventKeyboardDOMEventDispatch";
         break;
-    case AXProperty::RadioButtonGroup:
-        stream << "RadioButtonGroup";
+    case AXProperty::RadioButtonGroupMembers:
+        stream << "RadioButtonGroupMembers";
         break;
     case AXProperty::RelativeFrame:
         stream << "RelativeFrame";

--- a/Source/WebCore/accessibility/AXNotifications.h
+++ b/Source/WebCore/accessibility/AXNotifications.h
@@ -120,6 +120,7 @@ namespace WebCore {
     macro(PressDidSucceed) \
     macro(PressDidFail) \
     macro(PressedStateChanged) \
+    macro(RadioGroupMembershipChanged) \
     macro(ReadOnlyStatusChanged) \
     macro(RequiredStatusChanged) \
     macro(SortDirectionChanged) \

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1929,6 +1929,19 @@ void AXObjectCache::onDetailsSummarySlotChange(const HTMLDetailsElement& details
     }
 }
 
+void AXObjectCache::onRadioGroupMembershipChanged(HTMLElement& radio)
+{
+    if (auto* radioElement = dynamicDowncast<HTMLInputElement>(radio)) {
+        for (auto& sibling : radioElement->radioButtonGroup()) {
+            if (sibling.ptr() == &radio)
+                continue;
+
+            if (auto* axObject = get(sibling.ptr()))
+                postNotification(axObject, &sibling->document(), AXNotification::RadioGroupMembershipChanged);
+        }
+    }
+}
+
 static bool isContentVisibilityHidden(const RenderStyle& style)
 {
     return style.usedContentVisibility() == ContentVisibility::Hidden;
@@ -4940,6 +4953,9 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             break;
         case AXNotification::IdAttributeChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IdentifierAttribute });
+            break;
+        case AXNotification::RadioGroupMembershipChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::RadioButtonGroupMembers });
             break;
         case AXNotification::ReadOnlyStatusChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::CanSetValueAttribute });

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -302,6 +302,7 @@ public:
     void onFocusChange(Element* oldElement, Element* newElement);
     void onInertOrVisibilityChange(RenderElement&);
     void onPopoverToggle(const HTMLElement&);
+    void onRadioGroupMembershipChanged(HTMLElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedOptionChanged(Element&);
     void onSelectedOptionChanged(RenderObject&, int);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -325,7 +325,7 @@ private:
     AXIsolatedObject* accessibilityHitTest(const IntPoint&) const final;
     AXIsolatedObject* focusedUIElement() const final;
     AXIsolatedObject* internalLinkElement() const final { return objectAttributeValue(AXProperty::InternalLinkElement); }
-    AccessibilityChildrenVector radioButtonGroup() const final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::RadioButtonGroup)); }
+    AccessibilityChildrenVector radioButtonGroup() const final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::RadioButtonGroupMembers)); }
     AXIsolatedObject* scrollBar(AccessibilityOrientation) final;
     const String placeholderValue() const final { return stringAttributeValue(AXProperty::PlaceholderValue); }
     String abbreviation() const final { return stringAttributeValue(AXProperty::Abbreviation); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -787,6 +787,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::CellScope:
             properties.append({ AXProperty::CellScope, axObject.cellScope().isolatedCopy() });
             break;
+        case AXProperty::RadioButtonGroupMembers:
+            properties.append({ AXProperty::RadioButtonGroupMembers, axIDs(axObject.radioButtonGroup()) });
+            break;
         case AXProperty::ScreenRelativePosition:
             properties.append({ AXProperty::ScreenRelativePosition, axObject.screenRelativePosition() });
             break;
@@ -2072,8 +2075,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::IsTree, object.isTree());
         if (object.isRadioButton()) {
             setProperty(AXProperty::NameAttribute, object.nameAttribute().isolatedCopy());
-            // FIXME: This property doesn't get updated when a page changes dynamically.
-            setObjectVectorProperty(AXProperty::RadioButtonGroup, object.radioButtonGroup());
+            setObjectVectorProperty(AXProperty::RadioButtonGroupMembers, object.radioButtonGroup());
         }
 
         if (object.isImage())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -261,7 +261,7 @@ enum class AXProperty : uint16_t {
 #endif
     PosInSet,
     PreventKeyboardDOMEventDispatch,
-    RadioButtonGroup,
+    RadioButtonGroupMembers,
     RelativeFrame,
     RemoteFrameOffset,
     RemoteFramePlatformElement,

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "RadioButtonGroups.h"
 
+#include "AXObjectCache.h"
 #include "HTMLInputElement.h"
 #include "Range.h"
 #include <ranges>
@@ -213,6 +214,9 @@ void RadioButtonGroups::addButton(HTMLInputElement& element)
     if (!group)
         group = makeUnique<RadioButtonGroup>();
     group->add(element);
+
+    if (CheckedPtr cache = element.protectedDocument()->existingAXObjectCache())
+        cache->onRadioGroupMembershipChanged(element);
 }
 
 Vector<Ref<HTMLInputElement>> RadioButtonGroups::groupMembers(const HTMLInputElement& element) const
@@ -287,6 +291,9 @@ void RadioButtonGroups::removeButton(HTMLInputElement& element)
     it->value->remove(element);
     if (it->value->isEmpty())
         m_nameToGroupMap.remove(it);
+
+    if (CheckedPtr cache = element.protectedDocument()->existingAXObjectCache())
+        cache->onRadioGroupMembershipChanged(element);
 }
 
 } // namespace


### PR DESCRIPTION
#### 5b80ea62b394ef3c268ba1c2b7ef929d8d7ffb9c
<pre>
AX: Ensure native HTML radio buttons on macOS maintain accurate group count when group membership changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=297929">https://bugs.webkit.org/show_bug.cgi?id=297929</a>
<a href="https://rdar.apple.com/159221583">rdar://159221583</a>

Reviewed by Tyler Wilcock.

When the membership of a native HTML radio group changes (e.g., adding one or more radio buttons to a group via user interaction),
AccessibilityNodeObject::radioButtonGroup() determines group membership when the AX object is first created. However,
any membership changes must also be propagated to the platform accessibility API so that the backing AX object used for querying
current AX state (mirrored in the AX isolated tree) is kept up-to-date.

This PR ensures that upon radio group membership change, a new AXNotification::RadioGroupMembershipChanged is dispatched for every
radio in the affected group. In this manner, assistive technologies will convey the accurate group count &quot;X of Y&quot; for existing members,
where X is the radio&apos;s current position in the group and Y is the group count.

Note: the cardinality of radio buttons is not derived from AXProperty::PosInSet nor AXProperty::SetSize because these attributes are
not queried by the platform accessibility API for this purpose. For native radio buttons, the &quot;X of Y&quot; assistive technology
announcement is exposed via NSAccessibilityLinkedUIElementsAttribute which calls into
AXCoreObject::linkedObjects().

* LayoutTests/accessibility/radio-button-group-dynamic-changes-expected.txt: Added.
* LayoutTests/accessibility/radio-button-group-dynamic-changes.html: Added.
* LayoutTests/platform/glib/TestExpectations: skip radio-button-group-dynamic-changes.html.

* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXNotifications.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onRadioGroupMembershipChanged):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroups::addButton):
(WebCore::RadioButtonGroups::removeButton):

Canonical link: <a href="https://commits.webkit.org/299585@main">https://commits.webkit.org/299585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca2475d4821132bf54988ee8cafe15e9c7279a2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99330 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99141 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25200 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42924 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51918 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->