### PR TITLE
[WPE][GTK] Fix leaks when using g_variant_iter_loop()

### DIFF
--- a/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
+++ b/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
@@ -121,8 +121,12 @@ static bool isSerializable(GVariant* variant)
         const char* key;
         GVariant* value;
         while (g_variant_iter_loop(&iter, "{&sv}", &key, &value)) {
-            if (!key || !isSerializable(value))
+            if (!key || !isSerializable(value)) {
+                // Normally g_variant_iter_loop() frees this for us, but not if
+                // we break out of the loop and never call it again.
+                g_variant_unref(value);
                 return false;
+            }
         }
         return true;
     }

--- a/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
+++ b/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
@@ -32,6 +32,8 @@
 #include "APISerializedScriptValue.h"
 #include <jsc/JSCContextPrivate.h>
 #include <jsc/JSCValuePrivate.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
 
 namespace WebKit {
 
@@ -63,17 +65,16 @@ auto JavaScriptEvaluationResult::GLibExtractor::toValue(GVariant* variant) -> Va
 {
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE("a{sv}"))) {
         ObjectMap objectMap;
-        GVariantIter iter;
-        g_variant_iter_init(&iter, variant);
+        GUniquePtr<GVariantIter> iter(g_variant_iter_new(variant));
         const char* key;
-        GVariant* value;
-        while (g_variant_iter_loop(&iter, "{&sv}", &key, &value)) {
+        GRefPtr<GVariant> value;
+        while (g_variant_iter_next(iter.get(), "{&sv}", &key, &value.outPtr())) {
             if (!key || !value)
                 continue;
             auto keyID = JSObjectID::generate();
             m_map.add(keyID, String::fromUTF8(key));
             auto valueID = JSObjectID::generate();
-            m_map.add(valueID, toValue(value));
+            m_map.add(valueID, toValue(value.get()));
             objectMap.add(keyID, valueID);
         }
         return { WTF::move(objectMap) };
@@ -116,12 +117,11 @@ static bool isSerializable(GVariant* variant)
         return true;
 
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE("a{sv}"))) {
-        GVariantIter iter;
-        g_variant_iter_init(&iter, variant);
+        GUniquePtr<GVariantIter> iter(g_variant_iter_new(variant));
         const char* key;
-        GVariant* value;
-        while (g_variant_iter_loop(&iter, "{&sv}", &key, &value)) {
-            if (!key || !isSerializable(value))
+        GRefPtr<GVariant> value;
+        while (g_variant_iter_next(iter.get(), "{&sv}", &key, &value.outPtr())) {
+            if (!key || !isSerializable(value.get()))
                 return false;
         }
         return true;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4436,6 +4436,8 @@ static Vector<std::pair<String, JavaScriptEvaluationResult>> parseAsyncFunctionA
         auto parameter = JavaScriptEvaluationResult::extract(value);
         if (!parameter) {
             *error = g_error_new(WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_INVALID_PARAMETER, "Invalid parameter %s passed as argument of async function call", key);
+            // Normally g_variant_iter_loop() frees this for us, but not if we break out of the loop and never call it again.
+            g_variant_unref(value);
             return argumentsVector;
         }
         argumentsVector.append({ String::fromUTF8(key), WTFMove(*parameter) });

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -90,7 +90,9 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
+#include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GSpanExtras.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CStringView.h>
 #include <wtf/text/StringBuilder.h>
@@ -4558,15 +4560,14 @@ static Vector<std::pair<String, JavaScriptEvaluationResult>> parseAsyncFunctionA
 
     Vector<std::pair<String, JavaScriptEvaluationResult>> argumentsVector;
 
-    GVariantIter iter;
-    g_variant_iter_init(&iter, arguments);
+    GUniquePtr<GVariantIter> iter(g_variant_iter_new(arguments));
     const char* key;
-    GVariant* value;
-    while (g_variant_iter_loop(&iter, "{&sv}", &key, &value)) {
+    GRefPtr<GVariant> value;
+    while (g_variant_iter_next(iter.get(), "{&sv}", &key, &value.outPtr())) {
         if (!key)
             continue;
 
-        auto parameter = JavaScriptEvaluationResult::extract(value);
+        auto parameter = JavaScriptEvaluationResult::extract(value.get());
         if (!parameter) {
             *error = g_error_new(WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_INVALID_PARAMETER, "Invalid parameter %s passed as argument of async function call", key);
             return argumentsVector;


### PR DESCRIPTION
#### 449035bdfe62c6434ed30eb8df64ecd92f1b76f0
<pre>
[WPE][GTK] Fix leaks when using g_variant_iter_loop()
<a href="https://bugs.webkit.org/show_bug.cgi?id=298066">https://bugs.webkit.org/show_bug.cgi?id=298066</a>

Reviewed by Patrick Griffis.

Milan pointed out that if we break out of a g_variant_iter_loop() loop,
then it cannot free the key or value for us. In these cases, we have to
free it manually.

The easiest solution is to just not use g_variant_iter_loop() in these
cases, to ensure we cannot mess up. g_variant_iter_next() is basically
the same thing, except it requires that we handle the ownership.

* Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp:
(WebKit::JavaScriptEvaluationResult::GLibExtractor::toValue):
(WebKit::isSerializable):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(parseAsyncFunctionArguments):

Canonical link: <a href="https://commits.webkit.org/315630@main">https://commits.webkit.org/315630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20d647acd77b04f817823fa6699acba83db4528f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127314 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132151 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172561 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112654 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27658 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181560 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140600 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43180 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140436 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37790 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43869 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108092 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35701 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115634 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42379 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6975 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42027 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->