### PR TITLE
[WPE] WPE Platform: do not set the current mode on every frame

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
@@ -86,6 +86,11 @@ bool Crtc::modeIsCurrent(drmModeModeInfo* mode) const
     return !memcmp(&m_currentMode.value(), mode, sizeof(drmModeModeInfo));
 }
 
+void Crtc::setCurrentMode(drmModeModeInfo* mode)
+{
+    m_currentMode = *mode;
+}
+
 std::unique_ptr<Connector> Connector::create(int fd, drmModeConnector* connector)
 {
     WPE::DRM::UniquePtr<drmModeObjectProperties> properties(drmModeObjectGetProperties(fd, connector->connector_id, DRM_MODE_OBJECT_CONNECTOR));

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -61,6 +61,7 @@ public:
     const Properties& properties() const { return m_properties; }
 
     bool modeIsCurrent(drmModeModeInfo*) const;
+    void setCurrentMode(drmModeModeInfo*);
 
 private:
     uint32_t m_id { 0 };

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
@@ -140,7 +140,7 @@ drmModeModeInfo* wpeScreenDRMGetMode(WPEScreenDRM* screen)
     return &screen->priv->mode;
 }
 
-const WPE::DRM::Crtc wpeScreenDRMGetCrtc(WPEScreenDRM* screen)
+WPE::DRM::Crtc& wpeScreenDRMGetCrtc(WPEScreenDRM* screen)
 {
     return *screen->priv->crtc;
 }
@@ -218,6 +218,8 @@ void wpeScreenDRMCreateDumbBufferIfNeeded(WPEScreenDRM* screen, int fd, uint32_t
         drmModeDestroyDumbBuffer(fd, handle);
         return;
     }
+
+    priv->crtc->setCurrentMode(&priv->mode);
 
     priv->dumb.bufferID = handle;
     priv->dumb.frameBufferID = frameBufferID;

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h
@@ -30,7 +30,7 @@
 
 WPEScreen* wpeScreenDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&&, const WPE::DRM::Connector&);
 drmModeModeInfo* wpeScreenDRMGetMode(WPEScreenDRM*);
-const WPE::DRM::Crtc wpeScreenDRMGetCrtc(WPEScreenDRM*);
+WPE::DRM::Crtc& wpeScreenDRMGetCrtc(WPEScreenDRM*);
 double wpeScreenDRMGuessScale(WPEScreenDRM*);
 void wpeScreenDRMCreateDumbBufferIfNeeded(WPEScreenDRM*, int, uint32_t connectorID);
 void wpeScreenDRMDestroyDumbBufferIfNeeded(WPEScreenDRM*, int);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -315,7 +315,7 @@ static bool wpeViewDRMCommitAtomic(WPEViewDRM* view, WPE::DRM::Buffer* buffer, s
 
     auto* display = WPE_DISPLAY_DRM(wpe_view_get_display(WPE_VIEW(view)));
     auto* screen = WPE_SCREEN_DRM(wpeDisplayDRMGetScreen(display));
-    const auto& crtc = wpeScreenDRMGetCrtc(screen);
+    auto& crtc = wpeScreenDRMGetCrtc(screen);
     auto* mode = wpeScreenDRMGetMode(screen);
     auto fd = gbm_device_get_fd(wpe_display_drm_get_device(display));
     if (!crtc.modeIsCurrent(mode)) {
@@ -355,6 +355,9 @@ static bool wpeViewDRMCommitAtomic(WPEViewDRM* view, WPE::DRM::Buffer* buffer, s
         return false;
     }
 
+    if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+        crtc.setCurrentMode(mode);
+
     wpeScreenDRMDestroyDumbBufferIfNeeded(screen, fd);
 
     return true;
@@ -364,7 +367,7 @@ static bool wpeViewDRMCommitLegacy(WPEViewDRM* view, const WPE::DRM::Buffer& buf
 {
     auto* display = WPE_DISPLAY_DRM(wpe_view_get_display(WPE_VIEW(view)));
     auto* screen = WPE_SCREEN_DRM(wpeDisplayDRMGetScreen(display));
-    const auto& crtc = wpeScreenDRMGetCrtc(screen);
+    auto& crtc = wpeScreenDRMGetCrtc(screen);
     auto* mode = wpeScreenDRMGetMode(screen);
     auto fd = gbm_device_get_fd(wpe_display_drm_get_device(display));
     if (!crtc.modeIsCurrent(mode)) {
@@ -374,6 +377,8 @@ static bool wpeViewDRMCommitLegacy(WPEViewDRM* view, const WPE::DRM::Buffer& buf
             g_set_error_literal(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: failed to set CRTC");
             return false;
         }
+
+        crtc.setCurrentMode(mode);
     }
 
     // FIXME: support cursors in legacy mode.


### PR DESCRIPTION
#### 54594a521504bc38cb52ee7e1d692dd6258f8416
<pre>
[WPE] WPE Platform: do not set the current mode on every frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=298088">https://bugs.webkit.org/show_bug.cgi?id=298088</a>

Reviewed by Nikolas Zimmermann.

If the desired mode doesn&apos;t match the initial one we always set the mode
on every frame because we are not updating the CRTC mode after setting
it.

Canonical link: <a href="https://commits.webkit.org/299426@main">https://commits.webkit.org/299426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bdea8993259cf2b2b7e640b5826c91fe345100f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70652 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90008 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59556 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 2 flakes 8 failures; Uploaded test results; 2 flakes 14 failures; Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30091 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68427 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127831 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98424 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21857 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18942 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51048 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->