### PR TITLE
[WebXR][OpenXR] Unavailable poke and pinch poses with hand interaction profile

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
@@ -85,7 +85,7 @@ XrResult OpenXRInputSource::initialize()
     RETURN_RESULT_IF_FAILED(createActionSpace(m_pointerAction, m_pointerSpace));
 
 #if defined(XR_EXT_hand_interaction)
-    if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME)) {
+    if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME ""_span)) {
         RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_pinch_ext"_s), m_pinchPoseAction));
         RETURN_RESULT_IF_FAILED(createActionSpace(m_pinchPoseAction, m_pinchSpace), m_instance);
         RETURN_RESULT_IF_FAILED(createAction(XR_ACTION_TYPE_POSE_INPUT, makeString(prefix, "_poke_ext"_s), m_pokePoseAction));
@@ -130,7 +130,7 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
         CHECK_XRCMD(createBinding(profile.path, m_pointerAction, makeString(m_subactionPathName, s_inputAimPath), bindings));
 
 #if defined(XR_EXT_hand_interaction)
-        if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME)) {
+        if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME ""_span)) {
             RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_pinchPoseAction, makeString(m_subactionPathName, s_inputPinchPath), bindings));
             RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_pokePoseAction, makeString(m_subactionPathName, s_inputPokePath), bindings));
         }


### PR DESCRIPTION
#### ab45d28d96e9b3315f85380fa3f9b7eb7c93391a
<pre>
[WebXR][OpenXR] Unavailable poke and pinch poses with hand interaction profile
<a href="https://bugs.webkit.org/show_bug.cgi?id=298038">https://bugs.webkit.org/show_bug.cgi?id=298038</a>

Reviewed by Adrian Perez de Castro.

Similar fix as 0d7a5cbd@main. The code was trying to check the
availability of some extensions passing a char* instead of a
span resulting in the method returning always false.

* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp:
(WebKit::OpenXRInputSource::initialize):
(WebKit::OpenXRInputSource::suggestBindings const):

Canonical link: <a href="https://commits.webkit.org/299260@main">https://commits.webkit.org/299260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da25404379a206488d580c4772538fd7918a1461

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89877 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29969 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45332 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98543 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98328 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21735 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50880 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44665 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->