### PR TITLE
Use official HDR-suppression APIs

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -71,17 +71,6 @@ classes = [
 ]
 
 [[temporary-usage]]
-request = "rdar://157880054"
-cleanup = "rdar://157880263"
-classes = [
-    "_UITraitHDRHeadroomUsage",
-]
-selectors = [
-    { name = "_headroomUsage", class = "UITraitCollection" },
-]
-requires = ["HAVE_SUPPORT_HDR_DISPLAY_APIS"]
-
-[[temporary-usage]]
 request = "rdar://157884624"
 cleanup = "rdar://157884972"
 selectors = [

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -107,7 +107,7 @@
 #endif
 
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-#import <UIKit/_UITraitHDRHeadroomUsage.h>
+#import <UIKit/UITraitCollection.h>
 #endif
 
 #import <pal/ios/ManagedConfigurationSoftLink.h>
@@ -291,8 +291,8 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
 #endif
 
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-    [self registerForTraitChanges:@[[_UITraitHDRHeadroomUsage class]] withAction:@selector(_UITraitHDRHeadroomUsageDidChange)];
-    [self _UITraitHDRHeadroomUsageDidChange];
+    [self registerForTraitChanges:@[[UITraitHDRHeadroomUsageLimit class]] withAction:@selector(_hdrHeadroomUsageLimitDidChange)];
+    [self _hdrHeadroomUsageLimitDidChange];
 #endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 }
 
@@ -3919,10 +3919,10 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 #endif // HAVE(UIKIT_RESIZABLE_WINDOWS)
 
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-- (void)_UITraitHDRHeadroomUsageDidChange
+- (void)_hdrHeadroomUsageLimitDidChange
 {
-    const _UIHDRHeadroomUsage _headroomUsage = [[self traitCollection] _headroomUsage];
-    _page->setShouldSuppressHDR(_headroomUsage != _UIHDRHeadroomUsageEnabled);
+    const UIHDRHeadroomUsageLimit hdrHeadroomUsageLimit = [[self traitCollection] hdrHeadroomUsageLimit];
+    _page->setShouldSuppressHDR(hdrHeadroomUsageLimit == UIHDRHeadroomUsageLimitActive);
 }
 #endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 


### PR DESCRIPTION
#### 1a76ef7e9b2af3d12aa84871e3eb566cdddedd72
<pre>
Use official HDR-suppression APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=298075">https://bugs.webkit.org/show_bug.cgi?id=298075</a>
<a href="https://rdar.apple.com/153610894">rdar://153610894</a>

Reviewed by Aditya Keerthi.

The iOS SDK now includes the UITraitHDRHeadroomUsageLimit class, which
provides trait-change notifications when the app should limit (or not)
its high dynamic range.

* Source/WebKit/Configurations/AllowedSPI.toml: Remove the now-unused SPI, see <a href="https://rdar.apple.com/157880263">rdar://157880263</a>
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _registerForNotifications]):
(-[WKWebView _hdrHeadroomUsageLimitDidChange]):
(-[WKWebView _UITraitHDRHeadroomUsageDidChange]): Deleted.

Canonical link: <a href="https://commits.webkit.org/299343@main">https://commits.webkit.org/299343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2587973b91bcd4d3ef1116eb49532efc8c3b1ee2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70636 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/466d9618-6606-452f-ab14-2366cc9c3a88) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89997 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59547 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb3999ff-2959-4302-9262-6bc1ebe66569) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70501 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5addd232-6ea0-433e-85e9-481aaca9a270) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30083 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68411 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127815 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98630 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25042 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21850 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41982 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51032 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46504 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->