### PR TITLE
Change Options::initialize() to be able to take a lambda for options customization.

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCOptions.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCOptions.cpp
@@ -191,7 +191,7 @@ static gboolean jscOptionsSetValue(const char* option, const GValue* value)
         return TRUE;                                                    \
     }
 
-    Options::initialize();
+    Options::initialize([] { });
     FOR_EACH_JSC_OPTION(SET_OPTION_VALUE)
 #undef SET_OPTION_VALUE
 
@@ -209,7 +209,7 @@ static gboolean jscOptionsGetValue(const char* option, GValue* value)
         return TRUE;                                                    \
     }
 
-    Options::initialize();
+    Options::initialize([] { });
     FOR_EACH_JSC_OPTION(GET_OPTION_VALUE)
 #undef GET_OPTION_VALUE
 
@@ -646,7 +646,7 @@ void jsc_options_foreach(JSCOptionsFunc function, gpointer userData)
             return;                                                     \
     }
 
-    Options::initialize();
+    Options::initialize([] { });
     FOR_EACH_JSC_OPTION(VISIT_OPTION)
 #undef VISIT_OPTION
 }
@@ -703,7 +703,7 @@ GOptionGroup* jsc_options_get_option_group(void)
         names->append(WTFMove(name));                                   \
     }
 
-    Options::initialize();
+    Options::initialize([] { });
     FOR_EACH_JSC_OPTION(REGISTER_OPTION)
 #undef REGISTER_OPTION
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -6061,7 +6061,9 @@ static void testGPRInfoConsistency()
 // Using WTF_IGNORES_THREAD_SAFETY_ANALYSIS because the function is still holding crashLock when exiting.
 void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
-    JSC::initialize();
+    JSC::initialize([] {
+        JSC::Options::useJITCage() = false;
+    });
     unsigned numberOfTests = 0;
 
     Deque<RefPtr<SharedTask<void()>>> tasks;

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2865,7 +2865,9 @@ int main(int argc, char** argv)
         break;
     }
     
-    JSC::initialize();
+    JSC::initialize([] {
+        JSC::Options::useJITCage() = false;
+    });
 
     for (unsigned i = 0; i <= 2; ++i) {
         JSC::Options::defaultB3OptLevel() = i;

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1010,7 +1010,9 @@ int main(int argc, char** argv)
     JSC::Config::configureForTesting();
 
     WTF::initializeMainThread();
-    JSC::initialize();
+    JSC::initialize([] {
+        JSC::Options::useJITCage() = false;
+    });
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
     JSC::JITOperationList::populatePointersInEmbedder(&startOfJITOperationsInTestB3, &endOfJITOperationsInTestB3);

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4071,12 +4071,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void CommandLine::parseArguments(int argc, char** argv)
 {
     Options::AllowUnfinalizedAccessScope scope;
-    Options::initialize();
-    Options::useSharedArrayBuffer() = true;
-
+    Options::initialize([] {
+        Options::useSharedArrayBuffer() = true;
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(APPLETV) && !PLATFORM(WATCHOS)
-    Options::crashIfCantAllocateJITMemory() = true;
+        Options::crashIfCantAllocateJITMemory() = true;
 #endif
+    });
 
     if (Options::dumpOptions()) {
         printf("Command line:");

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -76,11 +76,18 @@ enum class JSCProfileTag { };
 
 void initialize()
 {
+    initialize([] {
+        // No extra options customization needed by default.
+    });
+}
+
+void initializeWithOptionsCustomization(const ScopedLambda<void()>& optionsCustomizationCallback)
+{
     static std::once_flag onceFlag;
 
-    std::call_once(onceFlag, [] {
+    std::call_once(onceFlag, [&] {
         WTF::initialize();
-        Options::initialize();
+        Options::initialize(optionsCustomizationCallback);
 
         initializePtrTagLookup();
 

--- a/Source/JavaScriptCore/runtime/InitializeThreading.h
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,9 +29,17 @@
 #pragma once
 
 #include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/ScopedLambda.h>
+#include <wtf/StdLibExtras.h>
 
 namespace JSC {
 
 JS_EXPORT_PRIVATE void initialize();
+JS_EXPORT_PRIVATE void initializeWithOptionsCustomization(const ScopedLambda<void()>& optionsCustomizationCallback);
+
+ALWAYS_INLINE void initialize(const Invocable<void()> auto& optionsCustomizationCallback)
+{
+    SUPPRESS_FORWARD_DECL_ARG initializeWithOptionsCustomization(scopedLambda<void()>(optionsCustomizationCallback));
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1000,13 +1000,13 @@ inline bool strncasecmp(const char* str1, const char* str2, size_t n)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-void Options::initialize()
+void Options::initializeWithOptionsCustomization(const ScopedLambda<void()>& optionsCustomizationCallback)
 {
     static std::once_flag initializeOptionsOnceFlag;
     
     std::call_once(
         initializeOptionsOnceFlag,
-        [] {
+        [&] {
             AllowUnfinalizedAccessScope scope;
 
             // Sanity check that options address computation is working.
@@ -1074,6 +1074,9 @@ void Options::initialize()
                 (hwPhysicalCPUMax() >= 4) && (hwL3CacheSize() >= static_cast<int64_t>(6 * MB));
 #endif
 
+            // Client gets the last word on what options they want to override.
+            optionsCustomizationCallback();
+
             // No more options changes after this point. notifyOptionsChanged() will
             // do sanity checks and fix up options as needed.
             notifyOptionsChanged();
@@ -1084,7 +1087,6 @@ void Options::initialize()
             if (Options::useMachForExceptions())
                 handleSignalsWithMach();
 #endif
-
     });
 }
 

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
+#include <wtf/ScopedLambda.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -109,7 +110,13 @@ public:
 #endif
     };
 
-    JS_EXPORT_PRIVATE static void initialize();
+    JS_EXPORT_PRIVATE static void initializeWithOptionsCustomization(const ScopedLambda<void()>& optionsCustomizationCallback);
+
+    ALWAYS_INLINE static void initialize(const Invocable<void()> auto& optionsCustomizationCallback)
+    {
+        SUPPRESS_FORWARD_DECL_ARG initializeWithOptionsCustomization(scopedLambda<void()>(optionsCustomizationCallback));
+    }
+
     static void finalize();
 
     JS_EXPORT_PRIVATE static bool setAllJITCodeValidations(const char* arg);


### PR DESCRIPTION
#### 08920cfe4e8592299e984d0df6de401c79fb72b4
<pre>
Change Options::initialize() to be able to take a lambda for options customization.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298077">https://bugs.webkit.org/show_bug.cgi?id=298077</a>
<a href="https://rdar.apple.com/159407484">rdar://159407484</a>

Reviewed by Yusuke Suzuki.

We&apos;ll also use this mechanism to disable JSC_useJITCage for testmasm, testair, and testb3.
These tests are not intended to exercise JITCage functionality.

* Source/JavaScriptCore/API/glib/JSCOptions.cpp:
(jscOptionsSetValue):
(jscOptionsGetValue):
(jsc_options_foreach):
(jsc_options_get_option_group):
* Source/JavaScriptCore/assembler/testmasm.cpp:
* Source/JavaScriptCore/b3/air/testair.cpp:
(main):
* Source/JavaScriptCore/b3/testb3_1.cpp:
(main):
* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
(JSC::initializeWithOptionsCustomization):
* Source/JavaScriptCore/runtime/InitializeThreading.h:
(JSC::initialize):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::initializeWithOptionsCustomization):
(JSC::Options::initialize): Deleted.
* Source/JavaScriptCore/runtime/Options.h:
(JSC::Options::initialize):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::setJSCOptions):
(WebKit::disableJSC):

Canonical link: <a href="https://commits.webkit.org/299323@main">https://commits.webkit.org/299323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5150c2b57da893962d11589e7991b58758fcc805

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70621 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0bd89ee-f44f-4e60-ae98-9c09b4da0a47) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89988 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a6fe821-9a9a-4281-aa19-583752bcff69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ffbfc2a-c448-4b5d-bb04-f448eb47f9e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68393 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110680 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127800 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117076 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98624 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98408 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41967 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18898 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51017 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145772 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44802 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37483 "Found 1 new JSC binary failure: testapi, Found 18602 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/concat1.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->