### PR TITLE
[css-anchor-position-1] Remember last-successful position option at ResizeObserver delivery time

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7534,9 +7534,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/container-queries/anchor
 # This is passing only on mac-wk2
 webkit.org/b/299561 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-003.html [ ImageOnlyFailure ]
 
-# Might be a test error, see https://github.com/w3c/csswg-drafts/issues/12577
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-non-anchored-fallback.html [ ImageOnlyFailure ]
-
 # timeouts
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-ident-function.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got 335
+PASS Should use the third fallback position with enough space left
 FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
 PASS Should use the first fallback position with enough space left and above
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+PASS Should use the third fallback position with enough space right
 FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 250
 PASS Should use the first fallback position with enough space right and below
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+PASS Should use the third fallback position with enough space right
 FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
 PASS Should use the first fallback position with enough space right and above
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 235 but got 435
+PASS Should use the third fallback position with enough space above
 FAIL Should use the second fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 358 but got 158
 PASS Should use the first fallback position with enough space above and right
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/base-style-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/base-style-invalidation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The chosen position fallbacks changes when the base style differs assert_equals: expected 20 but got 75
+PASS The chosen position fallbacks changes when the base style differs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Starts rendering with flip-block
-FAIL No successful position (with intermediate successful), keep flip-block assert_equals: expected 200 but got 0
+PASS No successful position (with intermediate successful), keep flip-block
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10391,6 +10391,14 @@ void Document::updateResizeObservations(Page& page)
         addConsoleMessage(MessageSource::Other, MessageLevel::Info, "ResizeObservers silenced due to: http://webkit.org/b/258597"_s);
         return;
     }
+
+    if (m_renderView) {
+        // Per spec, this is recorded when ResizeObserver events are determined and delivered.
+        // See https://drafts.csswg.org/css-anchor-position-1/#last-successful-position-option.
+        auto lastSuccessfulPositionOptionMap = Style::AnchorPositionEvaluator::recordLastSuccessfulPositionOptions(m_renderView->positionTryBoxes());
+        styleScope().setLastSuccessfulPositionOptionIndexMap(WTFMove(lastSuccessfulPositionOptionMap));
+    }
+
     if (!hasResizeObservers() && !m_resizeObserverForContainIntrinsicSize && !m_contentVisibilityDocumentState)
         return;
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -70,6 +70,7 @@
 #include "SVGSVGElement.h"
 #include "Settings.h"
 #include "StyleInheritedData.h"
+#include "StyleScope.h"
 #include "TransformState.h"
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
@@ -1130,6 +1131,12 @@ void RenderView::registerPositionTryBox(const RenderBox& box)
 void RenderView::unregisterPositionTryBox(const RenderBox& box)
 {
     m_positionTryBoxes.remove(box);
+
+    // Explicitly forget the last successful position option here, so if the box
+    // ever comes back (i.e display: none to non-none), we don't accidentally reuse
+    // the last successful position option.
+    if (auto styleable = Styleable::fromRenderer(box))
+        document().styleScope().forgetLastSuccessfulPositionOptionIndex(*styleable);
 }
 
 void RenderView::addCounterNeedingUpdate(RenderCounter& renderer)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3558,14 +3558,14 @@ void RenderStyle::setPositionTryFallbacks(FixedVector<Style::PositionTryFallback
     SET_NESTED_VAR(m_nonInheritedData, rareData, positionTryFallbacks, WTFMove(fallbacks));
 }
 
-std::optional<size_t> RenderStyle::lastSuccessfulPositionTryFallbackIndex() const
+std::optional<size_t> RenderStyle::usedPositionOptionIndex() const
 {
-    return m_nonInheritedData->rareData->lastSuccessfulPositionTryFallbackIndex;
+    return m_nonInheritedData->rareData->usedPositionOptionIndex;
 }
 
-void RenderStyle::setLastSuccessfulPositionTryFallbackIndex(std::optional<size_t> index)
+void RenderStyle::setUsedPositionOptionIndex(std::optional<size_t> index)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, lastSuccessfulPositionTryFallbackIndex, WTFMove(index));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, usedPositionOptionIndex, WTFMove(index));
 }
 
 std::optional<Style::PseudoElementIdentifier> RenderStyle::pseudoElementIdentifier() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2372,8 +2372,8 @@ public:
     const FixedVector<Style::PositionTryFallback>& positionTryFallbacks() const;
     void setPositionTryFallbacks(FixedVector<Style::PositionTryFallback>&&);
 
-    std::optional<size_t> lastSuccessfulPositionTryFallbackIndex() const;
-    void setLastSuccessfulPositionTryFallbackIndex(std::optional<size_t>);
+    std::optional<size_t> usedPositionOptionIndex() const;
+    void setUsedPositionOptionIndex(std::optional<size_t>);
 
     static constexpr OptionSet<PositionVisibility> initialPositionVisibility();
     inline OptionSet<PositionVisibility> positionVisibility() const;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -103,7 +103,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , positionAnchor(RenderStyle::initialPositionAnchor())
     , positionArea(RenderStyle::initialPositionArea())
     , positionTryFallbacks(RenderStyle::initialPositionTryFallbacks())
-    , lastSuccessfulPositionTryFallbackIndex()
+    , usedPositionOptionIndex()
     , blockStepSize(RenderStyle::initialBlockStepSize())
     , blockStepAlign(static_cast<unsigned>(RenderStyle::initialBlockStepAlign()))
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
@@ -210,7 +210,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , positionAnchor(o.positionAnchor)
     , positionArea(o.positionArea)
     , positionTryFallbacks(o.positionTryFallbacks)
-    , lastSuccessfulPositionTryFallbackIndex(o.lastSuccessfulPositionTryFallbackIndex)
+    , usedPositionOptionIndex(o.usedPositionOptionIndex)
     , blockStepSize(o.blockStepSize)
     , blockStepAlign(o.blockStepAlign)
     , blockStepInsert(o.blockStepInsert)
@@ -322,7 +322,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && positionAnchor == o.positionAnchor
         && positionArea == o.positionArea
         && positionTryFallbacks == o.positionTryFallbacks
-        && lastSuccessfulPositionTryFallbackIndex == o.lastSuccessfulPositionTryFallbackIndex
+        && usedPositionOptionIndex == o.usedPositionOptionIndex
         && blockStepSize == o.blockStepSize
         && blockStepAlign == o.blockStepAlign
         && blockStepInsert == o.blockStepInsert
@@ -482,7 +482,7 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT(positionAnchor);
     LOG_IF_DIFFERENT(positionArea);
     LOG_IF_DIFFERENT(positionTryFallbacks);
-    LOG_IF_DIFFERENT(lastSuccessfulPositionTryFallbackIndex);
+    LOG_IF_DIFFERENT(usedPositionOptionIndex);
     LOG_IF_DIFFERENT(positionVisibility);
 
     LOG_IF_DIFFERENT(blockStepSize);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -228,7 +228,7 @@ public:
     std::optional<Style::ScopedName> positionAnchor;
     std::optional<PositionArea> positionArea;
     FixedVector<Style::PositionTryFallback> positionTryFallbacks;
-    std::optional<size_t> lastSuccessfulPositionTryFallbackIndex;
+    std::optional<size_t> usedPositionOptionIndex;
 
     Style::BlockStepSize blockStepSize;
     PREFERRED_TYPE(BlockStepAlign) unsigned blockStepAlign : 2;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1594,6 +1594,21 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::defaultAnchorForBox(co
     return nullptr;
 }
 
+HashMap<AnchorPositionedKey, size_t> AnchorPositionEvaluator::recordLastSuccessfulPositionOptions(const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes)
+{
+    HashMap<Style::AnchorPositionedKey, size_t> lastSuccessfulPositionOptionMap;
+
+    for (const auto& positionTryBox : positionTryBoxes) {
+        auto styleable = Styleable::fromRenderer(positionTryBox);
+        ASSERT(styleable);
+
+        if (auto usedPositionOptionIndex = positionTryBox.style().usedPositionOptionIndex())
+            lastSuccessfulPositionOptionMap.add({ styleable->element, styleable->pseudoElementIdentifier }, *usedPositionOptionIndex);
+    }
+
+    return lastSuccessfulPositionOptionMap;
+}
+
 } // namespace Style
 
 } // namespace WebCore

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -194,6 +194,8 @@ public:
 
     static CheckedPtr<RenderBoxModelObject> defaultAnchorForBox(const RenderBox&);
 
+    static HashMap<AnchorPositionedKey, size_t> recordLastSuccessfulPositionOptions(const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes);
+
 private:
     static CheckedPtr<RenderBoxModelObject> findAnchorForAnchorFunctionAndAttemptResolution(BuilderState&, std::optional<ScopedName> elementName);
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1125,5 +1125,22 @@ void Scope::updateAnchorPositioningStateAfterStyleResolution()
     });
 }
 
+std::optional<size_t> Scope::lastSuccessfulPositionOptionIndexFor(const Styleable& styleable)
+{
+    AnchorPositionedKey key { styleable.element, styleable.pseudoElementIdentifier };
+    return m_lastSuccessfulPositionOptionIndexes.getOptional(key);
+}
+
+void Scope::setLastSuccessfulPositionOptionIndexMap(HashMap<AnchorPositionedKey, size_t>&& map)
+{
+    m_lastSuccessfulPositionOptionIndexes = WTFMove(map);
+}
+
+void Scope::forgetLastSuccessfulPositionOptionIndex(const Styleable& styleable)
+{
+    AnchorPositionedKey key { styleable.element, styleable.pseudoElementIdentifier };
+    m_lastSuccessfulPositionOptionIndexes.remove(key);
+}
+
 }
 }

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -33,6 +33,7 @@
 #include <WebCore/LayoutSize.h>
 #include <WebCore/StyleScopeIdentifier.h>
 #include <WebCore/StyleScopeOrdinal.h>
+#include <WebCore/Styleable.h>
 #include <WebCore/Timer.h>
 #include <memory>
 #include <wtf/CheckedPtr.h>
@@ -173,6 +174,10 @@ public:
     const AnchorPositionedToAnchorMap& anchorPositionedToAnchorMap() const { return m_anchorPositionedToAnchorMap; }
     void updateAnchorPositioningStateAfterStyleResolution();
 
+    std::optional<size_t> lastSuccessfulPositionOptionIndexFor(const Styleable&);
+    void setLastSuccessfulPositionOptionIndexMap(HashMap<AnchorPositionedKey, size_t>&&);
+    void forgetLastSuccessfulPositionOptionIndex(const Styleable&);
+
     bool invalidateForAnchorDependencies(LayoutDependencyUpdateContext&);
 
 private:
@@ -273,6 +278,9 @@ private:
         bool operator==(const AnchorPosition&) const = default;
     };
     SingleThreadWeakHashMap<const RenderBoxModelObject, AnchorPosition> m_anchorPositionsOnLastUpdate;
+    // Stores the last successful position option for each anchor-positioned element.
+    // This is recorded when ResizeObserver events are delivered, at Document::updateResizeObservations
+    HashMap<AnchorPositionedKey, size_t> m_lastSuccessfulPositionOptionIndexes;
 
     std::unique_ptr<MatchResultCache> m_matchResultCache;
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -219,11 +219,8 @@ private:
         // New style after applying the option.
         std::unique_ptr<RenderStyle> style;
 
-        // The used position option. If option is nullopt, no position option is used.
+        // The position option used to generate the style. If option is nullopt, no position option is used.
         std::optional<PositionTryFallback> option;
-
-        // Index of the option in the position-try-fallbacks list. If nullopt, no position option is used.
-        std::optional<size_t> fallbackIndex;
 
         // The size of the content box of the element when the style is generated.
         // Non-overlay scrollbars appearing or disappearing may affect the content box size that anchor functions are resolved against.


### PR DESCRIPTION
#### 755cd64e24a56c80bf33dca159d61c94519fce32
<pre>
[css-anchor-position-1] Remember last-successful position option at ResizeObserver delivery time
<a href="https://rdar.apple.com/159225250">rdar://159225250</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297932">https://bugs.webkit.org/show_bug.cgi?id=297932</a>

Reviewed by Antti Koivisto.

RenderStyle::lastSuccessfulPositionTryFallbackIndex is _actually_ the index of the position
option being applied to the style. Because we stop trying as soon as we find a working option,
given a box&apos;s style after style resolution, lastSuccessfulPositionTryFallbackIndex is _also_
the index of the last successful position option. This implies that the last successful position
option is remembered at style resolution time. However, the spec [1] dictates that the
last successful position option is remember _when_ ResizeObserver events are dispatched.
This patch aligns with that behavior by separating trying position options into two phases:

* During style resolution, each option is tried, and RenderStyle::usedPositionOptionIndex
(renamed from ::lastSuccessfulPositionTryFallbackIndex) is set for each style to denote
what&apos;s the option used to generate the style.
* When ResizeObserver events are dispatched (after style resolution), we loop through
each position-try box and save the usedPositionOptionIndex of each box. This is the
last successful position option of the box.
* At the next style resolution, we use the saved last successful position option to
adjust which option should be tried first.

[1]: <a href="https://drafts.csswg.org/css-anchor-position-1/#last-successful-position-option">https://drafts.csswg.org/css-anchor-position-1/#last-successful-position-option</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/base-style-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-intermediate-ignored-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateResizeObservations):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::unregisterPositionTryBox):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::usedPositionOptionIndex const):
(WebCore::RenderStyle::setUsedPositionOptionIndex):
(WebCore::RenderStyle::lastSuccessfulPositionTryFallbackIndex const): Deleted.
(WebCore::RenderStyle::setLastSuccessfulPositionTryFallbackIndex): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::recordLastSuccessfulPositionOptions):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::lastSuccessfulPositionOptionIndexFor):
(WebCore::Style::Scope::setLastSuccessfulPositionOptionIndexMap):
(WebCore::Style::Scope::forgetLastSuccessfulPositionOptionIndex):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::shouldInvalidateLastSuccessfulPositionOptionIndex):
(WebCore::Style::TreeResolver::styleForStyleable):
(WebCore::Style::TreeResolver::resolvePseudoElement):
(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::PositionOptions::currentOption const):
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::tryChoosePositionOption):
(WebCore::Style::lastSuccessfulPositionTryFallbackIndex): Deleted.
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/300890@main">https://commits.webkit.org/300890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be333ad084b93c2bb4875ed616f636a21cf1eab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76231 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3c3c2d7-5f32-47c7-87d0-4233f3cdc6c6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94409 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62637 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/304ad99d-ffef-410f-aeef-76647724d066) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c281c53-38dd-4472-936c-54acc57708a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74423 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133613 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102882 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102689 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26148 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26291 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47924 "Hash 9be333ad for PR 50010 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56673 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52036 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->