### PR TITLE
proxmox.com: Large amounts of extra vertical spacing between content.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-item-with-margin-left-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-item-with-margin-left-auto-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-item-with-margin-left-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-item-with-margin-left-auto.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#auto-margins">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<style>
+.content {
+  background-color: green;
+}
+.grid {
+  display: grid;
+  width: 100px;
+  font: 25px/1 Ahem;
+  color: green;
+}
+.subgrid {
+  grid-template-columns: subgrid;
+  display: grid;
+  margin-left: auto;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="grid">
+  <div class="subgrid">
+    <div class="content">X X X X X X X X</div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3186,6 +3186,13 @@ void RenderBox::computeInlineDirectionMargins(const RenderBlock& containingBlock
             marginEndLength = 0_css_px;
     }
 
+    if (isGridItem() && downcast<RenderGrid>(containingBlock).isComputingTrackSizes()) {
+        if (marginStartLength.isAuto())
+            marginStartLength = 0_css_px;
+        if (marginEndLength.isAuto())
+            marginEndLength = 0_css_px;
+    }
+
     auto handleMarginAuto = [&] {
         auto containerWidthForMarginAuto = availableSpaceAdjustedWithFloats.value_or(containerWidth);
         // Case One: The object is being centered in the containing block's available logical width.

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -48,6 +48,7 @@
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <wtf/Range.h>
 #include <wtf/Scope.h>
+#include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -241,6 +242,7 @@ std::optional<LayoutUnit> RenderGrid::availableSpaceForGutters(Style::GridTrackS
 
 void RenderGrid::computeTrackSizesForDefiniteSize(Style::GridTrackSizingDirection direction, LayoutUnit availableSpace, GridLayoutState& gridLayoutState)
 {
+    auto autoMarginResolutionScope = SetForScope(m_isComputingTrackSizes, true);
     m_trackSizingAlgorithm.run(direction, numTracks(direction), SizingOperation::TrackSizing, availableSpace, gridLayoutState);
     ASSERT(m_trackSizingAlgorithm.tracksAreWiderThanMinTrackBreadth());
 }
@@ -832,6 +834,7 @@ void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, Layo
 
 void RenderGrid::computeTrackSizesForIndefiniteSize(GridTrackSizingAlgorithm& algorithm, Style::GridTrackSizingDirection direction, GridLayoutState& gridLayoutState, LayoutUnit* minIntrinsicSize, LayoutUnit* maxIntrinsicSize) const
 {
+    auto autoMarginResolutionScope = SetForScope(m_isComputingTrackSizes, true);
     algorithm.run(direction, numTracks(direction), SizingOperation::IntrinsicSizeComputation, std::nullopt, gridLayoutState);
 
     size_t numberOfTracks = algorithm.tracks(direction).size();

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -82,6 +82,8 @@ public:
 
     bool canDropAnonymousBlockChild() const override { return false; }
 
+    bool isComputingTrackSizes() const { return m_isComputingTrackSizes; }
+
     bool hasDefiniteLogicalHeight() const;
     const std::optional<LayoutUnit> availableLogicalHeightForContentBox() const;
 
@@ -310,6 +312,8 @@ private:
     bool layoutUsingGridFormattingContext();
 
     std::optional<bool> m_hasGridFormattingContextLayout;
+
+    mutable bool m_isComputingTrackSizes { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4a61ed0984fb0ed96f45598f9df73b1217dd4a2a
<pre>
proxmox.com: Large amounts of extra vertical spacing between content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296988">https://bugs.webkit.org/show_bug.cgi?id=296988</a>
<a href="https://rdar.apple.com/157638931">rdar://157638931</a>

Reviewed by Alan Baradlay.

During track sizing we are supposed to treat any auto margins on grid
items as 0. These would then be resolved after we have computed the grid
area for the item. However, the attached testcase demonstrates that we
are not doing this correctly in all scenarios for at least the inline
margins.

The content is along the lines of
&lt;grid&gt;
  &lt;subgrid columns style=&quot;margin-left: auto&quot;&gt;
    &lt;div&gt; X X X X X X &lt;/div&gt;
  &lt;/subrid columns&gt;
&lt;/grid&gt;

When we resolve the row sizes for the grid we end up calling layout() on
the subgrid via GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem.
During the subgrid&apos;s layout while we are in updateLogicalWidth(), we end up
computing a logical width of 0 and a resulting margin-left value of
whatever the available space is. Then, we end up setting the subgrid&apos;s
columns to the column sizes of the parent grid since it is subgridded in
that dimension, but we also factor out the subgrid&apos;s incorrectly
computed margins which are the same size as the columns from the parent.
This ends up with column sizes of 0 for the content of the subgrid.
Later on when we compute the rows of the subgrid, we end up setting an
available space of 0 for its content which results in really tall
content and really tall rows in the parent as a result.

This patch corrects this behavior for the inline margins of grid item&apos;s
by keeping track of a new member on RenderGrid which keeps track of
whether or not we are in the middle of track sizing via SetForScope.
When we are resolving inline margins for grid items we set any auto
margins to 0 if we are in the middle of track sizing by checking for
this state.

Canonical link: <a href="https://commits.webkit.org/300422@main">https://commits.webkit.org/300422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b66f7ecfbff99443074551ba7a6968c1afd25ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129053 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/367e180e-1f5a-482d-8018-97bad1fffbff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93081 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1a574b2-84c7-470f-809c-5b048ed566d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73733 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ea73985-49a8-4e54-9175-30fac9aad378) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27800 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72536 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131779 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101625 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25758 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25006 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54996 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48717 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52067 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->