### PR TITLE
Add a quirk for encoded streams support

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -548,6 +548,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediastream/RTCDtlsTransport.idl
     Modules/mediastream/RTCDtlsTransportState.idl
     Modules/mediastream/RTCEncodedAudioFrame.idl
+    Modules/mediastream/RTCEncodedStreams.idl
     Modules/mediastream/RTCEncodedVideoFrame.idl
     Modules/mediastream/RTCError.idl
     Modules/mediastream/RTCErrorDetailType.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -612,6 +612,7 @@ $(PROJECT_DIR)/Modules/mediastream/RTCDegradationPreference.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCDtlsTransport.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCDtlsTransportState.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCEncodedAudioFrame.idl
+$(PROJECT_DIR)/Modules/mediastream/RTCEncodedStreams.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCEncodedVideoFrame.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCError.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCErrorDetailType.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2410,6 +2410,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCDtlsTransportState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCDtlsTransportState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCEncodedAudioFrame.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCEncodedAudioFrame.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCEncodedStreams.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCEncodedStreams.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCEncodedVideoFrame.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCEncodedVideoFrame.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCError.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -483,6 +483,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediastream/RTCDtlsTransport.idl \
     $(WebCore)/Modules/mediastream/RTCDtlsTransportState.idl \
     $(WebCore)/Modules/mediastream/RTCEncodedAudioFrame.idl \
+    $(WebCore)/Modules/mediastream/RTCEncodedStreams.idl \
     $(WebCore)/Modules/mediastream/RTCEncodedVideoFrame.idl \
     $(WebCore)/Modules/mediastream/RTCError.idl \
     $(WebCore)/Modules/mediastream/RTCErrorDetailType.idl \

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "config.h"
+#include "RTCEncodedStreamProducer.h"
+
+#if ENABLE(WEB_RTC)
+
+#include "JSRTCEncodedAudioFrame.h"
+#include "JSRTCEncodedVideoFrame.h"
+#include "ReadableStreamSource.h"
+#include "WritableStreamSink.h"
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RTCEncodedStreamProducer);
+
+RTCEncodedStreamProducer::~RTCEncodedStreamProducer() = default;
+
+ExceptionOr<Ref<RTCEncodedStreamProducer>> RTCEncodedStreamProducer::create(ScriptExecutionContext& context, Ref<RTCRtpTransformBackend>&& transformBackend, bool isVideo)
+{
+    auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context.globalObject());
+    if (!globalObject)
+        return Exception { ExceptionCode::InvalidStateError };
+
+    Ref readableSource = SimpleReadableStreamSource::create();
+    auto readable = ReadableStream::create(*globalObject, readableSource.copyRef());
+    if (readable.hasException())
+        return readable.releaseException();
+
+    Ref producer = adoptRef(*new RTCEncodedStreamProducer(context, readable.releaseReturnValue(), WTFMove(readableSource), WTFMove(transformBackend), isVideo));
+
+    if (auto exception = producer->initialize(*globalObject))
+        return { WTFMove(*exception) };
+
+    return producer;
+}
+
+RTCEncodedStreamProducer::RTCEncodedStreamProducer(ScriptExecutionContext& context, Ref<ReadableStream>&& readable, Ref<SimpleReadableStreamSource>&& readableSource, Ref<RTCRtpTransformBackend>&& transformBackend, bool isVideo)
+    : m_context({ context })
+    , m_readable(WTFMove(readable))
+    , m_readableSource(WTFMove(readableSource))
+    , m_transformBackend(WTFMove(transformBackend))
+    , m_isVideo(isVideo)
+{
+}
+
+std::optional<Exception> RTCEncodedStreamProducer::initialize(JSDOMGlobalObject& globalObject)
+{
+    auto writable = WritableStream::create(globalObject, SimpleWritableStreamSink::create([weakThis = WeakPtr { *this }](auto& context, auto value) -> ExceptionOr<void> {
+        RefPtr protectedThis = weakThis.get();
+        return protectedThis ? protectedThis->writeFrame(context, value) : Exception { ExceptionCode::InvalidStateError };
+    }));
+    if (writable.hasException())
+        return writable.releaseException();
+
+    lazyInitialize(m_writable, writable.releaseReturnValue());
+
+    m_transformBackend->setTransformableFrameCallback([weakThis = WeakPtr { *this }](Ref<RTCRtpTransformableFrame>&& frame) mutable {
+        callOnMainThread([weakThis, frame = WTFMove(frame)]() mutable {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->enqueueFrame(WTFMove(frame));
+        });
+    });
+    return { };
+}
+
+void RTCEncodedStreamProducer::enqueueFrame(Ref<RTCRtpTransformableFrame>&& frame)
+{
+    RefPtr context = m_context.get();
+    if (!context)
+        return;
+
+    auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context->globalObject());
+    if (!globalObject)
+        return;
+
+    Ref vm = globalObject->vm();
+    JSC::JSLockHolder lock(vm);
+
+    auto value = m_isVideo ? toJS(globalObject, globalObject, RTCEncodedVideoFrame::create(WTFMove(frame))) : toJS(globalObject, globalObject, RTCEncodedAudioFrame::create(WTFMove(frame)));
+
+    m_readableSource->enqueue(value);
+}
+
+ExceptionOr<void> RTCEncodedStreamProducer::writeFrame(ScriptExecutionContext& context, JSC::JSValue value)
+{
+    auto* globalObject = context.globalObject();
+    if (!globalObject)
+        return { };
+
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto frameConversionResult = convert<IDLUnion<IDLInterface<RTCEncodedAudioFrame>, IDLInterface<RTCEncodedVideoFrame>>>(*globalObject, value);
+    if (frameConversionResult.hasException(scope)) [[unlikely]]
+        return Exception { ExceptionCode::ExistingExceptionError };
+
+    auto frame = frameConversionResult.releaseReturnValue();
+    auto rtcFrame = WTF::switchOn(frame, [&](RefPtr<RTCEncodedAudioFrame>& value) {
+        return value->rtcFrame(vm);
+    }, [&](RefPtr<RTCEncodedVideoFrame>& value) {
+        return value->rtcFrame(vm);
+    });
+
+    // If no data, skip the frame since there is nothing to packetize or decode.
+    if (rtcFrame->data().data())
+        m_transformBackend->processTransformedFrame(rtcFrame.get());
+
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#pragma once
+
+#if ENABLE(WEB_RTC)
+
+#include "ExceptionOr.h"
+#include "RTCEncodedStreams.h"
+#include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class JSDOMGlobalObject;
+class RTCRtpTransformBackend;
+class RTCRtpTransformableFrame;
+class ScriptExecutionContext;
+class SimpleReadableStreamSource;
+
+class RTCEncodedStreamProducer final : public RefCounted<RTCEncodedStreamProducer>
+    , public CanMakeWeakPtr<RTCEncodedStreamProducer> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCEncodedStreamProducer);
+public:
+    static ExceptionOr<Ref<RTCEncodedStreamProducer>> create(ScriptExecutionContext&, Ref<RTCRtpTransformBackend>&&, bool isVideo);
+    ~RTCEncodedStreamProducer();
+
+    RTCEncodedStreams streams() { return { m_readable.get(), m_writable.get() }; }
+
+private:
+    RTCEncodedStreamProducer(ScriptExecutionContext&, Ref<ReadableStream>&&, Ref<SimpleReadableStreamSource>&&, Ref<RTCRtpTransformBackend>&&, bool isVideo);
+
+    void enqueueFrame(Ref<RTCRtpTransformableFrame>&&);
+    ExceptionOr<void> writeFrame(ScriptExecutionContext&, JSC::JSValue);
+
+    std::optional<Exception> initialize(JSDOMGlobalObject&);
+
+    WeakPtr<ScriptExecutionContext> m_context;
+    const Ref<ReadableStream> m_readable;
+    const Ref<SimpleReadableStreamSource> m_readableSource;
+    const RefPtr<WritableStream> m_writable;
+    const Ref<RTCRtpTransformBackend> m_transformBackend;
+    const bool m_isVideo { false };
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreams.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreams.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#pragma once
+
+#if ENABLE(WEB_RTC)
+
+#include "ReadableStream.h"
+#include "WritableStream.h"
+
+namespace WebCore {
+
+struct RTCEncodedStreams {
+    RefPtr<ReadableStream> readable;
+    RefPtr<WritableStream> writable;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreams.idl
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreams.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_RTC,
+    JSGenerateToJSObject
+] dictionary RTCEncodedStreams {
+    ReadableStream readable;
+    WritableStream writable;
+};

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
@@ -36,6 +36,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "Logging.h"
 #include "PeerConnectionBackend.h"
+#include "RTCEncodedStreamProducer.h"
 #include "RTCRtpCapabilities.h"
 #include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -121,6 +122,22 @@ std::optional<RTCRtpTransform::Internal> RTCRtpReceiver::transform()
     if (!m_transform)
         return { };
     return m_transform->internalTransform();
+}
+
+ExceptionOr<RTCEncodedStreams> RTCRtpReceiver::createEncodedStreams(ScriptExecutionContext& context)
+{
+    if (!m_backend)
+        return Exception { ExceptionCode::InvalidStateError };
+
+    if (!m_encodedStreamProducer) {
+        auto producerOrException = RTCEncodedStreamProducer::create(context, m_backend->rtcRtpTransformBackend(), m_track->isVideo());
+        if (producerOrException.hasException())
+            return producerOrException.releaseException();
+
+        lazyInitialize(m_encodedStreamProducer, producerOrException.releaseReturnValue());
+    }
+
+    return m_encodedStreamProducer->streams();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
@@ -43,6 +43,9 @@ namespace WebCore {
 
 class DeferredPromise;
 class PeerConnectionBackend;
+class RTCEncodedStreamProducer;
+
+struct RTCEncodedStreams;
 struct RTCRtpCapabilities;
 
 class RTCRtpReceiver final : public RefCounted<RTCRtpReceiver>
@@ -79,6 +82,8 @@ public:
     std::optional<RTCRtpTransform::Internal> transform();
     ExceptionOr<void> setTransform(std::unique_ptr<RTCRtpTransform>&&);
 
+    ExceptionOr<RTCEncodedStreams> createEncodedStreams(ScriptExecutionContext&);
+
     const Vector<WeakPtr<MediaStream>>& associatedStreams() const { return m_associatedStreams; }
     void setAssociatedStreams(Vector<WeakPtr<MediaStream>>&& streams) { m_associatedStreams = WTFMove(streams); }
 private:
@@ -96,6 +101,7 @@ private:
     std::unique_ptr<RTCRtpReceiverBackend> m_backend;
     WeakPtr<PeerConnectionBackend> m_connection;
     std::unique_ptr<RTCRtpTransform> m_transform;
+    const RefPtr<RTCEncodedStreamProducer> m_encodedStreamProducer;
     Vector<WeakPtr<MediaStream>> m_associatedStreams;
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.idl
@@ -42,4 +42,6 @@
     sequence<RTCRtpContributingSource> getContributingSources();
     sequence<RTCRtpSynchronizationSource> getSynchronizationSources();
     Promise<RTCStatsReport> getStats();
+
+    [CallWith=CurrentScriptExecutionContext, EnabledByQuirk=shouldEnableRTCEncodedStreams] RTCEncodedStreams createEncodedStreams();
 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -38,6 +38,7 @@
 #include "Logging.h"
 #include "RTCDTMFSender.h"
 #include "RTCDTMFSenderBackend.h"
+#include "RTCEncodedStreamProducer.h"
 #include "RTCPeerConnection.h"
 #include "RTCRtpCapabilities.h"
 #include "RTCRtpTransceiver.h"
@@ -255,6 +256,22 @@ std::optional<RTCRtpTransform::Internal> RTCRtpSender::transform()
     if (!m_transform)
         return { };
     return m_transform->internalTransform();
+}
+
+ExceptionOr<RTCEncodedStreams> RTCRtpSender::createEncodedStreams(ScriptExecutionContext& context)
+{
+    if (!m_backend)
+        return Exception { ExceptionCode::InvalidStateError };
+
+    if (!m_encodedStreamProducer) {
+        auto producerOrException = RTCEncodedStreamProducer::create(context, m_backend->rtcRtpTransformBackend(), m_trackKind == "video"_s);
+        if (producerOrException.hasException())
+            return producerOrException.releaseException();
+
+        lazyInitialize(m_encodedStreamProducer, producerOrException.releaseReturnValue());
+    }
+
+    return m_encodedStreamProducer->streams();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.h
@@ -45,7 +45,10 @@ namespace WebCore {
 
 class MediaStream;
 class RTCDTMFSender;
+class RTCEncodedStreamProducer;
 class RTCPeerConnection;
+
+struct RTCEncodedStreams;
 struct RTCRtpCapabilities;
 
 class RTCRtpSender final : public RefCounted<RTCRtpSender>
@@ -96,6 +99,8 @@ public:
     std::optional<RTCRtpTransform::Internal> transform();
     ExceptionOr<void> setTransform(std::unique_ptr<RTCRtpTransform>&&);
 
+    ExceptionOr<RTCEncodedStreams> createEncodedStreams(ScriptExecutionContext&);
+
 private:
     RTCRtpSender(RTCPeerConnection&, String&& trackKind, std::unique_ptr<RTCRtpSenderBackend>&&);
 
@@ -114,6 +119,7 @@ private:
     WeakPtr<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_connection;
     RefPtr<RTCDTMFSender> m_dtmfSender;
     std::unique_ptr<RTCRtpTransform> m_transform;
+    const RefPtr<RTCEncodedStreamProducer> m_encodedStreamProducer;
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
     uint64_t m_logIdentifier { 0 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.idl
@@ -45,4 +45,6 @@
     Promise<RTCStatsReport> getStats();
 
     [Conditional=WEB_RTC, EnabledBySetting=WebRTCDTMFEnabled] readonly attribute RTCDTMFSender? dtmf;
+
+    [CallWith=CurrentScriptExecutionContext, EnabledByQuirk=shouldEnableRTCEncodedStreams] RTCEncodedStreams createEncodedStreams();
 };

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -134,7 +134,9 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
     
     if (response.transports()) {
         auto transports = *response.transports();
-        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoTransportsKey), toArrayValue(transports.map(WebCore::toString)));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoTransportsKey), toArrayValue(transports.map([](auto transport) {
+            return WebCore::toString(transport);
+        })));
     }
 
     if (response.remainingDiscoverableCredentials())

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -282,6 +282,7 @@ Modules/mediastream/RTCRtpSFrameTransformer.cpp
 Modules/mediastream/RTCRtpScriptTransform.cpp
 Modules/mediastream/RTCRtpScriptTransformer.cpp
 Modules/mediastream/RTCRtpSender.cpp
+Modules/mediastream/RTCEncodedStreamProducer.cpp
 Modules/mediastream/RTCRtpTransceiver.cpp
 Modules/mediastream/RTCRtpTransform.cpp
 Modules/mediastream/RTCSctpTransport.cpp
@@ -4553,6 +4554,7 @@ JSRTCIceServerTransportProtocol.cpp
 JSRTCIceTcpCandidateType.cpp
 JSRTCIceTransport.cpp
 JSRTCIceTransportState.cpp
+JSRTCEncodedStreams.cpp
 JSRTCLocalSessionDescriptionInit.cpp
 JSRTCLogsCallback.cpp
 JSRTCOfferAnswerOptions.cpp

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -924,6 +924,13 @@ bool Quirks::shouldEnableEnumerateDeviceQuirk() const
 }
 #endif
 
+#if ENABLE(WEB_RTC)
+bool Quirks::shouldEnableRTCEncodedStreamsQuirk() const
+{
+    return needsQuirks() && m_quirksData.shouldEnableRTCEncodedStreamsQuirk;
+}
+#endif
+
 bool Quirks::shouldUnloadHeavyFrame() const
 {
     return needsQuirks() && m_quirksData.shouldUnloadHeavyFrames;

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -150,6 +150,10 @@ public:
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const;
     bool shouldEnableEnumerateDeviceQuirk() const;
 #endif
+#if ENABLE(WEB_RTC)
+    bool shouldEnableRTCEncodedStreamsQuirk() const;
+#endif
+
     bool shouldUnloadHeavyFrame() const;
 
     bool needsCanPlayAfterSeekedQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -154,6 +154,9 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk : 1 { false };
     bool shouldEnableEnumerateDeviceQuirk : 1 { false };
 #endif
+#if ENABLE(WEB_RTC)
+    bool shouldEnableRTCEncodedStreamsQuirk : 1 { false };
+#endif
 
 #if ENABLE(META_VIEWPORT)
     bool shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk : 1 { false };


### PR DESCRIPTION
#### 6940c056fa46606ded6aebde6bf70e95a20ef7d1
<pre>
Add a quirk for encoded streams support
<a href="https://rdar.apple.com/158736355">rdar://158736355</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297959">https://bugs.webkit.org/show_bug.cgi?id=297959</a>

Reviewed by Brent Fulgham.

We add createEncodedStreams behind a quirk.
For now, the quirk is not enabled as this is an experiment.

* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp: fix unified build issue.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp: Added.
(WebCore::RTCEncodedStreamProducer::create):
(WebCore::RTCEncodedStreamProducer::RTCEncodedStreamProducer):
(WebCore::m_isVideo):
(WebCore::RTCEncodedStreamProducer::initialize):
(WebCore::RTCEncodedStreamProducer::enqueueFrame):
(WebCore::RTCEncodedStreamProducer::writeFrame):
* Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.h: Added.
* Source/WebCore/Modules/mediastream/RTCEncodedStreams.h: Added.
* Source/WebCore/Modules/mediastream/RTCEncodedStreams.idl: Added.
* Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp:
(WebCore::RTCRtpReceiver::createEncodedStreams):
* Source/WebCore/Modules/mediastream/RTCRtpReceiver.h:
* Source/WebCore/Modules/mediastream/RTCRtpReceiver.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSender.cpp:
(WebCore::RTCRtpSender::createEncodedStreams):
* Source/WebCore/Modules/mediastream/RTCRtpSender.h:
* Source/WebCore/Modules/mediastream/RTCRtpSender.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldEnableRTCEncodedStreamsQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/299320@main">https://commits.webkit.org/299320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7872d677fd2ae8e96445f4b05eb3df3c1776a7e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70657 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff1cce58-e0b2-43ad-b0d7-c018a6d69921) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90013 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44fe69fe-f1ee-4b91-ac2f-ce5f4d00fcaa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70517 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac54023d-d8ce-46e7-b6c4-0a7c3f94f7d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24441 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68432 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127836 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98645 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98429 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25027 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42003 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46525 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->