### PR TITLE
Filter out some libwebrtc file for production builds like done for release builds

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig
@@ -71,6 +71,7 @@ EXCLUDED_SOURCE_FILE_NAMES_macosx = voice_processing_audio_unit.mm;
 EXCLUDED_SOURCE_FILE_NAMES_ios = macutils.cc macwindowpicker.cc audio_device_mac.cc audio_mixer_manager_mac.cc logging_mac.mm;
 EXCLUDED_SOURCE_FILE_NAMES_arm = *_sse.cc *_sse2.cc;
 
+EXCLUDED_SOURCE_FILE_NAMES[config=Production] = decode_rust_punycode.cc demangle.cc demangle_rust.cc stacktrace.cc symbolize_darwin.inc symbolize.cc utf8_for_code_point.cc;
 EXCLUDED_SOURCE_FILE_NAMES[config=Release] = decode_rust_punycode.cc demangle.cc demangle_rust.cc stacktrace.cc symbolize_darwin.inc symbolize.cc utf8_for_code_point.cc;
 
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*] = $(EXCLUDED_SOURCE_FILE_NAMES_ios) $(EXCLUDED_SOURCE_FILE_NAMES_arm);


### PR DESCRIPTION
#### 5c37b3507aeafb2ee2e9f54c555a15787626853e
<pre>
Filter out some libwebrtc file for production builds like done for release builds
<a href="https://rdar.apple.com/159356366">rdar://159356366</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298032">https://bugs.webkit.org/show_bug.cgi?id=298032</a>

Reviewed by Elliott Williams.

* Source/ThirdParty/libwebrtc/Configurations/libwebrtc.xcconfig:

Canonical link: <a href="https://commits.webkit.org/299275@main">https://commits.webkit.org/299275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/475948e81787da5d8d6892385868d9f6c1d9eaeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70477 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/720f7181-3509-44ab-b2ed-2c1f9ee22498) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89872 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4eb462b5-06d7-47d5-823d-cc1a0c433d68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41df92d8-06c1-4545-bbed-ba4e399dfca7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24287 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68247 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110537 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127657 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98537 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21726 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45196 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44659 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46346 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->