### PR TITLE
Add WebRTC related quirks for facebook

### DIFF
--- a/LayoutTests/webrtc/encoded-streams-quirks-expected.txt
+++ b/LayoutTests/webrtc/encoded-streams-quirks-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS encoded-streams-quirks
+

--- a/LayoutTests/webrtc/encoded-streams-quirks.html
+++ b/LayoutTests/webrtc/encoded-streams-quirks.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay playsinline controls></video>
+        <script src="routines.js"></script>
+        <script>
+promise_test(async (test) => {
+    let permission = await navigator.permissions.query({ name: "camera" });
+    assert_equals(permission.state, "prompt");
+    permission = await navigator.permissions.query({ name: "microphone" });
+    assert_equals(permission.state, "prompt");
+
+    if (!window.internals)
+        return;
+
+    window.internals.setTopDocumentURLForQuirks("https://www.facebook.com");
+
+    permission = await navigator.permissions.query({ name: "camera" });
+    assert_equals(permission.state, "granted");
+    permission = await navigator.permissions.query({ name: "microphone" });
+    assert_equals(permission.state, "granted");
+
+    const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            const audioSender = firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
+            let streams = audioSender.createEncodedStreams();
+            streams.readable.pipeTo(streams.writable);
+
+            const videoSender = firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+            streams = videoSender.createEncodedStreams();
+            streams.readable.pipeTo(streams.writable);
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                streams = trackEvent.receiver.createEncodedStreams();
+                streams.readable.pipeTo(streams.writable);
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        test.step_timeout(() => reject("Connections creation timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    await video.play();
+    await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+});
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -43,6 +43,7 @@
 #include "PermissionName.h"
 #include "PermissionQuerySource.h"
 #include "PermissionsPolicy.h"
+#include "Quirks.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "ServiceWorkerGlobalScope.h"
@@ -186,6 +187,10 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
             }
 #endif
 
+#if ENABLE(MEDIA_STREAM)
+            if (document->quirks().shouldEnableCameraAndMicrophonePermissionStateQuirk() && (permissionDescriptor.name == PermissionName::Camera || permissionDescriptor.name == PermissionName::Microphone) && *permissionState == PermissionState::Prompt)
+                permissionState = PermissionState::Granted;
+#endif
             promise.resolve(PermissionStatus::create(document, *permissionState, permissionDescriptor, PermissionQuerySource::Window, WTFMove(page)));
         });
         return;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -913,6 +913,13 @@ bool Quirks::shouldDisableImageCaptureQuirk() const
     return needsQuirks() && m_quirksData.shouldDisableImageCaptureQuirk;
 }
 
+#if ENABLE(MEDIA_STREAM)
+bool Quirks::shouldEnableCameraAndMicrophonePermissionStateQuirk() const
+{
+    return needsQuirks() && m_quirksData.shouldEnableCameraAndMicrophonePermissionStateQuirk;
+}
+#endif
+
 bool Quirks::shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const
 {
     return needsQuirks() && m_quirksData.shouldEnableSpeakerSelectionPermissionsPolicyQuirk;
@@ -2363,6 +2370,14 @@ static void handleFacebookQuirks(QuirksData& quirksData, const URL& quirksURL, c
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // facebook.com rdar://67273166
     quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = true;
+#endif
+#if ENABLE(MEDIA_STREAM)
+    // facebook.com rdar://158736355
+    quirksData.shouldEnableCameraAndMicrophonePermissionStateQuirk = true;
+#endif
+#if ENABLE(WEB_RTC)
+    // facebook.com rdar://158736355
+    quirksData.shouldEnableRTCEncodedStreamsQuirk = true;
 #endif
 }
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -149,6 +149,7 @@ public:
     bool shouldDisableImageCaptureQuirk() const;
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const;
     bool shouldEnableEnumerateDeviceQuirk() const;
+    bool shouldEnableCameraAndMicrophonePermissionStateQuirk() const;
 #endif
 #if ENABLE(WEB_RTC)
     bool shouldEnableRTCEncodedStreamsQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -153,6 +153,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldEnableLegacyGetUserMediaQuirk : 1 { false };
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk : 1 { false };
     bool shouldEnableEnumerateDeviceQuirk : 1 { false };
+    bool shouldEnableCameraAndMicrophonePermissionStateQuirk : 1 { false };
 #endif
 #if ENABLE(WEB_RTC)
     bool shouldEnableRTCEncodedStreamsQuirk : 1 { false };


### PR DESCRIPTION
#### 8d87092dab59f1d471ea830500581e2a89f6ce5b
<pre>
Add WebRTC related quirks for facebook
<a href="https://rdar.apple.com/137076210">rdar://137076210</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298059">https://bugs.webkit.org/show_bug.cgi?id=298059</a>

Reviewed by Brent Fulgham.

We add two quirks:
- We enable encoded streams quirk.
- We enable a quirk that changes permission query result from prompt to granted for camera and microphone.

* LayoutTests/webrtc/encoded-streams-quirks-expected.txt: Added.
* LayoutTests/webrtc/encoded-streams-quirks.html: Added.
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::query):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldEnableCameraAndMicrophonePermissionStateQuirk const):
(WebCore::handleFacebookQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/299357@main">https://commits.webkit.org/299357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46232620c57a8498e2f5449eaa380eefed9d4965

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70666 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aec777dc-f24c-4c58-83fa-dc13fdff5805) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90020 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59564 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67662492-42ec-4d44-8a62-681f8f9115c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6825ec60-6d5b-4473-b5de-ba78c952aa8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68441 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127845 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98653 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98437 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25051 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21878 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42012 "Hash 46232620 for PR 50025 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51062 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44847 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48194 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->