### PR TITLE
[Performance] Creating many video elements with controls is slow and uses a lot of memory

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -478,7 +478,9 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediacapabilities/VideoConfiguration.idl
     Modules/mediacapabilities/WorkerNavigator+MediaCapabilities.idl
 
+    Modules/mediacontrols/DOMWindow+MediaControls.idl
     Modules/mediacontrols/MediaControlsHost.idl
+    Modules/mediacontrols/MediaControlsUtils.idl
 
     Modules/mediarecorder/BlobEvent.idl
     Modules/mediarecorder/MediaRecorder.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -546,7 +546,9 @@ $(PROJECT_DIR)/Modules/mediacapabilities/Navigator+MediaCapabilities.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/TransferFunction.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/VideoConfiguration.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/WorkerNavigator+MediaCapabilities.idl
+$(PROJECT_DIR)/Modules/mediacontrols/DOMWindow+MediaControls.idl
 $(PROJECT_DIR)/Modules/mediacontrols/MediaControlsHost.idl
+$(PROJECT_DIR)/Modules/mediacontrols/MediaControlsUtils.idl
 $(PROJECT_DIR)/Modules/mediarecorder/BlobEvent.idl
 $(PROJECT_DIR)/Modules/mediarecorder/MediaRecorder.idl
 $(PROJECT_DIR)/Modules/mediarecorder/MediaRecorderErrorEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -824,6 +824,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+DeviceMotion.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+DeviceMotion.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+DeviceOrientation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+DeviceOrientation.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+MediaControls.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+MediaControls.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+RequestIdleCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+RequestIdleCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+Selection.cpp
@@ -1840,6 +1842,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaController.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaController.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsHost.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsHost.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsUtils.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaControlsUtils.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaDecodingConfiguration.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaDecodingConfiguration.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaDecodingType.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -416,7 +416,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediacapabilities/TransferFunction.idl \
     $(WebCore)/Modules/mediacapabilities/VideoConfiguration.idl \
     $(WebCore)/Modules/mediacapabilities/WorkerNavigator+MediaCapabilities.idl \
+    $(WebCore)/Modules/mediacontrols/DOMWindow+MediaControls.idl \
     $(WebCore)/Modules/mediacontrols/MediaControlsHost.idl \
+    $(WebCore)/Modules/mediacontrols/MediaControlsUtils.idl \
     $(WebCore)/Modules/mediarecorder/BlobEvent.idl \
     $(WebCore)/Modules/mediarecorder/MediaRecorder.idl \
     $(WebCore)/Modules/mediarecorder/MediaRecorderErrorEvent.idl \

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -44,6 +44,7 @@
 #include "Page.h"
 #include "PermissionsPolicy.h"
 #include "ScriptExecutionContextInlines.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -36,7 +36,7 @@
 #include <WebCore/PositionCallback.h>
 #include <WebCore/PositionErrorCallback.h>
 #include <WebCore/PositionOptions.h>
-#include <WebCore/ScriptWrappableInlines.h>
+#include <WebCore/ScriptWrappable.h>
 #include <WebCore/Timer.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -37,6 +37,7 @@
 #include "IDBTransaction.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
@@ -31,6 +31,7 @@
 #include "IDBKey.h"
 #include "IDBKeyData.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/mediacontrols/DOMWindow+MediaControls.idl
+++ b/Source/WebCore/Modules/mediacontrols/DOMWindow+MediaControls.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=VIDEO,
+    ImplementedBy=LocalDOMWindowMediaControls,
+    EnabledForWorld=isMediaControls,
+] partial interface DOMWindow {
+    [CallWith=CurrentDocument] readonly attribute MediaControlsUtils utils;
+};

--- a/Source/WebCore/Modules/mediacontrols/LocalDOMWindowMediaControls.cpp
+++ b/Source/WebCore/Modules/mediacontrols/LocalDOMWindowMediaControls.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalDOMWindowMediaControls.h"
+
+#if ENABLE(VIDEO)
+
+#include "MediaControlsUtils.h"
+#include "RenderTheme.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalDOMWindowMediaControls);
+
+LocalDOMWindowMediaControls::LocalDOMWindowMediaControls(DOMWindow& window)
+    : LocalDOMWindowProperty(dynamicDowncast<LocalDOMWindow>(&window))
+{
+}
+
+LocalDOMWindowMediaControls::~LocalDOMWindowMediaControls() = default;
+
+LocalDOMWindowMediaControls* LocalDOMWindowMediaControls::from(DOMWindow& window)
+{
+    RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(window);
+    if (!localWindow)
+        return nullptr;
+
+    auto* supplement = downcast<LocalDOMWindowMediaControls>(Supplement<LocalDOMWindow>::from(localWindow.get(), supplementName()));
+    if (!supplement) {
+        auto newSupplement = makeUnique<LocalDOMWindowMediaControls>(window);
+        supplement = newSupplement.get();
+        provideTo(localWindow.get(), supplementName(), WTFMove(newSupplement));
+    }
+    return supplement;
+}
+
+RefPtr<MediaControlsUtils> LocalDOMWindowMediaControls::utils(Document& document, DOMWindow& window)
+{
+    if (auto* supplement = from(window))
+        return supplement->ensureUtils(document);
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+Ref<MediaControlsUtils> LocalDOMWindowMediaControls::ensureUtils(Document& document)
+{
+    if (!m_utils)
+        m_utils = MediaControlsUtils::create(document);
+    return *m_utils;
+}
+
+ASCIILiteral LocalDOMWindowMediaControls::supplementName()
+{
+    return "LocalDOMWindowMediaControls"_s;
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/mediacontrols/LocalDOMWindowMediaControls.h
+++ b/Source/WebCore/Modules/mediacontrols/LocalDOMWindowMediaControls.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO)
+
+#include "LocalDOMWindowProperty.h"
+#include "Supplementable.h"
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TypeCasts.h>
+
+namespace WebCore {
+
+class DOMWindow;
+class LocalDOMWindow;
+class MediaControlsUtils;
+
+class LocalDOMWindowMediaControls : public Supplement<LocalDOMWindow>, public LocalDOMWindowProperty {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(LocalDOMWindowMediaControls, WEBCORE_EXPORT);
+public:
+    explicit LocalDOMWindowMediaControls(DOMWindow&);
+    virtual ~LocalDOMWindowMediaControls();
+
+    static LocalDOMWindowMediaControls* from(DOMWindow&);
+
+    static RefPtr<MediaControlsUtils> utils(Document&, DOMWindow&);
+
+private:
+    bool isLocalDOMWindowMediaControls() const { return true; }
+    static ASCIILiteral supplementName();
+
+    Ref<MediaControlsUtils> ensureUtils(Document&);
+
+    RefPtr<MediaControlsUtils> m_utils;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LocalDOMWindowMediaControls)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isLocalDOMWindowMediaControls(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -426,11 +426,6 @@ String MediaControlsHost::base64StringForIconNameAndType(const String& iconName,
     return RenderTheme::singleton().mediaControlsBase64StringForIconNameAndType(iconName, iconType);
 }
 
-String MediaControlsHost::formattedStringForDuration(double durationInSeconds)
-{
-    return RenderTheme::singleton().mediaControlsFormattedStringForDuration(durationInSeconds);
-}
-
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 
 #if ENABLE(CONTEXT_MENUS) && USE(ACCESSIBILITY_CONTEXT_MENUS)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO)
 
 #include "HTMLMediaElement.h"
+#include "JSValueInWrappedObject.h"
 #include "MediaSession.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -113,7 +114,6 @@ public:
 
     Vector<String, 2> shadowRootStyleSheets() const;
     static String base64StringForIconNameAndType(const String& iconName, const String& iconType);
-    static String formattedStringForDuration(double);
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
     bool showMediaControlsContextMenu(HTMLElement&, String&& optionsJSONString, Ref<VoidCallback>&&);
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
@@ -126,6 +126,9 @@ public:
 #if ENABLE(MEDIA_SESSION)
     void ensureMediaSessionObserver();
 #endif
+
+    const JSValueInWrappedObject& controllerWrapper() const { return m_controllerWrapper; }
+    JSValueInWrappedObject& controllerWrapper() { return m_controllerWrapper; }
 
 private:
     explicit MediaControlsHost(HTMLMediaElement&);
@@ -147,6 +150,8 @@ private:
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
     RefPtr<VoidCallback> m_showMediaControlsContextMenuCallback;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+
+    JSValueInWrappedObject m_controllerWrapper;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -41,6 +41,7 @@ enum DeviceType {
 
 [
     Conditional=VIDEO,
+    JSCustomMarkFunction,
     LegacyNoInterfaceObject,
 ] interface MediaControlsHost {
     readonly attribute DOMString layoutTraitsClassName;
@@ -82,8 +83,9 @@ enum DeviceType {
 
     readonly attribute sequence<DOMString> shadowRootStyleSheets;
     DOMString base64StringForIconNameAndType(DOMString iconName, DOMString iconType);
-    DOMString formattedStringForDuration(unrestricted double durationInSeconds);
     [Conditional=MEDIA_CONTROLS_CONTEXT_MENUS, EnabledBySetting=MediaControlsContextMenusEnabled] boolean showMediaControlsContextMenu(HTMLElement target, JSON options, VoidCallback callback);
 
     [Conditional=MEDIA_SESSION] undefined ensureMediaSessionObserver();
+
+    [Custom] attribute any controller;
 };

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaControlsUtils.h"
+
+#if ENABLE(VIDEO)
+
+#include "Blob.h"
+#include "DOMURL.h"
+#include "HTMLImageElement.h"
+#include "MIMETypeRegistry.h"
+#include "RenderTheme.h"
+
+namespace WebCore {
+
+MediaControlsUtils::MediaControlsUtils(Document& document)
+    : ContextDestructionObserver(&document)
+{
+}
+
+String MediaControlsUtils::formattedStringForDuration(double durationInSeconds)
+{
+    return RenderTheme::singleton().mediaControlsFormattedStringForDuration(std::fabs(durationInSeconds));
+}
+
+RefPtr<HTMLImageElement> MediaControlsUtils::createImageForIconNameAndType(const String& iconName, const String& iconType)
+{
+    RefPtr protectedDocument = document();
+    if (!protectedDocument)
+        return nullptr;
+
+    Ref image = HTMLImageElement::create(*protectedDocument);
+    image->setIsUserAgentShadowRootResource();
+
+    RefPtr buffer = RenderTheme::singleton().mediaControlsImageDataForIconNameAndType(iconName, iconType);
+    if (!buffer)
+        return image;
+
+    auto iconMIMEType = MIMETypeRegistry::mimeTypeForExtension(iconType);
+    if (iconMIMEType.isEmpty())
+        return image;
+
+    image->setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(*protectedDocument, Blob::create(protectedDocument.get(), buffer->extractData(), iconMIMEType)) });
+
+    return image;
+}
+
+Document* MediaControlsUtils::document() const
+{
+    return dynamicDowncast<Document>(scriptExecutionContext());
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO)
+
+#include "ContextDestructionObserver.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class Document;
+class HTMLImageElement;
+
+class MediaControlsUtils
+    : public RefCounted<MediaControlsUtils>
+    , public ContextDestructionObserver {
+public:
+    static Ref<MediaControlsUtils> create(Document& document) { return adoptRef(*new MediaControlsUtils(document)); }
+    ~MediaControlsUtils() = default;
+
+    String formattedStringForDuration(double);
+    RefPtr<HTMLImageElement> createImageForIconNameAndType(const String& iconName, const String& iconType);
+
+private:
+    Document* document() const;
+
+    MediaControlsUtils(Document&);
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=VIDEO,
+    LegacyNoInterfaceObject,
+    EnabledForWorld=isMediaControls,
+] interface MediaControlsUtils {
+    DOMString formattedStringForDuration(unrestricted double durationInSeconds);
+    HTMLImageElement createImageForIconNameAndType(DOMString iconName, DOMString iconType);
+};

--- a/Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -33,6 +33,7 @@
 #include "RTCDTMFToneChangeEvent.h"
 #include "RTCRtpSender.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -39,6 +39,7 @@
 #include "RTCDataChannelRemoteHandlerConnection.h"
 #include "RTCErrorEvent.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/ConsoleTypes.h>

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp
@@ -37,6 +37,7 @@
 
 #include "ExceptionOr.h"
 #include "RTCIceCandidateInit.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
@@ -36,6 +36,7 @@
 
 #include "Logging.h"
 #include "RTCPeerConnection.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -33,6 +33,7 @@
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakRandomNumber.h>

--- a/Source/WebCore/Modules/modern-media-controls/controls/icon-service.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/icon-service.js
@@ -74,16 +74,6 @@ const iconService = new class IconService {
     }
 
     // Public
-    get shadowRoot()
-    {
-        return this.shadowRootWeakRef ? this.shadowRootWeakRef.deref() : null;
-    }
-
-    set shadowRoot(shadowRoot)
-    {
-        this.shadowRootWeakRef = new WeakRef(shadowRoot);
-    }
-
     imageForIconAndLayoutTraits(icon, layoutTraits)
     {
         const [fileName, resourceDirectory] = this._fileNameAndResourceDirectoryForIconAndLayoutTraits(icon, layoutTraits);
@@ -93,21 +83,12 @@ const iconService = new class IconService {
         if (image)
             return image;
 
-        image = this.images[path] = new Image;
-
-        // Prevent this image from being shown if it's ever attached to the DOM.
-        image.style.display = "none";
-
-        // Must attach the `<img>` to the UA shadow root before setting `src` so that `isInUserAgentShadowTree` is correct.
-        this.shadowRoot?.appendChild(image);
-
-        if (this.mediaControlsHost)
-            image.src = `data:${MimeTypes[icon.type]};base64,${this.mediaControlsHost.base64StringForIconNameAndType(fileName, icon.type)}`;
-        else
+        if (utils?.createImageForIconNameAndType)
+            image = this.images[path] = utils.createImageForIconNameAndType(fileName, icon.type);
+        else {
+            image = this.images[path] = new Image;
             image.src = `${this.directoryPath}/${path}`;
-
-        // Remove the `<img>` from the shadow root once the `src` has been set as `isInUserAgentShadowTree` has already been checked by this point.
-        image.remove();
+        }
 
         return image;
     }

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
@@ -58,7 +58,7 @@ class SliderBase extends LayoutNode
 
     set inputAccessibleLabel(timeValue)
     {
-        this._input.element.setAttribute("aria-valuetext", formattedStringForDuration(timeValue));
+        this._input.element.setAttribute("aria-valuetext", utils.formattedStringForDuration(timeValue));
     }
 
     get disabled()

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
@@ -84,7 +84,7 @@ class TimeLabel extends LayoutNode
         if (propertyName === "value") {
             this.element.textContent = this._formattedTime();
 
-            const timeAsString = formattedStringForDuration(this.value);
+            const timeAsString = utils.formattedStringForDuration(this.value);
             switch (this._type) {
             case TimeLabel.Type.Elapsed:
                 this.element.setAttribute("aria-label", UIString("Elapsed: %s", timeAsString));

--- a/Source/WebCore/Modules/modern-media-controls/main.js
+++ b/Source/WebCore/Modules/modern-media-controls/main.js
@@ -26,22 +26,27 @@
 const MinimumSizeToShowAnyControl = 47;
 const MaximumSizeToShowSmallProminentControl = 88;
 
-let mediaControlsHost;
+// If running outside the media element's isolated world, polyfill the MediaControlsUtils object:
+if (!window.utils) {
+    window.utils = {
+        formattedStringForDuration: function(duration) {
+            return "";
+        },
+    };
+}
 
 // This is called from HTMLMediaElement::ensureMediaControls().
 function createControls(shadowRoot, media, host)
 {
     if (host) {
-        mediaControlsHost = host;
-
-        iconService.shadowRoot = shadowRoot;
-        iconService.mediaControlsHost = host;
-
         for (let styleSheet of host.shadowRootStyleSheets)
             shadowRoot.appendChild(document.createElement("style")).textContent = styleSheet;
     }
 
-    return new MediaController(shadowRoot, media, host);
+    controller = new MediaController(shadowRoot, media, host);
+    if (host)
+        host.controller = controller;
+    return controller;
 }
 
 function UIString(stringToLocalize, ...replacementStrings)
@@ -74,10 +79,3 @@ function unitizeTime(value, unit)
     return `${value} ${returnedUnit}`;
 }
 
-function formattedStringForDuration(timeInSeconds)
-{
-    if (mediaControlsHost)
-        return mediaControlsHost.formattedStringForDuration(Math.abs(timeInSeconds));
-    else
-        return "";
-}

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.h
@@ -28,6 +28,7 @@
 #if ENABLE(PAYMENT_REQUEST)
 
 #include "Event.h"
+#include "ExceptionOr.h"
 #include <wtf/URL.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -30,6 +30,7 @@
 
 #include "DOMRectReadOnly.h"
 #include "ExceptionOr.h"
+#include "ScriptWrappableInlines.h"
 #include "VideoColorSpace.h"
 
 namespace WebCore {

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -219,7 +219,9 @@ Modules/indexeddb/shared/IndexKey.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
 Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
+Modules/mediacontrols/LocalDOMWindowMediaControls.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
+Modules/mediacontrols/MediaControlsUtils.cpp
 Modules/mediarecorder/BlobEvent.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediarecorder/MediaRecorderErrorEvent.cpp
@@ -720,6 +722,7 @@ bindings/js/JSIntersectionObserverEntryCustom.cpp
 bindings/js/JSKeyframeEffectCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSLocationCustom.cpp
+bindings/js/JSMediaControlsHostCustom.cpp
 bindings/js/JSMediaSessionCustom.cpp
 bindings/js/JSMediaSourceCustom.cpp
 bindings/js/JSMediaStreamTrackCustom.cpp
@@ -1240,6 +1243,7 @@ dom/DocumentFontLoader.cpp
 dom/DocumentFragment.cpp
 dom/DocumentFullscreen.cpp
 dom/DocumentMarkerController.cpp
+dom/DocumentMediaElement.cpp
 dom/DocumentOrShadowRootFullscreen.cpp
 dom/DocumentParser.cpp
 dom/DocumentSharedObjectPool.cpp
@@ -4302,6 +4306,7 @@ JSMediaCapabilitiesEncodingInfo.cpp
 JSMediaCapabilitiesInfo.cpp
 JSMediaController.cpp
 JSMediaControlsHost.cpp
+JSMediaControlsUtils.cpp
 JSMediaDecodingConfiguration.cpp
 JSMediaDecodingType.cpp
 JSMediaDeviceInfo.cpp

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -78,6 +78,9 @@ public:
     void setAllowPostLegacySynchronousMessage() { m_allowPostLegacySynchronousMessage = true; }
     bool allowPostLegacySynchronousMessage() const { return m_allowPostLegacySynchronousMessage; }
 
+    void setIsMediaControls() { m_isMediaControls = true; }
+    bool isMediaControls() const { return m_isMediaControls; }
+
     DOMObjectWrapperMap& wrappers() { return m_wrappers; }
 
     Type type() const { return m_type; }
@@ -107,6 +110,7 @@ private:
     bool m_allowJSHandleCreation : 1 { false };
     bool m_allowNodeSerialization : 1 { false };
     bool m_allowPostLegacySynchronousMessage : 1 { false };
+    bool m_isMediaControls : 1 { false };
 };
 
 DOMWrapperWorld& normalWorld(JSC::VM&);

--- a/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSMediaControlsHost.h"
+
+#if ENABLE(VIDEO)
+
+namespace WebCore {
+
+JSC::JSValue JSMediaControlsHost::controller(JSC::JSGlobalObject& lexicalGlobalObject) const
+{
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().controllerWrapper(), [this](JSC::ThrowScope&) {
+        return wrapped().controllerWrapper().getValue(JSC::jsUndefined());
+    });
+}
+
+void JSMediaControlsHost::setController(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
+{
+    wrapped().controllerWrapper().set(lexicalGlobalObject.vm(), this, value);
+}
+
+template<typename Visitor>
+void JSMediaControlsHost::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().controllerWrapper().visit(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMediaControlsHost);
+
+} // namespace WebCore
+
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -751,6 +751,7 @@ namespace WebCore {
     macro(underlyingByteSource) \
     macro(underlyingSink) \
     macro(underlyingSource) \
+    macro(utils) \
     macro(view) \
     macro(visualViewport) \
     macro(webkit) \

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -52,6 +52,7 @@
 #include "PluginDocument.h"
 #include "SVGDocument.h"
 #include "SVGNames.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include "SecurityOriginPolicy.h"
 #include "Settings.h"

--- a/Source/WebCore/dom/DOMRectReadOnly.cpp
+++ b/Source/WebCore/dom/DOMRectReadOnly.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "DOMRectReadOnly.h"
 
+#include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/dom/DocumentMediaElement.cpp
+++ b/Source/WebCore/dom/DocumentMediaElement.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DocumentMediaElement.h"
+
+#if ENABLE(VIDEO)
+
+#include "CommonVM.h"
+#include "DOMWrapperWorld.h"
+#include "Document.h"
+#include "RenderTheme.h"
+#include "ScriptController.h"
+#include "ScriptSourceCode.h"
+#include <JavaScriptCore/CatchScope.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DocumentMediaElement);
+
+DocumentMediaElement& DocumentMediaElement::from(Document& document)
+{
+    auto* supplement = downcast<DocumentMediaElement>(Supplement<Document>::from(&document, supplementName()));
+    if (!supplement) {
+        auto newSupplement = makeUnique<DocumentMediaElement>(document);
+        supplement = newSupplement.get();
+        provideTo(&document, supplementName(), WTFMove(newSupplement));
+    }
+    return *supplement;
+}
+
+DocumentMediaElement::DocumentMediaElement(Document& document)
+    : m_document { document }
+{
+}
+
+Document& DocumentMediaElement::document() const
+{
+    return m_document;
+}
+
+ASCIILiteral DocumentMediaElement::supplementName()
+{
+    return "DocumentMediaElement"_s;
+};
+
+bool DocumentMediaElement::setupAndCallMediaControlsJS(NOESCAPE const JSSetupFunction& task)
+{
+    if (!ensureMediaControlsScript())
+        return false;
+
+    return setupAndCallJS(task);
+}
+
+DOMWrapperWorld& DocumentMediaElement::ensureIsolatedWorld()
+{
+    if (!m_isolatedWorld) {
+        m_isolatedWorld = DOMWrapperWorld::create(Ref { commonVM() }, DOMWrapperWorld::Type::Internal, "Media Controls (Document)"_s);
+        m_isolatedWorld->setIsMediaControls();
+    }
+    return *m_isolatedWorld;
+}
+
+bool DocumentMediaElement::ensureMediaControlsScript()
+{
+    if (m_haveParsedMediaControlsScript)
+        return true;
+
+    Ref document = this->document();
+    auto mediaControlsScripts = RenderTheme::singleton().mediaControlsScripts();
+    if (mediaControlsScripts.isEmpty() || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
+        return false;
+
+    m_haveParsedMediaControlsScript = setupAndCallJS([mediaControlsScripts = WTFMove(mediaControlsScripts)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject&, ScriptController& scriptController, DOMWrapperWorld& world) {
+        auto& vm = globalObject.vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        for (auto& mediaControlsScript : mediaControlsScripts) {
+            if (mediaControlsScript.isEmpty())
+                continue;
+            scriptController.evaluateInWorldIgnoringException(ScriptSourceCode(mediaControlsScript, JSC::SourceTaintedOrigin::Untainted), world);
+            RETURN_IF_EXCEPTION(scope, false);
+        }
+
+        return true;
+    });
+    return m_haveParsedMediaControlsScript;
+}
+
+bool DocumentMediaElement::setupAndCallJS(NOESCAPE const JSSetupFunction& task)
+{
+    Ref world = ensureIsolatedWorld();
+    Ref protectedDocument = this->document();
+    RefPtr protectedFrame = protectedDocument->frame();
+    if (!protectedFrame)
+        return false;
+    CheckedRef scriptController = protectedFrame->script();
+    auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(scriptController->globalObject(world));
+    if (!globalObject)
+        return false;
+    auto& vm = globalObject->vm();
+    JSC::JSLockHolder lock(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto* lexicalGlobalObject = globalObject;
+
+    auto reportExceptionAndReturnFalse = [&] () -> bool {
+        auto* exception = scope.exception();
+        scope.clearException();
+        reportException(globalObject, exception);
+        return false;
+    };
+
+    auto result = task(*globalObject, *lexicalGlobalObject, scriptController, world);
+    RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+    return result;
+}
+
+}
+
+#endif

--- a/Source/WebCore/dom/DocumentMediaElement.h
+++ b/Source/WebCore/dom/DocumentMediaElement.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO)
+
+#include <WebCore/Supplementable.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TypeCasts.h>
+
+namespace JSC {
+class JSGlobalObject;
+}
+
+namespace WebCore {
+
+class DOMWrapperWorld;
+class Document;
+class JSDOMGlobalObject;
+class ScriptController;
+
+class DocumentMediaElement final : public Supplement<Document> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DocumentMediaElement);
+public:
+    static DocumentMediaElement& from(Document&);
+
+    DocumentMediaElement(Document&);
+
+    using JSSetupFunction = Function<bool(JSDOMGlobalObject&, JSC::JSGlobalObject&, ScriptController&, DOMWrapperWorld&)>;
+    bool setupAndCallMediaControlsJS(NOESCAPE const JSSetupFunction&);
+
+private:
+    bool isDocumentMediaElement() const final { return true; }
+    static ASCIILiteral supplementName();
+
+    Document& document() const;
+
+    DOMWrapperWorld& ensureIsolatedWorld();
+    bool ensureMediaControlsScript();
+    bool setupAndCallJS(NOESCAPE const JSSetupFunction&);
+
+    CheckedRef<Document> m_document;
+    RefPtr<DOMWrapperWorld> m_isolatedWorld;
+    bool m_haveParsedMediaControlsScript { false };
+};
+
+}
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DocumentMediaElement)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isDocumentMediaElement(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -33,6 +33,7 @@
 #include "ElementRareData.h"
 #include "HTMLFormElement.h"
 #include "HTMLMaybeFormAssociatedCustomElement.h"
+#include "ScriptWrappableInlines.h"
 #include "ShadowRoot.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -33,6 +33,7 @@
 #include "JSDOMGlobalObject.h"
 #include "LocalDOMWindow.h"
 #include "Performance.h"
+#include "ScriptWrappableInlines.h"
 #include "UserGestureIndicator.h"
 #include "WorkerGlobalScope.h"
 #include <wtf/HexNumber.h>

--- a/Source/WebCore/dom/NamedNodeMap.cpp
+++ b/Source/WebCore/dom/NamedNodeMap.cpp
@@ -28,6 +28,7 @@
 #include "Attr.h"
 #include "ElementInlines.h"
 #include "HTMLElement.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/NodeIterator.cpp
+++ b/Source/WebCore/dom/NodeIterator.cpp
@@ -28,6 +28,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "NodeTraversal.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/TreeWalker.cpp
+++ b/Source/WebCore/dom/TreeWalker.cpp
@@ -27,6 +27,7 @@
 
 #include "ContainerNode.h"
 #include "NodeTraversal.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/TrustedScriptURL.cpp
+++ b/Source/WebCore/dom/TrustedScriptURL.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TrustedScriptURL.h"
 
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
@@ -35,6 +35,7 @@
 #include "JSTrustedScriptURL.h"
 #include "SVGNames.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "TrustedType.h"
 #include "TrustedTypePolicyOptions.h"
 #include "XLinkNames.h"

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -43,6 +43,7 @@
 #include "ReadableStream.h"
 #include "ReadableStreamSource.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include "SharedBuffer.h"
 #include "ThreadableBlobRegistry.h"

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -317,6 +317,11 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
     return candidate;
 }
 
+void HTMLImageElement::setIsUserAgentShadowRootResource()
+{
+    m_imageLoader->setElementIsUserAgentShadowRootResource(true);
+}
+
 void HTMLImageElement::evaluateDynamicMediaQueryDependencies()
 {
     RefPtr documentElement = document().documentElement();

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -150,6 +150,8 @@ public:
     bool isDroppedImagePlaceholder() const { return m_isDroppedImagePlaceholder; }
     void setIsDroppedImagePlaceholder() { m_isDroppedImagePlaceholder = true; }
 
+    void setIsUserAgentShadowRootResource();
+
     void evaluateDynamicMediaQueryDependencies();
 
     String referrerPolicyForBindings() const;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -588,7 +588,6 @@ public:
 
     void pageScaleFactorChanged();
     void userInterfaceLayoutDirectionChanged();
-    WEBCORE_EXPORT String getCurrentMediaControlsStatus();
     WEBCORE_EXPORT void setMediaControlsMaximumRightContainerButtonCountOverride(size_t);
     WEBCORE_EXPORT void setMediaControlsHidePlaybackRates(bool);
     MediaControlsHost* mediaControlsHost() { return m_mediaControlsHost.get(); }
@@ -1047,8 +1046,6 @@ private:
     enum class SleepType : uint8_t { None, Display, System };
     SleepType shouldDisableSleep() const;
 
-    DOMWrapperWorld& ensureIsolatedWorld();
-
     RefPtr<MediaSessionManagerInterface> sessionManager() const final;
     PlatformMediaSession::MediaType mediaType() const override;
     PlatformMediaSession::MediaType presentationType() const override;
@@ -1094,11 +1091,7 @@ private:
     void initializeMediaSession();
     void invalidateMediaSession();
 
-    void updateCaptionContainer();
     bool ensureMediaControls();
-
-    using JSSetupFunction = Function<bool(JSDOMGlobalObject&, JSC::JSGlobalObject&, ScriptController&, DOMWrapperWorld&)>;
-    bool setupAndCallJS(NOESCAPE const JSSetupFunction&);
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     void prepareForDocumentSuspension() final;
@@ -1330,7 +1323,6 @@ private:
     bool m_hasEverHadVideo : 1;
 
     bool m_mediaControlsDependOnPageScaleFactor : 1;
-    bool m_haveSetUpCaptionContainer : 1;
 
     bool m_isScrubbingRemotely : 1;
     bool m_waitingToEnterFullscreen : 1;
@@ -1413,7 +1405,6 @@ private:
 
     friend class MediaControlsHost;
     RefPtr<MediaControlsHost> m_mediaControlsHost;
-    RefPtr<DOMWrapperWorld> m_isolatedWorld;
 
 #if ENABLE(MEDIA_STREAM)
     RefPtr<MediaStream> m_mediaStreamSrcObject;

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -128,4 +128,7 @@ typedef (
 
     [Conditional=WIRELESS_PLAYBACK_TARGET, EnabledBySetting=WirelessPlaybackTargetAPIEnabled] undefined webkitShowPlaybackTargetPicker();
     [Conditional=WIRELESS_PLAYBACK_TARGET, EnabledBySetting=WirelessPlaybackTargetAPIEnabled] readonly attribute boolean webkitCurrentPlaybackTargetIsWireless;
+
+    // Internal
+    [EnabledForWorld=isMediaControls, ImplementedAs=mediaControlsHost] readonly attribute MediaControlsHost? controlsHost;
 };

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -52,6 +52,7 @@
 #include "RenderElement.h"
 #include "SVGImageElement.h"
 #include "ScriptExecutionContextInlines.h"
+#include "ScriptWrappableInlines.h"
 #include "SharedBuffer.h"
 #include "WebCodecsVideoFrame.h"
 #include "WorkerClient.h"

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -221,7 +221,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     CachedResourceHandle<CachedImage> newImage;
     if (!attr.isNull() && !StringView(attr).containsOnly<isASCIIWhitespace<char16_t>>()) {
         ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
-        options.contentSecurityPolicyImposition = element->isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
+        options.contentSecurityPolicyImposition = (element->isInUserAgentShadowTree() || m_elementIsUserAgentShadowRootResource) ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
         options.loadedFromPluginElement = is<HTMLPlugInElement>(element) ? LoadedFromPluginElement::Yes : LoadedFromPluginElement::No;
         options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
         options.serviceWorkersMode = is<HTMLPlugInElement>(element) ? ServiceWorkersMode::None : ServiceWorkersMode::All;

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -83,6 +83,7 @@ public:
     void decode(Ref<DeferredPromise>&&);
 
     void setLoadManually(bool loadManually) { m_loadManually = loadManually; }
+    void setElementIsUserAgentShadowRootResource(bool value) { m_elementIsUserAgentShadowRootResource = value; }
 
     // FIXME: Delete this code. beforeload event no longer exists.
     bool hasPendingBeforeLoadEvent() const { return m_hasPendingBeforeLoadEvent; }
@@ -145,6 +146,7 @@ private:
     bool m_imageComplete : 1;
     bool m_loadManually : 1;
     bool m_elementIsProtected : 1;
+    bool m_elementIsUserAgentShadowRootResource : 1 { false };
     LazyImageLoadState m_lazyImageLoadState { LazyImageLoadState::None };
 };
 

--- a/Source/WebCore/page/PerformanceMeasure.h
+++ b/Source/WebCore/page/PerformanceMeasure.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class SerializedScriptValue;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class PerformanceMeasure final : public PerformanceEntry {
 public:

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -86,6 +86,8 @@ public:
     virtual bool isNavigatorGamepad() const { return false; }
     virtual bool isUserMediaController() const { return false; }
     virtual bool isWorkerGlobalScopeCaches() const { return false; }
+    virtual bool isLocalDOMWindowMediaControls() const { return false; }
+    virtual bool isDocumentMediaElement() const { return false; }
 };
 
 template<typename T>

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -103,6 +103,7 @@ public:
 #if ENABLE(VIDEO)
     virtual Vector<String, 2> mediaControlsStyleSheets(const HTMLMediaElement&) { return { }; }
     virtual Vector<String, 2> mediaControlsScripts() { return { }; }
+    virtual RefPtr<FragmentedSharedBuffer> mediaControlsImageDataForIconNameAndType(const String&, const String&) { return nullptr; }
     virtual String mediaControlsBase64StringForIconNameAndType(const String&, const String&) { return String(); }
     virtual String mediaControlsFormattedStringForDuration(double) { return String(); }
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -216,6 +216,25 @@ Vector<String, 2> RenderThemeAdwaita::mediaControlsStyleSheets(const HTMLMediaEl
     return { m_mediaControlsStyleSheet };
 }
 
+RefPtr<FragmentedSharedBuffer> RenderThemeAdwaita::mediaControlsImageDataForIconNameAndType(const String& iconName, const String& iconType)
+{
+#if USE(GLIB)
+    auto path = makeString("/org/webkit/media-controls/"_s, iconName, '.', iconType);
+    auto data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
+    if (!data)
+        return nullptr;
+    return SharedBuffer::create(span(data));
+#elif PLATFORM(WIN)
+    auto path = webKitBundlePath(iconName, iconType, "media-controls"_s);
+    auto data = FileSystem::readEntireFile(path);
+    if (!data)
+        return nullptr;
+    return SharedBuffer::create(WTFMove(*data));
+#else
+    return nullptr;
+#endif
+}
+
 String RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType(const String& iconName, const String& iconType)
 {
 #if USE(GLIB)

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
@@ -53,6 +53,7 @@ private:
 #endif
 
 #if ENABLE(VIDEO)
+    RefPtr<FragmentedSharedBuffer> mediaControlsImageDataForIconNameAndType(const String&, const String&) override;
     String mediaControlsBase64StringForIconNameAndType(const String&, const String&) final;
     String mediaControlsFormattedStringForDuration(double) final;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -293,6 +293,7 @@ private:
 #if ENABLE(VIDEO)
     Vector<String, 2> mediaControlsStyleSheets(const HTMLMediaElement&) override;
     Vector<String, 2> mediaControlsScripts() override;
+    RefPtr<FragmentedSharedBuffer> mediaControlsImageDataForIconNameAndType(const String&, const String&) override;
     String mediaControlsBase64StringForIconNameAndType(const String&, const String&) override;
     String mediaControlsFormattedStringForDuration(double) override;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -413,6 +413,13 @@ Vector<String, 2> RenderThemeCocoa::mediaControlsScripts()
     };
 }
 
+RefPtr<FragmentedSharedBuffer> RenderThemeCocoa::mediaControlsImageDataForIconNameAndType(const String& iconName, const String& iconType)
+{
+    NSString *directory = @"modern-media-controls/images";
+    NSBundle *bundle = [NSBundle bundleForClass:[WebCoreRenderThemeBundle class]];
+    return SharedBuffer::create([NSData dataWithContentsOfFile:[bundle pathForResource:iconName.createNSString().get() ofType:iconType.createNSString().get() inDirectory:directory]]);
+}
+
 String RenderThemeCocoa::mediaControlsBase64StringForIconNameAndType(const String& iconName, const String& iconType)
 {
     NSString *directory = @"modern-media-controls/images";

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5816,11 +5816,6 @@ void Internals::systemBeep()
 
 #if ENABLE(VIDEO)
 
-String Internals::getCurrentMediaControlsStatusForElement(HTMLMediaElement& mediaElement)
-{
-    return mediaElement.getCurrentMediaControlsStatus();
-}
-
 void Internals::setMediaControlsMaximumRightContainerButtonCountOverride(HTMLMediaElement& mediaElement, size_t count)
 {
     mediaElement.setMediaControlsMaximumRightContainerButtonCountOverride(count);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -930,7 +930,6 @@ public:
     ExceptionOr<String> pathStringWithShrinkWrappedRects(const Vector<double>& rectComponents, double radius);
 
 #if ENABLE(VIDEO)
-    String getCurrentMediaControlsStatusForElement(HTMLMediaElement&);
     void setMediaControlsMaximumRightContainerButtonCountOverride(HTMLMediaElement&, size_t);
     void setMediaControlsHidePlaybackRates(HTMLMediaElement&, bool);
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1111,7 +1111,6 @@ enum ContentsFormat {
 
     DOMString pathStringWithShrinkWrappedRects(sequence<double> rectComponents, double radius);
 
-    [Conditional=VIDEO] DOMString getCurrentMediaControlsStatusForElement(HTMLMediaElement element);
     [Conditional=VIDEO] undefined setMediaControlsMaximumRightContainerButtonCountOverride(HTMLMediaElement element, unsigned long count);
     [Conditional=VIDEO] undefined setMediaControlsHidePlaybackRates(HTMLMediaElement element, boolean hidePlaybackRates);
 


### PR DESCRIPTION
#### cb5c26fdab720ac541971d67efb8f9e8ca2780e1
<pre>
[Performance] Creating many video elements with controls is slow and uses a lot of memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=297978">https://bugs.webkit.org/show_bug.cgi?id=297978</a>
<a href="https://rdar.apple.com/problem/159305371">rdar://problem/159305371</a>

Reviewed by Eric Carlson.

Loading the website <a href="https://neurodyne-demo.github.io">https://neurodyne-demo.github.io</a> in Safari results in a WebContent process
with 5.4GB of allocated memory, due to that site creating 952 &lt;audio&gt; elements, each with its
controls attribute enabled.

In addition to requring a lot of memory, creating and adding that many elements to the DOM is
very slow. On this machine, the PerformanceTests/Media/VideoElementWithControlsCreation.html
test shows a median time of 552ms to create and add 100 empty &lt;video&gt; elements to the DOM.

Much of this excess time and memory is due to each HTMLMediaElement creating its own
isolated DOMWrapperWorld to host the media controls scripts, requiring 952 worlds with 952
instances of the media controls script, and 952 caches of media controls images.

Rather than have each HTMLMediaElement own its own isolated DOMWrapperWorld, the media elements
within a Document can all share the same isolated world, and create and destroy their own
controls per-element, sharing a single instance of the media controls script and image cache.

After this change, the WebConent process allocates only 1.7GB of memory for the neurodyne website.
Additionally, the VideoElementWithControlsCreation.html performance test shows a median time
of 175ms.

Drive-by fixes and changes:

- There&apos;s no longer any need to manually make a connection between the media element wrapper, the
  MediaControlsHost wrapper, and the media controller javascript object. Those connections can be
  made directly in IDL. Added a custom &quot;controller&quot; property on MediaControlsHost wrapper which
  stores an arbitrary JSValue and add a custom visitor method which visits that object during GC.

- Images loaded via blob: urls can be blocked by CSP, so mark the Images created by MediaControlsHost
  as belonging to the User Agent shadow root, and exempt such images from CSP when loading.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediacontrols/DOMWindow+MediaControls.idl: Added.
* Source/WebCore/Modules/mediacontrols/LocalDOMWindowMediaControls.cpp: Added.
(WebCore::LocalDOMWindowMediaControls::LocalDOMWindowMediaControls):
(WebCore::LocalDOMWindowMediaControls::from):
(WebCore::LocalDOMWindowMediaControls::utils):
(WebCore::LocalDOMWindowMediaControls::ensureUtils):
(WebCore::LocalDOMWindowMediaControls::supplementName):
* Source/WebCore/Modules/mediacontrols/LocalDOMWindowMediaControls.h: Added.
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::formattedStringForDuration): Deleted.
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/mediacontrols/MediaControlsUtils.cpp: Added.
(WebCore::MediaControlsUtils::MediaControlsUtils):
(WebCore::MediaControlsUtils::formattedStringForDuration):
(WebCore::MediaControlsUtils::createImageForIconNameAndType):
(WebCore::MediaControlsUtils::document const):
* Source/WebCore/Modules/mediacontrols/MediaControlsUtils.h: Added.
(WebCore::MediaControlsUtils::create):
* Source/WebCore/Modules/mediacontrols/MediaControlsUtils.idl: Added.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
* Source/WebCore/Modules/modern-media-controls/controls/icon-service.js:
(const.iconService.new.IconService.prototype.imageForIconAndLayoutTraits):
(const.iconService.new.IconService.prototype.get shadowRoot): Deleted.
(const.iconService.new.IconService.prototype.set shadowRoot): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/slider-base.js:
(SliderBase.set inputAccessibleLabel):
* Source/WebCore/Modules/modern-media-controls/controls/time-label.js:
(TimeLabel.prototype.commitProperty):
* Source/WebCore/Modules/modern-media-controls/main.js:
(window.utils.window.utils.formattedStringForDuration):
(createControls):
(formattedStringForDuration): Deleted.
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::encodeAsCBOR):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::setIsMediaControls):
(WebCore::DOMWrapperWorld::isMediaControls const):
* Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp: Added.
(WebCore::JSMediaControlsHost::controller const):
(WebCore::JSMediaControlsHost::setController):
(WebCore::JSMediaControlsHost::visitAdditionalChildren):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/DocumentMediaElement.cpp: Added.
(WebCore::DocumentMediaElement::from):
(WebCore::DocumentMediaElement::DocumentMediaElement):
(WebCore::DocumentMediaElement::document const):
(WebCore::DocumentMediaElement::supplementName):
(WebCore::DocumentMediaElement::setupAndCallMediaControlsJS):
(WebCore::DocumentMediaElement::ensureIsolatedWorld):
(WebCore::DocumentMediaElement::ensureMediaControlsScript):
(WebCore::DocumentMediaElement::setupAndCallJS):
* Source/WebCore/dom/DocumentMediaElement.h: Added.
* Source/WebCore/dom/TrustedHTML.h:
* Source/WebCore/dom/TrustedScript.h:
* Source/WebCore/dom/TrustedScriptURL.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setIsUserAgentShadowRootResource):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::pauseAfterDetachedTask):
(WebCore::HTMLMediaElement::configureTextTracks):
(WebCore::HTMLMediaElement::setControllerJSProperty):
(WebCore::HTMLMediaElement::ensureMediaControls):
(WebCore::HTMLMediaElement::setShowingStats):
(WebCore::controllerJSValue): Deleted.
(WebCore::HTMLMediaElement::setupAndCallJS): Deleted.
(WebCore::HTMLMediaElement::updateCaptionContainer): Deleted.
(WebCore::HTMLMediaElement::ensureIsolatedWorld): Deleted.
(WebCore::HTMLMediaElement::getCurrentMediaControlsStatus): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.idl:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
* Source/WebCore/loader/ImageLoader.h:
(WebCore::ImageLoader::setElementIsUserAgentShadowRootResource):
* Source/WebCore/page/PerformanceMeasure.h:
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::mediaControlsImageDataForIconNameAndType):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::mediaControlsImageDataForIconNameAndType):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getCurrentMediaControlsStatusForElement): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/299342@main">https://commits.webkit.org/299342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04422506e2e01840842b431a9472f77016f72994

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70731 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51efff43-c9d9-4737-9f7c-c75272a35086) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90063 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/983a695f-e002-4b7f-84a1-b7758db92496) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f02497b7-5e12-4b0d-84e4-3dd537a0a1ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24508 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68508 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127909 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34396 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98489 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21933 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51126 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44912 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->