### PR TITLE
[GTK][WPE] Web process sometimes gets locked on exit

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -124,10 +124,10 @@ GLContext* PlatformDisplay::sharingGLContext()
     return m_sharingGLContext.get();
 }
 
-void PlatformDisplay::clearSharingGLContext()
+void PlatformDisplay::clearGLContexts()
 {
 #if USE(SKIA)
-    invalidateSkiaGLContexts();
+    clearSkiaGLContext();
 #endif
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     m_gstGLContext = nullptr;
@@ -158,7 +158,8 @@ void PlatformDisplay::terminateEGLDisplay()
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     m_gstGLDisplay = nullptr;
 #endif
-    clearSharingGLContext();
+
+    clearGLContexts();
 
     m_eglDisplay->terminate();
 }

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -82,7 +82,7 @@ public:
     virtual Type type() const = 0;
 
     WEBCORE_EXPORT GLContext* sharingGLContext();
-    void clearSharingGLContext();
+    void clearGLContexts();
     EGLDisplay eglDisplay() const;
     GLDisplay& glDisplay() const { return m_eglDisplay.get(); }
     bool eglCheckVersion(int major, int minor) const;
@@ -128,7 +128,7 @@ protected:
 
 private:
 #if USE(SKIA)
-    void invalidateSkiaGLContexts();
+    void clearSkiaGLContext();
 #endif
 
 #if ENABLE(WEBGL) && !PLATFORM(WIN)

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -620,7 +620,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
             jsonObject->setObject("Hardware Acceleration Information (Render process)"_s, WTFMove(hardwareAccelerationObject));
 
             // Clear the contexts used by the display before it's destroyed.
-            platformDisplay->clearSharingGLContext();
+            platformDisplay->clearGLContexts();
         }
 
 #if USE(GBM)
@@ -674,7 +674,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
             stopTable();
             jsonObject->setObject("Hardware Acceleration Information (Render process)"_s, WTFMove(hardwareAccelerationObject));
 
-            platformDisplay->clearSharingGLContext();
+            platformDisplay->clearGLContexts();
         }
 
 #if USE(GBM)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1928,7 +1928,8 @@ void WebPage::close()
 
     WEBPAGE_RELEASE_LOG_FORWARDABLE(Loading, WEBPAGE_CLOSE);
 
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ClearPageSpecificData(m_identifier), 0);
+    if (auto networkProcessConnection = WebProcess::singleton().protectedNetworkProcessConnection())
+        networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::ClearPageSpecificData(m_identifier), 0);
 
     m_isClosed = true;
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -115,6 +115,9 @@ void WebProcess::stopRunLoop()
     for (auto& webPage : copyToVector(m_pageMap.values()))
         webPage->close();
 
+    if (auto* display = PlatformDisplay::sharedDisplayIfExists())
+        display->clearGLContexts();
+
     AuxiliaryProcess::stopRunLoop();
 }
 


### PR DESCRIPTION
#### 5a0e48592bf4c531cef63cc1b7210149ac3dc28d
<pre>
[GTK][WPE] Web process sometimes gets locked on exit
<a href="https://bugs.webkit.org/show_bug.cgi?id=298025">https://bugs.webkit.org/show_bug.cgi?id=298025</a>

Reviewed by Nikolas Zimmermann.

It happens when the network connection is closed before WebPage::close
is called. In that case WebPage::close() tries to get a network process
connection to send ClearPageSpecificData message, but
WebProcess::ensureNetworkProcessConnection() fails causing a process
exit. In the exit handlers PlatformDisplay::invalidateSkiaGLContexts()
is called, which tries to invalidate the GL contexts of the painting
threads that are still running. We use RunLoop::dispatch() and a
semaphore to wait to clear context from painting threads, but that
doesn&apos;t work because painting threads don&apos;t run a loop. We should avoid
the early exit first by not calling
WebProcess::ensureNetworkProcessConnection() from WebPage::close(), but
we should also stop trying to invalidate the skia gl contexts from the
main thread. LayerTreeHost is the owner of the WorkerPool that runs the
painting tasks, so the gl contexts will be released when the threads
finish on LayerTreeHost destructor. We only need to care about the main
thread gl context for which we can just set to nullptr.

Canonical link: <a href="https://commits.webkit.org/299312@main">https://commits.webkit.org/299312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35698f378b23868533cffefd2f78df840be85886

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90003 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24433 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68420 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127824 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98421 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43861 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21860 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18896 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51041 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->