### PR TITLE
[JSC] Copy wasm section content to extracted data instead of calling parseUInt8 byte by byte

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -40,26 +40,15 @@ namespace JSC { namespace Wasm {
 
 constexpr CalleeBits NullWasmCallee = CalleeBits::nullCallee();
 
-Segment::Ptr Segment::create(std::optional<I32InitExpr> offset, uint32_t sizeInBytes, Kind kind)
+std::unique_ptr<Segment> Segment::tryCreate(std::optional<I32InitExpr> offset, uint32_t sizeInBytes, Kind kind)
 {
-    CheckedUint32 totalBytesChecked = sizeInBytes;
-    totalBytesChecked += sizeof(Segment);
-    if (totalBytesChecked.hasOverflowed())
-        return Ptr(nullptr, &Segment::destroy);
-    auto allocated = tryFastCalloc(totalBytesChecked, 1);
-    Segment* segment;
-    if (!allocated.getValue(segment))
-        return Ptr(nullptr, &Segment::destroy);
-    ASSERT(kind == Kind::Passive || !!offset);
-    segment->kind = kind;
-    segment->offsetIfActive = WTFMove(offset);
-    segment->sizeInBytes = sizeInBytes;
-    return Ptr(segment, &Segment::destroy);
-}
+    auto result = tryFastZeroedMalloc(allocationSize(sizeInBytes));
+    void* memory;
+    if (!result.getValue(memory))
+        return nullptr;
 
-void Segment::destroy(Segment *segment)
-{
-    fastFree(segment);
+    ASSERT(kind == Kind::Passive || !!offset);
+    return std::unique_ptr<Segment>(new (memory) Segment(sizeInBytes, kind, WTFMove(offset)));
 }
 
 String makeString(const Name& characters)

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -198,7 +198,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
 
     Vector<Export> exports;
     std::optional<uint32_t> startFunctionIndexSpace;
-    Vector<Segment::Ptr> data;
+    Vector<std::unique_ptr<Segment>> data;
     Vector<Element> elements;
     Vector<TableInformation> tables;
     Vector<GlobalInformation> globals;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -468,8 +468,8 @@ bool JSWebAssemblyInstance::memoryInit(uint32_t dstAddress, uint32_t srcAddress,
     if (sumOverflows<uint32_t>(srcAddress, length))
         return false;
 
-    const Segment::Ptr& segment = module().moduleInformation().data[dataSegmentIndex];
-    const uint32_t segmentSizeInBytes = m_passiveDataSegments.quickGet(dataSegmentIndex) ? segment->sizeInBytes : 0U;
+    auto& segment = module().moduleInformation().data[dataSegmentIndex];
+    const uint32_t segmentSizeInBytes = m_passiveDataSegments.quickGet(dataSegmentIndex) ? segment->sizeInBytes() : 0U;
     if (srcAddress + length > segmentSizeInBytes)
         return false;
 
@@ -599,8 +599,8 @@ bool JSWebAssemblyInstance::copyDataSegment(JSWebAssemblyArray* array, uint32_t 
     // Fail if the data segment index is out of bounds
     RELEASE_ASSERT(segmentIndex < module().moduleInformation().dataSegmentsCount());
     // Otherwise, get the `segmentIndex`th data segment
-    const Segment::Ptr& segment = module().moduleInformation().data[segmentIndex];
-    const uint32_t segmentSizeInBytes = m_passiveDataSegments.quickGet(segmentIndex) ? segment->sizeInBytes : 0U;
+    auto& segment = module().moduleInformation().data[segmentIndex];
+    const uint32_t segmentSizeInBytes = m_passiveDataSegments.quickGet(segmentIndex) ? segment->sizeInBytes() : 0U;
 
     // Caller checks that the (offset + lengthInBytes) calculation doesn't overflow
     if ((offset + lengthInBytes) > segmentSizeInBytes) {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -859,7 +859,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
 
     Wasm::Module& module = m_instance->module(); const Wasm::ModuleInformation& moduleInformation = module.moduleInformation();
 
-    const Vector<Wasm::Segment::Ptr>& data = moduleInformation.data;
+    const Vector<std::unique_ptr<Wasm::Segment>>& data = moduleInformation.data;
     
     std::optional<JSValue> exception;
 
@@ -903,17 +903,17 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
         uint8_t* memory = static_cast<uint8_t*>(wasmMemory.basePointer());
         uint64_t sizeInBytes = wasmMemory.size();
 
-        for (const Wasm::Segment::Ptr& segment : data) {
+        for (const auto& segment : data) {
             if (!segment->isActive())
                 continue;
             uint32_t offset = 0;
-            if (segment->offsetIfActive->isGlobalImport())
-                offset = static_cast<uint32_t>(m_instance->loadI32Global(segment->offsetIfActive->globalImportIndex()));
-            else if (segment->offsetIfActive->isConst())
-                offset = segment->offsetIfActive->constValue();
+            if (segment->offsetIfActive()->isGlobalImport())
+                offset = static_cast<uint32_t>(m_instance->loadI32Global(segment->offsetIfActive()->globalImportIndex()));
+            else if (segment->offsetIfActive()->isConst())
+                offset = segment->offsetIfActive()->constValue();
             else {
                 uint64_t result;
-                evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[segment->offsetIfActive->constantExpressionIndex()], moduleInformation, Wasm::Types::I32, result);
+                evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[segment->offsetIfActive()->constantExpressionIndex()], moduleInformation, Wasm::Types::I32, result);
                 RETURN_IF_EXCEPTION(scope, void());
                 offset = static_cast<uint32_t>(result);
             }
@@ -942,20 +942,20 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
         return exception.value();
 
     // Validation of all segment ranges comes before all Table and Memory initialization.
-    forEachActiveDataSegment([&](uint8_t* memory, uint64_t sizeInBytes, const Wasm::Segment::Ptr& segment, uint32_t offset) {
-        if (sizeInBytes < segment->sizeInBytes) [[unlikely]] {
-            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes, offset, ", segment is too big"_s);
+    forEachActiveDataSegment([&](uint8_t* memory, uint64_t sizeInBytes, const std::unique_ptr<Wasm::Segment>& segment, uint32_t offset) {
+        if (sizeInBytes < segment->sizeInBytes()) [[unlikely]] {
+            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes(), offset, ", segment is too big"_s);
             return IterationStatus::Done;
         }
-        if (offset > sizeInBytes - segment->sizeInBytes) [[unlikely]] {
-            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes, offset, ", segment writes outside of memory"_s);
+        if (offset > sizeInBytes - segment->sizeInBytes()) [[unlikely]] {
+            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes(), offset, ", segment writes outside of memory"_s);
             return IterationStatus::Done;
         }
 
         // Empty segments are valid, but only if memory isn't present, which would be undefined behavior in memcpy.
-        if (segment->sizeInBytes) {
+        if (segment->sizeInBytes()) {
             RELEASE_ASSERT(memory);
-            memcpy(memory + offset, &segment->byte(0), segment->sizeInBytes);
+            memcpy(memory + offset, segment->span().data(), segment->sizeInBytes());
         }
         return IterationStatus::Continue;
     });


### PR DESCRIPTION
#### 55e02ed439a110cfada886ab9ee81b28c5a52967
<pre>
[JSC] Copy wasm section content to extracted data instead of calling parseUInt8 byte by byte
<a href="https://bugs.webkit.org/show_bug.cgi?id=297988">https://bugs.webkit.org/show_bug.cgi?id=297988</a>
<a href="https://rdar.apple.com/159308336">rdar://159308336</a>

Reviewed by Yijia Huang.

Profiler pointed out that significant amount of time is used for
CustomSection and Segment copying. But they are just copying
byte-by-byte. We should just check the range and use memcpySpan.

* Source/JavaScriptCore/wasm/WasmFormat.cpp:
(JSC::Wasm::Segment::tryCreate):
(JSC::Wasm::Segment::create): Deleted.
(JSC::Wasm::Segment::destroy): Deleted.
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::Segment::byte): Deleted.
(JSC::Wasm::Segment::isActive const): Deleted.
(JSC::Wasm::Segment::isPassive const): Deleted.
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseData):
(JSC::Wasm::SectionParser::parseCustom):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::memoryInit):
(JSC::JSWebAssemblyInstance::copyDataSegment):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluate):

Canonical link: <a href="https://commits.webkit.org/299231@main">https://commits.webkit.org/299231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c302dd5a3e8ac884170c2c1752758cdd59eceac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118316 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70367 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee9590ba-09f3-4380-9bad-e61bf7074185) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2553fc2-d083-4fcf-87cd-db735f156311) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9068740a-abad-4a6b-aea9-312a30781600) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24202 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68142 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127551 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116828 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98465 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98251 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41698 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18853 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50768 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145526 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44555 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37436 "jscore-tests (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->