### PR TITLE
[WebGPU + Swift] Add runtime feature flag for Swift backend

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -38,7 +38,6 @@
 #import "WebGPUSwiftInternal.h"
 
 DEFINE_SWIFTCXX_THUNK(WebGPU::Buffer, copyFrom, void, const std::span<const uint8_t>, const size_t);
-DEFINE_SWIFTCXX_THUNK(WebGPU::Buffer, getMappedRange, std::span<uint8_t>, size_t, size_t);
 #endif
 
 namespace WebGPU {
@@ -292,9 +291,13 @@ static size_t computeRangeSize(uint64_t size, size_t offset)
     return result.value();
 }
   
-#if !ENABLE(WEBGPU_SWIFT)
 std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
 {
+#if ENABLE(WEBGPU_SWIFT)
+    if (isWebGPUSwiftEnabled())
+        return Buffer_getMappedRange_thunk(this, offset, size);
+#endif
+
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange
     if (!isValid())
         return std::span<uint8_t> { };
@@ -313,7 +316,6 @@ std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
         return { };
     return getBufferContents().subspan(offset);
 }
-#endif
 
 std::span<uint8_t> Buffer::getBufferContents()
 {

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -157,7 +157,7 @@ private:
     CommandEncoder(Device&);
 
     bool validatePopDebugGroup() const;
-#if !ENABLE(WEBGPU_SWIFT)
+
     NSString* validateFinishError() const;
     NSString* errorValidatingCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size);
     NSString* errorValidatingComputePassDescriptor(const WGPUComputePassDescriptor&) const;
@@ -166,7 +166,7 @@ private:
     NSString* errorValidatingCopyBufferToTexture(const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&) const;
     NSString* errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
     NSString* errorValidatingCopyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize) const;
-#endif
+
 private PUBLIC_IN_WEBGPU_SWIFT:
     void discardCommandBuffer();
 private:

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.h
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.h
@@ -54,5 +54,6 @@ WGPULimits defaultLimits();
 bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference);
 bool includesUnsupportedFeatures(const Vector<WGPUFeatureName>& target, const Vector<WGPUFeatureName>& reference);
 bool isShaderValidationEnabled(id<MTLDevice>);
+bool isWebGPUSwiftEnabled();
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -165,6 +165,16 @@ bool isShaderValidationEnabled(id<MTLDevice> device)
     return result;
 }
 
+bool isWebGPUSwiftEnabled()
+{
+    static std::once_flag onceFlag;
+    static bool isWebGPUSwiftEnabled;
+    std::call_once(onceFlag, [&] {
+        isWebGPUSwiftEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"WebKitWebGPUSwiftEnabled"];
+    });
+    return isWebGPUSwiftEnabled;
+}
+
 static HardwareCapabilities apple4(id<MTLDevice> device)
 {
     auto baseCapabilities = WebGPU::baseCapabilities(device);

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -572,10 +572,12 @@ void Queue::writeBuffer(Buffer& buffer, uint64_t bufferOffset, std::span<uint8_t
         }
     }
 #if ENABLE(WEBGPU_SWIFT)
-    WebGPU::writeBuffer(this, &buffer, bufferOffset, data);
-#else
-    writeBuffer(buffer.buffer(), bufferOffset, data);
+    if (isWebGPUSwiftEnabled()) {
+        WebGPU::writeBuffer(this, &buffer, bufferOffset, data);
+        return;
+    }
 #endif
+    writeBuffer(buffer.buffer(), bufferOffset, data);
 }
 
 static std::span<uint8_t> span(id<MTLBuffer> buffer)


### PR DESCRIPTION
#### 47b16051096f4d5d26ff2f4ee5c3ad07da3c600e
<pre>
[WebGPU + Swift] Add runtime feature flag for Swift backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=297672">https://bugs.webkit.org/show_bug.cgi?id=297672</a>
<a href="https://rdar.apple.com/158785613">rdar://158785613</a>

Reviewed by Mike Wyrzykowski.

Add a runtime option that uses NSUserDefaults to switch between the Swift and ObjC++ bits of WebGPU.

* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::getMappedRange):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::storeAction):
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::errorValidatingRenderPassDescriptor const):
(WebGPU::CommandEncoder::runClearEncoder):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::errorValidatingCopyBufferToBuffer):
(WebGPU::CommandEncoder::copyBufferToBuffer):
(WebGPU::CommandEncoder::copyBufferToTexture):
(WebGPU::CommandEncoder::clearTextureIfNeeded):
(WebGPU::CommandEncoder::copyTextureToBuffer):
(WebGPU::CommandEncoder::copyTextureToTexture):
(WebGPU::CommandEncoder::clearBuffer):
(WebGPU::CommandEncoder::finish):
(WebGPU::validateResolveQuerySet):
(WebGPU::CommandEncoder::resolveQuerySet):
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.mm: Added.
(WebGPU_Internal::isWebGPUSwiftEnabled):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeBuffer):

Canonical link: <a href="https://commits.webkit.org/299488@main">https://commits.webkit.org/299488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1890368744269dd9be8f7a647bd7e8c47bfc5919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70964 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0904c6f-09d9-44f1-b696-1d91667142b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90234 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59752 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dbfee359-4417-4227-a2ef-f9065bba8095) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70740 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4aa94502-1b2d-4321-8882-2b2fab5c09a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30369 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68753 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128141 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98896 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98676 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42373 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51356 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->