### PR TITLE
Simplify calls to CaptionUserPreferencesMediaAF::hasNullCaptionProfile()

### DIFF
--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -164,7 +164,7 @@ CaptionUserPreferencesMediaAF::~CaptionUserPreferencesMediaAF()
 CaptionUserPreferences::CaptionDisplayMode CaptionUserPreferencesMediaAF::captionDisplayMode() const
 {
     CaptionDisplayMode internalMode = CaptionUserPreferences::captionDisplayMode();
-    if (internalMode == CaptionDisplayMode::Manual || testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile())
+    if (internalMode == CaptionDisplayMode::Manual || testingMode() || !MediaAccessibilityLibrary())
         return internalMode;
 
     if (cachedCaptionDisplayMode().has_value())
@@ -196,7 +196,7 @@ void CaptionUserPreferencesMediaAF::platformSetCaptionDisplayMode(CaptionDisplay
 
 void CaptionUserPreferencesMediaAF::setCaptionDisplayMode(CaptionUserPreferences::CaptionDisplayMode mode)
 {
-    if (testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile()) {
+    if (testingMode() || !MediaAccessibilityLibrary()) {
         CaptionUserPreferences::setCaptionDisplayMode(mode);
         return;
     }
@@ -238,7 +238,7 @@ void CaptionUserPreferencesMediaAF::setCachedCaptionDisplayMode(CaptionDisplayMo
 bool CaptionUserPreferencesMediaAF::userPrefersCaptions() const
 {
     bool captionSetting = CaptionUserPreferences::userPrefersCaptions();
-    if (captionSetting || testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile())
+    if (captionSetting || testingMode() || !MediaAccessibilityLibrary())
         return captionSetting;
 
     RetainPtr captioningMediaCharacteristics = adoptCF(MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics(kMACaptionAppearanceDomainUser));
@@ -248,7 +248,7 @@ bool CaptionUserPreferencesMediaAF::userPrefersCaptions() const
 bool CaptionUserPreferencesMediaAF::userPrefersSubtitles() const
 {
     bool subtitlesSetting = CaptionUserPreferences::userPrefersSubtitles();
-    if (subtitlesSetting || testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile())
+    if (subtitlesSetting || testingMode() || !MediaAccessibilityLibrary())
         return subtitlesSetting;
     
     RetainPtr captioningMediaCharacteristics = adoptCF(MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics(kMACaptionAppearanceDomainUser));
@@ -258,7 +258,7 @@ bool CaptionUserPreferencesMediaAF::userPrefersSubtitles() const
 bool CaptionUserPreferencesMediaAF::userPrefersTextDescriptions() const
 {
     bool prefersTextDescriptions = CaptionUserPreferences::userPrefersTextDescriptions();
-    if (prefersTextDescriptions || testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile())
+    if (prefersTextDescriptions || testingMode() || !MediaAccessibilityLibrary())
         return prefersTextDescriptions;
 
     RetainPtr preferDescriptiveVideo = adoptCF(MAAudibleMediaPrefCopyPreferDescriptiveVideo());
@@ -430,6 +430,11 @@ bool CaptionUserPreferencesMediaAF::captionStrokeWidthForFont(float fontSize, co
     return true;
 }
 
+bool CaptionUserPreferencesMediaAF::testingMode() const
+{
+    return CaptionUserPreferences::testingMode() || hasNullCaptionProfile();
+}
+
 String CaptionUserPreferencesMediaAF::captionsTextEdgeCSS() const
 {
     MACaptionAppearanceBehavior behavior;
@@ -500,7 +505,7 @@ String CaptionUserPreferencesMediaAF::captionsDefaultFontCSS() const
 
 float CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance(bool& important) const
 {
-    if (testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile())
+    if (testingMode() || !MediaAccessibilityLibrary())
         return CaptionUserPreferences::captionFontSizeScaleAndImportance(important);
 
     MACaptionAppearanceBehavior behavior;
@@ -528,7 +533,7 @@ void CaptionUserPreferencesMediaAF::setPreferredLanguage(const String& language)
     if (CaptionUserPreferences::captionDisplayMode() == CaptionDisplayMode::Manual)
         return;
 
-    if (testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile()) {
+    if (testingMode() || !MediaAccessibilityLibrary()) {
         CaptionUserPreferences::setPreferredLanguage(language);
         return;
     }
@@ -544,7 +549,7 @@ void CaptionUserPreferencesMediaAF::setPreferredLanguage(const String& language)
 Vector<String> CaptionUserPreferencesMediaAF::preferredLanguages() const
 {
     auto preferredLanguages = CaptionUserPreferences::preferredLanguages();
-    if (testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile())
+    if (testingMode() || !MediaAccessibilityLibrary())
         return preferredLanguages;
 
     if (cachedPreferredLanguages().has_value())
@@ -574,13 +579,13 @@ void CaptionUserPreferencesMediaAF::setCachedPreferredLanguages(const Vector<Str
 
 void CaptionUserPreferencesMediaAF::setPreferredAudioCharacteristic(const String& characteristic)
 {
-    if (testingMode() || !MediaAccessibilityLibrary() || hasNullCaptionProfile())
+    if (testingMode() || !MediaAccessibilityLibrary())
         CaptionUserPreferences::setPreferredAudioCharacteristic(characteristic);
 }
 
 Vector<String> CaptionUserPreferencesMediaAF::preferredAudioCharacteristics() const
 {
-    if (testingMode() || !MediaAccessibilityLibrary() || !canLoad_MediaAccessibility_MAAudibleMediaCopyPreferredCharacteristics() || hasNullCaptionProfile())
+    if (testingMode() || !MediaAccessibilityLibrary() || !canLoad_MediaAccessibility_MAAudibleMediaCopyPreferredCharacteristics())
         return CaptionUserPreferences::preferredAudioCharacteristics();
 
     CFIndex characteristicCount = 0;
@@ -607,7 +612,7 @@ bool CaptionUserPreferencesMediaAF::hasNullCaptionProfile() const
 
 String CaptionUserPreferencesMediaAF::captionsStyleSheetOverride() const
 {
-    if (testingMode() || hasNullCaptionProfile())
+    if (testingMode())
         return CaptionUserPreferences::captionsStyleSheetOverride();
     
     StringBuilder captionsOverrideStyleSheet;

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -78,6 +78,8 @@ public:
     bool shouldFilterTrackMenu() const { return true; }
     
     WEBCORE_EXPORT static void setCaptionPreferencesDelegate(std::unique_ptr<CaptionPreferencesDelegate>&&);
+
+    bool testingMode() const final;
 #else
     bool shouldFilterTrackMenu() const { return false; }
 #endif


### PR DESCRIPTION
#### 7afa0e46c1b491b4c8f48a5bc01b4445dba9b30b
<pre>
Simplify calls to CaptionUserPreferencesMediaAF::hasNullCaptionProfile()
<a href="https://bugs.webkit.org/show_bug.cgi?id=298056">https://bugs.webkit.org/show_bug.cgi?id=298056</a>
<a href="https://rdar.apple.com/159385038">rdar://159385038</a>

Reviewed by Eric Carlson.

This is a follow-up to <a href="https://github.com/WebKit/WebKit/commit/e8284c96eb6205fa9ad7a78207394d1ef2984b9c.">https://github.com/WebKit/WebKit/commit/e8284c96eb6205fa9ad7a78207394d1ef2984b9c.</a> Instead of calling hasNullCaptionProfile()
in every place we call testingMode(), we should just override testingMode() and call hasNullCaptionProfile() from there.

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::captionDisplayMode const):
(WebCore::CaptionUserPreferencesMediaAF::setCaptionDisplayMode):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersCaptions const):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersSubtitles const):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersTextDescriptions const):
(WebCore::CaptionUserPreferencesMediaAF::testingMode const):
(WebCore::CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance const):
(WebCore::CaptionUserPreferencesMediaAF::setPreferredLanguage):
(WebCore::CaptionUserPreferencesMediaAF::preferredLanguages const):
(WebCore::CaptionUserPreferencesMediaAF::setPreferredAudioCharacteristic):
(WebCore::CaptionUserPreferencesMediaAF::preferredAudioCharacteristics const):
(WebCore::CaptionUserPreferencesMediaAF::captionsStyleSheetOverride const):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:

Canonical link: <a href="https://commits.webkit.org/299287@main">https://commits.webkit.org/299287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d60357d2f871ef3c173957d6ab83622cbcf48eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70547 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0cee54a-b359-452a-9b44-f960868afb7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89932 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1e0aa83-070a-4f14-96c4-bcfc0ea97889) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70435 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32c490c6-ea2c-4ff7-8a50-ffa053bd5330) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24344 "Found 7 new test failures: http/tests/media/media-source/media-source-video-fit-fill.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/media_fragment_seek.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-exit.html imported/w3c/web-platform-tests/media-source/mediasource-buffered-seek.html imported/w3c/web-platform-tests/media-source/mediasource-h264-play-starved.html imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68319 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24533 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34251 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102452 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43790 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18880 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45265 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50943 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44728 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46415 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->