### PR TITLE
Re-merge 298725@main

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -55,8 +55,11 @@ public:
     void setAllowAutofill() { m_allowAutofill = true; }
     bool allowAutofill() const { return m_allowAutofill; }
 
-    void setNodeInfoEnabled() { m_nodeInfoEnabled = true; }
-    bool nodeInfoEnabled() const { return m_nodeInfoEnabled; }
+    bool allowJSHandleCreation() const { return m_allowJSHandleCreation; }
+    void setAllowJSHandleCreation() { m_allowJSHandleCreation = true; }
+
+    void setAllowNodeSerialization() { m_allowNodeSerialization = true; }
+    bool allowNodeSerialization() const { return m_allowNodeSerialization; }
 
     void setAllowElementUserInfo() { m_allowElementUserInfo = true; }
     bool allowElementUserInfo() const { return m_allowElementUserInfo; }
@@ -93,12 +96,13 @@ private:
     String m_name;
     Type m_type { Type::Internal };
 
-    bool m_allowAutofill { false };
-    bool m_allowElementUserInfo { false };
-    bool m_shadowRootIsAlwaysOpen { false };
-    bool m_closedShadowRootIsExposedForExtensions { false };
-    bool m_shouldDisableLegacyOverrideBuiltInsBehavior { false };
-    bool m_nodeInfoEnabled { false };
+    bool m_allowAutofill : 1 { false };
+    bool m_allowElementUserInfo : 1 { false };
+    bool m_shadowRootIsAlwaysOpen : 1 { false };
+    bool m_closedShadowRootIsExposedForExtensions : 1 { false };
+    bool m_shouldDisableLegacyOverrideBuiltInsBehavior : 1 { false };
+    bool m_allowJSHandleCreation : 1 { false };
+    bool m_allowNodeSerialization : 1 { false };
 };
 
 DOMWrapperWorld& normalWorld(JSC::VM&);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -833,7 +833,7 @@ VisualViewport& LocalDOMWindow::visualViewport()
 
 bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world)
 {
-    if (world.nodeInfoEnabled())
+    if (world.allowJSHandleCreation() || world.allowNodeSerialization())
         return true;
 
     RefPtr frame = this->frame();

--- a/Source/WebCore/page/WebKitJSHandle.idl
+++ b/Source/WebCore/page/WebKitJSHandle.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledForWorld=nodeInfoEnabled,
+    EnabledForWorld=allowJSHandleCreation,
     Exposed=Window,
     ExportMacro=WEBCORE_EXPORT
 ] interface WebKitJSHandle {

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -31,8 +31,8 @@
     Exposed=Window
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
-    [EnabledForWorld=nodeInfoEnabled, CallWith=CurrentDocument] WebKitJSHandle createJSHandle(object object);
-    [EnabledForWorld=nodeInfoEnabled] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
+    [EnabledForWorld=allowJSHandleCreation, CallWith=CurrentDocument] WebKitJSHandle createJSHandle(object object);
+    [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
 };
 
 dictionary WebKitSerializedNodeInit {

--- a/Source/WebCore/page/WebKitSerializedNode.idl
+++ b/Source/WebCore/page/WebKitSerializedNode.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledForWorld=nodeInfoEnabled,
+    EnabledForWorld=allowNodeSerialization,
     Exposed=Window,
     ExportMacro=WEBCORE_EXPORT
 ] interface WebKitSerializedNode {

--- a/Source/WebKit/Shared/ContentWorldData.serialization.in
+++ b/Source/WebKit/Shared/ContentWorldData.serialization.in
@@ -27,7 +27,8 @@ header: "ContentWorldData.h"
     AllowAutofill,
     AllowElementUserInfo,
     DisableLegacyBuiltinOverrides,
-    AllowNodeInfo,
+    AllowJSHandleCreation,
+    AllowNodeSerialization,
 };
 
 [DebugDecodingFailure] struct WebKit::ContentWorldData {

--- a/Source/WebKit/Shared/ContentWorldShared.h
+++ b/Source/WebKit/Shared/ContentWorldShared.h
@@ -44,7 +44,8 @@ enum class ContentWorldOption : uint8_t {
     AllowAutofill = 1 << 1,
     AllowElementUserInfo = 1 << 2,
     DisableLegacyBuiltinOverrides = 1 << 3,
-    AllowNodeInfo = 1 << 4,
+    AllowJSHandleCreation = 1 << 4,
+    AllowNodeSerialization = 1 << 5,
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -62,8 +62,11 @@ public:
     bool disableLegacyBuiltinOverrides() const { return m_options.contains(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }
     void setDisableLegacyBuiltinOverrides(bool value) { m_options.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }
 
-    bool allowNodeInfo() const { return m_options.contains(WebKit::ContentWorldOption::AllowNodeInfo); }
-    void setNodeInfoEnabled() { m_options.add(WebKit::ContentWorldOption::AllowNodeInfo); }
+    bool allowJSHandleCreation() const { return m_options.contains(WebKit::ContentWorldOption::AllowJSHandleCreation); }
+    void setAllowJSHandleCreation() { m_options.add(WebKit::ContentWorldOption::AllowJSHandleCreation); }
+
+    bool allowNodeSerialization() const { return m_options.contains(WebKit::ContentWorldOption::AllowNodeSerialization); }
+    void setAllowNodeSerialization() { m_options.add(WebKit::ContentWorldOption::AllowNodeSerialization); }
 
     void addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy&);
     void userContentControllerProxyDestroyed(WebKit::WebUserContentControllerProxy&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -109,8 +109,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         optionSet.add(WebKit::ContentWorldOption::AllowElementUserInfo);
     if (configuration.disableLegacyBuiltinOverrides)
         optionSet.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides);
-    if (configuration.allowNodeInfo)
-        optionSet.add(WebKit::ContentWorldOption::AllowNodeInfo);
+    if (configuration.allowJSHandleCreation)
+        optionSet.add(WebKit::ContentWorldOption::AllowJSHandleCreation);
+    if (configuration.allowNodeSerialization)
+        optionSet.add(WebKit::ContentWorldOption::AllowNodeSerialization);
     Ref world = API::ContentWorld::sharedWorldWithName(configuration.name, optionSet);
     checkContentWorldOptions(world, configuration);
     return wrapper(WTFMove(world)).autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -50,8 +50,11 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
 @property (nonatomic) BOOL disableLegacyBuiltinOverrides;
 
-/*! @abstract A boolean indicating whether node info can be returned from JS to ObjC. */
-@property (nonatomic) BOOL allowNodeInfo;
+/*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
+@property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */
+@property (nonatomic) BOOL allowNodeSerialization WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -121,9 +121,14 @@ void InjectedBundleScriptWorld::setAllowAutofill()
     m_world->setAllowAutofill();
 }
 
-void InjectedBundleScriptWorld::setNodeInfoEnabled()
+void InjectedBundleScriptWorld::setAllowJSHandleCreation()
 {
-    m_world->setNodeInfoEnabled();
+    m_world->setAllowJSHandleCreation();
+}
+
+void InjectedBundleScriptWorld::setAllowNodeSerialization()
+{
+    m_world->setAllowNodeSerialization();
 }
 
 void InjectedBundleScriptWorld::setAllowElementUserInfo()

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -60,7 +60,8 @@ public:
     void makeAllShadowRootsOpen();
     void exposeClosedShadowRootsForExtensions();
     void disableOverrideBuiltinsBehavior();
-    void setNodeInfoEnabled();
+    void setAllowJSHandleCreation();
+    void setAllowNodeSerialization();
 
     const String& name() const { return m_name; }
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -134,8 +134,10 @@ InjectedBundleScriptWorld* WebUserContentController::addContentWorld(const Conte
             scriptWorld->setAllowElementUserInfo();
         if (world.options.contains(ContentWorldOption::DisableLegacyBuiltinOverrides))
             scriptWorld->disableOverrideBuiltinsBehavior();
-        if (world.options.contains(ContentWorldOption::AllowNodeInfo))
-            scriptWorld->setNodeInfoEnabled();
+        if (world.options.contains(ContentWorldOption::AllowJSHandleCreation))
+            scriptWorld->setAllowJSHandleCreation();
+        if (world.options.contains(ContentWorldOption::AllowNodeSerialization))
+            scriptWorld->setAllowNodeSerialization();
         return scriptWorld.ptr();
     }
     return nullptr;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1186,7 +1186,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     }
 
     if (parameters.allowJSHandleInPageContentWorld)
-        InjectedBundleScriptWorld::normalWorldSingleton().setNodeInfoEnabled();
+        InjectedBundleScriptWorld::normalWorldSingleton().setAllowJSHandleCreation();
 }
 
 void WebPage::updateAfterDrawingAreaCreation(const WebPageCreationParameters& parameters)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm
@@ -67,7 +67,7 @@ TEST(JSHandle, Basic)
     [navigationDelegate waitForDidFinishNavigation];
 
     RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
-    worldConfiguration.get().allowNodeInfo = YES;
+    worldConfiguration.get().allowJSHandleCreation = YES;
     RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
 
     RetainPtr<id> result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(onlyframe.contentWindow)" inFrame:nil inContentWorld:world.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SerializedNode.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SerializedNode.mm
@@ -39,7 +39,7 @@ TEST(SerializedNode, Basic)
     [webView loadHTMLString:@"<div id='testid'><div>test</div></div><template id='outerTemplate'><template id='innerTemplate'><span>Contents</span></template></template>" baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
 
     RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
-    worldConfiguration.get().allowNodeInfo = YES;
+    worldConfiguration.get().allowNodeSerialization = YES;
     RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
 
     auto verifyNodeSerialization = [world, webView] (const char* constructor, const char* accessor, const char* expected, const char* className, const char* init = "deep:true") {


### PR DESCRIPTION
#### a5e93ee0a9dc6ef8cab18418510e2c5035b13343
<pre>
Re-merge 298725@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=297989">https://bugs.webkit.org/show_bug.cgi?id=297989</a>
<a href="https://rdar.apple.com/159308797">rdar://159308797</a>

Unreviewed.

It was reverted in 298733@main because it broke the internal builds.
I fixed that by replacing this:
WK_API_AVAILABLE(WK_MAC_TBA, WK_IOS_TBA, WK_XROS_TBA)
with this:
WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::allowJSHandleCreation const):
(WebCore::DOMWrapperWorld::setAllowJSHandleCreation):
(WebCore::DOMWrapperWorld::setAllowNodeSerialization):
(WebCore::DOMWrapperWorld::allowNodeSerialization const):
(WebCore::DOMWrapperWorld::setNodeInfoEnabled): Deleted.
(WebCore::DOMWrapperWorld::nodeInfoEnabled const): Deleted.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
* Source/WebCore/page/WebKitJSHandle.idl:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebCore/page/WebKitSerializedNode.idl:
* Source/WebKit/Shared/ContentWorldData.serialization.in:
* Source/WebKit/Shared/ContentWorldShared.h:
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(+[WKContentWorld _worldWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::setAllowJSHandleCreation):
(WebKit::InjectedBundleScriptWorld::setAllowNodeSerialization):
(WebKit::InjectedBundleScriptWorld::setNodeInfoEnabled): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorld):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm:
(TestWebKitAPI::TEST(JSHandle, Basic)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SerializedNode.mm:
(TestWebKitAPI::TEST(SerializedNode, Basic)):

Canonical link: <a href="https://commits.webkit.org/299241@main">https://commits.webkit.org/299241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee7a0d4953ae6d810f7918bbc12ec56756b2a991

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70366 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0423aab-811b-4fd8-89d0-aee488ba867e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89792 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a27bcf9-5af8-4a8e-8bce-8407b0f43788) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70281 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab0870f3-1291-4260-b66c-6db705898165) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68141 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127550 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98470 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98257 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41697 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18858 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50767 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44554 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46241 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->