### PR TITLE
[ macOS Tahoe ] Update Test Expectations for 18 Sharedworker-data Tests (296326)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2272,25 +2272,6 @@ webkit.org/b/296300 [ Sequoia Debug arm64 ] webgl/2.0.y/conformance2/offscreenca
 
 webkit.org/b/296297 fast/images/image-map-outline-with-paint-root-offset.html [ Pass Failure ]
 
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https.html [ Failure ]
-webkit.org/b/296326 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https.html [ Failure ]
-
 webkit.org/b/296344 imported/w3c/web-platform-tests/webrtc/RTCRtpSender-replaceTrack.https.html [ Pass Failure ]
 
 webkit.org/b/296348 [ Sequoia ] http/tests/cache/disk-cache/shattered-deduplication.html [ Pass Failure ] 


### PR DESCRIPTION
#### e6a8647e9eb7ff2c156898f25fe1d535d803e6ab
<pre>
[ macOS Tahoe ] Update Test Expectations for 18 Sharedworker-data Tests (296326)
<a href="https://bugs.webkit.org/show_bug.cgi?id=296326">https://bugs.webkit.org/show_bug.cgi?id=296326</a>
<a href="https://rdar.apple.com/156404653">rdar://156404653</a>

Reviewed by Sihui Liu and Per Arne Vollan.

EWS results now match actual browser behavior as determined by wpt.live tests that
were run on versions of MacOS prior to these supposed failures.  While the EWS previously
appeared to pass these tests, it was not accurately reflecting real-world behavior. This
is not a regression but a progression because now the EWS tests results accurately reflect
actual behavior / results. We should rebaseline these tests to the real-world results from
wpt.live.

* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt:
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt.
* LayoutTests/platform/mac-sequoia/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt.
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/299295@main">https://commits.webkit.org/299295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbf739efa435bcb1a74b4cb8a2c5b7ad38b97f50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70571 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4cbeaf5-3367-4aa7-82a6-e3c291f254fc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89955 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c68f659-f054-4e7b-b847-952151618e60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106257 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70457 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/905a9d64-8f83-4e45-8459-29f5ef4eac0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68343 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127750 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98600 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98384 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21800 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18886 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45289 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44752 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48099 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46439 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->