### PR TITLE
[ iOS Release ] TestIPC.ConnectionTest/ConnectionRunLoopTest.SendAndInvalidate/ServerIsA  is a flaky crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -827,7 +827,12 @@ TEST_P(ConnectionRunLoopTest, SendAsyncAndInvalidateOnDispatcher)
 
 // Tests that all sent messages are received, even if sender invalidates
 // without synchronizing with the receiver.
+// FIXME when rdar://159131152 is resolved
+#if PLATFORM(IOS)
+TEST_P(ConnectionRunLoopTest, DISABLED_SendAndInvalidate)
+#else
 TEST_P(ConnectionRunLoopTest, SendAndInvalidate)
+#endif
 {
     constexpr uint64_t messageCount = 1777;
     ASSERT_TRUE(openA());


### PR DESCRIPTION
#### 0c09c333160d31646d376fb3e323d76ba4b5dee0
<pre>
[ iOS Release ] TestIPC.ConnectionTest/ConnectionRunLoopTest.SendAndInvalidate/ServerIsA  is a flaky crash
<a href="https://rdar.apple.com/159131152">rdar://159131152</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297870">https://bugs.webkit.org/show_bug.cgi?id=297870</a>

Reviewed by Ryan Haddad.

Disabling flaky crashing API test till the fix is applied.

* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/299262@main">https://commits.webkit.org/299262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c807b8a31753ee64b159d3c44caaf7f50d743000

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70392 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75c87124-13fb-456d-af40-131ebbf9c99f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89807 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59430 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/471a694e-99c4-47d2-ab10-f6c4f97d9480) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70296 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d94ad20-e737-45fc-b2bf-a8c6077b51e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24215 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68166 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127575 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98482 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98269 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21660 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41722 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18865 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45116 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44579 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47923 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46266 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->