### PR TITLE
[ews] Remove Apply-WatchList-EWS queue

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -218,11 +218,6 @@
       "workernames": ["ews2000", "ews151", "ews253", "webkit-misc"]
     },
     {
-      "name": "Apply-WatchList-EWS", "shortname": "watchlist",
-      "factory": "WatchListFactory", "platform": "*",
-      "workernames": ["webkit-misc"]
-    },
-    {
       "name": "GTK-Build-EWS", "shortname": "gtk", "icon": "buildOnly",
       "factory": "GTKBuildFactory", "platform": "gtk",
       "configuration": "release", "architectures": ["x86_64"],
@@ -505,7 +500,7 @@
     {
       "type": "Try_Userpass", "name": "try", "port": 5555,
       "builderNames": [
-            "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-18-Build-EWS", "iOS-18-Simulator-Build-EWS",
+            "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-18-Build-EWS", "iOS-18-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
             "macOS-Sequoia-Debug-Build-EWS", "macOS-Sonoma-Release-Build-EWS", "macOS-Safer-CPP-Checks-EWS",
             "Services-EWS", "Style-EWS", "tvOS-18-Build-EWS", "tvOS-18-Simulator-Build-EWS", "visionOS-2-Build-EWS", "visionOS-2-Simulator-Build-EWS",

--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -62,7 +62,7 @@ class Events(service.BuildbotService):
         'build-webkit-org-unit-tests', 'buildbot-check-config', 'buildbot-check-config-for-build-webkit', 'buildbot-check-config-for-ews',
         'ews-unit-tests', 'resultsdbpy-unit-tests',
         'upload-built-product', 'upload-test-results',
-        'apply-watch-list', 'bindings-tests', 'check-webkit-style',
+        'bindings-tests', 'check-webkit-style',
         'webkitperl-tests', 're-run-webkitperl-tests', 'webkitpy-tests'
     ]
 

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -79,23 +79,6 @@ class StyleFactory(factory.BuildFactory):
         self.addStep(CheckStyle())
 
 
-class WatchListFactory(factory.BuildFactory):
-    def __init__(self, platform, configuration=None, architectures=None, triggers=None, remotes=None, additionalArguments=None, **kwargs):
-        factory.BuildFactory.__init__(self)
-        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=triggers, remotes=remotes, additionalArguments=additionalArguments))
-        self.addStep(ValidateChange())
-        self.addStep(PrintConfiguration())
-        self.addStep(CleanGitRepo())
-        self.addStep(SetCredentialHelper())
-        self.addStep(CheckOutSource())
-        self.addStep(FetchBranches())
-        self.addStep(UpdateWorkingDirectory())
-        self.addStep(ShowIdentifier())
-        self.addStep(ApplyPatch())
-        self.addStep(CheckOutPullRequest())
-        self.addStep(ApplyWatchList())
-
-
 class SaferCPPStaticAnalyzerFactory(factory.BuildFactory):
     findModifiedLayoutTests = False
 

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -43,20 +43,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'checkout-pull-request',
             'check-webkit-style'
         ],
-        'Apply-WatchList-EWS': [
-            'configure-build',
-            'validate-change',
-            'configuration',
-            'clean-up-git-repo',
-            'set-credential-helper',
-            'checkout-source',
-            'fetch-branch-references',
-            'update-working-directory',
-            'show-identifier',
-            'apply-patch',
-            'checkout-pull-request',
-            'apply-watch-list'
-        ],
         'GTK-Build-EWS': [
             'configure-build',
             'validate-change',

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -38,7 +38,7 @@ from .factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQu
                         GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
                         StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPECairoBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory, PlayStationBuildFactory,
                         WinBuildFactory, WinTestsFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory,  visionOSBuildFactory, visionOSEmbeddedBuildFactory, visionOSTestsFactory, macOSBuildFactory, macOSBuildOnlyFactory,
-                        macOSWK1Factory, macOSWK2Factory, ServicesFactory, SaferCPPStaticAnalyzerFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)
+                        macOSWK1Factory, macOSWK2Factory, ServicesFactory, SaferCPPStaticAnalyzerFactory, UnsafeMergeQueueFactory, watchOSBuildFactory)
 
 from .utils import get_custom_suffix
 

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6121,24 +6121,6 @@ class CleanGitRepo(steps.ShellSequence, ShellMixin):
         return {'step': 'Cleaned up git repository'}
 
 
-class ApplyWatchList(shell.ShellCommandNewStyle):
-    name = 'apply-watch-list'
-    description = ['applying watchilist']
-    descriptionDone = ['Applied WatchList']
-    bug_id = WithProperties('%(bug_id)s')
-    command = ['python3', 'Tools/Scripts/webkit-patch', 'apply-watchlist-local', bug_id]
-    haltOnFailure = True
-    flunkOnFailure = True
-
-    def __init__(self, **kwargs):
-        super().__init__(timeout=2 * 60, logEnviron=False, **kwargs)
-
-    def getResultSummary(self):
-        if self.results != SUCCESS:
-            return {'step': 'Failed to apply watchlist'}
-        return super().getResultSummary()
-
-
 class PushCommitToWebKitRepo(shell.ShellCommandNewStyle):
     name = 'push-commit-to-webkit-repo'
     descriptionDone = ['Pushed commit to WebKit repository']

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -516,43 +516,6 @@ Total errors found: 8 in 48 files''')
         return self.runStep()
 
 
-class TestApplyWatchList(BuildStepMixinAdditions, unittest.TestCase):
-    def setUp(self):
-        self.longMessage = True
-        return self.setUpBuildStep()
-
-    def tearDown(self):
-        return self.tearDownBuildStep()
-
-    def test_success(self):
-        self.setupStep(ApplyWatchList())
-        self.setProperty('bug_id', '1234')
-        self.expectRemoteCommands(
-            ExpectShell(workdir='wkdir',
-                        timeout=120,
-                        logEnviron=False,
-                        command=['python3', 'Tools/Scripts/webkit-patch', 'apply-watchlist-local', '1234'])
-            + ExpectShell.log('stdio', stdout='Result of watchlist: cc "" messages ""')
-            + 0,
-        )
-        self.expectOutcome(result=SUCCESS, state_string='Applied WatchList')
-        return self.runStep()
-
-    def test_failure(self):
-        self.setupStep(ApplyWatchList())
-        self.setProperty('bug_id', '1234')
-        self.expectRemoteCommands(
-            ExpectShell(workdir='wkdir',
-                        timeout=120,
-                        logEnviron=False,
-                        command=['python3', 'Tools/Scripts/webkit-patch', 'apply-watchlist-local', '1234'])
-            + ExpectShell.log('stdio', stdout='Unexpected failure')
-            + 2,
-        )
-        self.expectOutcome(result=FAILURE, state_string='Failed to apply watchlist')
-        return self.runStep()
-
-
 class TestRunBindingsTests(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True
@@ -4406,7 +4369,7 @@ class TestCheckChangeRelevance(BuildStepMixinAdditions, unittest.TestCase):
 
     def test_queues_without_relevance_info(self):
         CheckChangeRelevance._get_patch = lambda x: 'Sample patch'
-        queues = ['Commit-Queue', 'Style-EWS', 'Apply-WatchList-EWS', 'GTK-Build-EWS', 'GTK-WK2-Tests-EWS',
+        queues = ['Commit-Queue', 'Style-EWS', 'GTK-Build-EWS', 'GTK-WK2-Tests-EWS',
                   'iOS-13-Build-EWS', 'iOS-13-Simulator-Build-EWS', 'iOS-13-Simulator-WK2-Tests-EWS',
                   'macOS-Catalina-Release-Build-EWS', 'macOS-Catalina-Release-WK2-Tests-EWS', 'macOS-Catalina-Debug-Build-EWS',
                   'PlayStation-Build-EWS', 'Win-Build-EWS', 'WPE-Build-EWS', 'WebKitPerl-Tests-EWS', 'WPE-Cairo-Build-EWS']


### PR DESCRIPTION
#### 51ca632654156138327726463d586636b28ae8ef
<pre>
[ews] Remove Apply-WatchList-EWS queue
<a href="https://rdar.apple.com/134890652">rdar://134890652</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284134">https://bugs.webkit.org/show_bug.cgi?id=284134</a>

Reviewed by Brianna Fan.

This change disables Apply-WatchList-EWS. This queue is currently broken and usage of Bugzilla patches has declined.

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/events.py:
(Events):
* Tools/CISupport/ews-build/factories.py:
(StyleFactory.__init__):
(WatchListFactory): Deleted.
(WatchListFactory.__init__): Deleted.
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/ews-build/steps.py:
(CleanGitRepo.getResultSummary):
(ApplyWatchList): Deleted.
(ApplyWatchList.__init__): Deleted.
(ApplyWatchList.getResultSummary): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestCheckChangeRelevance.test_queues_without_relevance_info):

Canonical link: <a href="https://commits.webkit.org/299461@main">https://commits.webkit.org/299461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af1b8a64777a77035bd33097a269600feaa3b590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70567 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2bc5cd9-5d8f-4297-bb23-41ed7bd58371) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89951 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59521 "Too many flaky failures: compositing/transforms/transformed-replaced-with-shadow-children.html, css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/navigation/ping-attribute/anchor-cookie.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/css/css-mixins/function-attr.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, storage/indexeddb/prefetch-invalidation.html, webgl/2.0.y/conformance2/query/occlusion-query.html, webgl/2.0.y/conformance2/textures/canvas/tex-2d-rgba8ui-rgba_integer-unsigned_byte.html, webgl/2.0.y/conformance2/textures/webgl_canvas/tex-2d-rgb565-rgb-unsigned_short_5_6_5.html, webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html, workers/btoa-oom.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc541648-def4-4d35-b3df-3f63c258f704) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70454 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0beeb263-0ee0-4d4f-ab49-9d1505e696d0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68339 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127746 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45415 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98598 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/117932 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41913 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45285 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44748 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48095 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->