### PR TITLE
[SPI Checking] Fix allowlists on the open source build

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -143,6 +143,7 @@ request = "rdar://157886589"
 selectors = [
     {name = "allowedCategories", class = "WPFingerprintingScript"},
 ]
+requires = ["ENABLE_SCRIPT_TRACKING_PRIVACY_PROTECTIONS"]
 
 [[temporary-usage]]
 request = "rdar://157888734"
@@ -155,12 +156,19 @@ selectors = [
     { name = "_setPrivacyProxyFailClosed:", class = "NSURLRequest" },
     { name = "_setPrivacyProxyFailClosedForUnreachableHosts:", class = "NSURLRequest" },
     { name = "_setPrivacyProxyFailClosedForUnreachableNonMainHosts:", class = "NSURLRequest" },
-    { name = "_setPrivacyProxyStrictFailClosed:", class = "NSURLRequest" },
     { name = "_setProhibitPrivacyProxy:", class = "NSURLRequest" },
     { name = "_setUseEnhancedPrivacyMode:", class = "NSURLRequest" },
     { name = "_setWebSearchContent:", class = "NSURLRequest" },
 ]
 requires = ["HAVE_SYSTEM_SUPPORT_FOR_ADVANCED_PRIVACY_PROTECTIONS"]
+
+[[temporary-usage]]
+request = "rdar://157888734"
+cleanup = "rdar://157888769"
+selectors = [
+    { name = "_setPrivacyProxyStrictFailClosed:", class = "NSURLRequest" },
+]
+requires = ["HAVE_STRICT_FAIL_CLOSED"]
 
 [[temporary-usage]]
 request = "rdar://157889218"


### PR DESCRIPTION
#### 51a56455cda965d5bf685ed08e4c8c4b1b736ca7
<pre>
[SPI Checking] Fix allowlists on the open source build
<a href="https://bugs.webkit.org/show_bug.cgi?id=298052">https://bugs.webkit.org/show_bug.cgi?id=298052</a>

Reviewed by Brianna Fan.

* Source/WebKit/Configurations/AllowedSPI.toml:

Canonical link: <a href="https://commits.webkit.org/299285@main">https://commits.webkit.org/299285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/070abe62efa038c4b6b26fd8ddd5f755249916ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/027598af-5171-47c9-8f02-bd5d7773d01b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89920 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80125022-b241-4f3e-a5ef-42d0963377ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70400 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5e700d9-a635-49ad-a92a-43b78d38fdcf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30008 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68304 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127711 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98580 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98365 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25008 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21777 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50928 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44713 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->