### PR TITLE
Enable by default support for Wasm Memory buffer APIs

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -648,7 +648,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, true, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useWasmJSStringBuiltins, false, Normal, "Enable the implementation of the JS String Builtins proposal."_s) \
-    v(Bool, useWasmMemoryToBufferAPIs, false, Normal, "Enable the toFixedLengthBuffer() and toResizableBuffer() Wasm Memory.prototype functions."_s) \
+    v(Bool, useWasmMemoryToBufferAPIs, true, Normal, "Enable the toFixedLengthBuffer() and toResizableBuffer() Wasm Memory.prototype functions."_s) \
     v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \


### PR DESCRIPTION
#### b3fa045c1cb905093b83e16917f209a9ef0768a4
<pre>
Enable by default support for Wasm Memory buffer APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=297986">https://bugs.webkit.org/show_bug.cgi?id=297986</a>
<a href="https://rdar.apple.com/159305098">rdar://159305098</a>

Reviewed by Mark Lam.

This patch enables by default the new Wasm Memory APIs
.toFixedLengthBuffer() and .toResizableBuffer() which are
part of Interop 2025.

Canonical link: <a href="https://commits.webkit.org/299236@main">https://commits.webkit.org/299236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91351e342839b583f5a2f4177ee8be2d180c7612

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70354 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7520ff73-ea56-44ef-a78d-23c63eb66d74) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89781 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31cc5c51-4b78-47a4-85fb-5c0018947717) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70270 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78487e39-1246-4163-a25d-b915a75362ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24191 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68129 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110418 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127538 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116815 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98458 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98244 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24978 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41685 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50755 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145513 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44542 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37434 "Found 1 new JSC binary failure: testapi, Found 19681 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default, ChakraCore.yaml/ChakraCore/test/Function/bind.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47886 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->