### PR TITLE
PROGRESSION(299195@main): [ iOS Release ] imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https.html was progressed

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8250,6 +8250,4 @@ webkit.org/b/297674 [ Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV
 
 webkit.org/b/295435 compositing/layer-creation/overlap-animation-container.html [ Pass Failure ]
 
-webkit.org/b/297984 [ Release ] imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https.html [ Failure ]
-
 webkit.org/b/298042 [ Release ] http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https-expected.txt
@@ -6,7 +6,7 @@ Opener opens a new window, to a network document with the same origin and COOP v
 Opener's iframe navigates its parent frame (opener) to about:blank.
 Verify the openee still has access to its opener.
 
-FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://localhost:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
+PASS Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://localhost:9443
 FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://127.0.0.1:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
 FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin-allow-popups), iframe origin: https://127.0.0.1:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
 


### PR DESCRIPTION
#### 4eef98fccaf59517829aa2556fcf3340bfc1b3eb
<pre>
PROGRESSION(299195@main): [ iOS Release ] imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https.html was progressed
<a href="https://bugs.webkit.org/show_bug.cgi?id=297984">https://bugs.webkit.org/show_bug.cgi?id=297984</a>
<a href="https://rdar.apple.com/159301962">rdar://159301962</a>

Unreviewed expectation removal.

* LayoutTests/platform/ios/TestExpectations: Remove expectation.
</pre>