### PR TITLE
Frame opener being self should be reflected in new processes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-opener-is-self-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/iframe-opener-is-self-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Cross-origin check: true
+CONSOLE MESSAGE: Same-origin check: true
+

--- a/LayoutTests/http/tests/site-isolation/iframe-opener-is-self.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-opener-is-self.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+	if (window.testRunner) {
+		window.testRunner.waitUntilDone();
+	}
+	
+	let checkingSame = false;
+	window.addEventListener("message", event => {
+		if (event.data == "set as self done") {
+			window.frames[0].postMessage("check", "*")
+			checkingSame = true;
+		} else {
+			if (checkingSame) {
+				console.log(`Cross-origin check: ${event.data}`);
+				window.frames[1].postMessage("check", "*")
+				checkingSame = false;
+			} else {
+				console.log(`Same-origin check: ${event.data}`);
+				window.testRunner?.dumpAsText();
+				window.testRunner?.notifyDone();
+			}
+		}
+	}, false);
+
+	window.onload = () => {
+		window.frames[0].postMessage("set as self", "*");
+	}
+</script>
+
+<iframe src="http://localhost:8000/site-isolation/resources/iframe-opener-is-self-first.html" name="namedframe"></iframe>
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/iframe-opener-is-self-second.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-first.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-first.html
@@ -1,0 +1,8 @@
+FIRST
+<script>
+	window.addEventListener("message", event => {
+		if (event.data == "set as self") {
+			window.open("http://localhost:8000/site-isolation/resources/iframe-opener-is-self-third.html", "namedframe");
+		}
+	}, false);
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-second.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-second.html
@@ -1,0 +1,8 @@
+SECOND
+<script>
+	window.addEventListener("message", event => {
+		if (event.data == "check") {
+			window.parent.postMessage(window.parent.frames[0].opener === window.parent.frames[0], "*");
+		}
+	}, false);
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-third.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-third.html
@@ -1,0 +1,10 @@
+THIRD
+<script>
+	window.parent.postMessage("set as self done", "*");
+	window.addEventListener("message", event => {
+		if (event.data == "check") {
+			window.parent.postMessage(window.parent.frames[0].opener === window.parent.frames[0], "*")
+		}
+	}, false);
+</script>
+


### PR DESCRIPTION
#### 863bdab17c88d54ca79a4052be330b465fb1ffa9
<pre>
Frame opener being self should be reflected in new processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=297990">https://bugs.webkit.org/show_bug.cgi?id=297990</a>
<a href="https://rdar.apple.com/137765422">rdar://137765422</a>

Reviewed by Alex Christensen.

Added a test confirming that this issue has been resolved.

* LayoutTests/http/tests/site-isolation/iframe-opener-is-self-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/iframe-opener-is-self.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-first.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-second.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-opener-is-self-third.html: Added.

Canonical link: <a href="https://commits.webkit.org/299336@main">https://commits.webkit.org/299336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64268d63ac6e2a33c61b88f81d5164669de60262

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89918 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59496 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24338 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127709 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98579 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25038 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21775 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41876 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45248 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->