### PR TITLE
[JSC] Skip wasm tests that disable JIT on 32-bit JSC

### DIFF
--- a/JSTests/wasm/noJIT/noJIT.js
+++ b/JSTests/wasm/noJIT/noJIT.js
@@ -1,4 +1,4 @@
-//@ skip unless $isWasmPlatform
+//@ skip if !$isWasmPlatform || $addressBits <= 32
 //@ runDefaultWasm("--useJIT=0")
 if (typeof WebAssembly == "undefined")
     throw new Error("Expect WebAssembly global object is defined");

--- a/JSTests/wasm/stress/cc-int-to-int-no-jit.js
+++ b/JSTests/wasm/stress/cc-int-to-int-no-jit.js
@@ -1,3 +1,4 @@
+//@ skip if $addressBits <= 32
 //@ runDefaultWasm("-m", "--useJIT=0", "--useWasm=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js
+++ b/JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js
@@ -1,3 +1,4 @@
+//@ skip if $addressBits <= 32
 //@ runDefault("--jitPolicyScale=0.1", "--useJIT=0", "--watchdog-exception-ok", "--watchdog=500")
 function instantiate(moduleBase64, importObject) {
     let bytes = Uint8Array.fromBase64(moduleBase64);

--- a/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
@@ -1,4 +1,4 @@
-//@ skip if !$isWasmPlatform
+//@ skip if !$isWasmPlatform || $addressBits <= 32
 //@ runDefault("--maximumWasmDepthForInlining=10", "--maximumWasmCalleeSizeForInlining=10000000", "--maximumWasmCallerSizeForInlining=10000000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace-with-catch.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);


### PR DESCRIPTION
#### 0e4cdfa07c852a9029f4d912f9feca77be64af0b
<pre>
[JSC] Skip wasm tests that disable JIT on 32-bit JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=297977">https://bugs.webkit.org/show_bug.cgi?id=297977</a>

Reviewed by Justin Michaud and Sosuke Suzuki.

32-bit JSC doesn&apos;t support IPInt yet, so we need to skip these tests for now

* JSTests/wasm/noJIT/noJIT.js:
* JSTests/wasm/stress/cc-int-to-int-no-jit.js:
* JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js:
* JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js:

Canonical link: <a href="https://commits.webkit.org/299257@main">https://commits.webkit.org/299257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f3c9c47df31da6efff5c87cae534c10b6224a67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46551 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89768 "Found 1 new test failure: http/wpt/service-workers/service-worker-spinning-activate.https.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59400 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29862 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68115 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110404 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127524 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116801 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24992 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21622 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41671 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45065 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145499 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44527 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37431 "Found 1 new JSC binary failure: testapi, Found 19699 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->