### PR TITLE
[css-mixins-1] Parse @function parameters

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6821,6 +6821,9 @@ imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-input-001.h
 imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-input-002.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-padding.html [ Skip ]
 
+# css-mixins / @function failures
+imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom.html [ Skip ]
+
 # These tests have been flaky since their import.
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-top-navigation-child-special-cases.tentative.sub.window.html [ DumpJSConsoleLogInStdErr Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-top-navigation-child.tentative.sub.window.html [ DumpJSConsoleLogInStdErr Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-parsing-expected.txt
@@ -1,54 +1,54 @@
 
-FAIL @function --foo() is valid assert_equals: expected 1 but got 0
-FAIL @function --foo( ) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo( --x ) is valid assert_equals: expected 1 but got 0
+PASS @function --foo() is valid
+PASS @function --foo( ) is valid
+PASS @function --foo(--x) is valid
+PASS @function --foo( --x ) is valid
 PASS @function --foo () is invalid
 PASS @function --foo (--x) is invalid
-FAIL @function --foo(--x auto) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <angle>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <color>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <custom-ident>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <image>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <integer>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <length>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <length-percentage>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <number>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <percentage>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <resolution>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <string>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <time>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <url>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <transform-function>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <transform-list>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(auto)) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(<length>)) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(<length> | auto)) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(none | auto)) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(*)) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x, --y) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x, --y, --z) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <length>, --y, --z) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x, --y <number>, --z <angle>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x : 10px) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(*): 10px) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <length>: 10px) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <length>: 10px, --y) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x, --y <length>: 10px) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(<length> | auto): auto) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(<length> | auto) : auto) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x:1px, --y, --z:2px) is valid assert_equals: expected 1 but got 0
+PASS @function --foo(--x auto) is valid
+PASS @function --foo(--x <angle>) is valid
+PASS @function --foo(--x <color>) is valid
+PASS @function --foo(--x <custom-ident>) is valid
+PASS @function --foo(--x <image>) is valid
+PASS @function --foo(--x <integer>) is valid
+PASS @function --foo(--x <length>) is valid
+PASS @function --foo(--x <length-percentage>) is valid
+PASS @function --foo(--x <number>) is valid
+PASS @function --foo(--x <percentage>) is valid
+PASS @function --foo(--x <resolution>) is valid
+PASS @function --foo(--x <string>) is valid
+PASS @function --foo(--x <time>) is valid
+PASS @function --foo(--x <url>) is valid
+PASS @function --foo(--x <transform-function>) is valid
+PASS @function --foo(--x <transform-list>) is valid
+PASS @function --foo(--x type(auto)) is valid
+PASS @function --foo(--x type(<length>)) is valid
+PASS @function --foo(--x type(<length> | auto)) is valid
+PASS @function --foo(--x type(none | auto)) is valid
+PASS @function --foo(--x type(*)) is valid
+PASS @function --foo(--x, --y) is valid
+PASS @function --foo(--x, --y, --z) is valid
+PASS @function --foo(--x <length>, --y, --z) is valid
+PASS @function --foo(--x, --y <number>, --z <angle>) is valid
+PASS @function --foo(--x : 10px) is valid
+PASS @function --foo(--x type(*): 10px) is valid
+PASS @function --foo(--x <length>: 10px) is valid
+PASS @function --foo(--x <length>: 10px, --y) is valid
+PASS @function --foo(--x, --y <length>: 10px) is valid
+PASS @function --foo(--x type(<length> | auto): auto) is valid
+PASS @function --foo(--x type(<length> | auto) : auto) is valid
+PASS @function --foo(--x:1px, --y, --z:2px) is valid
 PASS @function --foo(--x: 10px !important) is invalid
 PASS @function --foo(--x <length>: 10deg) is invalid
 PASS @function --foo(--x <angle>: 10px) is invalid
 PASS @function --foo(--x <color>: 10px) is invalid
 PASS @function --foo(--x type(<color>+): red 5) is invalid
 PASS @function --foo(--x type(auto | none): thing) is invalid
-FAIL @function --foo(--x <length>#) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <length>+) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x type(<length>+)) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <transform-function>#) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x <transform-function>+) is valid assert_equals: expected 1 but got 0
+PASS @function --foo(--x <length>#) is valid
+PASS @function --foo(--x <length>+) is valid
+PASS @function --foo(--x type(<length>+)) is valid
+PASS @function --foo(--x <transform-function>#) is valid
+PASS @function --foo(--x <transform-function>+) is valid
 PASS @function --foo(--x <transform-list>#) is invalid
 PASS @function --foo(--x <transform-list>+) is invalid
 PASS @function --foo(--x *) is invalid
@@ -66,12 +66,12 @@ PASS @function --foo(--x, ;) is invalid
 PASS @function --foo(;) is invalid
 PASS @function --foo(]) is invalid
 PASS @function --foo(, --x]) is invalid
-FAIL @function --foo(--x) returns type(*) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x) returns <length> is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x) returns <length>+ is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x) returns type(<length>) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x) returns type(<length> | auto) is valid assert_equals: expected 1 but got 0
-FAIL @function --foo(--x) returns type(foo | bar) is valid assert_equals: expected 1 but got 0
+PASS @function --foo(--x) returns type(*) is valid
+PASS @function --foo(--x) returns <length> is valid
+PASS @function --foo(--x) returns <length>+ is valid
+PASS @function --foo(--x) returns type(<length>) is valid
+PASS @function --foo(--x) returns type(<length> | auto) is valid
+PASS @function --foo(--x) returns type(foo | bar) is valid
 PASS @function --foo(--x) ! is invalid
 PASS @function --foo(--x) ! <length> is invalid
 PASS @function --foo(--x) returns <length>! is invalid

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1173,6 +1173,20 @@ CSSFontVariantEmojiEnabled:
     WebCore:
       default: false
 
+CSSFunctionAtRuleEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS @function"
+  humanReadableDescription: "Enable CSS @function rule"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSInputSecurityEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1005,6 +1005,7 @@ css/StyleMedia.cpp
 css/StyleProperties.cpp
 css/StylePropertyShorthand.cpp
 css/StyleRule.cpp
+css/StyleRuleFunction.cpp
 css/StyleRuleImport.cpp
 css/StyleSheet.cpp
 css/StyleSheetContents.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -134,6 +134,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:
     case StyleRuleType::FontFeatureValuesBlock:
+    case StyleRuleType::Function:
+    case StyleRuleType::FunctionDeclarations:
         return createWrapper<CSSRule>(globalObject, WTFMove(rule));
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12798,6 +12798,18 @@
                 }
             }
         },
+        "@function": {
+            "result": {
+                "codegen-properties": {
+                    "settings-flag": "cssFunctionAtRuleEnabled",
+                    "parser-grammar": "<declaration-value>?"
+                },
+                "specification": {
+                    "category": "css-mixins",
+                    "url": "https://www.w3.org/TR/css-mixins-1/#descdef-function-result"
+                }
+            }
+        },
         "@view-transition": {
             "navigation": {
                 "values": [
@@ -12976,6 +12988,11 @@
             "shortname": "CSS Masking",
             "longname": "CSS Masking Module",
             "url": "https://drafts.fxtf.org/css-masking-1/"
+        },
+        "css-mixins": {
+            "shortname": "CSS Functions and Mixins",
+            "longname": "CSS Functions and Mixins Module",
+            "url": "https://www.w3.org/TR/css-mixins-1"
         },
         "css-motion-path": {
             "shortname": "CSS Motion Path",

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -49,6 +49,7 @@
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include "StylePropertiesInlines.h"
+#include "StyleRuleFunction.h"
 #include "StyleRuleImport.h"
 #include "StyleSheetContents.h"
 
@@ -135,6 +136,10 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleViewTransition>(*this));
     case StyleRuleType::PositionTry:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRulePositionTry>(*this));
+    case StyleRuleType::Function:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFunction>(*this));
+    case StyleRuleType::FunctionDeclarations:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFunctionDeclarations>(*this));
     case StyleRuleType::Margin:
         break;
     }
@@ -234,6 +239,12 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
         },
         [&](StyleRulePositionTry& rule) -> Ref<CSSRule> {
             return CSSPositionTryRule::create(rule, parentSheet);
+        },
+        [&](StyleRuleFunction&) -> Ref<CSSRule> {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](StyleRuleFunctionDeclarations&) -> Ref<CSSRule> {
+            RELEASE_ASSERT_NOT_REACHED();
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/StyleRuleFunction.cpp
+++ b/Source/WebCore/css/StyleRuleFunction.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleRuleFunction.h"
+
+namespace WebCore {
+
+Ref<StyleRuleFunction> StyleRuleFunction::create(const AtomString& name, Vector<Parameter>&& parameters, CSSCustomPropertySyntax&& returnType, Vector<Ref<StyleRuleBase>>&& rules)
+{
+    return adoptRef(*new StyleRuleFunction(name, WTFMove(parameters), WTFMove(returnType), WTFMove(rules)));
+}
+
+StyleRuleFunction::StyleRuleFunction(const AtomString& name, Vector<Parameter>&& parameters, CSSCustomPropertySyntax&& returnType, Vector<Ref<StyleRuleBase>>&& rules)
+    : StyleRuleGroup(StyleRuleType::Function, WTFMove(rules))
+    , m_name(name)
+    , m_parameters(WTFMove(parameters))
+    , m_returnType(WTFMove(returnType))
+{
+}
+
+StyleRuleFunction::StyleRuleFunction(const StyleRuleFunction&) = default;
+
+StyleRuleFunctionDeclarations::StyleRuleFunctionDeclarations(Ref<StyleProperties>&& properties)
+    : StyleRuleBase(StyleRuleType::FunctionDeclarations)
+    , m_properties(WTFMove(properties))
+{
+}
+
+StyleRuleFunctionDeclarations::StyleRuleFunctionDeclarations(const StyleRuleFunctionDeclarations&) = default;
+
+}

--- a/Source/WebCore/css/StyleRuleFunction.h
+++ b/Source/WebCore/css/StyleRuleFunction.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCustomPropertySyntax.h"
+#include "CSSVariableData.h"
+#include "StyleRule.h"
+
+namespace WebCore {
+
+class StyleRuleFunction final : public StyleRuleGroup {
+public:
+    struct Parameter {
+        AtomString name;
+        CSSCustomPropertySyntax type;
+        RefPtr<CSSVariableData> defaultValue;
+    };
+
+    static Ref<StyleRuleFunction> create(const AtomString& name, Vector<Parameter>&&, CSSCustomPropertySyntax&& returnType, Vector<Ref<StyleRuleBase>>&&);
+
+    Ref<StyleRuleFunction> copy() const { return adoptRef(*new StyleRuleFunction(*this)); }
+
+    AtomString name() const { return m_name; }
+    const Vector<Parameter>& parameters() const { return m_parameters; }
+    const CSSCustomPropertySyntax& returnType() const { return m_returnType; }
+
+private:
+    StyleRuleFunction(const AtomString& name, Vector<Parameter>&&, CSSCustomPropertySyntax&& returnType, Vector<Ref<StyleRuleBase>>&&);
+    StyleRuleFunction(const StyleRuleFunction&);
+
+    const AtomString m_name;
+    const Vector<Parameter> m_parameters;
+    const CSSCustomPropertySyntax m_returnType;
+};
+
+class StyleRuleFunctionDeclarations : public StyleRuleBase {
+public:
+    static Ref<StyleRuleFunctionDeclarations> create(Ref<StyleProperties>&& properties)
+    {
+        return adoptRef(*new StyleRuleFunctionDeclarations(WTFMove(properties)));
+    }
+
+    Ref<StyleRuleFunctionDeclarations> copy() const { return adoptRef(*new StyleRuleFunctionDeclarations(*this)); }
+
+    // Only contains property "result" and custom properties.
+    const StyleProperties& properties() const { return m_properties.get(); }
+
+private:
+    StyleRuleFunctionDeclarations(Ref<StyleProperties>&&);
+    StyleRuleFunctionDeclarations(const StyleRuleFunctionDeclarations&);
+
+    const Ref<StyleProperties> m_properties;
+};
+
+}
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleFunction)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.type() == WebCore::StyleRuleType::Function; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleFunctionDeclarations)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.type() == WebCore::StyleRuleType::FunctionDeclarations; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -55,7 +55,9 @@ enum class StyleRuleType : uint8_t {
     Scope,
     StartingStyle,
     NestedDeclarations,
-    PositionTry
+    PositionTry,
+    Function,
+    FunctionDeclarations,
 };
 
 static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::ViewTransition;

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -587,6 +587,8 @@ bool StyleSheetContents::traverseSubresources(NOESCAPE const Function<bool(const
         case StyleRuleType::StartingStyle:
         case StyleRuleType::ViewTransition:
         case StyleRuleType::PositionTry:
+        case StyleRuleType::Function:
+        case StyleRuleType::FunctionDeclarations:
             return false;
         };
         ASSERT_NOT_REACHED();
@@ -662,6 +664,8 @@ bool StyleSheetContents::mayDependOnBaseURL() const
         case StyleRuleType::StartingStyle:
         case StyleRuleType::ViewTransition:
         case StyleRuleType::PositionTry:
+        case StyleRuleType::Function:
+        case StyleRuleType::FunctionDeclarations:
             return false;
         };
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -46,6 +46,7 @@ CSSAtRuleID cssAtRuleID(StringView name)
         { "font-face"_s,             CSSAtRuleFontFace },
         { "font-feature-values"_s,   CSSAtRuleFontFeatureValues },
         { "font-palette-values"_s,   CSSAtRuleFontPaletteValues },
+        { "function"_s,              CSSAtRuleFunction },
         { "import"_s,                CSSAtRuleImport },
         { "keyframes"_s,             CSSAtRuleKeyframes },
         { "layer"_s,                 CSSAtRuleLayer },

--- a/Source/WebCore/css/parser/CSSAtRuleID.h
+++ b/Source/WebCore/css/parser/CSSAtRuleID.h
@@ -64,6 +64,7 @@ enum CSSAtRuleID : uint8_t {
     CSSAtRuleFontPaletteValues,
     CSSAtRuleScope,
     CSSAtRuleStartingStyle,
+    CSSAtRuleFunction,
 };
 
 CSSAtRuleID cssAtRuleID(StringView name);

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+class CSSParserTokenRange;
+
 struct CSSCustomPropertySyntax {
     enum class Type : uint8_t {
         Length,
@@ -68,7 +70,12 @@ struct CSSCustomPropertySyntax {
     bool isUniversal() const { return definition.isEmpty(); }
 
     static std::optional<CSSCustomPropertySyntax> parse(StringView);
+    static std::optional<CSSCustomPropertySyntax> consumeType(CSSParserTokenRange&);
+
+
     static CSSCustomPropertySyntax universal() { return { }; }
+
+    bool containsUnknownType() const;
 
 private:
     template<typename CharacterType> static std::optional<Component> parseComponent(std::span<const CharacterType>);

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -55,6 +55,7 @@ class StyleRuleFontFace;
 class StyleRuleFontFeatureValues;
 class StyleRuleFontFeatureValuesBlock;
 class StyleRuleFontPaletteValues;
+class StyleRuleFunction;
 class StyleRuleImport;
 class StyleRuleKeyframes;
 class StyleRuleLayer;
@@ -172,6 +173,7 @@ private:
     RefPtr<StyleRuleStartingStyle> consumeStartingStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleViewTransition> consumeViewTransitionRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRulePositionTry> consumePositionTryRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleFunction> consumeFunctionRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -126,6 +126,8 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     case StyleRuleType::Property:
     case StyleRuleType::ViewTransition:
     case StyleRuleType::NestedDeclarations:
+    case StyleRuleType::Function:
+    case StyleRuleType::FunctionDeclarations:
         // These rule types do not contain rules that apply directly to an element (i.e. these rules should not appear
         // in the Styles details sidebar of the Elements tab in Web Inspector).
         return RuleFlatteningStrategy::Ignore;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -235,6 +235,8 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
     case StyleRuleType::Margin:
     case StyleRuleType::Namespace:
     case StyleRuleType::FontFeatureValuesBlock:
+    case StyleRuleType::Function:
+    case StyleRuleType::FunctionDeclarations:
         return;
 
     case StyleRuleType::Charset:


### PR DESCRIPTION
#### d0125fd9c712caabe78fd340c5500e6daf7c143d
<pre>
[css-mixins-1] Parse @function parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=298027">https://bugs.webkit.org/show_bug.cgi?id=298027</a>
<a href="https://rdar.apple.com/159352694">rdar://159352694</a>

Reviewed by Alan Baradlay and Sam Weinig.

Initial parsing support for <a href="https://www.w3.org/TR/css-mixins-1/#function-rule">https://www.w3.org/TR/css-mixins-1/#function-rule</a>

Also add a setting for the feature, disabled by default.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-parsing-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
* Source/WebCore/css/StyleRuleFunction.cpp: Added.
(WebCore::StyleRuleFunction::create):
(WebCore::StyleRuleFunction::StyleRuleFunction):
(WebCore::StyleRuleFunctionDeclarations::StyleRuleFunctionDeclarations):
* Source/WebCore/css/StyleRuleFunction.h: Added.
(WebCore::StyleRuleFunctionDeclarations::create):
(WebCore::StyleRuleFunctionDeclarations::copy const):
(WebCore::StyleRuleFunctionDeclarations::properties const):
(isType):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
(WebCore::StyleSheetContents::mayDependOnBaseURL const):
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSAtRuleID.h:
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
(WebCore::CSSCustomPropertySyntax::consumeType):
(WebCore::CSSCustomPropertySyntax::containsUnknownType const):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeAtRule):
(WebCore::CSSParser::consumeFunctionRule):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):

Canonical link: <a href="https://commits.webkit.org/299265@main">https://commits.webkit.org/299265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f99a6bf4b28bef2edefb9ff743780f5059ea7d61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70495 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c0cfb71-a300-4b04-a3e4-5e348e287210) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46700 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5083de06-ec06-4450-bd45-668229ca685d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca317e22-6d55-4509-9c07-d3862eb10e17) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68265 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110555 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127675 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116951 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24997 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21746 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50892 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145647 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44677 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37457 "Found 1 new JSC binary failure: testapi, Found 18590 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48024 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->