### PR TITLE
Add interface to access WTF::decodeHostName through WebKit.framework

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -1884,6 +1884,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKNSStringExtras {
+    header "_WKNSStringExtras.h"
+    export *
+  }
+
+  explicit module _WKNSURLExtras {
+    header "_WKNSURLExtras.h"
+    export *
+  }
+
   explicit module _WKNSWindowExtras {
     header "_WKNSWindowExtras.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2790,6 +2790,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKNSStringExtras {
+    header "_WKNSStringExtras.h"
+    export *
+  }
+
+  explicit module _WKNSURLExtras {
+    header "_WKNSURLExtras.h"
+    export *
+  }
+
   explicit module _WKNSWindowExtras {
     header "_WKNSWindowExtras.h"
     export *

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -290,6 +290,8 @@ UIProcess/API/Cocoa/_WKJSHandle.mm
 UIProcess/API/Cocoa/_WKLinkIconParameters.mm
 UIProcess/API/Cocoa/_WKModalContainerInfo.mm
 UIProcess/API/Cocoa/_WKNotificationData.mm
+UIProcess/API/Cocoa/_WKNSStringExtras.mm
+UIProcess/API/Cocoa/_WKNSURLExtras.mm
 UIProcess/API/Cocoa/_WKPageLoadTiming.mm
 UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
 UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4301,11 +4301,6 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
     });
 }
 
-+ (NSString *)_userVisibleStringForURL:(NSURL *)url
-{
-    return WTF::userVisibleString(url);
-}
-
 - (void)_toggleInWindow
 {
     THROW_IF_SUSPENDED;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -444,8 +444,6 @@ for this property.
 // The result frame info is the frame that contains the hit node.
 - (void)_hitTestAtPoint:(CGPoint)point inFrameCoordinateSpace:(WKFrameInfo *)frame completionHandler:(void (^)(_WKJSHandle *, NSError *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-+ (NSString *)_userVisibleStringForURL:(NSURL *)url WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-
 - (void)_takePDFSnapshotWithConfiguration:(WKSnapshotConfiguration *)snapshotConfiguration completionHandler:(void (^)(NSData *pdfSnapshotData, NSError *error))completionHandler WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 - (void)_getPDFFirstPageSizeInFrame:(_WKFrameHandle *)frame completionHandler:(void(^)(CGSize))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNSStringExtras.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNSStringExtras.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,63 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "_WKTextInputContext.h"
+#import <WebKit/WKFoundation.h>
 
-#import "_WKTextInputContextInternal.h"
-#import <WebCore/ElementContext.h>
-#import <wtf/cocoa/TypeCastsCocoa.h>
+@interface NSString (WKExtras)
 
-@implementation _WKTextInputContext {
-    WebCore::ElementContext _textInputContext;
-}
-
-- (instancetype)init
-{
-    return nil;
-}
-
-- (instancetype)_initWithTextInputContext:(const WebCore::ElementContext&)context
-{
-    self = [super init];
-    if (!self)
-        return nil;
-
-    _textInputContext = context;
-
-    return self;
-}
-
-- (CGRect)boundingRect
-{
-    return _textInputContext.boundingRect;
-}
-
-- (const WebCore::ElementContext&)_textInputContext
-{
-    return _textInputContext;
-}
-
-- (BOOL)isEqual:(id)otherObject
-{
-    if (self == otherObject)
-        return YES;
-
-    auto *other = dynamic_objc_cast<_WKTextInputContext>(otherObject);
-    if (!other)
-        return NO;
-
-    return _textInputContext == other->_textInputContext;
-}
-
-- (NSUInteger)hash
-{
-    return _textInputContext.nodeIdentifier ? _textInputContext.nodeIdentifier->toUInt64() : 0;
-}
-
-- (id)copyWithZone:(NSZone *)zone
-{
-    return [self retain];
-}
+- (NSString *)_wk_decodeHostName WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNSStringExtras.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNSStringExtras.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,62 +24,15 @@
  */
 
 #import "config.h"
-#import "_WKTextInputContext.h"
+#import "_WKNSURLExtras.h"
 
-#import "_WKTextInputContextInternal.h"
-#import <WebCore/ElementContext.h>
-#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/cocoa/NSURLExtras.h>
 
-@implementation _WKTextInputContext {
-    WebCore::ElementContext _textInputContext;
-}
+@implementation NSString (WKExtras)
 
-- (instancetype)init
+- (NSString *)_wk_decodeHostName
 {
-    return nil;
-}
-
-- (instancetype)_initWithTextInputContext:(const WebCore::ElementContext&)context
-{
-    self = [super init];
-    if (!self)
-        return nil;
-
-    _textInputContext = context;
-
-    return self;
-}
-
-- (CGRect)boundingRect
-{
-    return _textInputContext.boundingRect;
-}
-
-- (const WebCore::ElementContext&)_textInputContext
-{
-    return _textInputContext;
-}
-
-- (BOOL)isEqual:(id)otherObject
-{
-    if (self == otherObject)
-        return YES;
-
-    auto *other = dynamic_objc_cast<_WKTextInputContext>(otherObject);
-    if (!other)
-        return NO;
-
-    return _textInputContext == other->_textInputContext;
-}
-
-- (NSUInteger)hash
-{
-    return _textInputContext.nodeIdentifier ? _textInputContext.nodeIdentifier->toUInt64() : 0;
-}
-
-- (id)copyWithZone:(NSZone *)zone
-{
-    return [self retain];
+    return WTF::decodeHostName(self);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNSURLExtras.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNSURLExtras.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,63 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "_WKTextInputContext.h"
+#import <WebKit/WKFoundation.h>
 
-#import "_WKTextInputContextInternal.h"
-#import <WebCore/ElementContext.h>
-#import <wtf/cocoa/TypeCastsCocoa.h>
+@interface NSURL (WKExtras)
 
-@implementation _WKTextInputContext {
-    WebCore::ElementContext _textInputContext;
-}
-
-- (instancetype)init
-{
-    return nil;
-}
-
-- (instancetype)_initWithTextInputContext:(const WebCore::ElementContext&)context
-{
-    self = [super init];
-    if (!self)
-        return nil;
-
-    _textInputContext = context;
-
-    return self;
-}
-
-- (CGRect)boundingRect
-{
-    return _textInputContext.boundingRect;
-}
-
-- (const WebCore::ElementContext&)_textInputContext
-{
-    return _textInputContext;
-}
-
-- (BOOL)isEqual:(id)otherObject
-{
-    if (self == otherObject)
-        return YES;
-
-    auto *other = dynamic_objc_cast<_WKTextInputContext>(otherObject);
-    if (!other)
-        return NO;
-
-    return _textInputContext == other->_textInputContext;
-}
-
-- (NSUInteger)hash
-{
-    return _textInputContext.nodeIdentifier ? _textInputContext.nodeIdentifier->toUInt64() : 0;
-}
-
-- (id)copyWithZone:(NSZone *)zone
-{
-    return [self retain];
-}
+- (NSString *)_wk_userVisibleString WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNSURLExtras.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNSURLExtras.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,62 +24,15 @@
  */
 
 #import "config.h"
-#import "_WKTextInputContext.h"
+#import "_WKNSURLExtras.h"
 
-#import "_WKTextInputContextInternal.h"
-#import <WebCore/ElementContext.h>
-#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/cocoa/NSURLExtras.h>
 
-@implementation _WKTextInputContext {
-    WebCore::ElementContext _textInputContext;
-}
+@implementation NSURL (WKExtras)
 
-- (instancetype)init
+- (NSString *)_wk_userVisibleString
 {
-    return nil;
-}
-
-- (instancetype)_initWithTextInputContext:(const WebCore::ElementContext&)context
-{
-    self = [super init];
-    if (!self)
-        return nil;
-
-    _textInputContext = context;
-
-    return self;
-}
-
-- (CGRect)boundingRect
-{
-    return _textInputContext.boundingRect;
-}
-
-- (const WebCore::ElementContext&)_textInputContext
-{
-    return _textInputContext;
-}
-
-- (BOOL)isEqual:(id)otherObject
-{
-    if (self == otherObject)
-        return YES;
-
-    auto *other = dynamic_objc_cast<_WKTextInputContext>(otherObject);
-    if (!other)
-        return NO;
-
-    return _textInputContext == other->_textInputContext;
-}
-
-- (NSUInteger)hash
-{
-    return _textInputContext.nodeIdentifier ? _textInputContext.nodeIdentifier->toUInt64() : 0;
-}
-
-- (id)copyWithZone:(NSZone *)zone
-{
-    return [self retain];
+    return WTF::userVisibleString(self);
 }
 
 @end

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -30,6 +30,7 @@
 
 #import "APIFrameHandle.h"
 #import "APINavigationAction.h"
+#import "APIPageConfiguration.h"
 #import "PopUpSOAuthorizationSession.h"
 #import "RedirectSOAuthorizationSession.h"
 #import "SubFrameSOAuthorizationSession.h"
@@ -39,9 +40,11 @@
 #import <WebCore/ResourceRequest.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <pal/spi/cocoa/AuthKitSPI.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/Function.h>
 #import <wtf/ThreadAssertions.h>
 #import <wtf/TZoneMallocInlines.h>
+
 #import <pal/cocoa/AppSSOSoftLink.h>
 
 #define AUTHORIZATIONCOORDINATOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - SOAuthorizationCoordinator::" fmt, this, ##__VA_ARGS__)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -36,6 +36,9 @@
 #import "SharedBufferReference.h"
 #import "WKAPICast.h"
 #import "WKBrowsingContextHandleInternal.h"
+#import "WKMouseDeviceObserver.h"
+#import "WKStylusDeviceObserver.h"
+#import "WebPageProxy.h"
 #import "WebProcessMessages.h"
 #import "WebProcessPool.h"
 #import <WebCore/ActivityState.h>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -44,6 +44,7 @@
 #import <WebCore/ScrollingTreePositionedNode.h>
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/SetForScope.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/TextStream.h>
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -36,6 +36,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/Vector.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #import "NearFieldSoftLink.h"
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -36,6 +36,7 @@
 #import "WKFormSelectControl.h"
 #import "WKWebViewPrivateForTesting.h"
 #import "WebPageProxy.h"
+#import "WebPreferencesDefaultValues.h"
 #import <UIKit/UIKit.h>
 #import <WebCore/LocalizedStrings.h>
 #import <numbers>

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -42,6 +42,7 @@
 #import "WKWebViewPrivateForTesting.h"
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
+#import "WebPreferences.h"
 #import <Foundation/Foundation.h>
 #import <Security/SecCertificate.h>
 #import <Security/SecTrust.h>

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h
@@ -26,6 +26,7 @@
 #if ENABLE(SERVICE_CONTROLS)
 
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakPtr.h>
 #import <wtf/text/WTFString.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -61,6 +61,7 @@
 #import <WebCore/DragItem.h>
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/LegacyNSPasteboardTypes.h>
+#import <WebCore/LocalizedStrings.h>
 #import <WebCore/Pasteboard.h>
 #import <WebCore/Quirks.h>
 #import <WebCore/SharedBuffer.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2618,6 +2618,8 @@
 		F634445612A885C8000612D8 /* APISecurityOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = F634445512A885C8000612D8 /* APISecurityOrigin.h */; };
 		FA0B9DB32E4DAA4D0029560E /* APICompletionListener.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0B9DB22E4DA71F0029560E /* APICompletionListener.h */; };
 		FA1ED3F42B76B93700C90F3B /* CoreIPCCFType.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA1ED3F32B76B90700C90F3B /* CoreIPCCFType.mm */; };
+		FA2F854F2E60CBDD00D0ECA8 /* _WKNSURLExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = FA2F854D2E60CA7D00D0ECA8 /* _WKNSURLExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA2F85502E60CBE700D0ECA8 /* _WKNSStringExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = FA2F854B2E60CA7D00D0ECA8 /* _WKNSStringExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA39AE682B23972B008F93CD /* CoreIPCAuditToken.h in Headers */ = {isa = PBXBuildFile; fileRef = FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */; };
 		FA4066E02D44733200A2E622 /* WKPageFullScreenClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FA4066DF2D4472CE00A2E622 /* WKPageFullScreenClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA4FE2662B75EB290016E671 /* CoreIPCNull.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA4FE2642B75EAFF0016E671 /* CoreIPCNull.mm */; };
@@ -8647,6 +8649,10 @@
 		FA1A7DE42E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageVideoPresentationManagerProxy.h; sourceTree = "<group>"; };
 		FA1A7DE52E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemotePageVideoPresentationManagerProxy.cpp; sourceTree = "<group>"; };
 		FA1ED3F32B76B90700C90F3B /* CoreIPCCFType.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCCFType.mm; sourceTree = "<group>"; };
+		FA2F854B2E60CA7D00D0ECA8 /* _WKNSStringExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKNSStringExtras.h; sourceTree = "<group>"; };
+		FA2F854C2E60CA7D00D0ECA8 /* _WKNSStringExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKNSStringExtras.mm; sourceTree = "<group>"; };
+		FA2F854D2E60CA7D00D0ECA8 /* _WKNSURLExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKNSURLExtras.h; sourceTree = "<group>"; };
+		FA2F854E2E60CA7D00D0ECA8 /* _WKNSURLExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKNSURLExtras.mm; sourceTree = "<group>"; };
 		FA39AE4B2B2269C4008F93CD /* APIDictionary.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIDictionary.serialization.in; sourceTree = "<group>"; };
 		FA39AE4C2B229187008F93CD /* WebImage.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebImage.serialization.in; sourceTree = "<group>"; };
 		FA39AE4D2B22D766008F93CD /* APIObject.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIObject.serialization.in; sourceTree = "<group>"; };
@@ -12208,6 +12214,10 @@
 				51130EC7294466AF00E076C5 /* _WKNotificationData.h */,
 				51130EC6294466AF00E076C5 /* _WKNotificationData.mm */,
 				51130EC5294466AE00E076C5 /* _WKNotificationDataInternal.h */,
+				FA2F854B2E60CA7D00D0ECA8 /* _WKNSStringExtras.h */,
+				FA2F854C2E60CA7D00D0ECA8 /* _WKNSStringExtras.mm */,
+				FA2F854D2E60CA7D00D0ECA8 /* _WKNSURLExtras.h */,
+				FA2F854E2E60CA7D00D0ECA8 /* _WKNSURLExtras.mm */,
 				9323611D1B015DA800FA9232 /* _WKOverlayScrollbarStyle.h */,
 				9B12A4D42C73C155008A9AAB /* _WKPageLoadTiming.h */,
 				9B12A4D52C73C155008A9AAB /* _WKPageLoadTiming.mm */,
@@ -16991,6 +17001,8 @@
 				51130ECA294466AF00E076C5 /* _WKNotificationData.h in Headers */,
 				51130EC8294466AF00E076C5 /* _WKNotificationDataInternal.h in Headers */,
 				A118A9F31908B8EA00F7C92B /* _WKNSFileManagerExtras.h in Headers */,
+				FA2F85502E60CBE700D0ECA8 /* _WKNSStringExtras.h in Headers */,
+				FA2F854F2E60CBDD00D0ECA8 /* _WKNSURLExtras.h in Headers */,
 				A5C0F0A72000654D00536536 /* _WKNSWindowExtras.h in Headers */,
 				9323611E1B015DA800FA9232 /* _WKOverlayScrollbarStyle.h in Headers */,
 				9B12A4D62C73C155008A9AAB /* _WKPageLoadTiming.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -25,9 +25,12 @@
 
 #import "config.h"
 
+#import "PlatformUtilities.h"
 #import "Test.h"
 #import "WTFTestUtilities.h"
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKNSStringExtras.h>
+#import <WebKit/_WKNSURLExtras.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
@@ -63,7 +66,7 @@ static const char* originalDataAsString(NSURL *URL)
 
 static const char* userVisibleString(NSURL *URL)
 {
-    return [WKWebView _userVisibleStringForURL:URL].UTF8String;
+    return [URL _wk_userVisibleString].UTF8String;
 }
 
 static NSURL *literalURL(const char* literal)
@@ -79,16 +82,16 @@ TEST(URLExtras, URLExtras)
     EXPECT_STREQ("http://site.com", userVisibleString(literalURL("http://site.com")));
     EXPECT_STREQ("http://%77ebsite.com", userVisibleString(literalURL("http://%77ebsite.com")));
 
-    EXPECT_STREQ("-.example.com", [WTF::decodeHostName(@"-.example.com") UTF8String]);
-    EXPECT_STREQ("-a.example.com", [WTF::decodeHostName(@"-a.example.com") UTF8String]);
-    EXPECT_STREQ("a-.example.com", [WTF::decodeHostName(@"a-.example.com") UTF8String]);
-    EXPECT_STREQ("ab--cd.example.com", [WTF::decodeHostName(@"ab--cd.example.com") UTF8String]);
+    EXPECT_WK_STREQ("-.example.com", [@"-.example.com" _wk_decodeHostName]);
+    EXPECT_WK_STREQ("-a.example.com", [@"-a.example.com" _wk_decodeHostName]);
+    EXPECT_WK_STREQ("a-.example.com", [@"a-.example.com" _wk_decodeHostName]);
+    EXPECT_WK_STREQ("ab--cd.example.com", [@"ab--cd.example.com" _wk_decodeHostName]);
 #if HAVE(NSURL_EMPTY_PUNYCODE_CHECK)
-    EXPECT_NULL([WTF::decodeHostName(@"xn--.example.com") UTF8String]);
+    EXPECT_NULL([@"xn--.example.com" _wk_decodeHostName]);
 #else
-    EXPECT_STREQ(".example.com", [WTF::decodeHostName(@"xn--.example.com") UTF8String]);
+    EXPECT_WK_STREQ(".example.com", [@"xn--.example.com" _wk_decodeHostName]);
 #endif
-    EXPECT_STREQ("a..example.com", [WTF::decodeHostName(@"a..example.com") UTF8String]);
+    EXPECT_WK_STREQ("a..example.com", [@"a..example.com" _wk_decodeHostName]);
 }
     
 TEST(URLExtras, URLExtras_Spoof)
@@ -245,7 +248,7 @@ TEST(URLExtras, URLExtras_DivisionSign)
 
     // Separate functions that deal with just a host name on its own.
     EXPECT_STREQ("site.xn--comothersite-kjb.org", [WTF::encodeHostName(@"site.com\xC3\xB7othersite.org") UTF8String]);
-    EXPECT_STREQ("site.com\xC3\xB7othersite.org", [WTF::decodeHostName(@"site.com\xC3\xB7othersite.org") UTF8String]);
+    EXPECT_WK_STREQ("site.com\xC3\xB7othersite.org", [@"site.com\xC3\xB7othersite.org" _wk_decodeHostName]);
 }
 
 TEST(WTF, URLExtras_Solidus)
@@ -268,7 +271,7 @@ TEST(WTF, URLExtras_Solidus)
 
     // Separate functions that deal with just a host name on its own.
     EXPECT_STREQ("site.com/othersite.org", [WTF::encodeHostName(@"site.com\xEF\xBC\x8Fothersite.org") UTF8String]);
-    EXPECT_STREQ("site.com/othersite.org", [WTF::decodeHostName(@"site.com\xEF\xBC\x8Fothersite.org") UTF8String]);
+    EXPECT_WK_STREQ("site.com/othersite.org", [@"site.com\xEF\xBC\x8Fothersite.org" _wk_decodeHostName]);
 }
 
 TEST(URLExtras, URLExtras_Space)
@@ -277,7 +280,7 @@ TEST(URLExtras, URLExtras_Space)
 
     // Code path similar to the one used when typing in a URL.
     EXPECT_STREQ("", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
-    EXPECT_STREQ("", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
+    EXPECT_NULL(userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
 
     // Code paths similar to the ones used for URLs found in webpages or HTTP responses.
     EXPECT_STREQ("http://site.com\xE3\x80\x80othersite.org", originalDataAsString(literalURL("http://site.com\xE3\x80\x80othersite.org")));
@@ -287,7 +290,7 @@ TEST(URLExtras, URLExtras_Space)
 
     // Separate functions that deal with just a host name on its own.
     EXPECT_STREQ("site.com othersite.org", [WTF::encodeHostName(@"site.com\xE3\x80\x80othersite.org") UTF8String]);
-    EXPECT_STREQ("site.com\xE3\x80\x80othersite.org", [WTF::decodeHostName(@"site.com\xE3\x80\x80othersite.org") UTF8String]);
+    EXPECT_WK_STREQ("site.com\xE3\x80\x80othersite.org", [@"site.com\xE3\x80\x80othersite.org" _wk_decodeHostName]);
 }
 
 TEST(URLExtras, URLExtras_File)


### PR DESCRIPTION
#### 09381537dd79db08273bc2c7afc1d434fcfaac3a
<pre>
Add interface to access WTF::decodeHostName through WebKit.framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=297987">https://bugs.webkit.org/show_bug.cgi?id=297987</a>

Reviewed by Tim Horton.

This will allow us to begin removing WebKitLegacy.framework from the base system.
Currently, _web_decodeHostName is used by the browser in the base system.
This provides an alternative.  This alternative returns nil on failure instead
of the original string, so adopters will need to be aware of that difference.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(+[WKWebView _decodeHostName:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(URLExtras, URLExtras)):
(TestWebKitAPI::TEST(URLExtras, URLExtras_DivisionSign)):
(TestWebKitAPI::TEST(WTF, URLExtras_Solidus)):
(TestWebKitAPI::TEST(URLExtras, URLExtras_Space)):

Canonical link: <a href="https://commits.webkit.org/299302@main">https://commits.webkit.org/299302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0b089ca910e6da77389fec552bdb832b757e54f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7286f185-cef8-45db-897c-80a4f3851910) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89981 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b636ad3c-6f3c-4281-b84f-7b5dbd553b5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70485 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9716e002-5949-44a8-9ac5-04d60b426dbb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24398 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68376 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24589 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45452 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102508 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21827 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18891 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45322 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51000 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44785 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48132 "Build is in progress. Recent messages:") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->