### PR TITLE
Navigation API: Don't allow the javascript: protocol in navigation.navigate()

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/navigate-javascript-url-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/navigate-javascript-url-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigate() to a javascript: URL
+

--- a/LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
+++ b/LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/navigate-javascript-url.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+
+<script type="module">
+
+promise_test(async t => {
+  async function ensureWindowLoadEventFired(t) {
+    return new Promise(resolve => {
+      const callback = () => t.step_timeout(resolve, 0);
+      if (document.readyState === 'complete') {
+        callback();
+      } else {
+        window.onload = callback;
+      }
+    });
+  }
+
+  // Wait for after the load event so that we are definitely testing the
+  // javascript: URL as the cause of the rejections.
+  await ensureWindowLoadEventFired(t);
+
+  navigation.onnavigate = t.unreached_func("onnavigate should not be called");
+  navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");
+  navigation.onnavigateerror = t.unreached_func("onnavigateerror should not be called");
+
+  let result;
+  result = navigation.navigate("javascript:'foo'");
+  await assertBothRejectDOM(t, result, "NotSupportedError");
+
+  result = navigation.navigate("javascript:'foo'", { history: "replace" });
+  await assertBothRejectDOM(t, result, "NotSupportedError");
+
+  result = navigation.navigate("javascript:'foo'", { history: "push" });
+  await assertBothRejectDOM(t, result, "NotSupportedError");
+}, "navigate() to a javascript: URL");
+</script>

--- a/LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/resources/helpers.js
+++ b/LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/resources/helpers.js
@@ -1,0 +1,154 @@
+window.assertReturnValue = (result, w = window) => {
+  assert_equals(Object.getPrototypeOf(result), w.Object.prototype, "result object must be from the right realm");
+  assert_array_equals(Reflect.ownKeys(result), ["committed", "finished"]);
+  assert_true(result.committed instanceof w.Promise);
+  assert_true(result.finished instanceof w.Promise);
+  assert_not_equals(result.committed, result.finished);
+};
+
+window.assertNeverSettles = (t, result, w = window) => {
+  assertReturnValue(result, w);
+  result.committed.then(
+    t.unreached_func("committed must not fulfill"),
+    t.unreached_func("committed must not reject")
+  );
+
+  result.finished.then(
+    t.unreached_func("finished must not fulfill"),
+    t.unreached_func("finished must not reject")
+  );
+};
+
+window.assertBothFulfillEntryNotAvailable = async (t, result, w = window) => {
+  assertReturnValue(result, w);
+
+  // Don't use await here so that we can catch out-of-order settlements.
+  let committedValue;
+  result.committed.then(
+    t.step_func(v => { committedValue = v;}),
+    t.unreached_func("committed must not reject")
+  );
+
+  const finishedValue = await result.finished;
+
+  assert_not_equals(committedValue, undefined, "committed must fulfill before finished");
+  assert_equals(finishedValue, committedValue, "committed and finished must fulfill with the same value");
+  assert_true(finishedValue instanceof w.NavigationHistoryEntry, "fulfillment value must be a NavigationHistoryEntry");
+};
+
+window.assertBothFulfill = async (t, result, expected, w = window) => {
+  assertReturnValue(result, w);
+
+  // Don't use await here so that we can catch out-of-order settlements.
+  let committedValue;
+  result.committed.then(
+    t.step_func(v => { committedValue = v; }),
+    t.unreached_func("committed must not reject")
+  );
+
+  const finishedValue = await result.finished;
+
+  assert_not_equals(committedValue, undefined, "committed must fulfill before finished");
+  assert_equals(finishedValue, committedValue, "committed and finished must fulfill with the same value");
+  assert_true(finishedValue instanceof w.NavigationHistoryEntry, "fulfillment value must be a NavigationHistoryEntry");
+  assert_equals(finishedValue, expected);
+};
+
+window.assertCommittedFulfillsFinishedRejectsExactly = async (t, result, expectedEntry, expectedRejection, w = window) => {
+  assertReturnValue(result, w);
+
+  // Don't use await here so that we can catch out-of-order settlements.
+  let committedValue;
+  result.committed.then(
+    t.step_func(v => { committedValue = v; }),
+    t.unreached_func("committed must not reject")
+  );
+
+  await promise_rejects_exactly(t, expectedRejection, result.finished);
+
+  assert_not_equals(committedValue, undefined, "committed must fulfill before finished rejects");
+  assert_true(committedValue instanceof w.NavigationHistoryEntry, "fulfillment value must be a NavigationHistoryEntry");
+  assert_equals(committedValue, expectedEntry);
+};
+
+window.assertCommittedFulfillsFinishedRejectsDOM = async (t, result, expectedEntry, expectedDOMExceptionCode, w = window, domExceptionConstructor = w.DOMException, navigationHistoryEntryConstuctor = w.NavigationHistoryEntry) => {
+  assertReturnValue(result, w);
+
+  let committedValue;
+  result.committed.then(
+    t.step_func(v => { committedValue = v; }),
+    t.unreached_func("committed must not reject")
+  );
+
+  await promise_rejects_dom(t, expectedDOMExceptionCode, domExceptionConstructor, result.finished);
+
+  assert_not_equals(committedValue, undefined, "committed must fulfill before finished rejects");
+  assert_true(committedValue instanceof navigationHistoryEntryConstuctor, "fulfillment value must be an NavigationHistoryEntry");
+  assert_equals(committedValue, expectedEntry);
+};
+
+// We cannot use Promise.all() because the automatic coercion behavior when
+// promises from multiple realms are involved causes it to hang if one of the
+// promises is from a detached iframe's realm. See discussion at
+// https://github.com/whatwg/html/issues/11252#issuecomment-2984143855.
+window.waitForAllLenient = (iterable) => {
+  const { promise: all, resolve, reject } = Promise.withResolvers();
+  let remaining = 0;
+  let results = [];
+  for (const promise of iterable) {
+    let index = remaining++;
+    promise.then(v => {
+      results[index] = v;
+      --remaining;
+      if (!remaining) {
+        resolve(results);
+      }
+      return v;
+    }, v => reject(v));
+  }
+
+  if (!remaining) {
+    resolve(results);
+  }
+
+  return all;
+}
+
+window.assertBothRejectExactly = async (t, result, expectedRejection, w = window) => {
+  assertReturnValue(result, w);
+
+  let committedReason, finishedReason;
+  await waitForAllLenient([
+    result.committed.then(
+      t.unreached_func("committed must not fulfill"),
+      t.step_func(r => { committedReason = r; })
+    ),
+    result.finished.then(
+      t.unreached_func("finished must not fulfill"),
+      t.step_func(r => { finishedReason = r; })
+    )
+  ]);
+
+  assert_equals(committedReason, finishedReason, "committed and finished must reject with the same value");
+  assert_equals(expectedRejection, committedReason);
+};
+
+window.assertBothRejectDOM = async (t, result, expectedDOMExceptionCode, w = window, domExceptionConstructor = w.DOMException) => {
+  assertReturnValue(result, w);
+
+  // Don't use await here so that we can catch out-of-order settlements.
+  let committedReason, finishedReason;
+  await waitForAllLenient([
+    result.committed.then(
+      t.unreached_func("committed must not fulfill"),
+      t.step_func(r => { committedReason = r; })
+    ),
+    result.finished.then(
+      t.unreached_func("finished must not fulfill"),
+      t.step_func(r => { finishedReason = r; })
+    )
+  ]);
+
+  assert_equals(committedReason, finishedReason, "committed and finished must reject with the same value");
+  assert_throws_dom(expectedDOMExceptionCode, domExceptionConstructor, () => { throw committedReason; });
+};

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -430,8 +430,9 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
     if (!newURL.isValid())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::SyntaxError, "Invalid URL"_s);
 
-    if (options.history == HistoryBehavior::Push && newURL.protocolIsJavaScript())
-        return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::NotSupportedError, "A \"push\" navigation was explicitly requested, but only a \"replace\" navigation is possible when navigating to a javascript: URL."_s);
+    // Reject all JavaScript URLs in Navigation API.
+    if (newURL.protocolIsJavaScript())
+        return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::NotSupportedError, "Navigation API does not support javascript: URLs."_s);
 
     if (options.history == HistoryBehavior::Push && currentURL.isAboutBlank())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::NotSupportedError, "A \"push\" navigation was explicitly requested, but only a \"replace\" navigation is possible while on an about:blank document."_s);


### PR DESCRIPTION
#### 73dbd370fb9ac54bfa367f4e7d6fa6855315d46e
<pre>
Navigation API: Don&apos;t allow the javascript: protocol in navigation.navigate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=297650">https://bugs.webkit.org/show_bug.cgi?id=297650</a>
<a href="https://rdar.apple.com/158867866">rdar://158867866</a>

Reviewed by Tim Nguyen.

navigation.navigate(&quot;javascript:alert(1)&quot;) is a new script execution sink that was newly added.
We believe that it would be more useful for new APIs to not support the legacy javascript:
protocol, compared to just keeping it because other APIs like location.href support it.

<a href="https://github.com/whatwg/html/pull/11533">https://github.com/whatwg/html/pull/11533</a>

* LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/navigate-javascript-url-expected.txt: Added.
* LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/navigate-javascript-url.html: Added.
* LayoutTests/http/wpt/navigation-api/navigation-methods/return-value/resources/helpers.js: Added.
(window.assertReturnValue):
(window.assertNeverSettles):
(window.assertBothFulfillEntryNotAvailable.async t):
(window.assertBothFulfill.async t):
(window.assertCommittedFulfillsFinishedRejectsExactly.async t):
(window.assertCommittedFulfillsFinishedRejectsDOM.async t):
(window.waitForAllLenient):
(window.assertBothRejectExactly.async t):
(window.assertBothRejectDOM.async t):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::navigate):

Canonical link: <a href="https://commits.webkit.org/299235@main">https://commits.webkit.org/299235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14722b100c04ae68ca118be0f9d6379af01367d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70332 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1809ede-b555-45f7-81e8-1f9d883787d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89765 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a78f0ef-895d-4ff4-a0d0-dd526c36a8c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70258 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f6ee58c-e16a-4655-b8f7-844387ec4a94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24170 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68109 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127518 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98445 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98231 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43628 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41665 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50735 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44521 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47866 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->