### PR TITLE
Add support for https://w3c.github.io/webrtc-pc/#dom-rtcrtpheaderextensionparameters-encrypted

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2461,6 +2461,8 @@ webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ 
 
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Pass Failure ]
 
+webrtc/encrypted-rtp-header-extensions.html [ Failure ]
+
 # Requires video scaling adaptation.
 webrtc/video-maxBitrate.html [ Failure ]
 webrtc/video-maxBitrate-vp8.html [ Failure ]

--- a/LayoutTests/webrtc/encrypted-rtp-header-extensions-expected.txt
+++ b/LayoutTests/webrtc/encrypted-rtp-header-extensions-expected.txt
@@ -1,0 +1,3 @@
+
+PASS encrypted-rtp-header-extensions
+

--- a/LayoutTests/webrtc/encrypted-rtp-header-extensions.html
+++ b/LayoutTests/webrtc/encrypted-rtp-header-extensions.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+    <head>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async test => {
+    const pc1 = new RTCPeerConnection();
+    pc1.addTransceiver("audio");
+    const offer = await pc1.createOffer();
+
+    let sdp = offer.sdp;
+    sdp = sdp.replace("urn:ietf:params:rtp-hdrext:ssrc-audio-level", "urn:ietf:params:rtp-hdrext:encrypt urn:ietf:params:rtp-hdrext:ssrc-audio-level");
+
+    await pc1.setLocalDescription({ type:"offer", sdp });
+    const pc2 = new RTCPeerConnection();
+    await pc2.setRemoteDescription(offer);
+
+    const answer = await pc2.createAnswer();
+    sdp = answer.sdp;
+    sdp = sdp.replace("urn:ietf:params:rtp-hdrext:ssrc-audio-level", "urn:ietf:params:rtp-hdrext:encrypt urn:ietf:params:rtp-hdrext:ssrc-audio-level");
+    await pc2.setLocalDescription(answer);
+    await pc1.setRemoteDescription({ type:"answer", sdp });
+
+    let parameters = pc1.getSenders()[0].getParameters();
+
+    assert_true(parameters.headerExtensions[0].encrypted);
+    await pc1.getSenders()[0].setParameters(parameters);
+
+    // Modifying encrypted should reject.
+    parameters = pc1.getSenders()[0].getParameters();
+    parameters.headerExtensions[0].encrypted = false;
+    return promise_rejects_dom(test, 'InvalidModificationError', pc1.getSenders()[0].setParameters(parameters));
+});
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.h
@@ -34,6 +34,7 @@ namespace WebCore {
 struct RTCRtpHeaderExtensionParameters {
     String uri;
     unsigned short id;
+    bool encrypted { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.idl
@@ -29,7 +29,7 @@
     JSGenerateToJSObject,
     JSGenerateToNativeObject
 ] dictionary RTCRtpHeaderExtensionParameters {
-    DOMString uri;
-    unsigned short id;
-    // FIXME: Add boolean encrypted;
+    required DOMString uri;
+    required unsigned short id;
+    boolean encrypted = false;
 };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -166,6 +166,7 @@ static inline RTCRtpHeaderExtensionParameters toRTCHeaderExtensionParameters(con
 
     parameters.uri = fromStdString(rtcParameters.uri);
     parameters.id = rtcParameters.id;
+    parameters.encrypted = rtcParameters.encrypt;
 
     return parameters;
 }
@@ -176,6 +177,7 @@ static inline webrtc::RtpExtension fromRTCHeaderExtensionParameters(const RTCRtp
 
     rtcParameters.uri = parameters.uri.utf8().data();
     rtcParameters.id = parameters.id;
+    rtcParameters.encrypt = parameters.encrypted;
 
     return rtcParameters;
 }


### PR DESCRIPTION
#### 342a0caa5e7611576b237194e772bece2ef47dcc
<pre>
Add support for <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpheaderextensionparameters-encrypted">https://w3c.github.io/webrtc-pc/#dom-rtcrtpheaderextensionparameters-encrypted</a>
<a href="https://rdar.apple.com/159279401">rdar://159279401</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297960">https://bugs.webkit.org/show_bug.cgi?id=297960</a>

Reviewed by Brent Fulgham.

Populate encrypted from and to libwebrtc and expose it to JS.
We mark test as failing in Glib since there is probably no backend support.

* LayoutTests/webrtc/encrypted-rtp-header-extensions-expected.txt: Added.
* LayoutTests/webrtc/encrypted-rtp-header-extensions.html: Added.
* Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.h:
* Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.idl:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::toRTCHeaderExtensionParameters):
(WebCore::fromRTCHeaderExtensionParameters):

Canonical link: <a href="https://commits.webkit.org/299356@main">https://commits.webkit.org/299356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57bb24c6ae4a190d4b3e391a2dc4c83f1a9e1c0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70457 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fed11e5-2138-48e9-8a04-e465812a892c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59463 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30f9aeb1-5369-484c-a4e0-ffdfc6a3fbc5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70345 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1341bcea-d96d-4af7-a8c3-9bf07f717533) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68230 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127638 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98526 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41807 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50855 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44642 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46329 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->