### PR TITLE
Add UserMessageHandler.postLegacySynchronousMessage for Music

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -75,6 +75,9 @@ public:
     void disableLegacyOverrideBuiltInsBehavior() { m_shouldDisableLegacyOverrideBuiltInsBehavior = true; }
     bool shouldDisableLegacyOverrideBuiltInsBehavior() const { return m_shouldDisableLegacyOverrideBuiltInsBehavior; }
 
+    void setAllowPostLegacySynchronousMessage() { m_allowPostLegacySynchronousMessage = true; }
+    bool allowPostLegacySynchronousMessage() const { return m_allowPostLegacySynchronousMessage; }
+
     DOMObjectWrapperMap& wrappers() { return m_wrappers; }
 
     Type type() const { return m_type; }
@@ -103,6 +106,7 @@ private:
     bool m_shouldDisableLegacyOverrideBuiltInsBehavior : 1 { false };
     bool m_allowJSHandleCreation : 1 { false };
     bool m_allowNodeSerialization : 1 { false };
+    bool m_allowPostLegacySynchronousMessage : 1 { false };
 };
 
 DOMWrapperWorld& normalWorld(JSC::VM&);

--- a/Source/WebCore/page/UserMessageHandler.cpp
+++ b/Source/WebCore/page/UserMessageHandler.cpp
@@ -65,6 +65,13 @@ ExceptionOr<void> UserMessageHandler::postMessage(JSC::JSGlobalObject& globalObj
     return { };
 }
 
+JSC::JSValue UserMessageHandler::postLegacySynchronousMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+{
+    if (!m_descriptor)
+        return JSC::jsUndefined();
+    return m_descriptor->didPostLegacySynchronousMessage(*this, globalObject, value);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(USER_MESSAGE_HANDLERS)

--- a/Source/WebCore/page/UserMessageHandler.h
+++ b/Source/WebCore/page/UserMessageHandler.h
@@ -49,6 +49,7 @@ public:
     virtual ~UserMessageHandler();
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
+    JSC::JSValue postLegacySynchronousMessage(JSC::JSGlobalObject&, JSC::JSValue);
 
     UserMessageHandlerDescriptor* descriptor() { return m_descriptor.get(); }
     void invalidateDescriptor() { m_descriptor = nullptr; }

--- a/Source/WebCore/page/UserMessageHandler.idl
+++ b/Source/WebCore/page/UserMessageHandler.idl
@@ -31,4 +31,5 @@
     Exposed=Window
 ] interface UserMessageHandler {
     [CallWith=CurrentGlobalObject] Promise<any> postMessage(any message);
+    [CallWith=CurrentGlobalObject, EnabledForWorld=allowPostLegacySynchronousMessage] any postLegacySynchronousMessage(any message);
 };

--- a/Source/WebCore/page/UserMessageHandlerDescriptor.h
+++ b/Source/WebCore/page/UserMessageHandlerDescriptor.h
@@ -52,7 +52,7 @@ public:
     WEBCORE_EXPORT const DOMWrapperWorld& world() const;
 
     virtual void didPostMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue, Function<void(JSC::JSValue, const String&)>&&) = 0;
-
+    virtual JSC::JSValue didPostLegacySynchronousMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue) = 0;
 private:
     AtomString m_name;
     const Ref<DOMWrapperWorld> m_world;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -186,6 +186,7 @@ struct WebPageCreationParameters {
     bool useDarkAppearance { false };
     bool useElevatedUserInterfaceLevel { false };
     bool allowJSHandleInPageContentWorld { false };
+    bool allowPostingLegacySynchronousMessages { false };
 
 #if PLATFORM(MAC)
     std::optional<WebCore::DestinationColorSpace> colorSpace { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -108,6 +108,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     bool useDarkAppearance;
     bool useElevatedUserInterfaceLevel;
     bool allowJSHandleInPageContentWorld;
+    bool allowPostingLegacySynchronousMessages;
 
 #if PLATFORM(MAC)
     std::optional<WebCore::DestinationColorSpace> colorSpace;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -377,6 +377,16 @@ bool PageConfiguration::allowJSHandleInPageContentWorld() const
     return m_data.allowJSHandleInPageContentWorld;
 }
 
+void PageConfiguration::setAllowPostingLegacySynchronousMessages(bool allow)
+{
+    m_data.allowPostingLegacySynchronousMessages = allow;
+}
+
+bool PageConfiguration::allowPostingLegacySynchronousMessages() const
+{
+    return m_data.allowPostingLegacySynchronousMessages;
+}
+
 void PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(bool delaysWebProcessLaunchUntilFirstLoad)
 {
     RELEASE_LOG(Process, "%p - PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(%d)", this, delaysWebProcessLaunchUntilFirstLoad);

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -459,6 +459,9 @@ public:
     void setAllowJSHandleInPageContentWorld(bool);
     bool allowJSHandleInPageContentWorld() const;
 
+    void setAllowPostingLegacySynchronousMessages(bool);
+    bool allowPostingLegacySynchronousMessages() const;
+
     void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_data.contentSecurityPolicyModeForExtension = mode; }
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_data.contentSecurityPolicyModeForExtension; }
 
@@ -644,6 +647,7 @@ private:
         bool showsSystemScreenTimeBlockingView { true };
         bool shouldSendConsoleLogsToUIProcessForTesting { false };
         bool allowJSHandleInPageContentWorld { false };
+        bool allowPostingLegacySynchronousMessages { false };
 
 #if PLATFORM(VISION)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -665,6 +665,23 @@ static NSString *defaultApplicationNameForUserAgent()
         _pageConfiguration->setRelatedPage(nullptr);
 }
 
+- (void)_setAllowPostingLegacySynchronousMessages:(BOOL)allow
+{
+    RetainPtr bundleID = (__bridge NSString *)CFBundleGetIdentifier(CFBundleGetMainBundle());
+    RELEASE_ASSERT([bundleID isEqualToString:@"com.apple.WebKit.TestWebKitAPI"]
+#if PLATFORM(MAC)
+        || [bundleID isEqualToString:@"com.apple.TV"]
+        || [bundleID isEqualToString:@"com.apple.Music"]
+#endif
+    );
+    self._protectedPageConfiguration->setAllowPostingLegacySynchronousMessages(allow);
+}
+
+- (BOOL)_allowPostingLegacySynchronousMessages
+{
+    return self._protectedPageConfiguration->allowPostingLegacySynchronousMessages();
+}
+
 - (WKWebView *)_webViewToCloneSessionStorageFrom
 {
     if (RefPtr page = self._protectedPageConfiguration->pageToCloneSessionStorageFrom())

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -99,6 +99,8 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 @property (nonatomic, setter=_setOverrideReferrerForAllRequests:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+@property (nonatomic, setter=_setAllowPostingLegacySynchronousMessages:) BOOL _allowPostingLegacySynchronousMessages WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @property (nonatomic, readonly) WKWebsiteDataStore *_websiteDataStoreIfExists WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, copy, setter=_setCORSDisablingPatterns:) NSArray<NSString *> *_corsDisablingPatterns WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, copy, setter=_setMaskedURLSchemes:) NSSet<NSString *> *_maskedURLSchemes WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -397,6 +397,11 @@ void WebUserContentControllerProxy::didPostMessage(WebPageProxyIdentifier pagePr
     handler->client().didPostMessage(*page, WTFMove(frameInfoData), handler->world(), WTFMove(message), WTFMove(reply));
 }
 
+void WebUserContentControllerProxy::didPostLegacySynchronousMessage(WebPageProxyIdentifier webPageProxyID, FrameInfoData&& frameInfoData, ScriptMessageHandlerIdentifier messageHandlerID, JavaScriptEvaluationResult&& message, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&& reply)
+{
+    didPostMessage(webPageProxyID, WTFMove(frameInfoData), messageHandlerID, WTFMove(message), WTFMove(reply));
+}
+
 #if ENABLE(CONTENT_EXTENSIONS)
 void WebUserContentControllerProxy::addContentRuleList(API::ContentRuleList& contentRuleList, const WTF::URL& extensionBaseURL)
 {

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -141,8 +141,10 @@ public:
 private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 
     void didPostMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&);
+    void didPostLegacySynchronousMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&);
 
     void addContentWorld(API::ContentWorld&);
 

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in
@@ -30,4 +30,5 @@
 ]
 messages -> WebUserContentControllerProxy {
     DidPostMessage(WebKit::WebPageProxyIdentifier pageID, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, WebKit::JavaScriptEvaluationResult message) -> (Expected<WebKit::JavaScriptEvaluationResult, String> reply)
+    DidPostLegacySynchronousMessage(WebKit::WebPageProxyIdentifier pageID, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, WebKit::JavaScriptEvaluationResult message) -> (Expected<WebKit::JavaScriptEvaluationResult, String> reply) Synchronous
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12163,7 +12163,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 
     parameters.httpsUpgradeEnabled = preferences->upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
     parameters.allowJSHandleInPageContentWorld = m_configuration->allowJSHandleInPageContentWorld();
-    
+    parameters.allowPostingLegacySynchronousMessages = m_configuration->allowPostingLegacySynchronousMessages();
+
 #if ENABLE(APP_HIGHLIGHTS)
     parameters.appHighlightsVisible = appHighlightsVisibility() ? HighlightVisibility::Visible : HighlightVisibility::Hidden;
 #endif

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -131,6 +131,11 @@ void InjectedBundleScriptWorld::setAllowNodeSerialization()
     m_world->setAllowNodeSerialization();
 }
 
+void InjectedBundleScriptWorld::setAllowPostingLegacySynchronousMessages()
+{
+    m_world->setAllowPostLegacySynchronousMessage();
+}
+
 void InjectedBundleScriptWorld::setAllowElementUserInfo()
 {
     m_world->setAllowElementUserInfo();

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -62,6 +62,7 @@ public:
     void disableOverrideBuiltinsBehavior();
     void setAllowJSHandleCreation();
     void setAllowNodeSerialization();
+    void setAllowPostingLegacySynchronousMessages();
 
     const String& name() const { return m_name; }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1187,6 +1187,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
     if (parameters.allowJSHandleInPageContentWorld)
         InjectedBundleScriptWorld::normalWorldSingleton().setAllowJSHandleCreation();
+    if (parameters.allowPostingLegacySynchronousMessages)
+        InjectedBundleScriptWorld::normalWorldSingleton().setAllowPostingLegacySynchronousMessages();
 }
 
 void WebPage::updateAfterDrawingAreaCreation(const WebPageCreationParameters& parameters)


### PR DESCRIPTION
#### 1a312fad1c168e8099434b3a5443247030ddabf4
<pre>
Add UserMessageHandler.postLegacySynchronousMessage for Music
<a href="https://bugs.webkit.org/show_bug.cgi?id=298069">https://bugs.webkit.org/show_bug.cgi?id=298069</a>
<a href="https://rdar.apple.com/159397219">rdar://159397219</a>

Reviewed by Tim Horton.

Music has a vast catalog of static third party web content from the iTunes days that
they can&apos;t update, and it relies on JS synchonously controlling the application.
It has been migrated from WebKitLegacy to multi-process WebKit, but it still relies
on WKBundlePostSynchronousMessage to achieve this functionality.  On Windows, it
uses HostObjectSyncProxy.  This may seem like it is adding a new synchronous message,
but it does so only for Music on macOS, and it provides a path towards removing their
use of WKBundlePostSynchronousMessage and the injected bundle in general.

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::setAllowPostLegacySynchronousMessage):
(WebCore::DOMWrapperWorld::allowPostLegacySynchronousMessage const):
* Source/WebCore/page/UserMessageHandler.cpp:
(WebCore::UserMessageHandler::postLegacySynchronousMessage):
* Source/WebCore/page/UserMessageHandler.h:
* Source/WebCore/page/UserMessageHandler.idl:
* Source/WebCore/page/UserMessageHandlerDescriptor.h:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::setAllowPostingLegacySynchronousMessages):
(API::PageConfiguration::allowPostingLegacySynchronousMessages const):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _setAllowPostingLegacySynchronousMessages:]):
(-[WKWebViewConfiguration _allowPostingLegacySynchronousMessages]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::didPostLegacySynchronousMessage):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::setAllowPostingLegacySynchronousMessages):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(-[TestScriptMessageHandlerWithReply userContentController:didReceiveScriptMessage:replyHandler:]):
(LegacySynchronousMessages)):

Canonical link: <a href="https://commits.webkit.org/299303@main">https://commits.webkit.org/299303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c5d1ab475c5b8cdf1372b8fd9636b8a183f5451

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc44dfd2-797d-45af-a68e-29baefb08b4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46807 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89977 "Found 1 new test failure: http/wpt/service-workers/service-worker-spinning-activate.https.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8055a50c-07ef-446d-a32f-65d763604d59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70481 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ac802aa-460a-4321-8bd1-784af19ca53e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24397 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68375 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/100439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127782 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45451 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102507 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/98399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43837 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21826 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18892 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45321 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50999 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44784 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46471 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->