### PR TITLE
[WebXR][OpenXR] Unreliable click events using hand interaction profile

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h
@@ -114,12 +114,13 @@ struct OpenXRAxis {
 };
 
 struct OpenXRInteractionProfile {
-    ASCIILiteral path;
+    const ASCIILiteral path;
     std::span<const OpenXRProfileId> profileIds;
     std::span<const OpenXRButton> buttons;
     std::span<const OpenXRAxis> axes;
 };
 
+constexpr ASCIILiteral handInteractionProfileName { "/interaction_profiles/ext/hand_interaction_ext"_s };
 constexpr std::array<OpenXRProfileId, 3> handInteractionProfileIds { "generic-hand-select-grasp", "generic-hand-select", "generic-hand" };
 constexpr std::array<OpenXRButton, 2> handInteractionProfileButtons {
     OpenXRButton { .type = OpenXRButtonType::Trigger, .path = s_pathPinchExt, .flags = OpenXRButtonFlags::Value, .hand = OpenXRHandFlags::Both },
@@ -127,13 +128,14 @@ constexpr std::array<OpenXRButton, 2> handInteractionProfileButtons {
 };
 
 constexpr OpenXRInteractionProfile handInteractionProfile {
-    "/interaction_profiles/ext/hand_interaction_ext"_s,
+    handInteractionProfileName,
     handInteractionProfileIds,
     handInteractionProfileButtons,
     { }
 };
 
 // Default fallback when there isn't a specific controller binding.
+constexpr ASCIILiteral khrSimpleControllerName { "/interaction_profiles/khr/simple_controller"_s };
 constexpr std::array<ASCIILiteral, 1> khrSimpleProfileIds { "generic-button"_s };
 
 constexpr std::array<OpenXRButton, 1> khrSimpleButtons {
@@ -141,7 +143,7 @@ constexpr std::array<OpenXRButton, 1> khrSimpleButtons {
 };
 
 constexpr OpenXRInteractionProfile khrSimpleControllerProfile {
-    "/interaction_profiles/khr/simple_controller"_s,
+    khrSimpleControllerName,
     khrSimpleProfileIds,
     khrSimpleButtons,
     { }

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h
@@ -93,6 +93,7 @@ private:
 #if defined(XR_EXT_hand_joints_motion_range)
     bool m_supportsHandJointsMotionRange { false };
 #endif
+    bool m_usingHandInteractionProfile { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 1d859edbec260d5dc6b10cea38256e92448239ec
<pre>
[WebXR][OpenXR] Unreliable click events using hand interaction profile
<a href="https://bugs.webkit.org/show_bug.cgi?id=298091">https://bugs.webkit.org/show_bug.cgi?id=298091</a>

Reviewed by Adrian Perez de Castro.

The pinch gesture is measured by the pinch_ext/value path which
defines a float in the [0, 1] range, with 1 meaning both fingers
touching. The OpenXR spec does not define a press or touch paths
for pinches so clients must decide when the value means a pinch
(or a click).

Values returned by runtimes vary a lot so we cannot trust them.
It&apos;s better so set our own threshold to consider a pinch gesture
as taking action. Experience tells us that 0.9 is a very good one.

There is no need to apply those thresholds for controllers, because
runtimes provide touch and press events for physical elements like
triggers or buttons. That&apos;s why we apply this threshold only when
the hand interaction profile is used.

* Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp:
(WebKit::OpenXRInputSource::updateInteractionProfile):
(WebKit::OpenXRInputSource::collectButton const):
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.h:

Canonical link: <a href="https://commits.webkit.org/299321@main">https://commits.webkit.org/299321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd282845c7268448bd2bfe5f51d0a5faa62ae868

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70663 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90017 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30112 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127842 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98650 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25028 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42009 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45381 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51059 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->