### PR TITLE
Use repeating observer for OTS

### DIFF
--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -50,6 +50,7 @@ IncrementalSweeper::IncrementalSweeper(JSC::Heap* heap)
 
 void IncrementalSweeper::doWorkUntil(VM& vm, MonotonicTime deadline)
 {
+    m_hasWork = true; // assume true since we might reset to first directory and we'll clear this anyway if we're wrong
     if (!m_currentDirectory)
         m_currentDirectory = vm.heap.objectSpace().firstDirectory();
 
@@ -87,6 +88,7 @@ void IncrementalSweeper::doSweep(VM& vm, MonotonicTime deadline, SweepTrigger tr
         m_lastOpportunisticTaskDidFinishSweeping = true;
 
     cancelTimer();
+    m_hasWork = false;
 }
 
 bool IncrementalSweeper::sweepNextBlock(VM& vm, SweepTrigger trigger)
@@ -133,6 +135,12 @@ void IncrementalSweeper::stopSweeping()
 {
     m_currentDirectory = nullptr;
     cancelTimer();
+    m_hasWork = false;
+}
+
+bool IncrementalSweeper::hasWork()
+{
+    return m_hasWork;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.h
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.h
@@ -42,6 +42,7 @@ public:
     void doWorkUntil(VM&, MonotonicTime deadline);
     void doWork(VM&) final;
     void stopSweeping();
+    bool hasWork();
 
 private:
     enum class SweepTrigger : bool { Timer, OpportunisticTask };
@@ -51,6 +52,7 @@ private:
     
     BlockDirectory* m_currentDirectory;
     bool m_lastOpportunisticTaskDidFinishSweeping { false };
+    bool m_hasWork { false };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1744,6 +1744,11 @@ void VM::performOpportunisticallyScheduledTasks(MonotonicTime deadline, OptionSe
     heap.sweeper().doWorkUntil(*this, deadline);
 }
 
+bool VM::hasOpportunisticWork()
+{
+    return (heap.m_shouldDoOpportunisticFullCollection && heap.m_totalBytesVisitedAfterLastFullCollect) || (heap.totalBytesAllocatedThisCycle() && heap.m_bytesAllocatedBeforeLastEdenCollect) || heap.sweeper().hasWork();
+}
+
 void VM::invalidateStructureChainIntegrity(StructureChainIntegrityEvent)
 {
     if (auto* megamorphicCache = this->megamorphicCache())

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -353,6 +353,7 @@ public:
         HasImminentlyScheduledWork = 1 << 0,
     };
     JS_EXPORT_PRIVATE void performOpportunisticallyScheduledTasks(MonotonicTime deadline, OptionSet<SchedulerOptions>);
+    JS_EXPORT_PRIVATE bool hasOpportunisticWork();
 
     Structure* cellButterflyStructure(IndexingType indexingType) { return rawImmutableButterflyStructure(indexingType).get(); }
 

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -42,9 +42,15 @@ namespace WebCore {
 OpportunisticTaskScheduler::OpportunisticTaskScheduler(Page& page)
     : m_page(&page)
     , m_runLoopObserver(makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::OpportunisticTask, [weakThis = WeakPtr { this }] {
-        if (auto protectedThis = weakThis.get())
+        // if (true)
+        //     return;
+        if (auto protectedThis = weakThis.get()) {
             protectedThis->runLoopObserverFired();
-    }, RunLoopObserver::Type::OneShot))
+            RefPtr page = protectedThis->m_page.get();
+            if (!page->hasOpportunisticWork())
+                protectedThis->m_runLoopObserver->invalidate();
+        }
+    }, RunLoopObserver::Type::Repeating))
 {
 }
 
@@ -64,9 +70,10 @@ void OpportunisticTaskScheduler::rescheduleIfNeeded(MonotonicTime deadline)
 
     m_runloopCountAfterBeingScheduled = 0;
     m_currentDeadline = deadline;
-    m_runLoopObserver->invalidate();
-    if (!m_runLoopObserver->isScheduled())
-        m_runLoopObserver->schedule();
+    // m_runLoopObserver->invalidate();
+    // if (!m_runLoopObserver->isScheduled())
+    //     m_runLoopObserver->schedule();
+    m_runLoopObserver->schedule();
 }
 
 Ref<ImminentlyScheduledWorkScope> OpportunisticTaskScheduler::makeScheduledWorkScope()
@@ -121,8 +128,8 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
 
     if (!shouldRunTask) {
         dataLogLnIf(verbose, "[OPPORTUNISTIC TASK] GaveUp: task gets rescheduled ", remainingTime, " ", hasImminentlyScheduledWork(), " ", page->preferredRenderingUpdateInterval(), " ", m_runloopCountAfterBeingScheduled, " signpost:(", JSC::activeJSGlobalObjectSignpostIntervalCount.load(), ")");
-        m_runLoopObserver->invalidate();
-        m_runLoopObserver->schedule();
+        // m_runLoopObserver->invalidate();
+        // m_runLoopObserver->schedule();
         return;
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5283,6 +5283,11 @@ void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
     deleteRemovedNodesAndDetachedRenderers();
 }
 
+bool Page::hasOpportunisticWork()
+{
+    return commonVM().hasOpportunisticWork();
+}
+
 void Page::deleteRemovedNodesAndDetachedRenderers()
 {
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1243,6 +1243,7 @@ public:
 
     void opportunisticallyRunIdleCallbacks(MonotonicTime deadline);
     WEBCORE_EXPORT void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+    WEBCORE_EXPORT bool hasOpportunisticWork();
     void deleteRemovedNodesAndDetachedRenderers();
     String ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData&);
     WEBCORE_EXPORT void setMediaKeysStorageDirectory(const String&);

--- a/Source/WebCore/platform/RunLoopObserver.cpp
+++ b/Source/WebCore/platform/RunLoopObserver.cpp
@@ -42,6 +42,8 @@ void RunLoopObserver::runLoopObserverFired()
     ASSERT(m_runLoopObserver);
 #endif
     m_callback();
+    if (!isRepeating())
+        m_isScheduled = false;
 }
 
 #if !USE(CF)

--- a/Source/WebCore/platform/RunLoopObserver.h
+++ b/Source/WebCore/platform/RunLoopObserver.h
@@ -99,6 +99,7 @@ private:
 #if USE(CF)
     WellKnownOrder m_order { WellKnownOrder::GraphicsCommit };
     RetainPtr<PlatformRunLoopObserver> m_runLoopObserver;
+    bool m_isScheduled { false };
 #endif
 };
 


### PR DESCRIPTION
#### 46927fe39894989d1747e9286beff5716eb4de75
<pre>
Use repeating observer for OTS
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::doWorkUntil):
(JSC::IncrementalSweeper::doSweep):
(JSC::IncrementalSweeper::stopSweeping):
(JSC::IncrementalSweeper::hasWork):
* Source/JavaScriptCore/heap/IncrementalSweeper.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::hasOpportunisticWork):
* Source/JavaScriptCore/runtime/VM.h:
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::rescheduleIfNeeded):
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::hasOpportunisticWork):
* Source/WebCore/page/Page.h:
</pre>
----------------------------------------------------------------------
#### ee0898d2d15f40cf672ea55b05d6c578d82f285f
<pre>
Avoid redundant calls to CFRunLoopObserver
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/RunLoopObserver.cpp:
(WebCore::RunLoopObserver::runLoopObserverFired):
* Source/WebCore/platform/RunLoopObserver.h:
* Source/WebCore/platform/cf/RunLoopObserverCF.cpp:
(WebCore::RunLoopObserver::runLoopObserverFired):
(WebCore::RunLoopObserver::schedule):
(WebCore::RunLoopObserver::invalidate):
(WebCore::RunLoopObserver::isScheduled const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46927fe39894989d1747e9286beff5716eb4de75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28609 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124448 "Hash 46927fe3 for PR 49952 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70335 "Hash 46927fe3 for PR 49952 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dbadac40-0d22-4199-88b1-a8982d14027a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46548 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/124448 "Hash 46927fe3 for PR 49952 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/70335 "Hash 46927fe3 for PR 49952 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/509966c1-75b4-4c29-8e2b-43490ab0601d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30798 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106057 "Found 8 new API test failures: TestWebKitAPI.FullscreenZoomInitialFrame.WebKit, TestWebKitAPI.WebKitLegacy.SelectionAppearanceUpdatesInEditableWebView, TestWebKitAPI.PointerLockTests.ClientDisplaysAlertSheetWhilePointerLockActive, TestWebKitAPI.PageVisibilityStateWithWindowChanges.WebKit2, TestWebKitAPI.WebKit2.ConnectedToHardwareConsole, TestWebKitAPI.PointerLockTests.Simple, TestWebKitAPI.SiteIsolation.AdvanceFocusAcrossFrames, TestWebKitAPI.WebKit.NoResumeSoundPlayedToTheEndAfterThePageBecomesVisible (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/124448 "Hash 46927fe3 for PR 49952 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35805080-6458-420d-81a2-c52dae817e39) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29864 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24178 "Found 60 new test failures: accessibility/insert-children-assert.html accessibility/mac/dynamic-modal.html accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html accessibility/mac/invalid-tree-root-at-iframe.html accessibility/menu-list-crash2.html accessibility/scroll-to-make-visible-empty-bounding-box-element.html animations/3d/change-transform-in-end-event.html animations/3d/matrix-transform-type-animation.html animations/3d/replace-filling-transform.html animations/added-while-suspended.html ... (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68112 "Hash 46927fe3 for PR 49952 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110401 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100225 "Found 1 new API test failure: TestWebKitAPI.WebKitLegacy.WebGLPrepareDisplayOnWebThread (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24354 "Found 6 new test failures: fast/forms/select/mac-wk2/inactive-appearance.html fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html fast/shadow-dom/focus-ring-on-shadow-host-sibling.html fast/shadow-dom/focus-ring-on-shadow-host.html intersection-observer/root-element-deleted.html scrollbars/corner-resizer-window-inactive.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127521 "Hash 46927fe3 for PR 49952 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116798 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45192 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34075 "Found 6 new test failures: fast/forms/select/mac-wk2/inactive-appearance.html fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html fast/shadow-dom/focus-ring-on-shadow-host-sibling.html fast/shadow-dom/focus-ring-on-shadow-host.html intersection-observer/root-element-deleted.html scrollbars/corner-resizer-window-inactive.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/127521 "Hash 46927fe3 for PR 49952 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102276 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/127521 "Hash 46927fe3 for PR 49952 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43632 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21619 "Found 7 new test failures: fast/forms/select/mac-wk2/inactive-appearance.html fast/selectors/selection-window-inactive-stroke-color.html fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html fast/shadow-dom/focus-ring-on-shadow-host-sibling.html fast/shadow-dom/focus-ring-on-shadow-host.html intersection-observer/root-element-deleted.html scrollbars/corner-resizer-window-inactive.html (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41668 "Hash 46927fe3 for PR 49952 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50738 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145496 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44524 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37429 "Found 1 new JSC binary failure: testapi, Found 19693 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->