### PR TITLE
Add a Test-Sequence header to the webkitpy <-> WKTR/DRT server protocol

### DIFF
--- a/Tools/DumpRenderTree/DumpRenderTree.h
+++ b/Tools/DumpRenderTree/DumpRenderTree.h
@@ -48,6 +48,7 @@ class TestRunner;
 
 extern volatile bool done;
 extern bool gUsingServerMode;
+extern uint64_t gTestSequenceNumber;
 
 // FIXME: This is a bad abstraction.  We should insted pass this to other controller objects which need access to it.
 extern RefPtr<TestRunner> gTestRunner;

--- a/Tools/DumpRenderTree/PixelDumpSupport.cpp
+++ b/Tools/DumpRenderTree/PixelDumpSupport.cpp
@@ -114,6 +114,7 @@ void printPNG(const unsigned char* data, const size_t dataLength, const char* ch
     Vector<unsigned char> bytesToAdd;
     convertChecksumToPNGComment(checksum, bytesToAdd);
 
+    fprintf(testResult, "Test-Sequence: %llu\n", gTestSequenceNumber);
     fprintf(testResult, "Content-Type: image/png\n");
     fprintf(testResult, "Content-Length: %lu\n", static_cast<unsigned long>(dataLength + bytesToAdd.size()));
 

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_failures_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_failures_unittest.py
@@ -81,7 +81,8 @@ class TestFailuresTest(unittest.TestCase):
             FailureMissingAudio,
             FailureAudioMismatch,
             FailureDocumentLeak,
-            FailureEarlyExit)
+            FailureEarlyExit,
+            FailureSequenceMismatch)
         self.assertEqual(failure_classes, ALL_FAILURE_CLASSES)
 
     def test_equals(self):

--- a/Tools/WebKitTestRunner/PixelDumpSupport.cpp
+++ b/Tools/WebKitTestRunner/PixelDumpSupport.cpp
@@ -67,12 +67,13 @@ static size_t offsetAfterIHDRChunk(const unsigned char* data, const size_t dataL
     return pngHeaderLength + pngIHDRChunkLength;
 }
 
-void printPNG(const unsigned char* data, const size_t dataLength, const char* checksum)
+void printPNG(const unsigned char* data, const size_t dataLength, const char* checksum, uint64_t testSequenceNumber)
 {
     Vector<unsigned char> bytesToAdd;
     convertChecksumToPNGComment(checksum, bytesToAdd);
 
     printf("Content-Type: %s\n", "image/png");
+    printf("Test-Sequence: %llu\n", testSequenceNumber);
     printf("Content-Length: %lu\n", static_cast<unsigned long>(dataLength + bytesToAdd.size()));
 
     size_t insertOffset = offsetAfterIHDRChunk(data, dataLength);

--- a/Tools/WebKitTestRunner/PixelDumpSupport.h
+++ b/Tools/WebKitTestRunner/PixelDumpSupport.h
@@ -29,6 +29,6 @@
 #ifndef PixelDumpSupport_h
 #define PixelDumpSupport_h
 
-void printPNG(const unsigned char* data, const size_t dataLength, const char* checksum);
+void printPNG(const unsigned char* data, const size_t dataLength, const char* checksum, uint64_t testSequenceNumber = 0);
 
 #endif // PixelDumpSupport_h

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -251,9 +251,10 @@ void TestInvocation::dumpWebProcessUnresponsiveness(const char* errorMessage)
         fprintf(stderr, "Failed receive expected sample response, got:\n\t\"%s\"\nContinuing...\n", buffer);
 }
 
-void TestInvocation::dump(const char* textToStdout, const char* textToStderr, bool seenError)
+void TestInvocation::dump(const char* textToStdout, const char* textToStderr, bool seenError, uint64_t testSequenceNumber)
 {
     printf("Content-Type: text/plain\n");
+    printf("Test-Sequence: %llu\n", testSequenceNumber);
     if (textToStdout)
         fputs(textToStdout, stdout);
     if (textToStderr)
@@ -295,9 +296,9 @@ void TestInvocation::dumpResults()
         m_textOutput.append(TestController::singleton().dumpPrivateClickMeasurement());
 
     if (m_textOutput.hasOverflowed())
-        dump("text output overflowed");
+        dump("text output overflowed", nullptr, false, m_identifier);
     else if (m_textOutput.length() || !m_audioResult)
-        dump(m_textOutput.toString().utf8().data());
+        dump(m_textOutput.toString().utf8().data(), nullptr, false, m_identifier);
     else
         dumpAudio(m_audioResult.get());
 
@@ -326,6 +327,7 @@ void TestInvocation::dumpAudio(WKDataRef audioData)
         return;
 
     printf("Content-Type: audio/wav\n");
+    printf("Test-Sequence: %llu\n", m_identifier);
     printf("Content-Length: %lu\n", static_cast<unsigned long>(span.size()));
 
     fwrite(span.data(), 1, span.size(), stdout);

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -109,7 +109,7 @@ private:
     bool resolveForceImmediateCompletion();
 
     void dumpResults();
-    static void dump(const char* textToStdout, const char* textToStderr = 0, bool seenError = false);
+    static void dump(const char* textToStdout, const char* textToStderr = 0, bool seenError = false, uint64_t testSequenceNumber = 0);
     enum class SnapshotResultType { WebView, WebContents };
     void dumpPixelsAndCompareWithExpected(SnapshotResultType, WKArrayRef repaintRects, WKImageRef = nullptr);
     void dumpAudio(WKDataRef);

--- a/Tools/WebKitTestRunner/cairo/TestInvocationCairo.cpp
+++ b/Tools/WebKitTestRunner/cairo/TestInvocationCairo.cpp
@@ -72,14 +72,14 @@ static cairo_status_t writeFunction(void* closure, const unsigned char* data, un
     return CAIRO_STATUS_SUCCESS;
 }
 
-static void dumpBitmap(cairo_surface_t* surface, const char* checksum)
+static void dumpBitmap(cairo_surface_t* surface, const char* checksum, uint64_t testSequenceNumber)
 {
     Vector<unsigned char> pixelData;
     cairo_surface_write_to_png_stream(surface, writeFunction, &pixelData);
     const size_t dataLength = pixelData.size();
     const unsigned char* data = pixelData.span().data();
 
-    printPNG(data, dataLength, checksum);
+    printPNG(data, dataLength, checksum, testSequenceNumber);
 }
 
 static void paintRepaintRectOverlay(cairo_surface_t* surface, WKArrayRef repaintRects)
@@ -126,7 +126,7 @@ void TestInvocation::dumpPixelsAndCompareWithExpected(SnapshotResultType snapsho
     char actualHash[33];
     computeSHA1HashStringForCairoSurface(surface, actualHash);
     if (!compareActualHashToExpectedAndDumpResults(actualHash))
-        dumpBitmap(surface, actualHash);
+        dumpBitmap(surface, actualHash, m_identifier);
 
     cairo_surface_destroy(surface);
 }

--- a/Tools/WebKitTestRunner/cocoa/TestInvocationCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestInvocationCocoa.mm
@@ -134,7 +134,7 @@ static std::optional<std::string> hashForBlackImageOfSize(WKSize size)
 }
 #endif // PLATFORM(MAC)
 
-static void dumpBitmap(CGContextRef bitmapContext, const std::string& checksum, WKSize imageSize, WKSize windowSize)
+static void dumpBitmap(CGContextRef bitmapContext, const std::string& checksum, WKSize imageSize, WKSize windowSize, uint64_t testSequenceNumber)
 {
     auto image = adoptCF(CGBitmapContextCreateImage(bitmapContext));
     auto imageData = adoptCF(CFDataCreateMutable(0, 0));
@@ -154,7 +154,7 @@ static void dumpBitmap(CGContextRef bitmapContext, const std::string& checksum, 
     const unsigned char* data = CFDataGetBytePtr(imageData.get());
     const size_t dataLength = CFDataGetLength(imageData.get());
 
-    printPNG(data, dataLength, checksum.c_str());
+    printPNG(data, dataLength, checksum.c_str(), testSequenceNumber);
 }
 
 static void paintRepaintRectOverlay(CGContextRef context, WKSize imageSize, WKArrayRef repaintRects)
@@ -253,7 +253,7 @@ void TestInvocation::dumpPixelsAndCompareWithExpected(SnapshotResultType snapsho
     } while (gotBlackSnapshot && numTries++ < maxNumTries);
 
     if (!compareActualHashToExpectedAndDumpResults(snapshotHash))
-        dumpBitmap(context.get(), snapshotHash, imageSize, windowSize);
+        dumpBitmap(context.get(), snapshotHash, imageSize, windowSize, m_identifier);
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
+++ b/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
@@ -60,12 +60,12 @@ static std::string computeSHA1HashStringForPixmap(const SkPixmap& pixmap)
     return result;
 }
 
-static void dumpPixmap(const SkPixmap& pixmap, const std::string& checksum)
+static void dumpPixmap(const SkPixmap& pixmap, const std::string& checksum, uint64_t testSequenceNumber)
 {
     SkDynamicMemoryWStream stream;
     SkPngEncoder::Encode(&stream, pixmap, { });
     auto data = stream.detachAsData();
-    printPNG(data->bytes(), data->size(), checksum.c_str());
+    printPNG(data->bytes(), data->size(), checksum.c_str(), testSequenceNumber);
 }
 
 void TestInvocation::dumpPixelsAndCompareWithExpected(SnapshotResultType snapshotType, WKArrayRef repaintRects, WKImageRef webImage)
@@ -103,7 +103,7 @@ void TestInvocation::dumpPixelsAndCompareWithExpected(SnapshotResultType snapsho
 
     auto snapshotHash = computeSHA1HashStringForPixmap(pixmap);
     if (!compareActualHashToExpectedAndDumpResults(snapshotHash))
-        dumpPixmap(pixmap, snapshotHash);
+        dumpPixmap(pixmap, snapshotHash, m_identifier);
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### b5b0a0d736a2
<pre>
Add a Test-Sequence header to the webkitpy &lt;-&gt; WKTR/DRT server protocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=298004">https://bugs.webkit.org/show_bug.cgi?id=298004</a>

Reviewed by NOBODY (OOPS!).

This keeps count of the number of run test commands sent on both sides
of the protocol, allowing some basic synchronization.

It is less ideal than setting some abstract UUID (because
incrementing accidentally is possible), but this is landable in a much
lower-impact way that doesn&apos;t break the communication protocol,
allowing older WKTR/DRT builds (e.g., from build archives) to still
work with current webkitpy.

We report failures as CRASH, because a driver synchronization issue is
a significant one. Of course, by the point this occurs, it&apos;s reporting
a _following_ test as CRASH (and almost certainly the _immediately_
following test), and not the one that caused the synchronization issue
to start with.

Explanation of why this fixes the bug (OOPS!).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5b0a0d736a2ba48257a2a04695a8f54ffe7557b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121224 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31578 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127655 "Hash b5b0a0d7 for PR 49978 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73305 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49499 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/127655 "Hash b5b0a0d7 for PR 49978 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61264 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e89f709-3e6d-4656-a128-c88c2f731063) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108640 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/127655 "Hash b5b0a0d7 for PR 49978 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58b2a733-6d3e-4d3b-bc52-b7fbc6de86f8) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120581 "Found 69 webkitpy test failures: webkitpy.common.net.resultsjsonparser_unittest.ParsedJSONResultsTest.test_basic, webkitpy.common.net.resultsjsonparser_unittest.ParsedJSONResultsTest.test_not_interrupted, webkitpy.layout_tests.models.test_failures_unittest.TestFailuresTest.test_message_is_virtual, webkitpy.layout_tests.models.test_failures_unittest.TestFailuresTest.test_pickle_roundtrip, webkitpy.layout_tests.models.test_failures_unittest.TestFailuresTest.test_unknown_failure_type, webkitpy.layout_tests.run_webkit_tests_integrationtest.RebaselineTest.test_missing_results, webkitpy.layout_tests.run_webkit_tests_integrationtest.RebaselineTest.test_new_baseline, webkitpy.layout_tests.run_webkit_tests_integrationtest.RebaselineTest.test_reset_results, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_additional_platform_directory, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.serial_test_basic ...") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32251 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26760 "Found 1 new test failure: scrollbars/scrollevent-iframe-no-scrolling-wheel.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71239 "Hash b5b0a0d7 for PR 49978 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26939 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130498 "Hash b5b0a0d7 for PR 49978 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36598 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/130498 "Hash b5b0a0d7 for PR 49978 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104824 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/130498 "Hash b5b0a0d7 for PR 49978 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24047 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44845 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48009 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47480 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->