### PR TITLE
dNR:

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.h
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.h
@@ -233,18 +233,42 @@ struct WEBCORE_EXPORT RedirectAction {
     void applyToRequest(ResourceRequest&, const URL&);
 };
 
-struct ReportIdentifierAction {
+struct ReportIdentifierAction : public ActionWithStringMetadata<ReportIdentifierAction> {
     double identifier;
 
-    ReportIdentifierAction isolatedCopy() const { return { identifier }; }
+    ReportIdentifierAction(String string)
+    : ActionWithStringMetadata<ReportIdentifierAction> { { WTFMove(string) } }
+    , identifier(0)
+    {
+    }
+
+    ReportIdentifierAction(String string, double identifier)
+    : ActionWithStringMetadata<ReportIdentifierAction> { { WTFMove(string) } }
+    , identifier(identifier)
+    {
+    }
+
+    ReportIdentifierAction isolatedCopy() const & { return { string.isolatedCopy(), identifier }; }
+    ReportIdentifierAction isolatedCopy() && { return { WTFMove(string).isolatedCopy(), identifier }; }
     friend bool operator==(const ReportIdentifierAction&, const ReportIdentifierAction&) = default;
+
     void serialize(Vector<uint8_t>& vector) const
     {
         vector.reserveCapacity(vector.size() + sizeof(identifier));
         vector.append(asByteSpan(identifier));
+
+        ActionWithStringMetadata<ReportIdentifierAction>::serialize(vector);
     }
-    static ReportIdentifierAction deserialize(std::span<const uint8_t> span) { return { reinterpretCastSpanStartTo<double>(span) }; }
-    static size_t serializedLength(std::span<const uint8_t>) { return sizeof(identifier); }
+
+    static ReportIdentifierAction deserialize(std::span<const uint8_t> span)
+    {
+        return { ActionWithStringMetadata<ReportIdentifierAction>::deserialize(span.subspan(sizeof(identifier))).string, reinterpretCastSpanStartTo<double>(span) };
+    }
+
+    static size_t serializedLength(std::span<const uint8_t> span)
+    {
+        return ActionWithStringMetadata<ReportIdentifierAction>::serializedLength(span.subspan(sizeof(identifier))) + sizeof(identifier);
+    }
 };
 
 using ActionData = Variant<

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -310,11 +310,14 @@ static std::optional<Expected<ContentExtensionRule, std::error_code>> loadRuleId
     if (!identifier.has_value())
         return makeUnexpected(ContentExtensionError::JSONInvalidRuleIdentifier);
 
+    auto rulesetIdentifierValue = ruleObject.getValue("_rulesetIdentifier"_s);
+    auto rulesetIdentifier = rulesetIdentifierValue ? rulesetIdentifierValue->asString() : nullString();
+
     auto trigger = loadTrigger(ruleObject);
     if (!trigger.has_value())
         return makeUnexpected(trigger.error());
 
-    return { { { WTFMove(trigger.value()), Action { ReportIdentifierAction { identifier.value() } } } } };
+    return { { { WTFMove(trigger.value()), Action { ReportIdentifierAction { rulesetIdentifier, identifier.value() } } } } };
 }
 
 static Expected<Vector<ContentExtensionRule>, std::error_code> loadEncodedRules(const String& ruleJSON, CSSSelectorsAllowed selectorsAllowed)

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -43,6 +43,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "Page.h"
+#include "RegistrableDomain.h"
 #include "ResourceLoadInfo.h"
 #include "ScriptController.h"
 #include "ScriptSourceCode.h"
@@ -246,10 +247,14 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
     URL frameURL;
     bool mainFrameContext = false;
     RequestMethod requestMethod = readRequestMethod(initiatingDocumentLoader.request().httpMethod()).value_or(RequestMethod::None);
+    double frameId;
+    double parentFrameId;
 
     if (auto* frame = initiatingDocumentLoader.frame()) {
         mainFrameContext = frame->isMainFrame();
         currentDocument = frame->document();
+        frameId = mainFrameContext ? 0 : static_cast<double>(frame->frameID().toUInt64());
+        parentFrameId = !mainFrameContext && frame->tree().parent() ? static_cast<double>(frame->tree().parent()->frameID().toUInt64()) : -1;
 
         if (initiatingDocumentLoader.isLoadingMainResource()
             && frame->isMainFrame()
@@ -317,12 +322,30 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
                     results.summary.redirectActions.append({ redirectAction, m_contentExtensions.get(contentRuleListIdentifier)->extensionBaseURL() });
                 }
             }, [&] (const ReportIdentifierAction& reportIdentifierAction) {
-                // FIXME: <rdar://157880177> Include the rest of the parameters on the ContentRuleListMatchedRule struct.
-                ContentRuleListMatchedRule matchedRule;
-                matchedRule.request.url = url.string();
-                matchedRule.rule.extensionId = contentRuleListIdentifier;
-                matchedRule.rule.ruleId = reportIdentifierAction.identifier;
-                page.chrome().client().contentRuleListMatchedRule(matchedRule);
+                std::optional<String> initiator;
+                std::optional<String> documentId;
+                std::optional<String> frameType;
+
+                // FIXME: <rdar://159289161> Include the parentDocumentId parameter once we can make it work with site isolation
+                if (currentDocument && resourceType.containsAny({ ResourceType::TopDocument, ResourceType::ChildDocument }))
+                    documentId = currentDocument->identifier().toString();
+
+                if (resourceType == ResourceType::TopDocument)
+                    frameType = "outermost_frame"_s;
+                else if (resourceType == ResourceType::ChildDocument)
+                    frameType = "sub_frame"_s;
+
+                if (currentDocument && currentDocument->url().isValid()) {
+                    auto domain = RegistrableDomain { frameURL };
+
+                    if (!domain.isEmpty())
+                        initiator = domain.string();
+                }
+
+                // We set the tabId to -1 because it will be filled in by the web extension context.
+                // We create a requestId here since ResourceRequest objects don't have one, and it's a non-optional parameter.
+                // We set documentLifecycle to null because that will require Safari API to be implemented.
+                page.chrome().client().contentRuleListMatchedRule({ { reportIdentifierAction.identifier, reportIdentifierAction.string, contentRuleListIdentifier }, { frameId, parentFrameId, initiatingDocumentLoader.request().httpMethod(), WTF::UUID::createVersion4Weak().toString(), -1, resourceTypeToStringForMatchedRule(resourceType), url.string(), initiator, documentId, std::nullopt, frameType, std::nullopt } });
             }), action.data());
         }
 

--- a/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
+++ b/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
@@ -7,28 +7,35 @@
 namespace WebCore {
 
 struct ContentRuleListMatchedRule {
+    struct MatchedRule {
+        double ruleId;
+        String rulesetId;
+        std::optional<String> extensionId;
+    };
+
     struct Request {
+        double frameId;
+        double parentFrameId;
+        String method;
+        String requestId;
+        double tabId;
+        String type;
+        String url;
+        std::optional<String> initiator;
         std::optional<String> documentId;
         std::optional<String> documentLifecycle;
-        std::optional<double> frameId;
         std::optional<String> frameType;
-        std::optional<String> initiator;
-        std::optional<String> method;
         std::optional<String> parentDocumentId;
-        std::optional<double> parentFrameId;
-        std::optional<String> requestId;
-        std::optional<String> type;
-        std::optional<String> url;
     };
 
-    struct MatchedRule {
-        std::optional<String> extensionId;
-        std::optional<double> ruleId;
-        std::optional<String> rulesetId;
-    };
+    ContentRuleListMatchedRule(MatchedRule rule, Request request)
+        : rule(rule)
+        , request(request)
+    {
+    }
 
-    Request request;
     MatchedRule rule;
+    Request request;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -589,6 +589,9 @@
 /* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many enabled static rulesets */
 "Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored." = "Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.";
 
+/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for a duplicated rule id */
+"`declarative_net_request` ruleset with id `%@` duplicates the rule id `%@`." = "`declarative_net_request` ruleset with id `%@` duplicates the rule id `%@`.";
+
 /* Button for exiting full screen when in full screen media playback */
 "Exit Full Screen" = "Exit Full Screen";
 

--- a/Source/WebCore/loader/ResourceLoadInfo.cpp
+++ b/Source/WebCore/loader/ResourceLoadInfo.cpp
@@ -228,6 +228,39 @@ ASCIILiteral resourceTypeToString(OptionSet<ResourceType> resourceTypes)
     }
 }
 
+ASCIILiteral resourceTypeToStringForMatchedRule(OptionSet<ResourceType> resourceTypes)
+{
+    switch (*resourceTypes.begin()) {
+    case ResourceType::TopDocument:
+        return "main_frame"_s;
+    case ResourceType::ChildDocument:
+        return "sub_frame"_s;
+    case ResourceType::Image:
+        return "image"_s;
+    case ResourceType::StyleSheet:
+        return "stylesheet"_s;
+    case ResourceType::Script:
+        return "script"_s;
+    case ResourceType::Font:
+        return "font"_s;
+    case ResourceType::WebSocket:
+        return "websocket"_s;
+    case ResourceType::Fetch:
+        return "xmlhttprequest"_s;
+    case ResourceType::Media:
+        return "media"_s;
+    case ResourceType::Ping:
+        return "ping"_s;
+    case ResourceType::CSPReport:
+        return "csp_report"_s;
+    case ResourceType::SVGDocument:
+    case ResourceType::Popup:
+    case ResourceType::Other:
+    default:
+        return "other"_s;
+    }
+}
+
 } // namespace WebCore::ContentExtensions
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -102,6 +102,7 @@ std::optional<OptionSet<LoadContext>> readLoadContext(StringView);
 std::optional<RequestMethod> readRequestMethod(StringView);
 
 ASCIILiteral resourceTypeToString(OptionSet<ResourceType>);
+ASCIILiteral resourceTypeToStringForMatchedRule(OptionSet<ResourceType>);
 
 struct ResourceLoadInfo {
     URL resourceURL;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6148,28 +6148,29 @@ struct WebCore::ContentRuleListResults {
 };
 
 struct WebCore::ContentRuleListMatchedRule {
-    WebCore::ContentRuleListMatchedRule::Request request;
     WebCore::ContentRuleListMatchedRule::MatchedRule rule;
+    WebCore::ContentRuleListMatchedRule::Request request;
 };
 
 [Nested] struct WebCore::ContentRuleListMatchedRule::Request {
+    double frameId;
+    double parentFrameId;
+    String method;
+    String requestId;
+    double tabId;
+    String type;
+    String url;
+    std::optional<String> initiator;
     std::optional<String> documentId;
     std::optional<String> documentLifecycle;
-    std::optional<double> frameId;
     std::optional<String> frameType;
-    std::optional<String> initiator;
-    std::optional<String> method;
     std::optional<String> parentDocumentId;
-    std::optional<double> parentFrameId;
-    std::optional<String> requestId;
-    std::optional<String> type;
-    std::optional<String> url;
 };
 
 [Nested] struct WebCore::ContentRuleListMatchedRule::MatchedRule {
+    double ruleId;
+    String rulesetId;
     std::optional<String> extensionId;
-    std::optional<double> ruleId;
-    std::optional<String> rulesetId;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4671,6 +4671,9 @@ void WebExtensionContext::compileDeclarativeNetRequestRules(NSDictionary *rulesD
         NSArray<NSString *> *parsingErrorStrings;
         auto *allConvertedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:allJSONObjects errorStrings:&parsingErrorStrings];
 
+        for (NSString *errorString in parsingErrorStrings)
+            recordError(m_extension->createError(WebExtension::Error::InvalidDeclarativeNetRequest, errorString));
+
         auto *webKitRules = encodeJSONString(allConvertedRules, JSONOptions::FragmentsAllowed);
         if (!webKitRules) {
             dispatch_async(dispatch_get_main_queue(), makeBlockPtr([completionHandler = WTFMove(completionHandler)]() mutable {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -675,6 +675,9 @@ void WebExtensionController::handleContentRuleListMatchedRule(WebPageProxyIdenti
         if (!tab)
             break;
 
+        // FIXME: <rdar://99141106> Implement declarativeNetRequest.testMatchOutcome; until then, extensionId should be null
+        matchedRule.rule.extensionId = std::nullopt;
+        matchedRule.request.tabId = toWebAPI(tab->identifier());
         context->handleContentRuleListMatchedRule(*tab, matchedRule);
 
         break;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
@@ -27,10 +27,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_EXTERN NSString * const sessionRulesetID;
+WK_EXTERN NSString * const dynamicRulesetID;
+
 WK_EXTERN
 @interface _WKWebExtensionDeclarativeNetRequestRule : NSObject
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary errorString:(NSString * _Nullable * _Nullable)outErrorString NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString * _Nullable * _Nullable)outErrorString NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -38,6 +41,7 @@ WK_EXTERN
 
 @property (nonatomic, readonly) NSInteger ruleID;
 @property (nonatomic, readonly) NSInteger priority;
+@property (nonatomic, readonly, copy) NSString *rulesetID;
 @property (nonatomic, readonly, copy) NSDictionary *action;
 @property (nonatomic, readonly, copy) NSDictionary *condition;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -26,6 +26,9 @@
 #import "config.h"
 #import "_WKWebExtensionDeclarativeNetRequestRule.h"
 
+NSString * const sessionRulesetID = @"_session";
+NSString * const dynamicRulesetID = @"_dynamic";
+
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #if !__has_feature(objc_arc)
@@ -112,7 +115,7 @@ using namespace WebKit;
 
 @implementation _WKWebExtensionDeclarativeNetRequestRule
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary errorString:(NSString **)outErrorString
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString **)outErrorString
 {
     if (!(self = [super init]))
         return nil;
@@ -138,6 +141,8 @@ using namespace WebKit;
 
         return nil;
     }
+
+    _rulesetID = rulesetID;
 
     NSString *exceptionString;
     if (!validateDictionary(ruleDictionary, nil, requiredKeysInRuleDictionary, keyToExpectedValueTypeInRuleDictionary, &exceptionString)) {
@@ -879,6 +884,7 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
         @"trigger": triggerDictionary,
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
         @"_identifier": @(_ruleID),
+        @"_rulesetIdentifier": _rulesetID,
 #endif
     };
 
@@ -1252,7 +1258,7 @@ static NSInteger priorityForRuleType(NSString *ruleType)
 
 @implementation _WKWebExtensionDeclarativeNetRequestRule
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary errorString:(NSString **)outErrorString
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString **)outErrorString
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -133,7 +133,6 @@ using namespace WebKit;
         declarativeNetRequestRuleConditionKey: NSDictionary.class,
     };
 
-    // FIXME: <rdar://72159785> Make sure every rule ID is unique.
     _ruleID = objectForKey<NSNumber>(ruleDictionary, declarativeNetRequestRuleIDKey).integerValue;
     if (!_ruleID) {
         if (outErrorString)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 WK_EXTERN
 @interface _WKWebExtensionDeclarativeNetRequestTranslator : NSObject
 
-+ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSArray<NSArray<NSDictionary *> *> *)jsonObjects errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
-+ (NSArray<NSArray<NSDictionary *> *> *)jsonObjectsFromData:(NSArray<NSData *> *)jsonDataArray errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
++ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjects errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
++ (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjectsFromData:(NSDictionary<NSString *, NSData *> *)jsonData errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -740,7 +740,7 @@ private:
     // DeclarativeNetRequest methods.
     // Loading/unloading static rules
     void loadDeclarativeNetRequestRules(CompletionHandler<void(bool)>&&);
-    void compileDeclarativeNetRequestRules(NSArray *, CompletionHandler<void(bool)>&&);
+    void compileDeclarativeNetRequestRules(NSDictionary *, CompletionHandler<void(bool)>&&);
     void unloadDeclarativeNetRequestState();
     String declarativeNetRequestContentRuleListFilePath();
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -82,6 +82,7 @@ static NSString * const methodKey = @"method";
 static NSString * const parentDocumentIdKey = @"parentDocumentId";
 static NSString * const parentFrameIdKey = @"parentFrameId";
 static NSString * const requestIdKey = @"requestId";
+static NSString * const tabIdKey = @"tabId";
 static NSString * const typeKey = @"type";
 static NSString * const urlKey = @"url";
 
@@ -96,22 +97,23 @@ static inline NSDictionary *toWebAPI(const WebCore::ContentRuleListMatchedRule& 
     NSMutableDictionary *request = [NSMutableDictionary dictionary];
     NSMutableDictionary *rule = [NSMutableDictionary dictionary];
 
-    request[documentIdKey] = matchedRuleInfo.request.documentId.has_value() ? matchedRuleInfo.request.documentId.value().createNSString().get() : nil;
-    request[documentLifecycleKey] = matchedRuleInfo.request.documentId.has_value() ? matchedRuleInfo.request.documentLifecycle.value().createNSString().get() : nil;
-    request[frameIdKey] = matchedRuleInfo.request.frameId.has_value() ? @(matchedRuleInfo.request.frameId.value()) : nil;
-    request[frameTypeKey] = matchedRuleInfo.request.frameType.has_value() ? matchedRuleInfo.request.frameType.value().createNSString().get() : nil;
+    request[frameIdKey] = @(matchedRuleInfo.request.frameId);
+    request[parentFrameIdKey] = @(matchedRuleInfo.request.parentFrameId);
+    request[methodKey] = matchedRuleInfo.request.method.createNSString().get();
+    request[requestIdKey] = matchedRuleInfo.request.requestId.createNSString().get();
+    request[typeKey] = matchedRuleInfo.request.type.createNSString().get();
+    request[tabIdKey] = @(matchedRuleInfo.request.tabId);
+    request[urlKey] = matchedRuleInfo.request.url.createNSString().get();
     request[initiatorKey] = matchedRuleInfo.request.initiator.has_value() ? matchedRuleInfo.request.initiator.value().createNSString().get() : nil;
-    request[methodKey] = matchedRuleInfo.request.method.has_value() ? matchedRuleInfo.request.method.value().createNSString().get() : nil;
+    request[documentIdKey] = matchedRuleInfo.request.documentId.has_value() ? matchedRuleInfo.request.documentId.value().createNSString().get() : nil;
+    request[documentLifecycleKey] = matchedRuleInfo.request.documentLifecycle.has_value() ? matchedRuleInfo.request.documentLifecycle.value().createNSString().get() : nil;
+    request[frameTypeKey] = matchedRuleInfo.request.frameType.has_value() ? matchedRuleInfo.request.frameType.value().createNSString().get() : nil;
     request[parentDocumentIdKey] = matchedRuleInfo.request.parentDocumentId.has_value() ? matchedRuleInfo.request.parentDocumentId.value().createNSString().get() : nil;
-    request[parentFrameIdKey] = matchedRuleInfo.request.parentFrameId.has_value() ? @(matchedRuleInfo.request.parentFrameId.value()) : nil;
-    request[requestIdKey] = matchedRuleInfo.request.requestId.has_value() ? matchedRuleInfo.request.requestId.value().createNSString().get() : nil;
-    request[typeKey] = matchedRuleInfo.request.type.has_value() ? matchedRuleInfo.request.type.value().createNSString().get() : nil;
-    request[urlKey] = matchedRuleInfo.request.url.has_value() ? matchedRuleInfo.request.url.value().createNSString().get() : nil;
     result[requestKey] = [request copy];
 
+    rule[ruleIdKey] = @(matchedRuleInfo.rule.ruleId);
+    rule[rulesetIdKey] = matchedRuleInfo.rule.rulesetId.createNSString().get();
     rule[extensionIdKey] = matchedRuleInfo.rule.extensionId.has_value() ? matchedRuleInfo.rule.extensionId.value().createNSString().get() : nil;
-    rule[ruleIdKey] = matchedRuleInfo.rule.ruleId.has_value() ? @(matchedRuleInfo.rule.ruleId.value()) : nil;
-    rule[rulesetIdKey] = matchedRuleInfo.rule.rulesetId.has_value() ? matchedRuleInfo.rule.rulesetId.value().createNSString().get() : nil;
     result[ruleKey] = [rule copy];
 
     return [result copy];
@@ -175,7 +177,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
     NSString *ruleErrorString;
     size_t index = 0;
     for (NSDictionary *ruleDictionary in rulesToAdd) {
-        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
+        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:dynamicRulesetID errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
             *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;
@@ -246,7 +248,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
     NSString *ruleErrorString;
     size_t index = 0;
     for (NSDictionary *ruleDictionary in rulesToAdd) {
-        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
+        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:sessionRulesetID errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
             *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -3434,23 +3434,23 @@ TEST_F(ContentExtensionTest, ReportIdentifierAction)
 {
     // Different identifiers
     auto backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/first\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/second\"},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/first\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset 1\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/second\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset 2\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/first"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/second"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/first"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset 1"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/second"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset 2"_s, 2 } })));
 
     // Different action types and identifiers
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"cookies\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"css\"},\"_identifier\":2},"_s
-        "{\"action\":{\"type\":\"notify\",\"notification\":\"test\"},\"trigger\":{\"url-filter\":\"notify\"},\"_identifier\":3}"_s
+        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"cookies\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"css\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"notify\",\"notification\":\"test\"},\"trigger\":{\"url-filter\":\"notify\"},\"_identifier\":3,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/cookies"_s)), Vector<Action>::from(Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/css"_s)), Vector<Action>::from(Action { ContentExtensions::ReportIdentifierAction { 2 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".hidden"_s } } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/notify"_s)), Vector<Action>::from(Action { ContentExtensions::NotifyAction { { "test"_s } } }, Action { ContentExtensions::ReportIdentifierAction { 3 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/cookies"_s)), Vector<Action>::from(Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/css"_s)), Vector<Action>::from(Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".hidden"_s } } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/notify"_s)), Vector<Action>::from(Action { ContentExtensions::NotifyAction { { "test"_s } } }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 3 } })));
 
     // With and without identifiers
     backend = makeBackend("["_s
@@ -3458,67 +3458,67 @@ TEST_F(ContentExtensionTest, ReportIdentifierAction)
         "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"without-id\"}}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/with-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/with-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { ""_s, 1 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/without-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() })));
 
     // Multiple matches with one request
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":2},"_s
-        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".ad\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":3}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".ad\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":3,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/multi-test"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } }, Action { ContentExtensions::ReportIdentifierAction { 3 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".ad"_s } } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/multi-test"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } }, Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 3 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".ad"_s } } })));
 
     // With conditions
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"if-domain\":[\"example.com\"]},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"unless-domain\":[\"trusted.com\"]},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"if-domain\":[\"example.com\"]},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"unless-domain\":[\"trusted.com\"]},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://example.com/"_s)),
-        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://other.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://other.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://trusted.com/"_s)), Vector<Action>()));
 
     // With resource types
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"script\"]},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"image\"]},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"script\"]},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"image\"]},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.js"_s, ResourceType::Script)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.png"_s, ResourceType::Image)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.js"_s, ResourceType::Script)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.png"_s, ResourceType::Image)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.html"_s)), Vector<Action>()));
 
     // With ignore rules
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
         "{\"action\":{\"type\":\"ignore-previous-rules\"},\"trigger\":{\"url-filter\":\"ignore-previous\"}},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/block-me"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/block-me"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/ignore-previous-block-me"_s)),
-        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } }), true));
+        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } }), true));
 
     // With load types
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"third-party\"]},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"first-party\"]},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"third-party\"]},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"first-party\"]},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://analytics.com/track.js"_s, "https://example.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/analytics"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://analytics.com/track.js"_s, "https://example.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/analytics"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
 
     // With complex regex
     backend = makeBackend("["_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"^https://[a-z]+\\\\.ads\\\\.com/\"},\"_identifier\":1},"_s
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"\\\\.jpg\\\\?.*tracking\"},\"_identifier\":2}"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"^https://[a-z]+\\\\.ads\\\\.com/\"},\"_identifier\":1,\"_rulesetIdentifier\":\"Test Ruleset\"},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"\\\\.jpg\\\\?.*tracking\"},\"_identifier\":2,\"_rulesetIdentifier\":\"Test Ruleset\"}"_s
     "]"_s);
 
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://cdn.ads.com/banner"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
-    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/image.jpg?tracking=123"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://cdn.ads.com/banner"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/image.jpg?tracking=123"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { "Test Ruleset"_s, 2 } })));
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -1448,6 +1448,45 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, OnRuleMatchedDebugDynamicRules)
 }
 #endif
 
+TEST(WKWebExtensionAPIDeclarativeNetRequest, DuplicatedRuleIDs)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"let enabledRulesets = await browser.declarativeNetRequest.getEnabledRulesets()",
+        @"browser.test.assertEq(enabledRulesets.length, 1, 'The static ruleset should be enabled.')",
+
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *declarativeNetRequestManifest = @{
+        @"name": @"Test",
+        @"description": @"Test dNR extension",
+        @"version": @"1",
+        @"manifest_version": @3,
+        @"permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"declarative_net_request": @{
+            @"rule_resources": @[
+                @{
+                    @"id": @"duplicated_rule_id",
+                    @"enabled": @YES,
+                    @"path": @"rules.json"
+                }
+            ]
+        }
+    };
+
+    auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"foo\" } }, { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"bar\" } } ]";
+
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules });
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    NSArray<NSError *> *errors = manager.get().context.errors;
+    ASSERT_EQ(errors.count, 1ul);
+    ASSERT_TRUE([errors.firstObject.localizedDescription isEqualToString:@"`declarative_net_request` ruleset with id `duplicated_rule_id` duplicates the rule id `1`."]);
+}
+
 // MARK: Rule translation tests
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RequiredAndOptionalKeys)


### PR DESCRIPTION
#### e7d817fb0f4fb767b45d24d242c2f22f4aa52694
<pre>
dNR: make sure every rule ID is unique
<a href="https://bugs.webkit.org/show_bug.cgi?id=298070">https://bugs.webkit.org/show_bug.cgi?id=298070</a>
<a href="https://rdar.apple.com/72159785">rdar://72159785</a>

Reviewed by NOBODY (OOPS!).

This simple patch reports an error when a static dNR ruleset contains a duplicate identifier. It&apos;s
important that we do this so that developers are aware that they might be getting incorrect
information from onRuleMatchedDebug.

The error is surfaced in Safari&apos;s extensions preferences pane.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm:
(WebKit::for):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, DuplicatedRuleIDs)):
</pre>
----------------------------------------------------------------------
#### 12356a825f1d591a16934e169cd0801cfede1332
<pre>
dNR: include the rest of the parameters on the MatchedRuleInfoDebug object
<a href="https://bugs.webkit.org/show_bug.cgi?id=297881">https://bugs.webkit.org/show_bug.cgi?id=297881</a>
<a href="https://rdar.apple.com/157880177">rdar://157880177</a>

Reviewed by NOBODY (OOPS!).

This patch makes the necessary changes to include the rest of the information on the MatchedRuleInfo
object that&apos;s passed to the onRuleMatchedDebug listeners.

Most of the request properties could easily be set with the information that is already available in
ContentExtensionsBackend::processContentRuleListsForLoad. However, we are missing the rulesetId
property of the rule object, and it&apos;s not readily available because compiled content rule lists do
not track which ruleset a rule belongs to. This patch updates the ReportIdentifierAction to inherit
from ActionWithStringMetadata so that we can serialize its ruleset identifier too in addition to the
rule identifier.

For cleaner code, we&apos;ve chosen to serialize the ruleset identifier repeatedly because most popular
dNR web extensions appear to choose fairly short strings for the IDs. If this proves to consume too
much memory in the future, we can update the strings to be serialized once and store an index to it
in the ReportIdentifierAction.

The identifiers of static rulesets are set in the manifest. Session and dynamic rules have the
identifier, &quot;_session&quot; and &quot;_dynamic,&quot; respectively.

For information about the properties that we&apos;ve added, take a look at:
<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/onRuleMatchedDebug#listener">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/onRuleMatchedDebug#listener</a>

It&apos;s worth noting that we aren&apos;t including the parentDocumentId right now because there is some work
to be done to support it with site isolation turned on. That work is tracked with: <a href="https://rdar.apple.com/159289161">rdar://159289161</a>

Added a new tests and updated existing tests to validate this fix.

* Source/WebCore/contentextensions/ContentExtensionActions.h:
(WebCore::ContentExtensions::ReportIdentifierAction::ReportIdentifierAction):
(WebCore::ContentExtensions::ReportIdentifierAction::isolatedCopy const):
(WebCore::ContentExtensions::ReportIdentifierAction::isolatedCopy):
(WebCore::ContentExtensions::ReportIdentifierAction::serialize const):
(WebCore::ContentExtensions::ReportIdentifierAction::deserialize):
(WebCore::ContentExtensions::ReportIdentifierAction::serializedLength):
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadRuleIdentifier):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/contentextensions/ContentRuleListMatchedRule.h:
(WebCore::ContentRuleListMatchedRule::ContentRuleListMatchedRule):
* Source/WebCore/loader/ResourceLoadInfo.cpp:
(WebCore::ContentExtensions::resourceTypeToStringForMatchedRule):
* Source/WebCore/loader/ResourceLoadInfo.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::handleContentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::handleContentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule _webKitRuleWithWebKitActionType:chromeActionType:condition:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm:
(WebKit::for):
(+[_WKWebExtensionDeclarativeNetRequestTranslator jsonObjectsFromData:errorStrings:]):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules):
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, ReportIdentifierAction)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7d817fb0f4fb767b45d24d242c2f22f4aa52694

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118527 "Failed to checkout and rebase branch from PR 50036") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/38208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/28859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/70586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120405 "Failed to checkout and rebase branch from PR 50036") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/38904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/46790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/124699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/70586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121480 "Failed to checkout and rebase branch from PR 50036") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/38904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/28859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/124699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/38904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/28859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/68358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/38904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/28859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/45434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/46790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/45798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/28859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/28859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/45304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/50982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/44767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/46454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->