### PR TITLE
Adopt safer CPP in MediaPlayer.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -733,7 +733,6 @@ platform/graphics/ImageBackingStore.h
 platform/graphics/ImageBufferContextSwitcher.cpp
 platform/graphics/ImageFrame.h
 platform/graphics/ImageFrameWorkQueue.cpp
-platform/graphics/MediaPlayer.cpp
 platform/graphics/Path.cpp
 platform/graphics/TransparencyLayerContextSwitcher.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -752,7 +751,6 @@ platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cocoa/ImageAdapterCocoa.mm
-platform/graphics/cocoa/MediaPlayerCocoa.mm
 platform/graphics/controls/ApplePayButtonPart.cpp
 platform/graphics/controls/ButtonPart.h
 platform/graphics/controls/ColorWellPart.h

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -505,8 +505,8 @@ MediaPlayer::MediaPlayer(MediaPlayerClient& client, MediaPlayerEnums::MediaEngin
 MediaPlayer::~MediaPlayer()
 {
     ASSERT(!m_initializingMediaEngine);
-    if (m_private)
-        m_private->mediaPlayerWillBeDestroyed();
+    if (RefPtr privatePtr = m_private)
+        privatePtr->mediaPlayerWillBeDestroyed();
 }
 
 void MediaPlayer::invalidate()
@@ -703,7 +703,7 @@ bool MediaPlayer::hasAvailableVideoFrame() const
 void MediaPlayer::prepareForRendering()
 {
     m_shouldPrepareToRender = true;
-    m_private->prepareForRendering();
+    protectedPrivate()->prepareForRendering();
 }
 
 void MediaPlayer::cancelLoad()
@@ -716,7 +716,7 @@ void MediaPlayer::prepareToPlay()
     Ref<MediaPlayer> protectedThis(*this);
 
     m_shouldPrepareToPlay = true;
-    m_private->prepareToPlay();
+    protectedPrivate()->prepareToPlay();
 }
 
 void MediaPlayer::play()
@@ -731,29 +731,29 @@ void MediaPlayer::pause()
 
 void MediaPlayer::setBufferingPolicy(BufferingPolicy policy)
 {
-    m_private->setBufferingPolicy(policy);
+    protectedPrivate()->setBufferingPolicy(policy);
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 RefPtr<LegacyCDMSession> MediaPlayer::createSession(const String& keySystem, LegacyCDMSessionClient& client)
 {
-    return m_private->createSession(keySystem, client);
+    return protectedPrivate()->createSession(keySystem, client);
 }
 
 void MediaPlayer::setCDM(LegacyCDM* cdm)
 {
-    m_private->setCDM(cdm);
+    protectedPrivate()->setCDM(cdm);
 }
 
 void MediaPlayer::setCDMSession(LegacyCDMSession* session)
 {
-    m_private->setCDMSession(session);
+    protectedPrivate()->setCDMSession(session);
 }
 
 void MediaPlayer::keyAdded()
 {
-    m_private->keyAdded();
+    protectedPrivate()->keyAdded();
 }
 
 #endif
@@ -762,17 +762,17 @@ void MediaPlayer::keyAdded()
 
 void MediaPlayer::cdmInstanceAttached(CDMInstance& instance)
 {
-    m_private->cdmInstanceAttached(instance);
+    protectedPrivate()->cdmInstanceAttached(instance);
 }
 
 void MediaPlayer::cdmInstanceDetached(CDMInstance& instance)
 {
-    m_private->cdmInstanceDetached(instance);
+    protectedPrivate()->cdmInstanceDetached(instance);
 }
 
 void MediaPlayer::attemptToDecryptWithInstance(CDMInstance& instance)
 {
-    m_private->attemptToDecryptWithInstance(instance);
+    protectedPrivate()->attemptToDecryptWithInstance(instance);
 }
 
 #endif
@@ -781,7 +781,7 @@ void MediaPlayer::attemptToDecryptWithInstance(CDMInstance& instance)
 void MediaPlayer::setShouldContinueAfterKeyNeeded(bool should)
 {
     m_shouldContinueAfterKeyNeeded = should;
-    m_private->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
+    protectedPrivate()->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
 }
 #endif
 
@@ -812,7 +812,7 @@ bool MediaPlayer::timeIsProgressing() const
 
 bool MediaPlayer::setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&& callback)
 {
-    return m_private->setCurrentTimeDidChangeCallback(WTFMove(callback));
+    return protectedPrivate()->setCurrentTimeDidChangeCallback(WTFMove(callback));
 }
 
 MediaTime MediaPlayer::getStartDate() const
@@ -822,7 +822,7 @@ MediaTime MediaPlayer::getStartDate() const
 
 void MediaPlayer::willSeekToTarget(const MediaTime& time)
 {
-    m_private->willSeekToTarget(time);
+    protectedPrivate()->willSeekToTarget(time);
 }
 
 void MediaPlayer::seekToTarget(const SeekTarget& target)
@@ -862,27 +862,27 @@ bool MediaPlayer::seeking() const
 
 bool MediaPlayer::supportsFullscreen() const
 {
-    return m_private->supportsFullscreen();
+    return protectedPrivate()->supportsFullscreen();
 }
 
 bool MediaPlayer::canSaveMediaData() const
 {
-    return m_private->canSaveMediaData();
+    return protectedPrivate()->canSaveMediaData();
 }
 
 bool MediaPlayer::supportsScanning() const
 {
-    return m_private->supportsScanning();
+    return protectedPrivate()->supportsScanning();
 }
 
 bool MediaPlayer::supportsProgressMonitoring() const
 {
-    return m_private->supportsProgressMonitoring();
+    return protectedPrivate()->supportsProgressMonitoring();
 }
 
 bool MediaPlayer::requiresImmediateCompositing() const
 {
-    return m_private->requiresImmediateCompositing();
+    return protectedPrivate()->requiresImmediateCompositing();
 }
 
 FloatSize MediaPlayer::naturalSize()
@@ -902,7 +902,7 @@ bool MediaPlayer::hasAudio() const
 
 PlatformLayer* MediaPlayer::platformLayer() const
 {
-    return m_private->platformLayer();
+    return protectedPrivate()->platformLayer();
 }
     
 #if ENABLE(VIDEO_PRESENTATION_MODE)
@@ -919,22 +919,22 @@ void MediaPlayer::setVideoFullscreenLayer(PlatformLayer* layer, Function<void()>
 
 void MediaPlayer::updateVideoFullscreenInlineImage()
 {
-    m_private->updateVideoFullscreenInlineImage();
+    protectedPrivate()->updateVideoFullscreenInlineImage();
 }
 
 void MediaPlayer::setVideoFullscreenFrame(FloatRect frame)
 {
-    m_private->setVideoFullscreenFrame(frame);
+    protectedPrivate()->setVideoFullscreenFrame(frame);
 }
 
 void MediaPlayer::setVideoFullscreenGravity(MediaPlayer::VideoGravity gravity)
 {
-    m_private->setVideoFullscreenGravity(gravity);
+    protectedPrivate()->setVideoFullscreenGravity(gravity);
 }
 
 void MediaPlayer::setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode mode)
 {
-    m_private->setVideoFullscreenMode(mode);
+    protectedPrivate()->setVideoFullscreenMode(mode);
 }
 
 MediaPlayer::VideoFullscreenMode MediaPlayer::fullscreenMode() const
@@ -944,7 +944,7 @@ MediaPlayer::VideoFullscreenMode MediaPlayer::fullscreenMode() const
 
 void MediaPlayer::videoFullscreenStandbyChanged()
 {
-    m_private->videoFullscreenStandbyChanged();
+    protectedPrivate()->videoFullscreenStandbyChanged();
 }
 
 bool MediaPlayer::isVideoFullscreenStandby() const
@@ -970,7 +970,7 @@ void MediaPlayer::setSceneIdentifier(const String& identifier)
     if (m_sceneIdentifier == identifier)
         return;
     m_sceneIdentifier = identifier;
-    m_private->sceneIdentifierDidChange();
+    protectedPrivate()->sceneIdentifierDidChange();
 }
 #endif
 
@@ -981,24 +981,24 @@ void MediaPlayer::videoLayerSizeDidChange(const FloatSize& size)
 
 void MediaPlayer::setVideoLayerSizeFenced(const FloatSize& size, WTF::MachSendRightAnnotated&& fence)
 {
-    m_private->setVideoLayerSizeFenced(size, WTFMove(fence));
+    protectedPrivate()->setVideoLayerSizeFenced(size, WTFMove(fence));
 }
 
 #if PLATFORM(IOS_FAMILY)
 
 NSArray* MediaPlayer::timedMetadata() const
 {
-    return m_private->timedMetadata();
+    return protectedPrivate()->timedMetadata();
 }
 
 String MediaPlayer::accessLog() const
 {
-    return m_private->accessLog();
+    return protectedPrivate()->accessLog();
 }
 
 String MediaPlayer::errorLog() const
 {
-    return m_private->errorLog();
+    return protectedPrivate()->errorLog();
 }
 
 #endif
@@ -1015,7 +1015,7 @@ MediaPlayer::ReadyState MediaPlayer::readyState() const
 
 void MediaPlayer::setVolumeLocked(bool volumeLocked)
 {
-    m_private->setVolumeLocked(volumeLocked);
+    protectedPrivate()->setVolumeLocked(volumeLocked);
 }
 
 double MediaPlayer::volume() const
@@ -1026,7 +1026,7 @@ double MediaPlayer::volume() const
 void MediaPlayer::setVolume(double volume)
 {
     m_volume = volume;
-    m_private->setVolumeDouble(volume);
+    protectedPrivate()->setVolumeDouble(volume);
 }
 
 bool MediaPlayer::muted() const
@@ -1038,32 +1038,32 @@ void MediaPlayer::setMuted(bool muted)
 {
     m_muted = muted;
 
-    m_private->setMuted(muted);
+    protectedPrivate()->setMuted(muted);
 }
 
 bool MediaPlayer::hasClosedCaptions() const
 {
-    return m_private->hasClosedCaptions();
+    return protectedPrivate()->hasClosedCaptions();
 }
 
 void MediaPlayer::setClosedCaptionsVisible(bool closedCaptionsVisible)
 {
-    m_private->setClosedCaptionsVisible(closedCaptionsVisible);
+    protectedPrivate()->setClosedCaptionsVisible(closedCaptionsVisible);
 }
 
 double MediaPlayer::rate() const
 {
-    return m_private->rate();
+    return protectedPrivate()->rate();
 }
 
 void MediaPlayer::setRate(double rate)
 {
-    m_private->setRateDouble(rate);
+    protectedPrivate()->setRateDouble(rate);
 }
 
 double MediaPlayer::effectiveRate() const
 {
-    return m_private->effectiveRate();
+    return protectedPrivate()->effectiveRate();
 }
 
 double MediaPlayer::requestedRate() const
@@ -1079,7 +1079,7 @@ bool MediaPlayer::preservesPitch() const
 void MediaPlayer::setPreservesPitch(bool preservesPitch)
 {
     m_preservesPitch = preservesPitch;
-    m_private->setPreservesPitch(preservesPitch);
+    protectedPrivate()->setPreservesPitch(preservesPitch);
 }
 
 void MediaPlayer::setPitchCorrectionAlgorithm(PitchCorrectionAlgorithm pitchCorrectionAlgorithm)
@@ -1088,7 +1088,7 @@ void MediaPlayer::setPitchCorrectionAlgorithm(PitchCorrectionAlgorithm pitchCorr
         return;
 
     m_pitchCorrectionAlgorithm = pitchCorrectionAlgorithm;
-    m_private->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
+    protectedPrivate()->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
 }
 
 RefPtr<MediaPlayerPrivateInterface> MediaPlayer::protectedPrivate() const
@@ -1118,7 +1118,7 @@ MediaTime MediaPlayer::minTimeSeekable() const
 
 double MediaPlayer::seekableTimeRangesLastModifiedTime()
 {
-    return m_private->seekableTimeRangesLastModifiedTime();
+    return protectedPrivate()->seekableTimeRangesLastModifiedTime();
 }
 
 void MediaPlayer::bufferedTimeRangesChanged()
@@ -1133,7 +1133,7 @@ void MediaPlayer::seekableTimeRangesChanged()
 
 double MediaPlayer::liveUpdateInterval()
 {
-    return m_private->liveUpdateInterval();
+    return protectedPrivate()->liveUpdateInterval();
 }
 
 void MediaPlayer::didLoadingProgress(DidLoadingProgressCompletionHandler&& callback) const
@@ -1147,7 +1147,7 @@ void MediaPlayer::setPresentationSize(const IntSize& size)
         return;
 
     m_presentationSize = size;
-    m_private->setPresentationSize(size);
+    protectedPrivate()->setPresentationSize(size);
 }
 
 void MediaPlayer::setPageIsVisible(bool visible)
@@ -1171,13 +1171,13 @@ void MediaPlayer::setVisibleInViewport(bool visible)
         return;
 
     m_visibleInViewport = visible;
-    m_private->setVisibleInViewport(visible);
+    protectedPrivate()->setVisibleInViewport(visible);
 }
 
 void MediaPlayer::setResourceOwner(const ProcessIdentity& processIdentity)
 {
     m_processIdentity = processIdentity;
-    m_private->setResourceOwner(processIdentity);
+    protectedPrivate()->setResourceOwner(processIdentity);
 }
 
 MediaPlayer::Preload MediaPlayer::preload() const
@@ -1188,7 +1188,7 @@ MediaPlayer::Preload MediaPlayer::preload() const
 void MediaPlayer::setPreload(MediaPlayer::Preload preload)
 {
     m_preload = preload;
-    m_private->setPreload(preload);
+    protectedPrivate()->setPreload(preload);
 }
 
 void MediaPlayer::paint(GraphicsContext& context, const FloatRect& destination)
@@ -1203,13 +1203,13 @@ void MediaPlayer::paintCurrentFrameInContext(GraphicsContext& context, const Flo
 
 RefPtr<VideoFrame> MediaPlayer::videoFrameForCurrentTime()
 {
-    return m_private->videoFrameForCurrentTime();
+    return protectedPrivate()->videoFrameForCurrentTime();
 }
 
 
 RefPtr<NativeImage> MediaPlayer::nativeImageForCurrentTime()
 {
-    return m_private->nativeImageForCurrentTime();
+    return protectedPrivate()->nativeImageForCurrentTime();
 }
 
 DestinationColorSpace MediaPlayer::colorSpace()
@@ -1219,7 +1219,7 @@ DestinationColorSpace MediaPlayer::colorSpace()
 
 bool MediaPlayer::shouldGetNativeImageForCanvasDrawing() const
 {
-    return m_private->shouldGetNativeImageForCanvasDrawing();
+    return protectedPrivate()->shouldGetNativeImageForCanvasDrawing();
 }
 
 MediaPlayer::SupportsType MediaPlayer::supportsType(const MediaEngineSupportParameters& parameters)
@@ -1260,14 +1260,14 @@ bool MediaPlayer::isAvailable()
 
 bool MediaPlayer::supportsPictureInPicture() const
 {
-    return m_private->supportsPictureInPicture();
+    return protectedPrivate()->supportsPictureInPicture();
 }
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 bool MediaPlayer::isCurrentPlaybackTargetWireless() const
 {
-    return m_private->isCurrentPlaybackTargetWireless();
+    return protectedPrivate()->isCurrentPlaybackTargetWireless();
 }
 
 String MediaPlayer::wirelessPlaybackTargetName() const
@@ -1277,17 +1277,17 @@ String MediaPlayer::wirelessPlaybackTargetName() const
 
 MediaPlayer::WirelessPlaybackTargetType MediaPlayer::wirelessPlaybackTargetType() const
 {
-    return m_private->wirelessPlaybackTargetType();
+    return protectedPrivate()->wirelessPlaybackTargetType();
 }
 
 bool MediaPlayer::wirelessVideoPlaybackDisabled() const
 {
-    return m_private->wirelessVideoPlaybackDisabled();
+    return protectedPrivate()->wirelessVideoPlaybackDisabled();
 }
 
 void MediaPlayer::setWirelessVideoPlaybackDisabled(bool disabled)
 {
-    m_private->setWirelessVideoPlaybackDisabled(disabled);
+    protectedPrivate()->setWirelessVideoPlaybackDisabled(disabled);
 }
 
 void MediaPlayer::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackTargetWireless)
@@ -1297,44 +1297,44 @@ void MediaPlayer::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackT
 
 bool MediaPlayer::canPlayToWirelessPlaybackTarget() const
 {
-    return m_private->canPlayToWirelessPlaybackTarget();
+    return protectedPrivate()->canPlayToWirelessPlaybackTarget();
 }
 
 void MediaPlayer::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& device)
 {
-    m_private->setWirelessPlaybackTarget(WTFMove(device));
+    protectedPrivate()->setWirelessPlaybackTarget(WTFMove(device));
 }
 
 void MediaPlayer::setShouldPlayToPlaybackTarget(bool shouldPlay)
 {
-    m_private->setShouldPlayToPlaybackTarget(shouldPlay);
+    protectedPrivate()->setShouldPlayToPlaybackTarget(shouldPlay);
 }
 
 #endif
 
 double MediaPlayer::maxFastForwardRate() const
 {
-    return m_private->maxFastForwardRate();
+    return protectedPrivate()->maxFastForwardRate();
 }
 
 double MediaPlayer::minFastReverseRate() const
 {
-    return m_private->minFastReverseRate();
+    return protectedPrivate()->minFastReverseRate();
 }
 
 void MediaPlayer::acceleratedRenderingStateChanged()
 {
-    m_private->acceleratedRenderingStateChanged();
+    protectedPrivate()->acceleratedRenderingStateChanged();
 }
 
 bool MediaPlayer::supportsAcceleratedRendering() const
 {
-    return m_private->supportsAcceleratedRendering();
+    return protectedPrivate()->supportsAcceleratedRendering();
 }
 
 void MediaPlayer::setShouldMaintainAspectRatio(bool maintainAspectRatio)
 {
-    m_private->setShouldMaintainAspectRatio(maintainAspectRatio);
+    protectedPrivate()->setShouldMaintainAspectRatio(maintainAspectRatio);
 }
 
 void MediaPlayer::requestHostingContext(LayerHostingContextCallback&& callback)
@@ -1344,12 +1344,12 @@ void MediaPlayer::requestHostingContext(LayerHostingContextCallback&& callback)
 
 HostingContext MediaPlayer::hostingContext() const
 {
-    return m_private->hostingContext();
+    return protectedPrivate()->hostingContext();
 }
 
 bool MediaPlayer::didPassCORSAccessCheck() const
 {
-    return m_private->didPassCORSAccessCheck();
+    return protectedPrivate()->didPassCORSAccessCheck();
 }
 
 bool MediaPlayer::isCrossOrigin(const SecurityOrigin& origin) const
@@ -1365,32 +1365,32 @@ bool MediaPlayer::isCrossOrigin(const SecurityOrigin& origin) const
 
 MediaPlayer::MovieLoadType MediaPlayer::movieLoadType() const
 {
-    return m_private->movieLoadType();
+    return protectedPrivate()->movieLoadType();
 }
 
 MediaTime MediaPlayer::mediaTimeForTimeValue(const MediaTime& timeValue) const
 {
-    return m_private->mediaTimeForTimeValue(timeValue);
+    return protectedPrivate()->mediaTimeForTimeValue(timeValue);
 }
 
 unsigned MediaPlayer::decodedFrameCount() const
 {
-    return m_private->decodedFrameCount();
+    return protectedPrivate()->decodedFrameCount();
 }
 
 unsigned MediaPlayer::droppedFrameCount() const
 {
-    return m_private->droppedFrameCount();
+    return protectedPrivate()->droppedFrameCount();
 }
 
 unsigned MediaPlayer::audioDecodedByteCount() const
 {
-    return m_private->audioDecodedByteCount();
+    return protectedPrivate()->audioDecodedByteCount();
 }
 
 unsigned MediaPlayer::videoDecodedByteCount() const
 {
-    return m_private->videoDecodedByteCount();
+    return protectedPrivate()->videoDecodedByteCount();
 }
 
 void MediaPlayer::reloadTimerFired()
@@ -1441,8 +1441,8 @@ bool MediaPlayer::supportsKeySystem(const String& keySystem, const String& mimeT
 void MediaPlayer::setPrivateBrowsingMode(bool privateBrowsingMode)
 {
     m_inPrivateBrowsingMode = privateBrowsingMode;
-    if (m_private)
-        m_private->setPrivateBrowsingMode(m_inPrivateBrowsingMode);
+    if (RefPtr privateInterface = m_private)
+        privateInterface->setPrivateBrowsingMode(m_inPrivateBrowsingMode);
 }
 
 // Client callbacks.
@@ -1476,7 +1476,7 @@ void MediaPlayer::volumeChanged(double newVolume)
 {
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(newVolume);
-    m_volume = m_private->volume();
+    m_volume = protectedPrivate()->volume();
 #else
     m_volume = newVolume;
 #endif
@@ -1536,7 +1536,7 @@ void MediaPlayer::characteristicChanged()
 
 AudioSourceProvider* MediaPlayer::audioSourceProvider()
 {
-    return m_private->audioSourceProvider();
+    return protectedPrivate()->audioSourceProvider();
 }
 
 #endif
@@ -1576,7 +1576,7 @@ bool MediaPlayer::waitingForKey() const
 {
     if (!m_private)
         return false;
-    return m_private->waitingForKey();
+    return protectedPrivate()->waitingForKey();
 }
 #endif
 
@@ -1601,7 +1601,7 @@ long MediaPlayer::platformErrorCode() const
     if (!m_private)
         return 0;
 
-    return m_private->platformErrorCode();
+    return protectedPrivate()->platformErrorCode();
 }
 
 CachedResourceLoader* MediaPlayer::cachedResourceLoader()
@@ -1649,23 +1649,23 @@ void MediaPlayer::removeVideoTrack(VideoTrackPrivate& track)
 
 void MediaPlayer::setTextTrackRepresentation(TextTrackRepresentation* representation)
 {
-    m_private->setTextTrackRepresentation(representation);
+    protectedPrivate()->setTextTrackRepresentation(representation);
 }
 
 void MediaPlayer::syncTextTrackBounds()
 {
-    m_private->syncTextTrackBounds();
+    protectedPrivate()->syncTextTrackBounds();
 }
 
 void MediaPlayer::tracksChanged()
 {
-    m_private->tracksChanged();
+    protectedPrivate()->tracksChanged();
 }
 
 void MediaPlayer::notifyTrackModeChanged()
 {
-    if (m_private)
-        m_private->notifyTrackModeChanged();
+    if (RefPtr privateInterface = m_private)
+        privateInterface->notifyTrackModeChanged();
 }
 
 Vector<RefPtr<PlatformTextTrack>> MediaPlayer::outOfBandTrackSources()
@@ -1692,7 +1692,7 @@ void MediaPlayer::simulateAudioInterruption()
     if (!m_private)
         return;
 
-    m_private->simulateAudioInterruption();
+    protectedPrivate()->simulateAudioInterruption();
 }
 
 bool MediaPlayer::isGStreamerHolePunchingEnabled()
@@ -1703,14 +1703,14 @@ bool MediaPlayer::isGStreamerHolePunchingEnabled()
 
 void MediaPlayer::beginSimulatedHDCPError()
 {
-    if (m_private)
-        m_private->beginSimulatedHDCPError();
+    if (RefPtr privateInterface = m_private)
+        privateInterface->beginSimulatedHDCPError();
 }
 
 void MediaPlayer::endSimulatedHDCPError()
 {
-    if (m_private)
-        m_private->endSimulatedHDCPError();
+    if (RefPtr privateInterface = m_private)
+        privateInterface->endSimulatedHDCPError();
 }
 
 String MediaPlayer::languageOfPrimaryAudioTrack() const
@@ -1735,12 +1735,12 @@ unsigned long long MediaPlayer::fileSize() const
     if (!m_private)
         return 0;
     
-    return m_private->fileSize();
+    return protectedPrivate()->fileSize();
 }
 
 bool MediaPlayer::ended() const
 {
-    return m_private->ended();
+    return protectedPrivate()->ended();
 }
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayer::videoPlaybackQualityMetrics()
@@ -1795,8 +1795,8 @@ void MediaPlayer::getRawCookies(const URL& url, MediaPlayerClient::GetRawCookies
 
 void MediaPlayer::setShouldDisableSleep(bool flag)
 {
-    if (m_private)
-        m_private->setShouldDisableSleep(flag);
+    if (RefPtr privateInterface = m_private)
+        privateInterface->setShouldDisableSleep(flag);
 }
 
 bool MediaPlayer::shouldDisableSleep() const
@@ -1851,36 +1851,36 @@ const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaCaptionFormatTypes
 
 void MediaPlayer::applicationWillResignActive()
 {
-    m_private->applicationWillResignActive();
+    protectedPrivate()->applicationWillResignActive();
 }
 
 void MediaPlayer::applicationDidBecomeActive()
 {
-    m_private->applicationDidBecomeActive();
+    protectedPrivate()->applicationDidBecomeActive();
 }
 
 #if USE(AVFOUNDATION)
 
 AVPlayer* MediaPlayer::objCAVFoundationAVPlayer() const
 {
-    return m_private->objCAVFoundationAVPlayer();
+    return protectedPrivate()->objCAVFoundationAVPlayer();
 }
 
 #endif
 
 bool MediaPlayer::performTaskAtTime(Function<void()>&& task, const MediaTime& time)
 {
-    return m_private->performTaskAtTime(WTFMove(task), time);
+    return protectedPrivate()->performTaskAtTime(WTFMove(task), time);
 }
 
 bool MediaPlayer::shouldIgnoreIntrinsicSize()
 {
-    return m_private->shouldIgnoreIntrinsicSize();
+    return protectedPrivate()->shouldIgnoreIntrinsicSize();
 }
 
 void MediaPlayer::isLoopingChanged()
 {
-    m_private->isLoopingChanged();
+    protectedPrivate()->isLoopingChanged();
 }
 
 void MediaPlayer::remoteEngineFailedToLoad()
@@ -1896,7 +1896,7 @@ SecurityOriginData MediaPlayer::documentSecurityOrigin() const
 void MediaPlayer::setPreferredDynamicRangeMode(DynamicRangeMode mode)
 {
     m_preferredDynamicRangeMode = mode;
-    m_private->setPreferredDynamicRangeMode(mode);
+    protectedPrivate()->setPreferredDynamicRangeMode(mode);
 }
 
 void MediaPlayer::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
@@ -1904,12 +1904,12 @@ void MediaPlayer::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platfor
     if (m_platformDynamicRangeLimit == platformDynamicRangeLimit)
         return;
     m_platformDynamicRangeLimit = platformDynamicRangeLimit;
-    m_private->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
+    protectedPrivate()->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
 }
 
 void MediaPlayer::audioOutputDeviceChanged()
 {
-    m_private->audioOutputDeviceChanged();
+    protectedPrivate()->audioOutputDeviceChanged();
 }
 
 std::optional<MediaPlayerIdentifier> MediaPlayer::identifier() const
@@ -1925,28 +1925,28 @@ std::optional<VideoFrameMetadata> MediaPlayer::videoFrameMetadata()
 void MediaPlayer::startVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = true;
-    m_private->startVideoFrameMetadataGathering();
+    protectedPrivate()->startVideoFrameMetadataGathering();
 }
 
 void MediaPlayer::stopVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = false;
-    m_private->stopVideoFrameMetadataGathering();
+    protectedPrivate()->stopVideoFrameMetadataGathering();
 }
 
 void MediaPlayer::renderVideoWillBeDestroyed()
 {
-    m_private->renderVideoWillBeDestroyed();
+    protectedPrivate()->renderVideoWillBeDestroyed();
 }
 
 void MediaPlayer::setShouldDisableHDR(bool shouldDisable)
 {
-    m_private->setShouldDisableHDR(shouldDisable);
+    protectedPrivate()->setShouldDisableHDR(shouldDisable);
 }
 
 void MediaPlayer::playerContentBoxRectChanged(const LayoutRect& rect)
 {
-    m_private->playerContentBoxRectChanged(rect);
+    protectedPrivate()->playerContentBoxRectChanged(rect);
 }
 
 #if PLATFORM(COCOA)
@@ -1963,12 +1963,12 @@ String MediaPlayer::elementId() const
 
 bool MediaPlayer::supportsPlayAtHostTime() const
 {
-    return m_private->supportsPlayAtHostTime();
+    return protectedPrivate()->supportsPlayAtHostTime();
 }
 
 bool MediaPlayer::supportsPauseAtHostTime() const
 {
-    return m_private->supportsPauseAtHostTime();
+    return protectedPrivate()->supportsPauseAtHostTime();
 }
 
 bool MediaPlayer::playAtHostTime(const MonotonicTime& hostTime)
@@ -1976,7 +1976,7 @@ bool MediaPlayer::playAtHostTime(const MonotonicTime& hostTime)
     // It is invalid to call playAtHostTime() if the underlying
     // media player does not support it.
     ASSERT(supportsPlayAtHostTime());
-    return m_private->playAtHostTime(hostTime);
+    return protectedPrivate()->playAtHostTime(hostTime);
 }
 
 bool MediaPlayer::pauseAtHostTime(const MonotonicTime& hostTime)
@@ -1984,12 +1984,12 @@ bool MediaPlayer::pauseAtHostTime(const MonotonicTime& hostTime)
     // It is invalid to call pauseAtHostTime() if the underlying
     // media player does not support it.
     ASSERT(supportsPauseAtHostTime());
-    return m_private->pauseAtHostTime(hostTime);
+    return protectedPrivate()->pauseAtHostTime(hostTime);
 }
 
 void MediaPlayer::setShouldCheckHardwareSupport(bool value)
 {
-    m_private->setShouldCheckHardwareSupport(value);
+    protectedPrivate()->setShouldCheckHardwareSupport(value);
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -2003,7 +2003,7 @@ void MediaPlayer::setDefaultSpatialTrackingLabel(const String& defaultSpatialTra
     if (m_defaultSpatialTrackingLabel == defaultSpatialTrackingLabel)
         return;
     m_defaultSpatialTrackingLabel = defaultSpatialTrackingLabel;
-    m_private->setDefaultSpatialTrackingLabel(defaultSpatialTrackingLabel);
+    protectedPrivate()->setDefaultSpatialTrackingLabel(defaultSpatialTrackingLabel);
 }
 
 const String& MediaPlayer::spatialTrackingLabel() const
@@ -2016,7 +2016,7 @@ void MediaPlayer::setSpatialTrackingLabel(const String& spatialTrackingLabel)
     if (m_spatialTrackingLabel == spatialTrackingLabel)
         return;
     m_spatialTrackingLabel = spatialTrackingLabel;
-    m_private->setSpatialTrackingLabel(spatialTrackingLabel);
+    protectedPrivate()->setSpatialTrackingLabel(spatialTrackingLabel);
 }
 #endif
 
@@ -2026,7 +2026,7 @@ void MediaPlayer::setPrefersSpatialAudioExperience(bool value)
     if (m_prefersSpatialAudioExperience == value)
         return;
     m_prefersSpatialAudioExperience = value;
-    m_private->prefersSpatialAudioExperienceChanged();
+    protectedPrivate()->prefersSpatialAudioExperienceChanged();
 }
 #endif
 
@@ -2037,7 +2037,7 @@ auto MediaPlayer::soundStageSize() const -> SoundStageSize
 
 void MediaPlayer::soundStageSizeDidChange()
 {
-    m_private->soundStageSizeDidChange();
+    protectedPrivate()->soundStageSizeDidChange();
 }
 
 void MediaPlayer::setInFullscreenOrPictureInPicture(bool isInFullscreenOrPictureInPicture)
@@ -2046,7 +2046,7 @@ void MediaPlayer::setInFullscreenOrPictureInPicture(bool isInFullscreenOrPicture
         return;
 
     m_isInFullscreenOrPictureInPicture = isInFullscreenOrPictureInPicture;
-    m_private->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
+    protectedPrivate()->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
 }
 
 bool MediaPlayer::isInFullscreenOrPictureInPicture() const
@@ -2057,7 +2057,7 @@ bool MediaPlayer::isInFullscreenOrPictureInPicture() const
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 bool MediaPlayer::supportsLinearMediaPlayer() const
 {
-    return m_private->supportsLinearMediaPlayer();
+    return protectedPrivate()->supportsLinearMediaPlayer();
 }
 #endif
 
@@ -2071,7 +2071,7 @@ const Logger& MediaPlayer::mediaPlayerLogger()
 void MediaPlayer::setMessageClientForTesting(WeakPtr<MessageClientForTesting> internalMessageClient)
 {
     m_internalMessageClient = WTFMove(internalMessageClient);
-    m_private->setMessageClientForTesting(m_internalMessageClient);
+    protectedPrivate()->setMessageClientForTesting(m_internalMessageClient);
 }
 
 MessageClientForTesting* MediaPlayer::messageClientForTesting() const

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerCocoa.mm
@@ -34,7 +34,7 @@ namespace WebCore {
 
 void MediaPlayer::setVideoTarget(const PlatformVideoTarget& target)
 {
-    m_private->setVideoTarget(target);
+    protectedPrivate()->setVideoTarget(target);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 82787c2128146b297515567d2b7f798289bf4a2a
<pre>
Adopt safer CPP in MediaPlayer.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=297996">https://bugs.webkit.org/show_bug.cgi?id=297996</a>
<a href="https://rdar.apple.com/159317354">rdar://159317354</a>

Reviewed by Rupin Mittal.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::~MediaPlayer):
(WebCore::MediaPlayer::prepareForRendering):
(WebCore::MediaPlayer::prepareToPlay):
(WebCore::MediaPlayer::setBufferingPolicy):
(WebCore::MediaPlayer::createSession):
(WebCore::MediaPlayer::setCDM):
(WebCore::MediaPlayer::setCDMSession):
(WebCore::MediaPlayer::keyAdded):
(WebCore::MediaPlayer::cdmInstanceAttached):
(WebCore::MediaPlayer::cdmInstanceDetached):
(WebCore::MediaPlayer::attemptToDecryptWithInstance):
(WebCore::MediaPlayer::setShouldContinueAfterKeyNeeded):
(WebCore::MediaPlayer::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayer::willSeekToTarget):
(WebCore::MediaPlayer::supportsFullscreen const):
(WebCore::MediaPlayer::canSaveMediaData const):
(WebCore::MediaPlayer::supportsScanning const):
(WebCore::MediaPlayer::supportsProgressMonitoring const):
(WebCore::MediaPlayer::requiresImmediateCompositing const):
(WebCore::MediaPlayer::platformLayer const):
(WebCore::MediaPlayer::updateVideoFullscreenInlineImage):
(WebCore::MediaPlayer::setVideoFullscreenFrame):
(WebCore::MediaPlayer::setVideoFullscreenGravity):
(WebCore::MediaPlayer::setVideoFullscreenMode):
(WebCore::MediaPlayer::videoFullscreenStandbyChanged):
(WebCore::MediaPlayer::setSceneIdentifier):
(WebCore::MediaPlayer::setVideoLayerSizeFenced):
(WebCore::MediaPlayer::timedMetadata const):
(WebCore::MediaPlayer::accessLog const):
(WebCore::MediaPlayer::errorLog const):
(WebCore::MediaPlayer::setVolumeLocked):
(WebCore::MediaPlayer::setVolume):
(WebCore::MediaPlayer::setMuted):
(WebCore::MediaPlayer::hasClosedCaptions const):
(WebCore::MediaPlayer::setClosedCaptionsVisible):
(WebCore::MediaPlayer::rate const):
(WebCore::MediaPlayer::setRate):
(WebCore::MediaPlayer::effectiveRate const):
(WebCore::MediaPlayer::setPreservesPitch):
(WebCore::MediaPlayer::setPitchCorrectionAlgorithm):
(WebCore::MediaPlayer::seekableTimeRangesLastModifiedTime):
(WebCore::MediaPlayer::liveUpdateInterval):
(WebCore::MediaPlayer::setPresentationSize):
(WebCore::MediaPlayer::setVisibleInViewport):
(WebCore::MediaPlayer::setResourceOwner):
(WebCore::MediaPlayer::setPreload):
(WebCore::MediaPlayer::videoFrameForCurrentTime):
(WebCore::MediaPlayer::nativeImageForCurrentTime):
(WebCore::MediaPlayer::shouldGetNativeImageForCanvasDrawing const):
(WebCore::MediaPlayer::supportsPictureInPicture const):
(WebCore::MediaPlayer::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayer::wirelessPlaybackTargetType const):
(WebCore::MediaPlayer::wirelessVideoPlaybackDisabled const):
(WebCore::MediaPlayer::setWirelessVideoPlaybackDisabled):
(WebCore::MediaPlayer::canPlayToWirelessPlaybackTarget const):
(WebCore::MediaPlayer::setWirelessPlaybackTarget):
(WebCore::MediaPlayer::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayer::maxFastForwardRate const):
(WebCore::MediaPlayer::minFastReverseRate const):
(WebCore::MediaPlayer::acceleratedRenderingStateChanged):
(WebCore::MediaPlayer::supportsAcceleratedRendering const):
(WebCore::MediaPlayer::setShouldMaintainAspectRatio):
(WebCore::MediaPlayer::hostingContext const):
(WebCore::MediaPlayer::didPassCORSAccessCheck const):
(WebCore::MediaPlayer::movieLoadType const):
(WebCore::MediaPlayer::mediaTimeForTimeValue const):
(WebCore::MediaPlayer::decodedFrameCount const):
(WebCore::MediaPlayer::droppedFrameCount const):
(WebCore::MediaPlayer::audioDecodedByteCount const):
(WebCore::MediaPlayer::videoDecodedByteCount const):
(WebCore::MediaPlayer::setPrivateBrowsingMode):
(WebCore::MediaPlayer::volumeChanged):
(WebCore::MediaPlayer::audioSourceProvider):
(WebCore::MediaPlayer::waitingForKey const):
(WebCore::MediaPlayer::platformErrorCode const):
(WebCore::MediaPlayer::setTextTrackRepresentation):
(WebCore::MediaPlayer::syncTextTrackBounds):
(WebCore::MediaPlayer::tracksChanged):
(WebCore::MediaPlayer::notifyTrackModeChanged):
(WebCore::MediaPlayer::simulateAudioInterruption):
(WebCore::MediaPlayer::beginSimulatedHDCPError):
(WebCore::MediaPlayer::endSimulatedHDCPError):
(WebCore::MediaPlayer::fileSize const):
(WebCore::MediaPlayer::ended const):
(WebCore::MediaPlayer::setShouldDisableSleep):
(WebCore::MediaPlayer::applicationWillResignActive):
(WebCore::MediaPlayer::applicationDidBecomeActive):
(WebCore::MediaPlayer::objCAVFoundationAVPlayer const):
(WebCore::MediaPlayer::performTaskAtTime):
(WebCore::MediaPlayer::shouldIgnoreIntrinsicSize):
(WebCore::MediaPlayer::isLoopingChanged):
(WebCore::MediaPlayer::setPreferredDynamicRangeMode):
(WebCore::MediaPlayer::setPlatformDynamicRangeLimit):
(WebCore::MediaPlayer::audioOutputDeviceChanged):
(WebCore::MediaPlayer::startVideoFrameMetadataGathering):
(WebCore::MediaPlayer::stopVideoFrameMetadataGathering):
(WebCore::MediaPlayer::renderVideoWillBeDestroyed):
(WebCore::MediaPlayer::setShouldDisableHDR):
(WebCore::MediaPlayer::playerContentBoxRectChanged):
(WebCore::MediaPlayer::supportsPlayAtHostTime const):
(WebCore::MediaPlayer::supportsPauseAtHostTime const):
(WebCore::MediaPlayer::playAtHostTime):
(WebCore::MediaPlayer::pauseAtHostTime):
(WebCore::MediaPlayer::setShouldCheckHardwareSupport):
(WebCore::MediaPlayer::setDefaultSpatialTrackingLabel):
(WebCore::MediaPlayer::setSpatialTrackingLabel):
(WebCore::MediaPlayer::setPrefersSpatialAudioExperience):
(WebCore::MediaPlayer::soundStageSizeDidChange):
(WebCore::MediaPlayer::setInFullscreenOrPictureInPicture):
(WebCore::MediaPlayer::supportsLinearMediaPlayer const):
(WebCore::MediaPlayer::setMessageClientForTesting):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerCocoa.mm:
(WebCore::MediaPlayer::setVideoTarget):

Canonical link: <a href="https://commits.webkit.org/299296@main">https://commits.webkit.org/299296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d38bdcd7bc7ca4f29a19c1fe8c832dfd850613bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70593 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26c5d589-182a-45c3-aae5-be9a3ba1b1c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89969 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9dc2b0f7-f15c-4ef4-87cb-85f2b31cdd84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f77ea44-3d26-4164-8e25-9b2a43a014d5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68365 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24575 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45441 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102494 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/43826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18887 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50989 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/44774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46461 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->