### PR TITLE
FrameLoadRequest and NavigationAction should share common members

### DIFF
--- a/Source/WebCore/loader/FrameLoadRequest.cpp
+++ b/Source/WebCore/loader/FrameLoadRequest.cpp
@@ -43,9 +43,9 @@ FrameLoadRequest::FrameLoadRequest(Ref<Document>&& requester, SecurityOrigin& re
     , m_requesterSecurityOrigin { requesterSecurityOrigin }
     , m_resourceRequest { WTFMove(resourceRequest) }
     , m_frameName { frameName }
-    , m_downloadAttribute { downloadAttribute }
-    , m_initiatedByMainFrame { initiatedByMainFrame }
 {
+    setDownloadAttribute(downloadAttribute);
+    setInitiatedByMainFrame(initiatedByMainFrame);
 }
 
 FrameLoadRequest::FrameLoadRequest(LocalFrame& frame, ResourceRequest&& resourceRequest, SubstituteData&& substituteData)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1714,7 +1714,7 @@ void FrameLoader::load(FrameLoadRequest&& request)
     m_provisionalLoadHappeningInAnotherProcess = false;
 
     if (request.shouldCheckNewWindowPolicy()) {
-        NavigationAction action { request.requester(), request.resourceRequest(), InitiatedByMainFrame::Unknown, request.isRequestFromClientOrUserInput(), NavigationType::Other, request.shouldOpenExternalURLsPolicy() };
+        NavigationAction action { request, NavigationType::Other };
         action.setNewFrameOpenerPolicy(request.newFrameOpenerPolicy());
         policyChecker().checkNewWindowPolicy(WTFMove(action), WTFMove(request.resourceRequest()), { }, request.frameName(), [this, protectedThis = Ref { *this }] (ResourceRequest&& request, WeakPtr<FormState>&& weakFormState, const AtomString& frameName, const NavigationAction& action, ShouldContinuePolicyCheck shouldContinue) {
             continueLoadAfterNewWindowPolicy(WTFMove(request), RefPtr { weakFormState.get() }.get(), frameName, action, shouldContinue, AllowNavigationToInvalidURL::Yes, NewFrameOpenerPolicy::Suppress);
@@ -4850,7 +4850,8 @@ std::pair<RefPtr<Frame>, CreatedNewPage> createWindow(LocalFrame& openerFrame, F
 
     String openedMainFrameName = isBlankTargetFrameName(request.frameName()) ? String() : request.frameName();
     ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy = shouldOpenExternalURLsPolicyToApply(openerFrame, request);
-    NavigationAction action { request.requester(), request.resourceRequest(), request.initiatedByMainFrame(), request.isRequestFromClientOrUserInput(), NavigationType::Other, shouldOpenExternalURLsPolicy };
+    NavigationAction action { request, NavigationType::Other };
+    action.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     action.setNewFrameOpenerPolicy(features.wantsNoOpener() ? NewFrameOpenerPolicy::Suppress : NewFrameOpenerPolicy::Allow);
     RefPtr page = oldPage->chrome().createWindow(openerFrame, openedMainFrameName, features, action);
     if (!page)

--- a/Source/WebCore/loader/NavigationAction.cpp
+++ b/Source/WebCore/loader/NavigationAction.cpp
@@ -30,6 +30,7 @@
 #include "NavigationAction.h"
 
 #include "DocumentInlines.h"
+#include "FrameLoadRequest.h"
 #include "FrameLoader.h"
 #include "HistoryItem.h"
 #include "LocalFrame.h"
@@ -105,14 +106,14 @@ NavigationAction::NavigationAction(Document& requester, const ResourceRequest& o
     , m_originalRequest { originalRequest }
     , m_keyStateEventData { keyStateDataForFirstEventWithKeyState(event) }
     , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
-    , m_downloadAttribute { downloadAttribute }
-    , m_sourceElement { sourceElement }
     , m_type { type }
-    , m_shouldOpenExternalURLsPolicy { shouldOpenExternalURLsPolicy }
-    , m_initiatedByMainFrame { initiatedByMainFrame }
     , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(requester, originalRequest.url()) }
-    , m_isRequestFromClientOrUserInput { isRequestFromClientOrUserInput }
 {
+    setDownloadAttribute(downloadAttribute);
+    setSourceElement(sourceElement);
+    setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
+    setInitiatedByMainFrame(initiatedByMainFrame);
+    setIsRequestFromClientOrUserInput(isRequestFromClientOrUserInput);
 }
 
 NavigationAction::NavigationAction(Document& requester, const ResourceRequest& originalRequest, InitiatedByMainFrame initiatedByMainFrame, bool isRequestFromClientOrUserInput, FrameLoadType frameLoadType, bool isFormSubmission, Event* event, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, const AtomString& downloadAttribute, Element* sourceElement)
@@ -120,20 +121,31 @@ NavigationAction::NavigationAction(Document& requester, const ResourceRequest& o
     , m_originalRequest { originalRequest }
     , m_keyStateEventData { keyStateDataForFirstEventWithKeyState(event) }
     , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
-    , m_downloadAttribute { downloadAttribute }
-    , m_sourceElement { sourceElement }
     , m_type { navigationType(frameLoadType, isFormSubmission, !!event) }
-    , m_shouldOpenExternalURLsPolicy { shouldOpenExternalURLsPolicy }
-    , m_initiatedByMainFrame { initiatedByMainFrame }
     , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(requester, originalRequest.url()) }
-    , m_isRequestFromClientOrUserInput { isRequestFromClientOrUserInput }
+{
+    setDownloadAttribute(downloadAttribute);
+    setSourceElement(sourceElement);
+    setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
+    setInitiatedByMainFrame(initiatedByMainFrame);
+    setIsRequestFromClientOrUserInput(isRequestFromClientOrUserInput);
+}
+
+NavigationAction::NavigationAction(FrameLoadRequest& request, NavigationType type, Event* event)
+    : FrameLoadRequestBase(request)
+    , m_requester { NavigationRequester::from(request.protectedRequester().get()) }
+    , m_originalRequest { request.resourceRequest() }
+    , m_keyStateEventData { keyStateDataForFirstEventWithKeyState(event) }
+    , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
+    , m_type { type }
+    , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(request.protectedRequester().get(), request.resourceRequest().url()) }
 {
 }
 
 NavigationAction NavigationAction::copyWithShouldOpenExternalURLsPolicy(ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy) const
 {
     NavigationAction result(*this);
-    result.m_shouldOpenExternalURLsPolicy = shouldOpenExternalURLsPolicy;
+    result.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     return result;
 }
 

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -30,6 +30,7 @@
 
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
+#include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/GlobalFrameIdentifier.h>
 #include <WebCore/LayoutPoint.h>
@@ -43,7 +44,6 @@
 namespace WebCore {
 
 class Document;
-class Element;
 class Event;
 class HistoryItem;
 class MouseEvent;
@@ -56,11 +56,12 @@ enum class NavigationNavigationType : uint8_t;
 // NavigationAction should never hold a strong reference to the originating document either directly
 // or indirectly as doing so prevents its destruction even after navigating away from it because
 // DocumentLoader keeps around the NavigationAction for the last navigation.
-class NavigationAction {
+class NavigationAction : public FrameLoadRequestBase {
 public:
     NavigationAction();
     WEBCORE_EXPORT NavigationAction(Document&, const ResourceRequest&, InitiatedByMainFrame, bool, NavigationType = NavigationType::Other, ShouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow, Event* = nullptr, const AtomString& downloadAttribute = nullAtom(), Element* sourceElement = nullptr);
     NavigationAction(Document&, const ResourceRequest&, InitiatedByMainFrame, bool, FrameLoadType, bool isFormSubmission, Event* = nullptr, ShouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow, const AtomString& downloadAttribute = nullAtom(), Element* sourceElement = nullptr);
+    WEBCORE_EXPORT NavigationAction(FrameLoadRequest&, NavigationType = NavigationType::Other, Event* = nullptr);
 
     WEBCORE_EXPORT ~NavigationAction();
 
@@ -105,14 +106,6 @@ public:
     bool processingUserGesture() const { return m_userGestureToken ? m_userGestureToken->processingUserGesture() : false; }
     RefPtr<UserGestureToken> userGestureToken() const { return m_userGestureToken; }
 
-    ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy() const { return m_shouldOpenExternalURLsPolicy; }
-    void setShouldOpenExternalURLsPolicy(ShouldOpenExternalURLsPolicy policy) {  m_shouldOpenExternalURLsPolicy = policy; }
-    InitiatedByMainFrame initiatedByMainFrame() const { return m_initiatedByMainFrame; }
-
-    const AtomString& downloadAttribute() const { return m_downloadAttribute; }
-
-    Element* sourceElement() const { return m_sourceElement.get(); }
-
     bool treatAsSameOriginNavigation() const { return m_treatAsSameOriginNavigation; }
 
     bool hasOpenedFrames() const { return m_hasOpenedFrames; }
@@ -121,43 +114,20 @@ public:
     bool openedByDOMWithOpener() const { return m_openedByDOMWithOpener; }
     void setOpenedByDOMWithOpener() { m_openedByDOMWithOpener = true; }
 
-    NewFrameOpenerPolicy newFrameOpenerPolicy() const { return m_newFrameOpenerPolicy; }
-    void setNewFrameOpenerPolicy(NewFrameOpenerPolicy newFrameOpenerPolicy) { m_newFrameOpenerPolicy = newFrameOpenerPolicy; }
-
     void setTargetBackForwardItem(HistoryItem&);
     const std::optional<BackForwardItemIdentifier>& targetBackForwardItemIdentifier() const { return m_targetBackForwardItemIdentifier; }
 
     void setSourceBackForwardItem(HistoryItem*);
     const std::optional<BackForwardItemIdentifier>& sourceBackForwardItemIdentifier() const { return m_sourceBackForwardItemIdentifier; }
 
-    LockHistory lockHistory() const { return m_lockHistory; }
-    void setLockHistory(LockHistory lockHistory) { m_lockHistory = lockHistory; }
-
-    LockBackForwardList lockBackForwardList() const { return m_lockBackForwardList; }
-    void setLockBackForwardList(LockBackForwardList lockBackForwardList) { m_lockBackForwardList = lockBackForwardList; }
 
     const std::optional<PrivateClickMeasurement>& privateClickMeasurement() const { return m_privateClickMeasurement; };
     void setPrivateClickMeasurement(PrivateClickMeasurement&& privateClickMeasurement) { m_privateClickMeasurement = privateClickMeasurement; };
 
-    // The shouldReplaceDocumentIfJavaScriptURL parameter will go away when the FIXME to eliminate the
-    // corresponding parameter from ScriptController::executeIfJavaScriptURL() is addressed.
-    ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL() const { return m_shouldReplaceDocumentIfJavaScriptURL; }
-    void setShouldReplaceDocumentIfJavaScriptURL(ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL) { m_shouldReplaceDocumentIfJavaScriptURL = shouldReplaceDocumentIfJavaScriptURL; }
-
-    bool isRequestFromClientOrUserInput() const { return m_isRequestFromClientOrUserInput; }
-    void setIsRequestFromClientOrUserInput(bool isRequestFromClientOrUserInput) { m_isRequestFromClientOrUserInput = isRequestFromClientOrUserInput; }
-
-    bool isInitialFrameSrcLoad() const { return m_isInitialFrameSrcLoad; }
-    void setIsInitialFrameSrcLoad(bool isInitialFrameSrcLoad) { m_isInitialFrameSrcLoad = isInitialFrameSrcLoad; }
-
-    bool isContentRuleListRedirect() const { return m_isContentRuleListRedirect; }
-    void setIsContentRuleListRedirect(bool isContentRuleListRedirect) { m_isContentRuleListRedirect = isContentRuleListRedirect; }
 
     std::optional<NavigationNavigationType> navigationAPIType() const { return m_navigationAPIType; }
     void setNavigationAPIType(NavigationNavigationType navigationAPIType) { m_navigationAPIType = navigationAPIType; }
 
-    bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
-    void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
 
 private:
     // Do not add a strong reference to the originating document or a subobject that holds the
@@ -167,28 +137,16 @@ private:
     std::optional<UIEventWithKeyStateData> m_keyStateEventData;
     std::optional<MouseEventData> m_mouseEventData;
     RefPtr<UserGestureToken> m_userGestureToken { UserGestureIndicator::currentUserGesture() };
-    AtomString m_downloadAttribute;
-    RefPtr<Element> m_sourceElement;
     std::optional<BackForwardItemIdentifier> m_targetBackForwardItemIdentifier;
     std::optional<BackForwardItemIdentifier> m_sourceBackForwardItemIdentifier;
     std::optional<PrivateClickMeasurement> m_privateClickMeasurement;
-    ShouldReplaceDocumentIfJavaScriptURL m_shouldReplaceDocumentIfJavaScriptURL { ReplaceDocumentIfJavaScriptURL };
 
     NavigationType m_type;
     std::optional<NavigationNavigationType> m_navigationAPIType;
-    ShouldOpenExternalURLsPolicy m_shouldOpenExternalURLsPolicy;
-    InitiatedByMainFrame m_initiatedByMainFrame;
 
     bool m_treatAsSameOriginNavigation { false };
     bool m_hasOpenedFrames { false };
     bool m_openedByDOMWithOpener { false };
-    bool m_isRequestFromClientOrUserInput { false };
-    bool m_isInitialFrameSrcLoad { false };
-    bool m_isContentRuleListRedirect { false };
-    LockHistory m_lockHistory { LockHistory::No };
-    LockBackForwardList m_lockBackForwardList { LockBackForwardList::No };
-    NewFrameOpenerPolicy m_newFrameOpenerPolicy { NewFrameOpenerPolicy::Allow };
-    bool m_isFromNavigationAPI { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -82,8 +82,7 @@ void WebRemoteFrameClient::postMessageToRemote(FrameIdentifier source, const Str
 
 void WebRemoteFrameClient::changeLocation(FrameLoadRequest&& request)
 {
-    // FIXME: FrameLoadRequest and NavigationAction can probably be refactored to share more. <rdar://116202911>
-    NavigationAction action(request.requester(), request.resourceRequest(), request.initiatedByMainFrame(), request.isRequestFromClientOrUserInput());
+    NavigationAction action(request);
     // FIXME: action.request and request are probably duplicate information. <rdar://116203126>
     // FIXME: Get more parameters correct and add tests for each one. <rdar://116203354>
     dispatchDecidePolicyForNavigationAction(action, action.originalRequest(), ResourceResponse(), nullptr, { }, { }, { }, { }, IsPerformingHTTPFallback::No, { }, PolicyDecisionMode::Asynchronous, [protectedFrame = Ref { m_frame }, request = WTFMove(request)] (PolicyAction policyAction) mutable {


### PR DESCRIPTION
#### 713fff3547d4e810d303839a8960328205ecfd1c
<pre>
FrameLoadRequest and NavigationAction should share common members
<a href="https://bugs.webkit.org/show_bug.cgi?id=298009">https://bugs.webkit.org/show_bug.cgi?id=298009</a>
<a href="https://rdar.apple.com/116202911">rdar://116202911</a>

Reviewed by Chris Dumez.

NavigationAction was often constructed using a FrameLoadRequest object, however because they
did not share common members, calling the NavigationAction ctor would often be clunky and
illegible. This change implements a new base class FrameLoadRequestBase containing shared
member variables and functions which both NavigationAction and FrameLoadRequest inherit from.
This change also adds a new constructor to NavigationAction which takes FrameLoadRequest&amp;
as an argument which is used where possible.

* Source/WebCore/loader/FrameLoadRequest.cpp:
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::lockHistory const):
(WebCore::FrameLoadRequestBase::setLockHistory):
(WebCore::FrameLoadRequestBase::lockBackForwardList const):
(WebCore::FrameLoadRequestBase::setLockBackForwardList):
(WebCore::FrameLoadRequestBase::newFrameOpenerPolicy const):
(WebCore::FrameLoadRequestBase::setNewFrameOpenerPolicy):
(WebCore::FrameLoadRequestBase::shouldReplaceDocumentIfJavaScriptURL const):
(WebCore::FrameLoadRequestBase::setShouldReplaceDocumentIfJavaScriptURL):
(WebCore::FrameLoadRequestBase::shouldOpenExternalURLsPolicy const):
(WebCore::FrameLoadRequestBase::setShouldOpenExternalURLsPolicy):
(WebCore::FrameLoadRequestBase::downloadAttribute const):
(WebCore::FrameLoadRequestBase::sourceElement const):
(WebCore::FrameLoadRequestBase::setSourceElement):
(WebCore::FrameLoadRequestBase::initiatedByMainFrame const):
(WebCore::FrameLoadRequestBase::isRequestFromClientOrUserInput const):
(WebCore::FrameLoadRequestBase::setIsRequestFromClientOrUserInput):
(WebCore::FrameLoadRequestBase::isInitialFrameSrcLoad const):
(WebCore::FrameLoadRequestBase::setIsInitialFrameSrcLoad):
(WebCore::FrameLoadRequestBase::isContentRuleListRedirect const):
(WebCore::FrameLoadRequestBase::setIsContentRuleListRedirect):
(WebCore::FrameLoadRequestBase::isFromNavigationAPI const):
(WebCore::FrameLoadRequestBase::setIsFromNavigationAPI):
(WebCore::FrameLoadRequestBase::setDownloadAttribute):
(WebCore::FrameLoadRequestBase::setInitiatedByMainFrame):
(WebCore::FrameLoadRequest::disableShouldReplaceDocumentIfJavaScriptURL):
(WebCore::FrameLoadRequest::setIsRequestFromClientOrUserInput):
(WebCore::FrameLoadRequest::lockHistory const): Deleted.
(WebCore::FrameLoadRequest::setLockHistory): Deleted.
(WebCore::FrameLoadRequest::lockBackForwardList const): Deleted.
(WebCore::FrameLoadRequest::setLockBackForwardList): Deleted.
(WebCore::FrameLoadRequest::isInitialFrameSrcLoad const): Deleted.
(WebCore::FrameLoadRequest::setIsInitialFrameSrcLoad): Deleted.
(WebCore::FrameLoadRequest::isContentRuleListRedirect const): Deleted.
(WebCore::FrameLoadRequest::setIsContentRuleListRedirect): Deleted.
(WebCore::FrameLoadRequest::newFrameOpenerPolicy const): Deleted.
(WebCore::FrameLoadRequest::setNewFrameOpenerPolicy): Deleted.
(WebCore::FrameLoadRequest::shouldReplaceDocumentIfJavaScriptURL const): Deleted.
(WebCore::FrameLoadRequest::setShouldOpenExternalURLsPolicy): Deleted.
(WebCore::FrameLoadRequest::shouldOpenExternalURLsPolicy const): Deleted.
(WebCore::FrameLoadRequest::downloadAttribute const): Deleted.
(WebCore::FrameLoadRequest::sourceElement const): Deleted.
(WebCore::FrameLoadRequest::setSourceElement): Deleted.
(WebCore::FrameLoadRequest::initiatedByMainFrame const): Deleted.
(WebCore::FrameLoadRequest::isRequestFromClientOrUserInput const): Deleted.
(WebCore::FrameLoadRequest::isFromNavigationAPI const): Deleted.
(WebCore::FrameLoadRequest::setIsFromNavigationAPI): Deleted.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
(WebCore::createWindow):
* Source/WebCore/loader/NavigationAction.cpp:
(WebCore::NavigationAction::NavigationAction):
(WebCore::NavigationAction::copyWithShouldOpenExternalURLsPolicy const):
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::shouldOpenExternalURLsPolicy const): Deleted.
(WebCore::NavigationAction::setShouldOpenExternalURLsPolicy): Deleted.
(WebCore::NavigationAction::initiatedByMainFrame const): Deleted.
(WebCore::NavigationAction::downloadAttribute const): Deleted.
(WebCore::NavigationAction::sourceElement const): Deleted.
(WebCore::NavigationAction::newFrameOpenerPolicy const): Deleted.
(WebCore::NavigationAction::setNewFrameOpenerPolicy): Deleted.
(WebCore::NavigationAction::lockHistory const): Deleted.
(WebCore::NavigationAction::setLockHistory): Deleted.
(WebCore::NavigationAction::lockBackForwardList const): Deleted.
(WebCore::NavigationAction::setLockBackForwardList): Deleted.
(WebCore::NavigationAction::shouldReplaceDocumentIfJavaScriptURL const): Deleted.
(WebCore::NavigationAction::setShouldReplaceDocumentIfJavaScriptURL):
(WebCore::NavigationAction::isRequestFromClientOrUserInput const): Deleted.
(WebCore::NavigationAction::setIsRequestFromClientOrUserInput): Deleted.
(WebCore::NavigationAction::isInitialFrameSrcLoad const): Deleted.
(WebCore::NavigationAction::setIsInitialFrameSrcLoad): Deleted.
(WebCore::NavigationAction::isContentRuleListRedirect const): Deleted.
(WebCore::NavigationAction::setIsContentRuleListRedirect): Deleted.
(WebCore::NavigationAction::isFromNavigationAPI const): Deleted.
(WebCore::NavigationAction::setIsFromNavigationAPI): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::changeLocation):

Canonical link: <a href="https://commits.webkit.org/299706@main">https://commits.webkit.org/299706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b700fa0c684268f84cdca3665f822d5341fb1b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90759 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60064 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25201 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99331 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99143 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22586 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42929 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46223 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51923 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45688 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->