### PR TITLE
[ews] check-status-on-other-ewses step should indicate the status in the displayed summary

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6332,7 +6332,7 @@ class CheckStatusOnEWSQueues(buildstep.BuildStep, BugzillaMixin):
 
     @defer.inlineCallbacks
     def get_change_status(self, change_id, queue):
-        url = '{}status/{}/'.format(EWS_URL, change_id)
+        url = f'{EWS_URL}status/{change_id}/'
         try:
             response = yield TwistedAdditions.request(url, logger=lambda content: self._addToLog('stdio', content))
             if response.status_code != 200:
@@ -6354,7 +6354,19 @@ class CheckStatusOnEWSQueues(buildstep.BuildStep, BugzillaMixin):
         change_status_on_mac_wk2 = yield self.get_change_status(change_id, 'mac-wk2')
         if change_status_on_mac_wk2 == SUCCESS:
             self.setProperty('passed_mac_wk2', True)
+        elif change_status_on_mac_wk2 == FAILURE:
+            self.setProperty('passed_mac_wk2', False)
+        else:
+            self.setProperty('passed_mac_wk2', None)
         defer.returnValue(SUCCESS)
+
+    def getResultSummary(self):
+        passed_mac_wk2 = self.getProperty('passed_mac_wk2')
+        if passed_mac_wk2 is True:
+            return {'step': 'mac-wk2 tests already passed'}
+        if passed_mac_wk2 is False:
+            return {'step': 'mac-wk2 tests failed'}
+        return {'step': "mac-wk2 tests haven't completed"}
 
 
 class ValidateRemote(shell.ShellCommandNewStyle):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6936,26 +6936,23 @@ class TestCheckStatusOnEWSQueues(BuildStepMixinAdditions, unittest.TestCase):
     def test_success(self):
         CheckStatusOnEWSQueues.get_change_status = lambda cls, change_id, queue: SUCCESS
         self.setupStep(CheckStatusOnEWSQueues())
-        self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SUCCESS, state_string='Checked change status on other queues')
-        rc = self.runStep()
-        self.assertEqual(self.getProperty('passed_mac_wk2'), True)
-        return rc
-
-    def test_success_hash(self):
-        CheckStatusOnEWSQueues.get_change_status = lambda cls, change_id, queue: SUCCESS
-        self.setupStep(CheckStatusOnEWSQueues())
-        self.setProperty('github.head.sha', '0e5b5facb6445ca7a1feb46cee6322189df5282c')
-        self.expectOutcome(result=SUCCESS, state_string='Checked change status on other queues')
+        self.expectOutcome(result=SUCCESS, state_string='mac-wk2 tests already passed')
         rc = self.runStep()
         self.assertEqual(self.getProperty('passed_mac_wk2'), True)
         return rc
 
     def test_failure(self):
         self.setupStep(CheckStatusOnEWSQueues())
-        self.setProperty('patch_id', '1234')
         CheckStatusOnEWSQueues.get_change_status = lambda cls, change_id, queue: FAILURE
-        self.expectOutcome(result=SUCCESS, state_string='Checked change status on other queues')
+        self.expectOutcome(result=SUCCESS, state_string='mac-wk2 tests failed')
+        rc = self.runStep()
+        self.assertEqual(self.getProperty('passed_mac_wk2'), False)
+        return rc
+
+    def test_mac_wk2_not_finished_yet(self):
+        self.setupStep(CheckStatusOnEWSQueues())
+        CheckStatusOnEWSQueues.get_change_status = lambda cls, change_id, queue: None
+        self.expectOutcome(result=SUCCESS, state_string="mac-wk2 tests haven't completed")
         rc = self.runStep()
         self.assertEqual(self.getProperty('passed_mac_wk2'), None)
         return rc


### PR DESCRIPTION
#### aec210fe03ef0616fea0303ff4c6b6755e667ea2
<pre>
[ews] check-status-on-other-ewses step should indicate the status in the displayed summary
<a href="https://bugs.webkit.org/show_bug.cgi?id=298054">https://bugs.webkit.org/show_bug.cgi?id=298054</a>
<a href="https://rdar.apple.com/problem/159383516">rdar://problem/159383516</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/ews-build/steps.py:
(CheckStatusOnEWSQueues.get_change_status): Used f-string, drive-by fix.
(CheckStatusOnEWSQueues.run): Set passed_mac_wk2 as per the mac-wk2 status.
(CheckStatusOnEWSQueues.getResultSummary): Set custom step summary.
* Tools/CISupport/ews-build/steps_unittest.py:
(test_success): Removed unused property patch_id.
(test_success_hash): Removed as this unit-tests was essentially same as test_success.
(test_mac_wk2_not_finished_yet): Added unit-test for scenario when mac-wk2 build has not finished yet.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aec210fe03ef0616fea0303ff4c6b6755e667ea2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118659 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/38340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28991 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124839 "Failed to checkout and rebase branch from PR 50057") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/70719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a145021-3c6d-4377-814c-3e5cfca1d559) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120537 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/39036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/46922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/124839 "Failed to checkout and rebase branch from PR 50057") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/70719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2df30215-d399-4f63-9bc1-b272511c896b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121612 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/39036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/106391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/124839 "Failed to checkout and rebase branch from PR 50057") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73995d3c-1f6d-422a-8478-b3171f950019) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/39036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/24502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68496 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/39036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/24692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127897 "Failed to checkout and rebase branch from PR 50057") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45566 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/46922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/127897 "Failed to checkout and rebase branch from PR 50057") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/118083 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/45930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/102611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/127897 "Failed to checkout and rebase branch from PR 50057") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18906 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/45436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/44900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/46586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->