### PR TITLE
Consolidate definitions of `typedef struct objc_object* id`

### DIFF
--- a/Source/JavaScriptCore/API/tests/TypedArrayCTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TypedArrayCTest.cpp
@@ -36,7 +36,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 extern "C" void JSSynchronousGarbageCollectForDebugging(JSContextRef);
 
-static void id(void*, void*) { }
+static void bytesDeallocatorNoCopy(void*, void*) { }
 static void freePtr(void* ptr, void*)
 {
     free(ptr);
@@ -175,7 +175,7 @@ static int testConstructors(JSGlobalContextRef context, JSTypedArrayType type, u
     failed = failed || exception;
 
     // Test create with existing ptr.
-    typedArray = JSObjectMakeTypedArrayWithBytesNoCopy(context, type, ptr, length * byteSizes[type], id, nullptr, &exception);
+    typedArray = JSObjectMakeTypedArrayWithBytesNoCopy(context, type, ptr, length * byteSizes[type], bytesDeallocatorNoCopy, nullptr, &exception);
     failed = failed || exception || testAccess(context, typedArray, type, length, ptr);
 
     // Test create with existing ArrayBuffer.
@@ -254,7 +254,7 @@ int testTypedArrayCAPI()
     failed = failed || assertEqualsAsNumber(context, v, 1);
 
     // Test passing a buffer from a new array to an old array
-    typedArray = JSObjectMakeTypedArrayWithBytesNoCopy(context, kJSTypedArrayTypeUint32Array, buffer, 40, id, nullptr, nullptr);
+    typedArray = JSObjectMakeTypedArrayWithBytesNoCopy(context, kJSTypedArrayTypeUint32Array, buffer, 40, bytesDeallocatorNoCopy, nullptr, nullptr);
     buffer = static_cast<unsigned*>(JSObjectGetTypedArrayBytesPtr(context, typedArray, nullptr));
     ASSERT(buffer[1] == 1);
     buffer[1] = 20;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -31,6 +31,12 @@
 #endif
 #endif
 
+#ifndef __OBJC__
+WTF_EXTERN_C_BEGIN
+typedef struct objc_object* id;
+WTF_EXTERN_C_END
+#endif
+
 namespace WTF {
 
 class ASCIILiteral;

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -57,10 +57,6 @@
 #define NS_RETURNS_RETAINED
 #endif
 
-#ifndef __OBJC__
-typedef struct objc_object *id;
-#endif
-
 // Because ARC enablement is a compile-time choice, and we compile this header
 // both ways, we need a separate copy of our code when ARC is enabled.
 #if __has_feature(objc_arc)

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -48,7 +48,6 @@
 
 #if PLATFORM(COCOA)
 #import <wtf/RetainPtr.h>
-typedef struct objc_object* id;
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -29,10 +29,6 @@
 #include <WebCore/Widget.h>
 #include <wtf/Platform.h>
 
-#if PLATFORM(COCOA)
-typedef struct objc_object* id;
-#endif
-
 namespace WebCore {
 
 class Element;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -39,8 +39,6 @@
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 
-typedef struct objc_object* id;
-
 OBJC_CLASS CALayer;
 OBJC_CLASS NSArray;
 OBJC_CLASS NSAttributedString;


### PR DESCRIPTION
#### 776914a4705f8dd4cc436decdc4fd68758d0cb7b
<pre>
Consolidate definitions of `typedef struct objc_object* id`
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=298010">https://bugs.webkit.org/show_bug.cgi?id=298010</a>&gt;
&lt;<a href="https://rdar.apple.com/159330873">rdar://159330873</a>&gt;

Reviewed by Darin Adler.

Also declare typedef in WTF_EXTERN_C_BEGIN/END macros since this is a
plain C type.

* Source/JavaScriptCore/API/tests/TypedArrayCTest.cpp:
(id): Delete.
(bytesDeallocatorNoCopy): Add.
- Rename id() to bytesDeallocatorNoCopy().
(testConstructors):
(testTypedArrayCAPI):
- Update tests for renamed function.

* Source/WTF/wtf/Forward.h:
- Add typedef.
* Source/WTF/wtf/RetainPtr.h:
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/plugins/PluginViewBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
- Remove now redundant typedef.

Canonical link: <a href="https://commits.webkit.org/299268@main">https://commits.webkit.org/299268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2d005a3e7c2fd8456029210fbe9972763b61a13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70421 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f2f20d5-c4e3-40f9-ad0c-3a371b45c2d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89829 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70318 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24239 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68195 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110483 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127603 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116880 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98505 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98292 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21681 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41750 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18869 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50820 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145578 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44607 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37444 "Found 1 new JSC binary failure: testapi, Found 19714 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47951 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46294 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->