### PR TITLE
[Liquid Glass] [macOS] Safari tab bar changes colors when switching between default viewer and fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3373,6 +3373,17 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
     return adjustedColor.get() ?: color;
 }
 
+- (RetainPtr<NSScrollPocket>)_copyTopScrollPocket
+{
+    RetainPtr clonedScrollPocket = adoptNS([NSScrollPocket new]);
+    RetainPtr currentScrollPocket = _impl->topScrollPocket();
+    [clonedScrollPocket setEdge:[currentScrollPocket edge]];
+    [clonedScrollPocket setStyle:[currentScrollPocket style]];
+    [clonedScrollPocket setPrefersSolidColorHardPocket:[currentScrollPocket prefersSolidColorHardPocket]];
+    [clonedScrollPocket setCaptureColor:[currentScrollPocket captureColor]];
+    return clonedScrollPocket;
+}
+
 - (BOOL)_alwaysPrefersSolidColorHardPocket
 {
     return _alwaysPrefersSolidColorHardPocket;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -149,6 +149,7 @@ enum class HideScrollPocketReason : uint8_t {
 };
 }
 
+@class NSScrollPocket;
 @class WKColorExtensionView;
 @class WKContentView;
 @class WKPasswordView;
@@ -560,6 +561,7 @@ struct PerWebProcessState {
 
 #if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 - (NSColor *)_adjustedColorForTopContentInsetColorFromUIDelegate:(NSColor *)proposedColor;
+@property (nonatomic, readonly) RetainPtr<NSScrollPocket> _copyTopScrollPocket;
 @property (nonatomic, setter=_setAlwaysPrefersSolidColorHardPocket:) BOOL _alwaysPrefersSolidColorHardPocket;
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -41,16 +41,17 @@ namespace WebCore {
 class IntRect;
 }
 
-@class WKView;
+@class WKWebView;
+@class WKFullScreenPlaceholderView;
 @class WebCoreFullScreenPlaceholderView;
 
 typedef enum FullScreenState : NSInteger FullScreenState;
 
 @interface WKFullScreenWindowController : NSWindowController<NSWindowDelegate> {
 @private
-    WeakObjCPtr<NSView> _webView; // Cannot be retained, see <rdar://problem/14884666>.
+    WeakObjCPtr<WKWebView> _webView; // Cannot be retained, see <rdar://problem/14884666>.
     WeakPtr<WebKit::WebPageProxy> _page;
-    RetainPtr<WebCoreFullScreenPlaceholderView> _webViewPlaceholder;
+    RetainPtr<WKFullScreenPlaceholderView> _webViewPlaceholder;
     RetainPtr<NSView> _exitPlaceholder;
     RetainPtr<NSView> _clipView;
     RetainPtr<NSView> _backgroundView;
@@ -72,9 +73,9 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 @property (readonly) NSRect finalFrame;
 @property (assign) NSArray *savedConstraints;
 
-- (id)initWithWindow:(NSWindow *)window webView:(NSView *)webView page:(std::reference_wrapper<WebKit::WebPageProxy>)page;
+- (instancetype)initWithWindow:(NSWindow *)window webView:(WKWebView *)webView page:(std::reference_wrapper<WebKit::WebPageProxy>)page;
 
-- (WebCoreFullScreenPlaceholderView*)webViewPlaceholder;
+@property (nonatomic, readonly) WebCoreFullScreenPlaceholderView *webViewPlaceholder;
 
 - (BOOL)isFullScreen;
 


### PR DESCRIPTION
#### 4a75204691978d5a12d49d79967265a3669db9b4
<pre>
[Liquid Glass] [macOS] Safari tab bar changes colors when switching between default viewer and fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=298001">https://bugs.webkit.org/show_bug.cgi?id=298001</a>
<a href="https://rdar.apple.com/158063198">rdar://158063198</a>

Reviewed by Aditya Keerthi.

When entering element fullscreen, the web view is swapped for a `WebCoreFullScreenPlaceholderView`
that fills the same frame, while the real web view is moved out into the view controller for
fullscreen presentation. With regards to the top scroll pocket (i.e. the background behind the tab
bar), this causes a flash if the capture color of the top pocket is different than the background
color of Safari&apos;s title bar (i.e. the system background color) when beginning or ending the
transition animation, as the color changes from the top pocket color of the web view to the system
background.

To fix this, we teach `WebCoreFullScreenPlaceholderView` (now `WKFullScreenPlaceholderView`, a
subclass) to manage its own top scroll pocket that matches the original web view&apos;s color, style, and
height (i.e. top content inset amount), and similarly adopt `NSScrollViewSeparatorTrackingAdapter`.
The end result is that as the web view is being unparented, the top scroll pocket is swapped out
with the placeholder view&apos;s scroll pocket, whose color (and other properties) match the original
pocket.

See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _copyTopScrollPocket]):

Add an internal helper method to create a clone of the top scroll pocket.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:

Make an internal `WKFullScreenPlaceholderView` that subclasses `WebCoreFullScreenPlaceholderView`
and implements the `NSScrollViewSeparatorTrackingAdapter` methods necessary to ensure that Safari&apos;s
title bar container view&apos;s scroll pocket ducks out of the way, revealing this placeholder pocket.

(-[WKFullScreenPlaceholderView scrollViewFrame]):
(-[WKFullScreenPlaceholderView hasScrolledContentsUnderTitlebar]):
(-[WKFullScreenPlaceholderView setTopScrollPocket:topContentInset:]):
(-[WKFullScreenPlaceholderView setFrame:]):
(-[WKFullScreenPlaceholderView setBounds:]):
(-[WKFullScreenPlaceholderView setFrameSize:]):
(-[WKFullScreenPlaceholderView setBoundsSize:]):

Ensure that we properly recompute and update the placeholder scroll pocket&apos;s frame whenever the size
of this placeholder view changes. This ensures that the placeholder&apos;s scroll pocket frame doesn&apos;t
become stale as the Safari window is resized, while the actual web view is in the element fullscreen
view controller.

(-[WKFullScreenPlaceholderView _recomputeScrollPocketFrame]):
(-[WKFullScreenPlaceholderView scrollViewDrawsMagicPocket]):
(-[WKFullScreenPlaceholderView registerPocketContainer:onEdge:]):
(-[WKFullScreenPlaceholderView unregisterPocketContainer:onEdge:]):
(-[WKFullScreenWindowController initWithWindow:webView:page:]):
(-[WKFullScreenWindowController webViewPlaceholder]):
(-[WKFullScreenWindowController _continueEnteringFullscreenAfterPostingNotification:]):

See description for more details.

(-[WKFullScreenWindowController completeFinishExitFullScreenAnimation]):

Make sure we unregister the scroll view adapter before unparenting and clearing out the placeholder.

Canonical link: <a href="https://commits.webkit.org/299240@main">https://commits.webkit.org/299240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0a05ddd69525e37c0e604092e0c7e32ff90cc73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70411 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a118b69-1c80-4a7e-882f-fea862d4fe9d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83e7d437-c26f-4884-8f12-c624b74f6b7e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70309 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78f15f68-2ea0-40a0-9f10-9527057c6482) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29909 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68185 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127594 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98494 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21672 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50811 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44598 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->