### PR TITLE
TestWebKitAPI.ScreenTime.DoNotDonateURLsInOccludedWebView is a constant timeout

### DIFF
--- a/Tools/TestWebKitAPI/mac/mainMac.mm
+++ b/Tools/TestWebKitAPI/mac/mainMac.mm
@@ -45,6 +45,9 @@ static void handleArguments(int argc, char** argv, NSMutableDictionary *argument
     argumentDefaults[@"NSOverlayScrollersEnabled"] = @NO;
     argumentDefaults[@"AppleShowScrollBars"] = @"Always";
 
+    // FIXME: Remove once the root cause is fixed in rdar://159372811
+    argumentDefaults[@"NSEventConcurrentProcessingEnabled"] = @NO;
+
     for (int i = 1; i < argc; ++i) {
         // These defaults are not propagated manually but are only consulted in the UI process.
         if (strcmp(argv[i], "--remote-layer-tree") == 0)


### PR DESCRIPTION
#### f9f5867e78042bbbd61a427b93a4a1291486ca26
<pre>
TestWebKitAPI.ScreenTime.DoNotDonateURLsInOccludedWebView is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=297982">https://bugs.webkit.org/show_bug.cgi?id=297982</a>
<a href="https://rdar.apple.com/157154868">rdar://157154868</a>

Reviewed by Aditya Keerthi.

Set the `NSEventConcurrentProcessingEnabled` default to NO as a workaround to
fix the timeout of the `DoNotDonateURLsInOccludedWebView` API test. While this
is considered a workaround due to the current issue, the change is actually the
original behavior, which will be explained below.

Concurrent event processing was always enabled by AppKit. AppKit used to start
concurrent event processing under the condition that the application finished launching.
However, TestWebKitAPI is not an actual NSApplication. Thus, the
`NSApplicationDidFinishLaunchingNotification` would never be fired, and
concurrent event processing is not started.

Recent AppKit + HIToolbox changes now start concurrent event processing regardless
if an application finished launching or not, and consequently starts an NSEventThread.

Concurrent event processing currently breaks window occlusion detection in apps not using
`NSApplicationMain`, causing the API test to timeout when waiting for the window to be occluded.
By setting the default to NO, concurrent event processing is effectively disabled,
making the behavior the same prior to the AppKit + HIToolbox changes.

* Tools/TestWebKitAPI/mac/mainMac.mm:
(handleArguments):

Canonical link: <a href="https://commits.webkit.org/299278@main">https://commits.webkit.org/299278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9647e768b5be3758bbb03a499c1ceab546eeb378

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70499 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/407fb066-b940-4155-9255-f798785f27be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89893 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb0190cd-af55-49f6-9461-2fcfeeed467a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70378 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0049148b-420e-4a6d-9618-49ef5b36b41f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68269 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127679 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98559 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98344 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21749 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18873 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45218 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->