### PR TITLE
[WPE] WPE Platform: build WPEPlatform as a part of libWPEWebKit

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -504,8 +504,26 @@ if (ENABLE_WPE_PLATFORM)
     )
 
     list(APPEND WebKit_PRIVATE_LIBRARIES
-        WPEPlatform-${WPE_API_VERSION}
+        WPEPlatform
     )
+
+    if (ENABLE_WPE_PLATFORM_DRM)
+        list(APPEND WebKit_PRIVATE_LIBRARIES
+            WPEPlatformDRM
+        )
+    endif ()
+
+    if (ENABLE_WPE_PLATFORM_HEADLESS)
+        list(APPEND WebKit_PRIVATE_LIBRARIES
+            WPEPlatformHeadless
+        )
+    endif ()
+
+    if (ENABLE_WPE_PLATFORM_WAYLAND)
+        list(APPEND WebKit_PRIVATE_LIBRARIES
+            WPEPlatformWayland
+        )
+    endif ()
 
     list(APPEND WebKit_MESSAGES_IN_FILES
         UIProcess/glib/AcceleratedBackingStore
@@ -590,7 +608,6 @@ if (ENABLE_WPE_QT_API)
                 WebKit
                 ${GLIB_GOBJECT_LIBRARIES}
                 ${GLIB_LIBRARIES}
-                WPEPlatform-${WPE_API_VERSION}
         )
         target_include_directories(qtwpe PRIVATE
             $<TARGET_PROPERTY:WebKit,INCLUDE_DIRECTORIES>

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -121,11 +121,11 @@ set(WPEPlatform_LIBRARIES
 
 if (USE_GBM)
     list(APPEND WPEPlatform_LIBRARIES GBM::GBM)
-elseif (USE_LIBDRM)
-    list(APPEND WPEPlatform_LIBRARIES LibDRM::LibDRM)
 endif ()
 
 if (USE_LIBDRM)
+    list(APPEND WPEPlatform_LIBRARIES LibDRM::LibDRM)
+
     list(APPEND WPEPlatform_SOURCES
         ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreenSyncObserverDRM.cpp
     )
@@ -187,14 +187,13 @@ if (ENABLE_WPE_PLATFORM_WAYLAND)
     list(APPEND WPEPlatform_LIBRARIES WPEPlatformWayland)
 endif ()
 
-add_library(WPEPlatform-${WPE_API_VERSION} SHARED ${WPEPlatform_SOURCES})
-set_target_properties(WPEPlatform-${WPE_API_VERSION} PROPERTIES VERSION ${WPE_PLATFORM_VERSION} SOVERSION ${WPE_PLATFORM_VERSION_MAJOR})
-target_include_directories(WPEPlatform-${WPE_API_VERSION} PRIVATE ${WPEPlatform_PRIVATE_INCLUDE_DIRECTORIES})
-target_include_directories(WPEPlatform-${WPE_API_VERSION} SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
-target_link_libraries(WPEPlatform-${WPE_API_VERSION} ${WPEPlatform_LIBRARIES})
+add_library(WPEPlatform OBJECT ${WPEPlatform_SOURCES})
+target_include_directories(WPEPlatform PRIVATE ${WPEPlatform_PRIVATE_INCLUDE_DIRECTORIES})
+target_include_directories(WPEPlatform SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
+target_link_libraries(WPEPlatform ${WPEPlatform_LIBRARIES})
 
 GI_INTROSPECT(WPEPlatform ${WPE_API_VERSION} wpe/wpe-platform.h
-    TARGET WPEPlatform-${WPE_API_VERSION}
+    TARGET WebKit
     PACKAGE wpe-platform
     IDENTIFIER_PREFIX WPE
     SYMBOL_PREFIX wpe
@@ -213,7 +212,7 @@ GI_DOCGEN(WPEPlatform docs/wpeplatform.toml.in)
 if (ENABLE_WPE_PLATFORM_DRM)
     get_target_property(WPEPlatformDRM_SOURCES_FOR_INTROSPECTION WPEPlatformDRM SOURCES_FOR_INTROSPECTION)
     GI_INTROSPECT(WPEPlatformDRM ${WPE_API_VERSION} wpe/drm/wpe-drm.h
-        TARGET WPEPlatform-${WPE_API_VERSION}
+        TARGET WebKit
         PACKAGE wpe-platform-drm
         IDENTIFIER_PREFIX WPE
         SYMBOL_PREFIX wpe
@@ -232,7 +231,7 @@ endif ()
 if (ENABLE_WPE_PLATFORM_HEADLESS)
     get_target_property(WPEPlatformHeadless_SOURCES_FOR_INTROSPECTION WPEPlatformHeadless SOURCES_FOR_INTROSPECTION)
     GI_INTROSPECT(WPEPlatformHeadless ${WPE_API_VERSION} wpe/headless/wpe-headless.h
-        TARGET WPEPlatform-${WPE_API_VERSION}
+        TARGET WebKit
         PACKAGE wpe-platform-headless
         IDENTIFIER_PREFIX WPE
         SYMBOL_PREFIX wpe
@@ -251,7 +250,7 @@ endif ()
 if (ENABLE_WPE_PLATFORM_WAYLAND)
     get_target_property(WPEPlatformWayland_SOURCES_FOR_INTROSPECTION WPEPlatformWayland SOURCES_FOR_INTROSPECTION)
     GI_INTROSPECT(WPEPlatformWayland ${WPE_API_VERSION} wpe/wayland/wpe-wayland.h
-        TARGET WPEPlatform-${WPE_API_VERSION}
+        TARGET WebKit
         PACKAGE wpe-platform-wayland
         IDENTIFIER_PREFIX WPE
         SYMBOL_PREFIX wpe
@@ -266,8 +265,6 @@ if (ENABLE_WPE_PLATFORM_WAYLAND)
 
     GI_DOCGEN(WPEPlatformWayland docs/wpeplatform-wayland.toml.in)
 endif ()
-
-install(TARGETS WPEPlatform-${WPE_API_VERSION} LIBRARY DESTINATION "${LIB_INSTALL_DIR}")
 
 install(FILES "${CMAKE_BINARY_DIR}/wpe-platform-${WPE_API_VERSION}.pc"
         DESTINATION "${LIB_INSTALL_DIR}/pkgconfig"

--- a/Source/WebKit/WPEPlatform/wpe-platform-uninstalled.pc.in
+++ b/Source/WebKit/WPEPlatform/wpe-platform-uninstalled.pc.in
@@ -8,5 +8,5 @@ Description: Platform implementation for WPE WebKit
 URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
 Requires: glib-2.0 gobject-2.0 gio-2.0
-Libs: -L${libdir} -lWPEPlatform-@WPE_API_VERSION@
+Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
 Cflags: -I@WEBKIT_DIR@/WPEPlatform -I${includedir}/DerivedSources/WPEPlatform

--- a/Source/WebKit/WPEPlatform/wpe-platform.pc.in
+++ b/Source/WebKit/WPEPlatform/wpe-platform.pc.in
@@ -9,5 +9,5 @@ Description: Platform implementation for WPE WebKit
 URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
 Requires: glib-2.0 gobject-2.0 gio-2.0
-Libs: -L${libdir} -lWPEPlatform-@WPE_API_VERSION@
+Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
 Cflags: -I${includedir}/wpe-webkit-@WPE_API_VERSION@/wpe-platform

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
@@ -33,7 +33,6 @@
 #include <gbm.h>
 #include <glib-object.h>
 #include <wpe/wpe-platform.h>
-#include <xf86drmMode.h>
 
 G_BEGIN_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -188,16 +188,6 @@ static GRefPtr<GSource> wpeDisplayWaylandCreateEventSource(WPEDisplayWayland* di
     return source;
 }
 
-static void wpeDisplayWaylandConstructed(GObject* object)
-{
-    G_OBJECT_CLASS(wpe_display_wayland_parent_class)->constructed(object);
-#if USE(SYSPROF_CAPTURE)
-    // libWPEPlatform brings its own SysprofAnnotator copy, due to linking against static libWTF.
-    // Therefore we need to initialize it here, otherwise no marks will be received by sysprof.
-    SysprofAnnotator::createIfNeeded("WPE/Wayland Platform"_s);
-#endif
-}
-
 static void wpeDisplayWaylandDispose(GObject* object)
 {
     auto* priv = WPE_DISPLAY_WAYLAND(object)->priv;
@@ -656,7 +646,6 @@ struct zwp_linux_explicit_synchronization_v1* wpeDisplayWaylandGetLinuxExplicitS
 static void wpe_display_wayland_class_init(WPEDisplayWaylandClass* displayWaylandClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(displayWaylandClass);
-    objectClass->constructed = wpeDisplayWaylandConstructed;
     objectClass->dispose = wpeDisplayWaylandDispose;
 
     WPEDisplayClass* displayClass = WPE_DISPLAY_CLASS(displayWaylandClass);

--- a/Tools/MiniBrowser/wpe/CMakeLists.txt
+++ b/Tools/MiniBrowser/wpe/CMakeLists.txt
@@ -36,10 +36,6 @@ if (ENABLE_WPE_PLATFORM)
         ${WPEPlatform_DERIVED_SOURCES_DIR}
         ${WEBKIT_DIR}/WPEPlatform
     )
-
-    list(APPEND MiniBrowser_PRIVATE_LIBRARIES
-        WPEPlatform-${WPE_API_VERSION}
-    )
 endif ()
 
 if (NOT USE_GSTREAMER_FULL)

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -85,9 +85,6 @@ if (ENABLE_WPE_PLATFORM)
         ${WPEPlatform_DERIVED_SOURCES_DIR}
         ${WEBKIT_DIR}/WPEPlatform
     )
-    list(APPEND TestWebKit_PRIVATE_LIBRARIES
-        WPEPlatform-${WPE_API_VERSION}
-    )
 endif ()
 
 # TestWebKitAPIBase

--- a/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
@@ -27,12 +27,5 @@ list(APPEND WebKitGLibAPITest_LIBRARIES
 )
 
 if (ENABLE_WPE_PLATFORM)
-    list(APPEND WebKitGLibAPITestsCore_LIBRARIES
-        WPEPlatform-${WPE_API_VERSION}
-    )
-    list(APPEND WebKitGLibAPITest_LIBRARIES
-        WPEPlatform-${WPE_API_VERSION}
-    )
-
     add_subdirectory(WPEPlatform)
 endif ()

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
@@ -18,7 +18,10 @@ set(WPEPlatformMock_SYSTEM_INCLUDE_DIRECTORIES
 )
 
 set(WPEPlatformMock_LIBRARIES
-    WPEPlatform-${WPE_API_VERSION}
+    LibDRM::LibDRM
+    WTF
+    WebKit
+    bmalloc
 )
 
 add_library(WPEPlatformMock STATIC ${WPEPlatformMock_SOURCES})

--- a/Tools/WebKitTestRunner/PlatformWPE.cmake
+++ b/Tools/WebKitTestRunner/PlatformWPE.cmake
@@ -42,12 +42,6 @@ list(APPEND WebKitTestRunner_PRIVATE_LIBRARIES
     ${LIBXKBCOMMON_LIBRARIES}
 )
 
-if (ENABLE_WPE_PLATFORM)
-    list(APPEND WebKitTestRunner_LIBRARIES
-        WPEPlatform-${WPE_API_VERSION}
-    )
-endif ()
-
 list(APPEND TestRunnerInjectedBundle_LIBRARIES
     ${GLIB_LIBRARIES}
 )


### PR DESCRIPTION
#### bc99395ee3b1c2bc5f18e735b7d183198f60c0d2
<pre>
[WPE] WPE Platform: build WPEPlatform as a part of libWPEWebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=298014">https://bugs.webkit.org/show_bug.cgi?id=298014</a>

Reviewed by Adrian Perez de Castro.

Building a separate shared library for WPEPlatform means we end up with
two copies of WTF which has caused some problems with globals. We still
install a different pkg-config file for WPEPlatform but pointing to
libWPEWebKit instead, similar to what we do with the WPEPlatform
libraries.

Canonical link: <a href="https://commits.webkit.org/299246@main">https://commits.webkit.org/299246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0c2686a28dcc47ff275348160bb585c50147391

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46649 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89841 "Found 1 new test failure: http/wpt/service-workers/service-worker-spinning-activate.https.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106149 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70330 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24257 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24447 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34155 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102369 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21699 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18861 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44626 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->