### PR TITLE
Remove WKError macro in WAK code

### DIFF
--- a/Source/WebCore/platform/ios/wak/WAKView.mm
+++ b/Source/WebCore/platform/ios/wak/WAKView.mm
@@ -200,7 +200,7 @@ static void invalidateGStateCallback(WKViewRef view)
     ASSERT(_viewRef);
     if (_viewRef->isa.classInfo == &WKViewClassInfo)
         return adoptNS([[WAKView alloc] _initWithViewRef:_viewRef]).autorelease();
-    WKError ("unable to create wrapper for %s\n", _viewRef->isa.classInfo->name);
+    WTFLogAlways("_wrapperForViewRef: unable to create wrapper for %s\n", _viewRef->isa.classInfo->name);
     return nil;
 }
 
@@ -510,7 +510,7 @@ static void _WAKCopyWrapper(const void *value, void *context)
 {
     CGContextRef context = WKGetCurrentGraphicsContext();
     if (!context) {
-        WKError ("unable to get context for view");
+        WTFLogAlways("displayRect: unable to get context for view");
         return;
     }
 
@@ -525,7 +525,7 @@ static void _WAKCopyWrapper(const void *value, void *context)
 - (void)displayRectIgnoringOpacity:(NSRect)rect inContext:(CGContextRef)context
 {
     if (!context) {
-        WKError ("invalid parameter: context must not be NULL");
+        WTFLogAlways("displayRectIgnoringOpacity: invalid parameter: context must not be NULL");
         return;
     }
 

--- a/Source/WebCore/platform/ios/wak/WKUtilities.c
+++ b/Source/WebCore/platform/ios/wak/WKUtilities.c
@@ -33,10 +33,10 @@
 const CFArrayCallBacks WKCollectionArrayCallBacks = { 0, WKCollectionRetain, WKCollectionRelease, NULL, NULL };
 const CFSetCallBacks WKCollectionSetCallBacks = { 0, WKCollectionRetain, WKCollectionRelease, NULL, NULL, NULL };
 
-const void *WKCollectionRetain (CFAllocatorRef allocator, const void *value)
+const void *WKCollectionRetain(CFAllocatorRef allocator, const void *value)
 {
     UNUSED_PARAM(allocator);
-    return WAKRetain (value);
+    return WAKRetain(value);
 }
 
 const void *WAKRetain(const void *o)
@@ -48,7 +48,7 @@ const void *WAKRetain(const void *o)
     return object;
 }
 
-void WKCollectionRelease (CFAllocatorRef allocator, const void *value)
+void WKCollectionRelease(CFAllocatorRef allocator, const void *value)
 {
     UNUSED_PARAM(allocator);
     WAKRelease (value);
@@ -58,18 +58,18 @@ void WAKRelease(const void *o)
 {
     WAKObjectRef object = (WAKObjectRef)(uintptr_t)o;
 
-    if (object->referenceCount == 0) {
-        WKError ("attempt to release invalid object");
+    if (!object->referenceCount) {
+        WTFLogAlways("WAKRelease: attempt to release invalid object");
         return;
     }
     
     object->referenceCount--;
 
-    if (object->referenceCount == 0) {
+    if (!object->referenceCount) {
         const WKClassInfo *info = object->classInfo;
         while (info) {
             if (info->dealloc)
-                info->dealloc ((void *)(uintptr_t)object);
+                info->dealloc((void *)(uintptr_t)object);
             info = info->parent;
         }
     }
@@ -82,7 +82,7 @@ static void WAKObjectDealloc(WAKObjectRef v)
 
 WKClassInfo WAKObjectClass = { 0, "WAKObject", WAKObjectDealloc };
 
-const void *WKCreateObjectWithSize (size_t size, WKClassInfo *info)
+const void *WKCreateObjectWithSize(size_t size, WKClassInfo *info)
 {
     WAKObjectRef object = (WAKObjectRef)calloc(size, 1);
     if (!object)
@@ -95,24 +95,13 @@ const void *WKCreateObjectWithSize (size_t size, WKClassInfo *info)
     return object;
 }
 
-WTF_ATTRIBUTE_PRINTF(4, 5)
-void WKReportError(const char *file, int line, const char *function, const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    fprintf(stderr, "%s:%d %s:  ", file, line, function);
-    vfprintf(stderr, format, args);
-    va_end(args);
-    fprintf(stderr, "\n");
-}
-
-CFIndex WKArrayIndexOfValue (CFArrayRef array, const void *value)
+CFIndex WKArrayIndexOfValue(CFArrayRef array, const void *value)
 {
     CFIndex i, count, index = -1;
 
-    count = CFArrayGetCount (array);
+    count = CFArrayGetCount(array);
     for (i = 0; i < count; i++) {
-        if (CFArrayGetValueAtIndex (array, i) == value) {
+        if (CFArrayGetValueAtIndex(array, i) == value) {
             index = i;
             break;
         }

--- a/Source/WebCore/platform/ios/wak/WKUtilities.h
+++ b/Source/WebCore/platform/ios/wak/WKUtilities.h
@@ -67,9 +67,6 @@ void WAKRelease(const void *object);
 const void *WKCollectionRetain (CFAllocatorRef allocator, const void *value);
 void WKCollectionRelease (CFAllocatorRef allocator, const void *value);
 
-void WKReportError(const char *file, int line, const char *function, const char *format, ...);
-#define WKError(formatAndArgs...) WKReportError(__FILE__, __LINE__, __PRETTY_FUNCTION__, formatAndArgs)
-
 CFIndex WKArrayIndexOfValue (CFArrayRef array, const void *value);
 
 WKClassInfo *WKGetClassInfo(WAKObjectRef);

--- a/Source/WebCore/platform/ios/wak/WKView.mm
+++ b/Source/WebCore/platform/ios/wak/WKView.mm
@@ -34,7 +34,7 @@
 #import <wtf/Assertions.h>
 #import <wtf/IteratorRange.h>
 
-void _WKViewSetSuperview (WKViewRef view, WKViewRef superview)
+void _WKViewSetSuperview(WKViewRef view, WKViewRef superview)
 {
     // Not retained.
     view->superview = superview;
@@ -46,7 +46,7 @@ void _WKViewWillRemoveSubview(WKViewRef view, WKViewRef subview)
         view->context->willRemoveSubviewCallback(view, subview);
 }
 
-void _WKViewSetWindow (WKViewRef view, WAKWindow *window)
+void _WKViewSetWindow(WKViewRef view, WAKWindow *window)
 {
     if (view->window == window)
         return;
@@ -104,40 +104,40 @@ void WKViewInitialize (WKViewRef view, CGRect frame, WKViewContext *context)
 
 WKClassInfo WKViewClassInfo = { &WAKObjectClass, "WKView", _WKViewDealloc };
 
-WKViewRef WKViewCreateWithFrame (CGRect frame, WKViewContext *context)
+WKViewRef WKViewCreateWithFrame(CGRect frame, WKViewContext *context)
 {
     WKViewRef view = static_cast<WKViewRef>(const_cast<void*>(WKCreateObjectWithSize(sizeof(struct _WKView), &WKViewClassInfo)));
     if (!view)
         return 0;
     
-    WKViewInitialize (view, frame, context);
+    WKViewInitialize(view, frame, context);
     
     return view;
 }
 
-void _WKViewSetViewContext (WKViewRef view, WKViewContext *context)
+void _WKViewSetViewContext(WKViewRef view, WKViewContext *context)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("_WKViewSetViewContext: invalid parameter");
         return;
     }
     view->context = context;
 }
 
-CGRect WKViewGetBounds (WKViewRef view)
+CGRect WKViewGetBounds(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewGetBounds: invalid parameter");
         return CGRectZero;
     }
     
     return view->bounds;
 }
 
-CGRect WKViewGetFrame (WKViewRef view)
+CGRect WKViewGetFrame(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewGetFrame: invalid parameter");
         return CGRectZero;
     }
     
@@ -147,7 +147,7 @@ CGRect WKViewGetFrame (WKViewRef view)
 CGPoint WKViewGetOrigin(WKViewRef view)
 {
     if (!view) {
-        WKError("invalid parameter");
+        WTFLogAlways("WKViewGetOrigin: invalid parameter");
         return CGPointZero;
     }
 
@@ -157,7 +157,7 @@ CGPoint WKViewGetOrigin(WKViewRef view)
 static void _WKViewRecursivelyInvalidateGState(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("_WKViewRecursivelyInvalidateGState: invalid parameter");
         return;
     }
 
@@ -171,10 +171,10 @@ static void _WKViewRecursivelyInvalidateGState(WKViewRef view)
     }
 }
 
-void WKViewSetFrameOrigin (WKViewRef view, CGPoint newOrigin)
+void WKViewSetFrameOrigin(WKViewRef view, CGPoint newOrigin)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewSetFrameOrigin: invalid parameter");
         return;
     }
     
@@ -320,10 +320,10 @@ static void _WKViewAutoresizeChildren(WKViewRef view, const CGRect *oldSuperFram
     }        
 }
 
-void WKViewSetFrameSize (WKViewRef view, CGSize newSize)
+void WKViewSetFrameSize(WKViewRef view, CGSize newSize)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewSetFrameSize: invalid parameter");
         return;
     }
     
@@ -339,7 +339,7 @@ void WKViewSetFrameSize (WKViewRef view, CGSize newSize)
     WKViewSetBoundsSize(view, boundsSize);
 }
 
-void WKViewSetBoundsSize (WKViewRef view, CGSize newSize)
+void WKViewSetBoundsSize(WKViewRef view, CGSize newSize)
 {
     if (CGSizeEqualToSize(view->bounds.size, newSize))
         return;
@@ -349,7 +349,7 @@ void WKViewSetBoundsSize (WKViewRef view, CGSize newSize)
     CGRect newFrame = WKViewGetFrame(view);
     
     if (view->context && view->context->notificationCallback)
-        view->context->notificationCallback (view, WKViewNotificationViewFrameSizeChanged, view->context->notificationUserInfo);
+        view->context->notificationCallback(view, WKViewNotificationViewFrameSizeChanged, view->context->notificationUserInfo);
     
     _WKViewAutoresizeChildren(view, &oldFrame, &newFrame);    
     _WKViewRecursivelyInvalidateGState(view);
@@ -376,7 +376,7 @@ void WKViewSetScale(WKViewRef view, float scale)
     view->scale = scale;
     
     if (view->context && view->context->notificationCallback)
-        view->context->notificationCallback (view, WKViewNotificationViewFrameSizeChanged, view->context->notificationUserInfo);
+        view->context->notificationCallback(view, WKViewNotificationViewFrameSizeChanged, view->context->notificationUserInfo);
 }
 
 float WKViewGetScale(WKViewRef view)
@@ -384,79 +384,78 @@ float WKViewGetScale(WKViewRef view)
     return view->scale;
 }
 
-WAKWindow *WKViewGetWindow (WKViewRef view)
+WAKWindow *WKViewGetWindow(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewGetWindow: invalid parameter");
         return 0;
     }
     
     return view->window;
 }
 
-CFArrayRef WKViewGetSubviews (WKViewRef view)
+CFArrayRef WKViewGetSubviews(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewGetSubviews: invalid parameter");
         return 0;
     }
     
     return view->subviews;
 }
 
-void WKViewAddSubview (WKViewRef view, WKViewRef subview)
+void WKViewAddSubview(WKViewRef view, WKViewRef subview)
 {
     if (!view || !subview) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewAddSubview: invalid parameter");
         return;
     }
     
-    if (!view->subviews) {
+    if (!view->subviews)
         view->subviews = CFArrayCreateMutable(NULL, 0, &WKCollectionArrayCallBacks);
-    }
-    CFArrayAppendValue (view->subviews, subview);
-    _WKViewSetSuperview (subview, view);
-    
+
+    CFArrayAppendValue(view->subviews, subview);
+    _WKViewSetSuperview(subview, view);
+
     // Set the window on subview and all it's children.
-    _WKViewSetWindow (subview, view->window);
+    _WKViewSetWindow(subview, view->window);
 }
 
-void WKViewRemoveFromSuperview (WKViewRef view)
+void WKViewRemoveFromSuperview(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewRemoveFromSuperview: invalid parameter");
         return;
     }
 
-    _WKViewSetWindow (view, 0);
+    _WKViewSetWindow(view, 0);
 
-    if (!view->superview) {
+    if (!view->superview)
         return;
-    }
     
     CFMutableArrayRef svs = view->superview->subviews;
     if (!svs) {
-        WKError ("superview has no subviews");
+        WTFLogAlways("WKViewRemoveFromSuperview: superview has no subviews");
         return;
     }
 
-    CFIndex index = WKArrayIndexOfValue (svs, view);
+    CFIndex index = WKArrayIndexOfValue(svs, view);
     if (index < 0) {
-        WKError ("view not in superview subviews");
+        WTFLogAlways("WKViewRemoveFromSuperview: view not in superview subviews");
         return;
     }
 
     _WKViewWillRemoveSubview(view->superview, view);
     
-    CFArrayRemoveValueAtIndex (svs, index);
+    CFArrayRemoveValueAtIndex(svs, index);
 
-    _WKViewSetSuperview (view, 0);
+    _WKViewSetSuperview(view, 0);
 }
 
-WKViewRef WKViewFirstChild (WKViewRef view)
+WKViewRef WKViewFirstChild(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewFirstChild: invalid parameter");
         return 0;
     }
 
@@ -465,17 +464,17 @@ WKViewRef WKViewFirstChild (WKViewRef view)
     if (!sv)
         return 0;
         
-    CFIndex count = CFArrayGetCount (sv);
+    CFIndex count = CFArrayGetCount(sv);
     if (!count)
         return 0;
         
     return static_cast<WKViewRef>(const_cast<void*>(CFArrayGetValueAtIndex(sv, 0)));
 }
 
-WKViewRef WKViewNextSibling (WKViewRef view)
+WKViewRef WKViewNextSibling(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewNextSibling: invalid parameter");
         return 0;
     }
 
@@ -486,14 +485,14 @@ WKViewRef WKViewNextSibling (WKViewRef view)
     if (!svs)
         return 0;
         
-    CFIndex thisIndex = WKArrayIndexOfValue (svs, view);
+    CFIndex thisIndex = WKArrayIndexOfValue(svs, view);
     if (thisIndex < 0) {
-        WKError ("internal error, view is not present in superview subviews");
+        WTFLogAlways("WKViewNextSibling: internal error, view is not present in superview subviews");
         return 0;
     }
     
-    CFIndex count = CFArrayGetCount (svs);
-    if (thisIndex+1 >= count)
+    CFIndex count = CFArrayGetCount(svs);
+    if (thisIndex + 1 >= count)
         return 0;
         
     return static_cast<WKViewRef>(const_cast<void*>(CFArrayGetValueAtIndex(svs, thisIndex + 1)));
@@ -503,7 +502,7 @@ WKViewRef WKViewNextSibling (WKViewRef view)
 WKViewRef WKViewTraverseNext(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewTraverseNext: invalid parameter");
         return 0;
     }
 
@@ -539,7 +538,7 @@ CGAffineTransform _WKViewGetTransform(WKViewRef view)
 CGRect WKViewGetVisibleRect(WKViewRef viewRef)
 {
     if (!viewRef) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewGetVisibleRect: invalid parameter");
         return CGRectZero;
     }
 
@@ -565,7 +564,7 @@ CGRect WKViewGetVisibleRect(WKViewRef viewRef)
 CGRect WKViewConvertRectToSuperview(WKViewRef view, CGRect r)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertRectToSuperview: invalid parameter");
         return CGRectZero;
     }
     
@@ -575,14 +574,14 @@ CGRect WKViewConvertRectToSuperview(WKViewRef view, CGRect r)
 CGRect WKViewConvertRectToBase(WKViewRef view, CGRect r)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertRectToBase: invalid parameter");
         return CGRectZero;
     }
 
     CGRect aRect = r;
     
     while (view) {
-        aRect = WKViewConvertRectToSuperview (view, aRect);    
+        aRect = WKViewConvertRectToSuperview(view, aRect);
         view = view->superview;
     }
     
@@ -592,7 +591,7 @@ CGRect WKViewConvertRectToBase(WKViewRef view, CGRect r)
 CGPoint WKViewConvertPointToSuperview(WKViewRef view, CGPoint p)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertPointToSuperview: invalid parameter");
         return CGPointZero;
     }
 
@@ -602,7 +601,7 @@ CGPoint WKViewConvertPointToSuperview(WKViewRef view, CGPoint p)
 CGPoint WKViewConvertPointFromSuperview(WKViewRef view, CGPoint p)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertPointFromSuperview: invalid parameter");
         return CGPointZero;
     }
     
@@ -613,14 +612,14 @@ CGPoint WKViewConvertPointFromSuperview(WKViewRef view, CGPoint p)
 CGPoint WKViewConvertPointToBase(WKViewRef view, CGPoint p)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertPointToBase: invalid parameter");
         return CGPointZero;
     }
 
     CGPoint aPoint = p;
     
     while (view) {
-        aPoint = WKViewConvertPointToSuperview (view, aPoint);    
+        aPoint = WKViewConvertPointToSuperview(view, aPoint);
         view = view->superview;
     }
     
@@ -638,7 +637,7 @@ static std::span<WKViewRef> _WKViewGetAncestorViewsIncludingView(WKViewRef view,
     while (superview) {
         views[count++] = superview;
         if (count >= views.size()) {
-            WKError ("Exceeded maxViews, use malloc/realloc");
+            WTFLogAlways("_WKViewGetAncestorViewsIncludingView: Exceeded maxViews, use malloc/realloc");
             return { };
         }
         superview = superview->superview;
@@ -649,7 +648,7 @@ static std::span<WKViewRef> _WKViewGetAncestorViewsIncludingView(WKViewRef view,
 CGPoint WKViewConvertPointFromBase(WKViewRef view, CGPoint p)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertPointFromBase: invalid parameter");
         return CGPointZero;
     }
 
@@ -667,7 +666,7 @@ CGPoint WKViewConvertPointFromBase(WKViewRef view, CGPoint p)
 CGRect WKViewConvertRectFromSuperview(WKViewRef view, CGRect r)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertRectFromSuperview: invalid parameter");
         return CGRectZero;
     }
     
@@ -678,7 +677,7 @@ CGRect WKViewConvertRectFromSuperview(WKViewRef view, CGRect r)
 CGRect WKViewConvertRectFromBase(WKViewRef view, CGRect r)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewConvertRectFromBase: invalid parameter");
         return CGRectZero;
     }
 
@@ -693,7 +692,7 @@ CGRect WKViewConvertRectFromBase(WKViewRef view, CGRect r)
     return aRect;
 }
 
-bool WKViewAcceptsFirstResponder (WKViewRef view)
+bool WKViewAcceptsFirstResponder(WKViewRef view)
 {
     bool result = TRUE;
     if (view && view->context && view->context->responderCallback)
@@ -701,7 +700,7 @@ bool WKViewAcceptsFirstResponder (WKViewRef view)
     return result;
 }
 
-bool WKViewBecomeFirstResponder (WKViewRef view)
+bool WKViewBecomeFirstResponder(WKViewRef view)
 {
     bool result = TRUE;
     if (view && view->context && view->context->responderCallback)
@@ -709,7 +708,7 @@ bool WKViewBecomeFirstResponder (WKViewRef view)
     return result;
 }
 
-bool WKViewResignFirstResponder (WKViewRef view)
+bool WKViewResignFirstResponder(WKViewRef view)
 {
     bool result = TRUE;
     if (view && view->context && view->context->responderCallback)
@@ -720,16 +719,16 @@ bool WKViewResignFirstResponder (WKViewRef view)
 unsigned int WKViewGetAutoresizingMask(WKViewRef view)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewGetAutoresizingMask: invalid parameter");
         return 0;
     }    
     return view->autoresizingMask;
 }
 
-void WKViewSetAutoresizingMask (WKViewRef view, unsigned int mask)
+void WKViewSetAutoresizingMask(WKViewRef view, unsigned int mask)
 {
     if (!view) {
-        WKError ("invalid parameter");
+        WTFLogAlways("WKViewSetAutoresizingMask: invalid parameter");
         return;
     }    
     view->autoresizingMask = mask;


### PR DESCRIPTION
#### cda7d3dc6f70f7892387756c89c31711db0fca7b
<pre>
Remove WKError macro in WAK code
<a href="https://bugs.webkit.org/show_bug.cgi?id=298074">https://bugs.webkit.org/show_bug.cgi?id=298074</a>
<a href="https://rdar.apple.com/159403426">rdar://159403426</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Use the more common and safer WTFLogAlways instead. And fix a few existing style violations.

* Source/WebCore/platform/ios/wak/WAKView.mm:
(+[WAKView _wrapperForViewRef:]):
(-[WAKView displayRect:]):
(-[WAKView displayRectIgnoringOpacity:inContext:]):
* Source/WebCore/platform/ios/wak/WKUtilities.c:
(WKCollectionRelease):
(WAKRelease):
(WKArrayIndexOfValue):
(WKReportError): Deleted.
* Source/WebCore/platform/ios/wak/WKUtilities.h:
* Source/WebCore/platform/ios/wak/WKView.mm:
(_WKViewSetSuperview):
(_WKViewSetWindow):
(_WKViewSetViewContext):
(WKViewGetBounds):
(WKViewGetFrame):
(WKViewGetOrigin):
(_WKViewRecursivelyInvalidateGState):
(WKViewSetFrameOrigin):
(WKViewSetFrameSize):
(WKViewSetBoundsSize):
(WKViewSetScale):
(WKViewGetWindow):
(WKViewGetSubviews):
(WKViewAddSubview):
(WKViewRemoveFromSuperview):
(WKViewFirstChild):
(WKViewNextSibling):
(WKViewTraverseNext):
(WKViewGetVisibleRect):
(WKViewConvertRectToSuperview):
(WKViewConvertRectToBase):
(WKViewConvertPointToSuperview):
(WKViewConvertPointFromSuperview):
(WKViewConvertPointToBase):
(_WKViewGetAncestorViewsIncludingView):
(WKViewConvertPointFromBase):
(WKViewConvertRectFromSuperview):
(WKViewConvertRectFromBase):
(WKViewAcceptsFirstResponder):
(WKViewBecomeFirstResponder):
(WKViewResignFirstResponder):
(WKViewGetAutoresizingMask):
(WKViewSetAutoresizingMask):

Canonical link: <a href="https://commits.webkit.org/299297@main">https://commits.webkit.org/299297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/187b1548484d803d6bc5e24c601f1250abbae17a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118538 "35 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124710 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/70597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2612f995-3ca5-4802-be54-2e5b4cd11095) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/70597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ada5188-58e3-4873-8092-9b191b9fb6b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70477 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30a99d21-90a7-4e2a-92a5-67e04e463fba) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24392 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68369 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24583 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45445 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/127776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102502 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/127776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25013 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43827 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50993 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/44778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->