### PR TITLE
WebKit does not forward debug/info logging from the WebContent process

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -540,6 +540,7 @@ imported/w3c/web-platform-tests/server-timing/navigation_timing_idl.html [ Skip 
 imported/w3c/web-platform-tests/server-timing/navigation_timing_idl.https.html [ Skip ]
 
 # Console log lines may appear in a different order so we silence them.
+fullscreen/fullscreen-document-gc-crash.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/cookie-module.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/cookie-module-import-propagate.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/cookie-module-propagate.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3219,5 +3219,3 @@ http/tests/lockdown-mode [ Skip ]
 js/dom/lockdown-mode [ Skip ]
 
 webkit.org/b/289382 fast/canvas/offscreen-no-script-context-crash.html [ Skip ]
-
-webkit.org/b/297861 fullscreen/fullscreen-document-gc-crash.html [ Failure ]

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -288,6 +288,10 @@ struct WebProcessCreationParameters {
 #if HAVE(LIQUID_GLASS)
     bool isLiquidGlassEnabled { false };
 #endif
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    bool isDebugLoggingEnabled { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -231,4 +231,8 @@
 #if HAVE(LIQUID_GLASS)
     bool isLiquidGlassEnabled;
 #endif
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    bool isDebugLoggingEnabled;
+#endif
 };

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -547,6 +547,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(LIQUID_GLASS)
     parameters.isLiquidGlassEnabled = isLiquidGlassEnabled();
 #endif
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    parameters.isDebugLoggingEnabled = os_log_debug_enabled(OS_LOG_DEFAULT);
+#endif
 }
 
 void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationParameters& parameters)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -753,7 +753,7 @@ private:
     void accessibilityRelayProcessSuspended(bool);
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    void initializeLogForwarding();
+    void initializeLogForwarding(const WebProcessCreationParameters&);
 #endif
 
     bool isProcessBeingCachedForPerformance();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -367,7 +367,7 @@ static void setVideoDecoderBehaviors(OptionSet<VideoDecoderBehavior> videoDecode
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)
 {
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    initializeLogForwarding();
+    initializeLogForwarding(parameters);
 #endif
 
 #if ENABLE(NOTIFY_BLOCKING)
@@ -838,7 +838,7 @@ static bool shouldIgnoreLogMessage(std::span<const LChar> logChannel)
     return equalSpans(logChannel, "com.apple.xpc\0"_span8) || equalSpans(logChannel, "com.apple.CoreAnalytics\0"_span8);
 }
 
-static void registerLogClient(std::unique_ptr<LogClient>&& newLogClient)
+static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogClient>&& newLogClient)
 {
 #if PLATFORM(IOS_FAMILY)
     prewarmLogs();
@@ -849,27 +849,22 @@ static void registerLogClient(std::unique_ptr<LogClient>&& newLogClient)
 
     static os_log_hook_t prevHook = nullptr;
 
-#ifdef NDEBUG
     // OS_LOG_TYPE_DEFAULT implies default, fault, and error.
-    constexpr auto minimumType = OS_LOG_TYPE_DEFAULT;
-#else
     // OS_LOG_TYPE_DEBUG implies debug, info, default, fault, and error.
-    constexpr auto minimumType = OS_LOG_TYPE_DEBUG;
-#endif
+    const auto minimumType = isDebugLoggingEnabled ? OS_LOG_TYPE_DEBUG : OS_LOG_TYPE_DEFAULT;
+    WEBPROCESS_RELEASE_LOG(Process, "registerLogClient: Debug logging enabled: %d", isDebugLoggingEnabled);
 
-    prevHook = os_log_set_hook(minimumType, makeBlockPtr([](os_log_type_t type, os_log_message_t msg) {
+    prevHook = os_log_set_hook(minimumType, makeBlockPtr([isDebugLoggingEnabled](os_log_type_t type, os_log_message_t msg) {
         if (prevHook)
             prevHook(type, msg);
 
         if (msg->buffer_sz > 1024)
             return;
 
-#ifdef NDEBUG
-        // Don't send messages with types we don't want to log in release. Even though OS_LOG_TYPE_DEFAULT is the minimum,
+        // Don't send debug/info messages unless debug logging is enabled. Even though OS_LOG_TYPE_DEFAULT would be the minimum,
         // the hook will be called for other subsystems with debug and info types.
-        if (type & (OS_LOG_TYPE_DEBUG | OS_LOG_TYPE_INFO))
+        if (!isDebugLoggingEnabled && type & (OS_LOG_TYPE_DEBUG | OS_LOG_TYPE_INFO))
             return;
-#endif
 
         if (Thread::currentThreadIsRealtime())
             return;
@@ -900,7 +895,7 @@ static void registerLogClient(std::unique_ptr<LogClient>&& newLogClient)
     WTFSignpostIndirectLoggingEnabled = true;
 }
 
-void WebProcess::initializeLogForwarding()
+void WebProcess::initializeLogForwarding(const WebProcessCreationParameters& parameters)
 {
     if (os_trace_get_mode() != OS_TRACE_MODE_OFF)
         return;
@@ -908,6 +903,7 @@ void WebProcess::initializeLogForwarding()
     RefPtr parentConnection = parentProcessConnection();
     if (!parentConnection)
         return;
+
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
     static constexpr auto connectionBufferSizeLog2 = 17;
     auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2, 1_s);
@@ -916,14 +912,14 @@ void WebProcess::initializeLogForwarding()
     auto [connection, handle] = WTFMove(*connectionPair);
     connection->open(*this, RunLoop::currentSingleton());
     std::unique_ptr newLogClient = makeUnique<LogClient>(Ref { connection });
-    parentConnection->sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(WTFMove(handle), newLogClient->identifier()), [newLogClient = WTFMove(newLogClient), connection = WTFMove(connection)] (IPC::Semaphore&& wakeUpSemaphore, IPC::Semaphore&& clientWaitSemaphore) mutable {
+    parentConnection->sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(WTFMove(handle), newLogClient->identifier()), [newLogClient = WTFMove(newLogClient), connection = WTFMove(connection), isDebugLoggingEnabled = parameters.isDebugLoggingEnabled] (IPC::Semaphore&& wakeUpSemaphore, IPC::Semaphore&& clientWaitSemaphore) mutable {
         connection->setSemaphores(WTFMove(wakeUpSemaphore), WTFMove(clientWaitSemaphore));
-        registerLogClient(WTFMove(newLogClient));
+        registerLogClient(isDebugLoggingEnabled, WTFMove(newLogClient));
     });
 #else
     std::unique_ptr newLogClient = makeUnique<LogClient>(*parentConnection);
-    parentConnection->sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(newLogClient->identifier()), [newLogClient = WTFMove(newLogClient)] mutable {
-        registerLogClient(WTFMove(newLogClient));
+    parentConnection->sendWithAsyncReply(Messages::WebProcessProxy::CreateLogStream(newLogClient->identifier()), [newLogClient = WTFMove(newLogClient), isDebugLoggingEnabled = parameters.isDebugLoggingEnabled] mutable {
+        registerLogClient(isDebugLoggingEnabled, WTFMove(newLogClient));
     });
 #endif
 


### PR DESCRIPTION
#### 07f3f80e7b243b922dc34d43ebfec277fb738d7b
<pre>
WebKit does not forward debug/info logging from the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=298087">https://bugs.webkit.org/show_bug.cgi?id=298087</a>
<a href="https://rdar.apple.com/152591955">rdar://152591955</a>

Reviewed by NOBODY (OOPS!).

We used to only forward debug/info logging from the WebContent processes in
debug builds. While this may be OK for WebKit developers, this is insufficient
for underlying framework developers as they would generally use a release build
of WebKit.

To address the issue, we now rely on `os_log_debug_enabled(OS_LOG_DEFAULT)`
instead to determine if we should forward debug/info messages or not. This is
true when the developer is streaming debug logs or debug logging has been
explicitly enabled system wide (not the default).

* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::registerLogClient):
(WebKit::WebProcess::initializeLogForwarding):
</pre>
----------------------------------------------------------------------
#### 7e7f6ec7bb49b2be51830383c6ec7af8f34925a9
<pre>
REGRESSION(298605@main): Broke fullscreen/fullscreen-document-gc-crash.html on WebKit1
<a href="https://bugs.webkit.org/show_bug.cgi?id=297861">https://bugs.webkit.org/show_bug.cgi?id=297861</a>
<a href="https://rdar.apple.com/159120921">rdar://159120921</a>

Unreviewed, silence console logging to address the test failure.
The test uses the Navigation API and the console logging is not relevant
to what the test is trying to validate.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07f3f80e7b243b922dc34d43ebfec277fb738d7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118587 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38268 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28919 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124764 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70646 "Failed to checkout and rebase branch from PR 50053") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38964 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46850 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/124764 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/70646 "Failed to checkout and rebase branch from PR 50053") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121540 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/38964 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/28919 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/124764 "Failed to checkout and rebase branch from PR 50053") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/38964 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/28919 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68421 "Failed to checkout and rebase branch from PR 50053") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/38964 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/28919 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127825 "Failed to checkout and rebase branch from PR 50053") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/45494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/46850 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/127825 "Failed to checkout and rebase branch from PR 50053") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/45858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/28919 "Failed to checkout and rebase branch from PR 50053") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/127825 "Failed to checkout and rebase branch from PR 50053") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/28919 "Failed to checkout and rebase branch from PR 50053") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45364 "Failed to checkout and rebase branch from PR 50053") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51042 "Failed to checkout and rebase branch from PR 50053") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44827 "Failed to checkout and rebase branch from PR 50053") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46514 "Failed to checkout and rebase branch from PR 50053") | | | | 
<!--EWS-Status-Bubble-End-->