### PR TITLE
REGRESSION(283790@main) [WebDriver][GLIB] Some mouse actions stopped working

### DIFF
--- a/Source/WebDriver/Actions.h
+++ b/Source/WebDriver/Actions.h
@@ -30,6 +30,7 @@
 namespace WebDriver {
 
 enum class MouseButton { None, Left, Middle, Right };
+enum class MouseInteraction { Move, Down, Up, SingleClick, DoubleClick };
 enum class PointerType { Mouse, Pen, Touch };
 
 struct InputSource {

--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -2514,6 +2514,24 @@ static String mouseButtonForAutomation(MouseButton button)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+static String mouseInteractionForAutomation(MouseInteraction interaction)
+{
+    switch (interaction) {
+    case MouseInteraction::Move:
+        return "Move"_s;
+    case MouseInteraction::Down:
+        return "Down"_s;
+    case MouseInteraction::Up:
+        return "Up"_s;
+    case MouseInteraction::SingleClick:
+        return "SingleClick"_s;
+    case MouseInteraction::DoubleClick:
+        return "DoubleClick"_s;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 void Session::performMouseInteraction(int x, int y, MouseButton button, MouseInteraction interaction, Function<void(CommandResult&&)>&& completionHandler)
 {
     auto parameters = JSON::Object::create();
@@ -2896,9 +2914,11 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                     switch (action.subtype) {
                     case Action::Subtype::PointerUp:
                         currentState.pressedButton = std::nullopt;
+                        currentState.mouseInteraction = MouseInteraction::Up;
                         break;
                     case Action::Subtype::PointerDown:
                         currentState.pressedButton = action.button.value();
+                        currentState.mouseInteraction = MouseInteraction::Down;
                         break;
                     case Action::Subtype::PointerMove: {
                         if (!action.x || !action.y)
@@ -2910,6 +2930,7 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                         state->setObject("location"_s, WTFMove(location));
                         if (action.origin->type == PointerOrigin::Type::Element)
                             state->setString("nodeHandle"_s, action.origin->elementID.value());
+                        currentState.mouseInteraction = MouseInteraction::Move;
                         [[fallthrough]];
                     }
                     case Action::Subtype::Pause:
@@ -2926,6 +2947,8 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                     }
                     if (currentState.pressedButton)
                         state->setString("pressedButton"_s, mouseButtonForAutomation(currentState.pressedButton.value()));
+                    if (currentState.mouseInteraction)
+                        state->setString("mouseInteraction"_s, mouseInteractionForAutomation(currentState.mouseInteraction.value()));
                     break;
                 }
                 case Action::Type::Key:

--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -242,11 +242,6 @@ private:
     void setInputFileUploadFiles(const String& elementID, const String& text, bool multiple, Function<void(CommandResult&&)>&&);
     void didSetInputFileUploadFiles(bool wasCancelled);
 
-    enum class MouseInteraction { Move,
-        Down,
-        Up,
-        SingleClick,
-        DoubleClick };
     void performMouseInteraction(int x, int y, MouseButton, MouseInteraction, Function<void(CommandResult&&)>&&);
 
     enum class KeyboardInteractionType { KeyPress,
@@ -275,6 +270,7 @@ private:
         Type type;
         String subtype;
         std::optional<MouseButton> pressedButton;
+        std::optional<MouseInteraction> mouseInteraction;
         std::optional<String> pressedKey;
         HashSet<String> pressedVirtualKeys;
     };

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -215,22 +215,10 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             },
             "test_context_click": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/291615"}}
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/272354"}}
             },
             "test_double_click": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/174674"}}
-            },
-            "test_drag_and_drop": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/291615"}}
-            },
-            "test_dragging_element_with_mouse_fires_events": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/291615"}}
-            },
-            "test_dragging_element_with_mouse_moves_it_to_another_list": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/291615"}}
-            },
-            "test_move_and_click": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/291615"}}
             },
             "test_selecting_multiple_items": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}


### PR DESCRIPTION
#### 0ec3a1f1a8e1f9b601d1477937df5fe09e56e2aa
<pre>
REGRESSION(283790@main) [WebDriver][GLIB] Some mouse actions stopped working
<a href="https://bugs.webkit.org/show_bug.cgi?id=280567">https://bugs.webkit.org/show_bug.cgi?id=280567</a>

Reviewed by Abrar Rahman Protyasha.

Ensure we forward the `mouseInteraction` field to avoid relying on
SimulatedInputDispatcher&apos;s heuristics.

Fixes over 40 failures in w3c/classic/perform_actions.

Also updated bug reference of test_context_click, which is still failing
despite this.

* Source/WebDriver/Actions.h:
* Source/WebDriver/Session.cpp:
(WebDriver::mouseInteractionForAutomation):
(WebDriver::Session::performActions):
* Source/WebDriver/Session.h:
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/299229@main">https://commits.webkit.org/299229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87ddba5cd0c02ff1b9363813b71716a89ba721e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89777 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70267 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127531 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98454 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24974 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21627 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50748 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->