### PR TITLE
Cpp style checker build/storage_class: Remove auto, add consts keywords

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1526,13 +1526,14 @@ def check_for_non_standard_constructs(clean_lines, line_number,
     # For the rest, work with both comments and strings removed.
     line = clean_lines.elided[line_number]
 
-    if search(r'\b(const|volatile|void|char|short|int|long'
+    if search(r'\b(const|constexpr|constinit|consteval|volatile|'
+              r'void|char|short|int|long'
               r'|float|double|signed|unsigned'
               r'|schar|u?int8|u?int16|u?int32|u?int64)'
-              r'\s+(auto|register|static|extern|typedef)\b',
+              r'\s+(static|extern|typedef|register)\b',
               line):
         error(line_number, 'build/storage_class', 5,
-              'Storage class (static, extern, typedef, etc) should be first.')
+              'Storage class (static, extern, typedef, register) should be first.')
 
     if match(r'\s*#\s*endif\s*[^/\s]+', line):
         error(line_number, 'build/endif_comment', 5,

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -3115,15 +3115,15 @@ class CppStyleTest(CppStyleTestBase):
                       % (code, result, expected_message))
 
     def test_build_storage_class(self):
-        qualifiers = [None, 'const', 'volatile']
+        qualifiers = [None, 'const', 'constexpr', 'volatile']
         signs = [None, 'signed', 'unsigned']
-        types = ['void', 'char', 'int', 'float', 'double',
+        types = ['void', 'char', 'float', 'double',
                  'schar', 'int8', 'uint8', 'int16', 'uint16',
                  'int32', 'uint32', 'int64', 'uint64']
-        storage_classes = ['auto', 'extern', 'register', 'static', 'typedef']
+        storage_classes = ['static', 'extern', 'typedef', 'register']
 
         build_storage_class_error_message = (
-            'Storage class (static, extern, typedef, etc) should be first.'
+            'Storage class (static, extern, typedef, register) should be first.'
             '  [build/storage_class] [5]')
 
         # Some explicit cases. Legal in C++, deprecated in C99.


### PR DESCRIPTION
#### 98733dc365104f240e01a4ad8b889212651c06c7
<pre>
Cpp style checker build/storage_class: Remove auto, add consts keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=298085">https://bugs.webkit.org/show_bug.cgi?id=298085</a>
<a href="https://rdar.apple.com/159426812">rdar://159426812</a>

Reviewed by Dan Glastonbury.

- `auto` is not a storage class anymore since C++11. `const auto` is
  actually common idiom nowadays.
- Add new &quot;const&quot;-based keywords (constexpr, etc.) to qualifiers that
  should be after the storage class. E.g., `static constexpr` is preferred.
- The error message can fit the full list of storage classes.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_for_non_standard_constructs):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest): Note: Removed &apos;int&apos; because `unsigned int` triggers [runtime/unsigned].

Canonical link: <a href="https://commits.webkit.org/299423@main">https://commits.webkit.org/299423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6ed428212613ee13aa5f750186d64792e9552af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07e4786f-8b84-428e-9e19-00e19afab495) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90002 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59559 "Found 1 new test failure: http/tests/navigation/ping-attribute/anchor-cookie.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe8695a2-4b0b-459f-97c2-84918568550a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba98bc8b-d870-4fdb-ba43-59bb6cac6c32) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/117945 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68419 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127823 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98634 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98418 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43866 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21859 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41990 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45362 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->