### PR TITLE
[css-mixins-1] Parse @function body

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6827,9 +6827,6 @@ imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-input-001.h
 imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-input-002.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-padding.html [ Skip ]
 
-# css-mixins / @function failures
-imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom.html [ Skip ]
-
 # These tests have been flaky since their import.
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-top-navigation-child-special-cases.tentative.sub.window.html [ DumpJSConsoleLogInStdErr Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-top-navigation-child.tentative.sub.window.html [ DumpJSConsoleLogInStdErr Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom-expected.txt
@@ -1,36 +1,36 @@
 
-FAIL Empty CSSFunctionRule assert_equals: expected 1 but got 0
-FAIL Single CSSFunctionDeclarations assert_equals: expected 1 but got 0
-FAIL CSSFunctionDescriptors (result) Can't find variable: CSSFunctionDescriptors
-FAIL CSSFunctionDescriptors (result, repeated) Can't find variable: CSSFunctionDescriptors
-FAIL CSSFunctionDescriptors (local variables) Can't find variable: CSSFunctionDescriptors
-FAIL CSSFunctionDescriptors (local variables, repeated) Can't find variable: CSSFunctionDescriptors
-FAIL CSSFunctionDescriptors (local variables and result) Can't find variable: CSSFunctionDescriptors
-FAIL CSSFunctionDescriptors serialization Can't find variable: CSSFunctionDescriptors
-FAIL Unknown descriptors Can't find variable: CSSFunctionDescriptors
-FAIL Unknown descriptors (mutation) Can't find variable: CSSFunctionDescriptors
-FAIL item() Can't find variable: CSSFunctionDescriptors
-FAIL Indexed property getter Can't find variable: CSSFunctionDescriptors
-FAIL @supports in body assert_equals: expected 1 but got 0
-FAIL CSSFunctionRule.name assert_equals: expected 1 but got 0
-FAIL CSSFunctionRule.getParameters() assert_equals: expected 6 but got 0
-FAIL CSSFunctionRule.returnType assert_equals: expected 5 but got 0
-FAIL CSSFunctionRule escapes assert_equals: expected 1 but got 0
-FAIL CSSFunctionRule.cssText (--empty) assert_equals: expected (string) "@function --empty() { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--ret-length) assert_equals: expected (string) "@function --ret-length() returns <length> { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--ret-length-auto) assert_equals: expected (string) "@function --ret-length-auto() returns type(<length> | auto) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-single) assert_equals: expected (string) "@function --param-single(--x) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-typed) assert_equals: expected (string) "@function --param-typed(--x <length>) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-typed-default) assert_equals: expected (string) "@function --param-typed-default(--x <length>: 10px) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-default) assert_equals: expected (string) "@function --param-default(--x: 10px) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-multi) assert_equals: expected (string) "@function --param-multi(--x, --y) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-multi-mixed) assert_equals: expected (string) "@function --param-multi-mixed(--x: 10px, --y, --z <length>) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--body-result) assert_equals: expected (string) "@function --body-result() { result: 10px; }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--body-locals) assert_equals: expected (string) "@function --body-locals() { --x: 1px; --y: 2px; result: 10px; }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-type-fn) assert_equals: expected (string) "@function --param-type-fn(--x <length>) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--param-type-fn-uni) assert_equals: expected (string) "@function --param-type-fn-uni(--x) { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--ret-type-fn) assert_equals: expected (string) "@function --ret-type-fn() { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--ret-type-fn-uni) assert_equals: expected (string) "@function --ret-type-fn-uni() { }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--body-result-multi) assert_equals: expected (string) "@function --body-result-multi() { result: 20px; }" but got (undefined) undefined
-FAIL CSSFunctionRule.cssText (--escaped-) assert_equals: expected (string) "@function --escaped-\\9 -tab(--param-\\9 -tab) { --local-\\9 -tab: 1px; }" but got (undefined) undefined
+PASS Empty CSSFunctionRule
+PASS Single CSSFunctionDeclarations
+PASS CSSFunctionDescriptors (result)
+PASS CSSFunctionDescriptors (result, repeated)
+PASS CSSFunctionDescriptors (local variables)
+PASS CSSFunctionDescriptors (local variables, repeated)
+PASS CSSFunctionDescriptors (local variables and result)
+PASS CSSFunctionDescriptors serialization
+PASS Unknown descriptors
+FAIL Unknown descriptors (mutation) assert_equals: expected 3 but got 1
+PASS item()
+PASS Indexed property getter
+PASS @supports in body
+PASS CSSFunctionRule.name
+FAIL CSSFunctionRule.getParameters() assert_object_equals: property "type" expected "<length>" got "*"
+FAIL CSSFunctionRule.returnType assert_equals: expected "<length>" but got "*"
+PASS CSSFunctionRule escapes
+PASS CSSFunctionRule.cssText (--empty)
+FAIL CSSFunctionRule.cssText (--ret-length) assert_equals: expected "@function --ret-length() returns <length> { }" but got "@function --ret-length() { }"
+FAIL CSSFunctionRule.cssText (--ret-length-auto) assert_equals: expected "@function --ret-length-auto() returns type(<length> | auto) { }" but got "@function --ret-length-auto() { }"
+PASS CSSFunctionRule.cssText (--param-single)
+FAIL CSSFunctionRule.cssText (--param-typed) assert_equals: expected "@function --param-typed(--x <length>) { }" but got "@function --param-typed(--x) { }"
+FAIL CSSFunctionRule.cssText (--param-typed-default) assert_equals: expected "@function --param-typed-default(--x <length>: 10px) { }" but got "@function --param-typed-default(--x: 10px) { }"
+PASS CSSFunctionRule.cssText (--param-default)
+PASS CSSFunctionRule.cssText (--param-multi)
+FAIL CSSFunctionRule.cssText (--param-multi-mixed) assert_equals: expected "@function --param-multi-mixed(--x: 10px, --y, --z <length>) { }" but got "@function --param-multi-mixed(--x: 10px, --y, --z) { }"
+PASS CSSFunctionRule.cssText (--body-result)
+PASS CSSFunctionRule.cssText (--body-locals)
+FAIL CSSFunctionRule.cssText (--param-type-fn) assert_equals: expected "@function --param-type-fn(--x <length>) { }" but got "@function --param-type-fn(--x) { }"
+PASS CSSFunctionRule.cssText (--param-type-fn-uni)
+PASS CSSFunctionRule.cssText (--ret-type-fn)
+PASS CSSFunctionRule.cssText (--ret-type-fn-uni)
+PASS CSSFunctionRule.cssText (--body-result-multi)
+FAIL CSSFunctionRule.cssText (--escaped-) assert_equals: expected "@function --escaped-\\9 -tab(--param-\\9 -tab) { --local-\\9 -tab: 1px; }" but got "@function --escaped-\\9 -tab(--param-\\9 -tab) { --local-\t-tab: 1px; }"
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1011,6 +1011,9 @@ set(WebCore_NON_SVG_IDL_FILES
     css/CSSFontFaceRule.idl
     css/CSSFontFeatureValuesRule.idl
     css/CSSFontPaletteValuesRule.idl
+    css/CSSFunctionDeclarations.idl
+    css/CSSFunctionDescriptors.idl
+    css/CSSFunctionRule.idl
     css/CSSGroupingRule.idl
     css/CSSImportRule.idl
     css/CSSKeyframeRule.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1265,6 +1265,9 @@ $(PROJECT_DIR)/css/CSSFontFaceDescriptors.idl
 $(PROJECT_DIR)/css/CSSFontFaceRule.idl
 $(PROJECT_DIR)/css/CSSFontFeatureValuesRule.idl
 $(PROJECT_DIR)/css/CSSFontPaletteValuesRule.idl
+$(PROJECT_DIR)/css/CSSFunctionDeclarations.idl
+$(PROJECT_DIR)/css/CSSFunctionDescriptors.idl
+$(PROJECT_DIR)/css/CSSFunctionRule.idl
 $(PROJECT_DIR)/css/CSSGroupingRule.idl
 $(PROJECT_DIR)/css/CSSImportRule.idl
 $(PROJECT_DIR)/css/CSSKeyframeRule.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -398,6 +398,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontFeatureValuesRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontFeatureValuesRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontPaletteValuesRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontPaletteValuesRule.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFunctionDeclarations.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFunctionDeclarations.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFunctionDescriptors.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFunctionDescriptors.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFunctionRule.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFunctionRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSGroupingRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSGroupingRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSHSL.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -984,6 +984,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/CSSFontFaceRule.idl \
     $(WebCore)/css/CSSFontFeatureValuesRule.idl \
     $(WebCore)/css/CSSFontPaletteValuesRule.idl \
+    $(WebCore)/css/CSSFunctionDeclarations.idl \
+    $(WebCore)/css/CSSFunctionDescriptors.idl \
+    $(WebCore)/css/CSSFunctionRule.idl \
     $(WebCore)/css/CSSGroupingRule.idl \
     $(WebCore)/css/CSSImportRule.idl \
     $(WebCore)/css/CSSLayerBlockRule.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -906,6 +906,9 @@ css/CSSFontStyleRangeValue.cpp
 css/CSSFontStyleWithAngleValue.cpp
 css/CSSFontValue.cpp
 css/CSSFontVariationValue.cpp
+css/CSSFunctionDeclarations.cpp
+css/CSSFunctionDescriptors.cpp
+css/CSSFunctionRule.cpp
 css/CSSFunctionValue.cpp
 css/CSSGradientValue.cpp
 css/CSSGridAutoRepeatValue.cpp
@@ -3675,6 +3678,9 @@ JSCSSFontFaceDescriptors.cpp
 JSCSSFontFaceRule.cpp
 JSCSSFontFeatureValuesRule.cpp
 JSCSSFontPaletteValuesRule.cpp
+JSCSSFunctionDeclarations.cpp
+JSCSSFunctionDescriptors.cpp
+JSCSSFunctionRule.cpp
 JSCSSGroupingRule.cpp
 JSCSSHSL.cpp
 JSCSSHWB.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -31,6 +31,8 @@
 #include "CSSFontFaceRule.h"
 #include "CSSFontFeatureValuesRule.h"
 #include "CSSFontPaletteValuesRule.h"
+#include "CSSFunctionDeclarations.h"
+#include "CSSFunctionRule.h"
 #include "CSSImportRule.h"
 #include "CSSKeyframeRule.h"
 #include "CSSKeyframesRule.h"
@@ -52,6 +54,8 @@
 #include "JSCSSFontFaceRule.h"
 #include "JSCSSFontFeatureValuesRule.h"
 #include "JSCSSFontPaletteValuesRule.h"
+#include "JSCSSFunctionDeclarations.h"
+#include "JSCSSFunctionRule.h"
 #include "JSCSSImportRule.h"
 #include "JSCSSKeyframeRule.h"
 #include "JSCSSKeyframesRule.h"
@@ -131,11 +135,13 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSViewTransitionRule>(globalObject, WTFMove(rule));
     case StyleRuleType::PositionTry:
         return createWrapper<CSSPositionTryRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::Function:
+        return createWrapper<CSSFunctionRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::FunctionDeclarations:
+        return createWrapper<CSSFunctionDeclarations>(globalObject, WTFMove(rule));
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:
     case StyleRuleType::FontFeatureValuesBlock:
-    case StyleRuleType::Function:
-    case StyleRuleType::FunctionDeclarations:
         return createWrapper<CSSRule>(globalObject, WTFMove(rule));
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/bindings/js/JSCSSStyleDeclarationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSStyleDeclarationCustom.cpp
@@ -27,11 +27,13 @@
 #include "JSCSSStyleDeclaration.h"
 
 #include "CSSFontFaceDescriptors.h"
+#include "CSSFunctionDescriptors.h"
 #include "CSSPageDescriptors.h"
 #include "CSSPositionTryDescriptors.h"
 #include "CSSStyleProperties.h"
 #include "DOMWrapperWorld.h"
 #include "JSCSSFontFaceDescriptors.h"
+#include "JSCSSFunctionDescriptors.h"
 #include "JSCSSPageDescriptors.h"
 #include "JSCSSPositionTryDescriptors.h"
 #include "JSCSSRuleCustom.h"
@@ -78,6 +80,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSPageDescriptors>(globalObject, WTFMove(declaration));
     case StyleDeclarationType::PositionTry:
         return createWrapper<CSSPositionTryDescriptors>(globalObject, WTFMove(declaration));
+    case StyleDeclarationType::Function:
+        return createWrapper<CSSFunctionDescriptors>(globalObject, WTFMove(declaration));
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -134,6 +134,9 @@ namespace WebCore {
     macro(CSSCounterStyleRule) \
     macro(CSSColor) \
     macro(CSSColorValue) \
+    macro(CSSFunctionDeclarations) \
+    macro(CSSFunctionDescriptors) \
+    macro(CSSFunctionRule) \
     macro(CSSHSL) \
     macro(CSSHWB) \
     macro(CSSImageValue) \

--- a/Source/WebCore/css/CSSFunctionDeclarations.cpp
+++ b/Source/WebCore/css/CSSFunctionDeclarations.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSFunctionDeclarations.h"
+
+#include "CSSFunctionDescriptors.h"
+#include "CSSSerializationContext.h"
+#include "StyleProperties.h"
+#include "StyleRuleFunction.h"
+
+namespace WebCore {
+
+CSSFunctionDeclarations::CSSFunctionDeclarations(StyleRuleFunctionDeclarations& rule, CSSStyleSheet* parent)
+    : CSSRule(parent)
+    , m_styleRule(rule)
+{
+}
+
+CSSFunctionDeclarations::~CSSFunctionDeclarations() = default;
+
+CSSFunctionDescriptors& CSSFunctionDeclarations::style()
+{
+    if (!m_descriptorsCSSOMWrapper) {
+        Ref styleRule = m_styleRule;
+        Ref properties = styleRule->mutableProperties();
+        m_descriptorsCSSOMWrapper = CSSFunctionDescriptors::create(properties, *this);
+    }
+    return *m_descriptorsCSSOMWrapper;
+}
+
+String CSSFunctionDeclarations::cssText() const
+{
+    Ref properties = m_styleRule->properties();
+    return properties->asText(CSS::defaultSerializationContext());
+}
+
+void CSSFunctionDeclarations::reattach(StyleRuleBase& rule)
+{
+    m_styleRule = downcast<StyleRuleFunctionDeclarations>(rule);
+
+    if (RefPtr wrapper = m_descriptorsCSSOMWrapper) {
+        Ref styleRule = m_styleRule;
+        Ref properties = styleRule->mutableProperties();
+        wrapper->reattach(properties);
+    }
+}
+
+}

--- a/Source/WebCore/css/CSSFunctionDeclarations.h
+++ b/Source/WebCore/css/CSSFunctionDeclarations.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSRule.h"
+
+namespace WebCore {
+
+class CSSFunctionDescriptors;
+class StyleRuleFunctionDeclarations;
+
+class CSSFunctionDeclarations final : public CSSRule {
+public:
+    static Ref<CSSFunctionDeclarations> create(StyleRuleFunctionDeclarations& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFunctionDeclarations(rule, sheet)); };
+
+    virtual ~CSSFunctionDeclarations();
+
+    CSSFunctionDescriptors& style();
+
+private:
+    CSSFunctionDeclarations(StyleRuleFunctionDeclarations&, CSSStyleSheet*);
+
+    String cssText() const final;
+    String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
+
+    void reattach(StyleRuleBase&) final;
+    StyleRuleType styleRuleType() const final { return StyleRuleType::FunctionDeclarations; }
+
+    Ref<StyleRuleFunctionDeclarations> m_styleRule;
+    RefPtr<CSSFunctionDescriptors> m_descriptorsCSSOMWrapper;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSFunctionDeclarations, StyleRuleType::FunctionDeclarations)
+

--- a/Source/WebCore/css/CSSFunctionDeclarations.idl
+++ b/Source/WebCore/css/CSSFunctionDeclarations.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=CSSFunctionAtRuleEnabled,
+    Exposed=Window
+] interface CSSFunctionDeclarations : CSSRule {
+  [SameObject, PutForwards=cssText] readonly attribute CSSFunctionDescriptors style;
+};

--- a/Source/WebCore/css/CSSFunctionDescriptors.cpp
+++ b/Source/WebCore/css/CSSFunctionDescriptors.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSFunctionDescriptors.h"
+
+#include "ExceptionOr.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CSSFunctionDescriptors);
+
+CSSFunctionDescriptors::CSSFunctionDescriptors(MutableStyleProperties& propertySet, CSSFunctionDeclarations& parentRule)
+    : PropertySetCSSDescriptors(propertySet, parentRule)
+{
+}
+
+CSSFunctionDescriptors::~CSSFunctionDescriptors() = default;
+
+StyleRuleType CSSFunctionDescriptors::ruleType() const
+{
+    return StyleRuleType::FunctionDeclarations;
+}
+
+// MARK: - Descriptors
+
+// @position-try 'margin'
+String CSSFunctionDescriptors::result() const
+{
+    return getPropertyValueInternal(CSSPropertyResult);
+}
+
+ExceptionOr<void> CSSFunctionDescriptors::setResult(const String& value)
+{
+    return setPropertyInternal(CSSPropertyResult, value, IsImportant::No);
+}
+
+}

--- a/Source/WebCore/css/CSSFunctionDescriptors.h
+++ b/Source/WebCore/css/CSSFunctionDescriptors.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PropertySetCSSDescriptors.h"
+
+namespace WebCore {
+
+class CSSFunctionDeclarations;
+class CSSPositionTryRule;
+struct CSSParserContext;
+
+class CSSFunctionDescriptors final : public PropertySetCSSDescriptors {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSFunctionDescriptors);
+public:
+    static Ref<CSSFunctionDescriptors> create(MutableStyleProperties& propertySet, CSSFunctionDeclarations& parentRule)
+    {
+        return adoptRef(*new CSSFunctionDescriptors(propertySet, parentRule));
+    }
+    virtual ~CSSFunctionDescriptors();
+
+    StyleDeclarationType styleDeclarationType() const final { return StyleDeclarationType::Function; }
+
+    String result() const;
+    ExceptionOr<void> setResult(const String&);
+
+    CSSFunctionDescriptors(MutableStyleProperties&, CSSFunctionDeclarations&);
+
+    StyleRuleType ruleType() const final;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_STYLE_DECLARATION(CSSFunctionDescriptors, StyleDeclarationType::Function)
+

--- a/Source/WebCore/css/CSSFunctionDescriptors.idl
+++ b/Source/WebCore/css/CSSFunctionDescriptors.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+typedef USVString CSSOMString;
+
+[
+    EnabledBySetting=CSSFunctionAtRuleEnabled,
+    Exposed=Window
+] interface CSSFunctionDescriptors : CSSStyleDeclaration {
+  attribute [LegacyNullToEmptyString] CSSOMString result;
+};

--- a/Source/WebCore/css/CSSFunctionRule.cpp
+++ b/Source/WebCore/css/CSSFunctionRule.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSFunctionRule.h"
+
+#include "CSSMarkup.h"
+#include "StyleRuleFunction.h"
+
+namespace WebCore {
+
+Ref<CSSFunctionRule> CSSFunctionRule::create(StyleRuleFunction& rule, CSSStyleSheet* parent)
+{
+    return adoptRef(*new CSSFunctionRule(rule, parent));
+}
+
+CSSFunctionRule::CSSFunctionRule(StyleRuleFunction& rule, CSSStyleSheet* parent)
+    : CSSGroupingRule(rule, parent)
+{
+}
+
+String CSSFunctionRule::name() const
+{
+    return styleRuleFunction().name();
+}
+
+auto CSSFunctionRule::getParameters() const -> Vector<FunctionParameter>
+{
+    Vector<FunctionParameter> result;
+    for (auto& parameter : styleRuleFunction().parameters()) {
+        RefPtr defaultValue = parameter.defaultValue;
+        result.append({
+            .name = parameter.name,
+            .type = "*"_s, // FIXME: Implement.
+            .defaultValue = defaultValue ? defaultValue->serialize() : nullString()
+        });
+    }
+    return result;
+}
+
+String CSSFunctionRule::returnType() const
+{
+    return "*"_s;
+}
+
+String CSSFunctionRule::cssText() const
+{
+    StringBuilder builder;
+    builder.append("@function "_s);
+    serializeIdentifier(name(), builder);
+    builder.append('(');
+
+    auto separator = ""_s;
+    for (auto& parameter : styleRuleFunction().parameters()) {
+        builder.append(separator);
+        serializeIdentifier(parameter.name, builder);
+        // FIMXE: Serialize the type.
+
+        if (RefPtr defaultValue = parameter.defaultValue)
+            builder.append(": "_s, defaultValue->serialize());
+        separator = ", "_s;
+    }
+
+    builder.append(") { "_s);
+
+    for (unsigned index = 0; index < length(); ++index) {
+        Ref rule = *item(index);
+        auto ruleText = rule->cssText();
+        builder.append(ruleText, ' ');
+    }
+    builder.append('}');
+
+    return builder.toString();
+
+}
+
+const StyleRuleFunction& CSSFunctionRule::styleRuleFunction() const
+{
+    return downcast<StyleRuleFunction>(groupRule());
+}
+
+}

--- a/Source/WebCore/css/CSSFunctionRule.h
+++ b/Source/WebCore/css/CSSFunctionRule.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGroupingRule.h"
+
+namespace WebCore {
+
+class StyleRuleFunction;
+
+class CSSFunctionRule final : public CSSGroupingRule {
+public:
+    static Ref<CSSFunctionRule> create(StyleRuleFunction&, CSSStyleSheet* parent);
+
+    struct FunctionParameter {
+        String name;
+        String type;
+        String defaultValue;
+    };
+
+    String name() const;
+    Vector<FunctionParameter> getParameters() const;
+    String returnType() const;
+
+    String cssText() const final;
+
+private:
+    const StyleRuleFunction& styleRuleFunction() const;
+
+    CSSFunctionRule(StyleRuleFunction&, CSSStyleSheet*);
+    StyleRuleType styleRuleType() const final { return StyleRuleType::Function; }
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSFunctionRule, StyleRuleType::Function)

--- a/Source/WebCore/css/CSSFunctionRule.idl
+++ b/Source/WebCore/css/CSSFunctionRule.idl
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+typedef USVString CSSOMString;
+
+[
+    JSGenerateToJSObject
+] dictionary FunctionParameter {
+  required CSSOMString name;
+  required CSSOMString type;
+  CSSOMString? defaultValue;
+};
+
+[
+    EnabledBySetting=CSSFunctionAtRuleEnabled,
+    Exposed=Window
+] interface CSSFunctionRule : CSSGroupingRule {
+  readonly attribute CSSOMString name;
+  sequence<FunctionParameter> getParameters();
+  readonly attribute CSSOMString returnType;
+};

--- a/Source/WebCore/css/CSSStyleDeclaration.h
+++ b/Source/WebCore/css/CSSStyleDeclaration.h
@@ -42,7 +42,8 @@ enum class StyleDeclarationType : uint8_t {
     Style,
     FontFace,
     Page,
-    PositionTry
+    PositionTry,
+    Function
 };
 
 class CSSStyleDeclaration : public ScriptWrappable, public AbstractRefCountedAndCanMakeSingleThreadWeakPtr<CSSStyleDeclaration> {

--- a/Source/WebCore/css/PropertySetCSSDescriptors.cpp
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.cpp
@@ -112,6 +112,9 @@ RefPtr<DeprecatedCSSOMValue> PropertySetCSSDescriptors::getPropertyCSSValue(cons
 
 String PropertySetCSSDescriptors::getPropertyValue(const String& propertyName)
 {
+    if (styleDeclarationType() == StyleDeclarationType::Function && isCustomPropertyName(propertyName))
+        return protectedPropertySet()->getCustomPropertyValue(propertyName);
+
     auto propertyID = cssPropertyID(propertyName);
     if (!isExposed(propertyID))
         return String();
@@ -246,6 +249,11 @@ RefPtr<DeprecatedCSSOMValue> PropertySetCSSDescriptors::wrapForDeprecatedCSSOM(C
 
 bool PropertySetCSSDescriptors::willMutate()
 {
+    if (styleDeclarationType() == StyleDeclarationType::Function) {
+        // FIXME: Use <declaration-rule-list> parsing.
+        return false;
+    }
+
     RefPtr strongParentRule = m_parentRule.get();
     ASSERT(strongParentRule);
     if (!strongParentRule)

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -27,6 +27,8 @@
 #include "CSSFontFaceRule.h"
 #include "CSSFontFeatureValuesRule.h"
 #include "CSSFontPaletteValuesRule.h"
+#include "CSSFunctionDeclarations.h"
+#include "CSSFunctionRule.h"
 #include "CSSGroupingRule.h"
 #include "CSSImportRule.h"
 #include "CSSKeyframeRule.h"
@@ -240,11 +242,11 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
         [&](StyleRulePositionTry& rule) -> Ref<CSSRule> {
             return CSSPositionTryRule::create(rule, parentSheet);
         },
-        [&](StyleRuleFunction&) -> Ref<CSSRule> {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](StyleRuleFunction& rule) -> Ref<CSSRule> {
+            return CSSFunctionRule::create(rule, parentSheet);
         },
-        [&](StyleRuleFunctionDeclarations&) -> Ref<CSSRule> {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](StyleRuleFunctionDeclarations& rule) -> Ref<CSSRule> {
+            return CSSFunctionDeclarations::create(rule, parentSheet);
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -71,7 +71,7 @@ public:
     bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting || type() == StyleRuleType::NestedDeclarations; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
     bool isNestedDeclarationsRule() const { return type() == StyleRuleType::NestedDeclarations; }
-    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle; }
+    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle || type() == StyleRuleType::Function; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
     bool isImportRule() const { return type() == StyleRuleType::Import; }
     bool isLayerRule() const { return type() == StyleRuleType::LayerBlock || type() == StyleRuleType::LayerStatement; }

--- a/Source/WebCore/css/StyleRuleFunction.cpp
+++ b/Source/WebCore/css/StyleRuleFunction.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleRuleFunction.h"
 
+#include "MutableStyleProperties.h"
 #include "StylePropertiesInlines.h"
 
 namespace WebCore {
@@ -52,5 +53,15 @@ StyleRuleFunctionDeclarations::StyleRuleFunctionDeclarations(Ref<StyleProperties
 }
 
 StyleRuleFunctionDeclarations::StyleRuleFunctionDeclarations(const StyleRuleFunctionDeclarations&) = default;
+
+MutableStyleProperties& StyleRuleFunctionDeclarations::mutableProperties()
+{
+    Ref properties = m_properties;
+
+    if (!is<MutableStyleProperties>(properties))
+        m_properties = properties->mutableCopy();
+
+    return downcast<MutableStyleProperties>(m_properties.get());
+}
 
 }

--- a/Source/WebCore/css/StyleRuleFunction.h
+++ b/Source/WebCore/css/StyleRuleFunction.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class MutableStyleProperties;
+
 class StyleRuleFunction final : public StyleRuleGroup {
 public:
     struct Parameter {
@@ -67,12 +69,13 @@ public:
 
     // Only contains property "result" and custom properties.
     const StyleProperties& properties() const { return m_properties.get(); }
+    MutableStyleProperties& mutableProperties();
 
 private:
     StyleRuleFunctionDeclarations(Ref<StyleProperties>&&);
     StyleRuleFunctionDeclarations(const StyleRuleFunctionDeclarations&);
 
-    const Ref<StyleProperties> m_properties;
+    Ref<StyleProperties> m_properties;
 };
 
 }

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -98,6 +98,7 @@ public:
         RegularRules,
         KeyframeRules,
         FontFeatureValuesRules,
+        ConditionalGroupRules,
         NoRules, // For parsing at-rules inside declaration lists (without nesting support)
     };
 
@@ -178,14 +179,16 @@ private:
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     ParsedPropertyVector consumeDeclarationListInNewNestingContext(CSSParserTokenRange, StyleRuleType);
+    Vector<Ref<StyleRuleBase>> consumeDeclarationRuleListInNewNestingContext(CSSParserTokenRange, StyleRuleType);
 
-    enum class OnlyDeclarations : bool { No, Yes };
+    enum class BlockAllowedRule : uint8_t { QualifiedRules = 1 << 0, Declarations = 1 << 1, AtRules = 1 << 2, };
 
     enum class ParsingStyleDeclarationsInRuleList : bool { No, Yes };
 
     // FIXME: We should return value for all those functions instead of using class member attributes.
-    void consumeBlockContent(CSSParserTokenRange, StyleRuleType, OnlyDeclarations, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
+    void consumeBlockContent(CSSParserTokenRange, StyleRuleType, OptionSet<BlockAllowedRule>, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
     void consumeDeclarationList(CSSParserTokenRange, StyleRuleType);
+    void consumeDeclarationRuleList(CSSParserTokenRange, StyleRuleType);
     void consumeStyleBlock(CSSParserTokenRange, StyleRuleType, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
     bool consumeDeclaration(CSSParserTokenRange, StyleRuleType);
     void consumeDeclarationValue(CSSParserTokenRange, CSSPropertyID, IsImportant, StyleRuleType);
@@ -203,7 +206,12 @@ private:
 
     bool isStyleNestedContext() const
     {
-        return !m_ancestorRuleTypeStack.isEmpty();
+        return !m_ancestorRuleTypeStack.isEmpty() && m_ancestorRuleTypeStack.last() != CSSParserEnum::NestedContextType::Function;
+    }
+
+    bool isFunctionNestedContext() const
+    {
+        return !m_ancestorRuleTypeStack.isEmpty() && m_ancestorRuleTypeStack.last() == CSSParserEnum::NestedContextType::Function;
     }
 
     bool hasStyleRuleAncestor() const

--- a/Source/WebCore/css/parser/CSSParserEnum.h
+++ b/Source/WebCore/css/parser/CSSParserEnum.h
@@ -34,9 +34,10 @@ namespace WebCore {
 
 namespace CSSParserEnum {
 
-enum class NestedContextType : bool {
+enum class NestedContextType : uint8_t {
     Style,
     Scope,
+    Function,
 };
 
 using NestedContext = std::optional<NestedContextType>;

--- a/Source/WebCore/css/query/MediaQueryParser.h
+++ b/Source/WebCore/css/query/MediaQueryParser.h
@@ -32,6 +32,7 @@ namespace WebCore {
 namespace MQ {
 
 struct MediaQuery;
+using MediaQueryList = Vector<MediaQuery>;
 
 struct MediaQueryParser : public GenericMediaQueryParser<MediaQueryParser>  {
     static MediaQueryList parse(const String&, const CSSParserContext&);


### PR DESCRIPTION
#### bd44685c5370772e97308f946e7455831e726fd5
<pre>
[css-mixins-1] Parse @function body
<a href="https://bugs.webkit.org/show_bug.cgi?id=298095">https://bugs.webkit.org/show_bug.cgi?id=298095</a>
<a href="https://rdar.apple.com/159440523">rdar://159440523</a>

Reviewed by Sam Weinig and Matthieu Dubet.

<a href="https://drafts.csswg.org/css-mixins/#function-body">https://drafts.csswg.org/css-mixins/#function-body</a>

@function body accepts nested @media and other conditional rules along with custom properties so
the parsing is more like regular style rules.

Also add most of the CSSOM to get some test coverage, <a href="https://drafts.csswg.org/css-mixins/#cssom">https://drafts.csswg.org/css-mixins/#cssom</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom-expected.txt:

Type parameter serialization is not implemented yet.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/JSCSSStyleDeclarationCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/css/CSSFunctionDeclarations.cpp: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
(WebCore::CSSFunctionDeclarations::CSSFunctionDeclarations):
(WebCore::CSSFunctionDeclarations::style):
(WebCore::CSSFunctionDeclarations::cssText const):
(WebCore::CSSFunctionDeclarations::reattach):
* Source/WebCore/css/CSSFunctionDeclarations.h: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
* Source/WebCore/css/CSSFunctionDeclarations.idl: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
* Source/WebCore/css/CSSFunctionDescriptors.cpp: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
(WebCore::CSSFunctionDescriptors::CSSFunctionDescriptors):
(WebCore::CSSFunctionDescriptors::ruleType const):
(WebCore::CSSFunctionDescriptors::result const):
(WebCore::CSSFunctionDescriptors::setResult):
* Source/WebCore/css/CSSFunctionDescriptors.h: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
* Source/WebCore/css/CSSFunctionDescriptors.idl: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
* Source/WebCore/css/CSSFunctionRule.cpp: Added.
(WebCore::CSSFunctionRule::create):
(WebCore::CSSFunctionRule::CSSFunctionRule):
(WebCore::CSSFunctionRule::name const):
(WebCore::CSSFunctionRule::getParameters const):
(WebCore::CSSFunctionRule::returnType const):
(WebCore::CSSFunctionRule::cssText const):
(WebCore::CSSFunctionRule::styleRuleFunction const):
* Source/WebCore/css/CSSFunctionRule.h: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
* Source/WebCore/css/CSSFunctionRule.idl: Copied from Source/WebCore/css/StyleRuleFunction.cpp.
* Source/WebCore/css/CSSStyleDeclaration.h:
* Source/WebCore/css/PropertySetCSSDescriptors.cpp:
(WebCore::PropertySetCSSDescriptors::getPropertyValue):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::createCSSOMWrapper const):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isGroupRule const):
* Source/WebCore/css/StyleRuleFunction.cpp:
(WebCore::StyleRuleFunctionDeclarations::mutableProperties):
* Source/WebCore/css/StyleRuleFunction.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeAtRule):

Add an allow mode to only allow &quot;conditional group rules&quot;.

(WebCore::CSSParser::consumeNestedGroupRules):
(WebCore::CSSParser::consumeFunctionRule):
(WebCore::CSSParser::consumeBlockContent):
(WebCore::CSSParser::consumeDeclarationRuleListInNewNestingContext):
(WebCore::CSSParser::consumeDeclarationList):
(WebCore::CSSParser::consumeDeclarationRuleList):

@function body takes &lt;declaration-rule-list&gt;, add parsing support for it.

(WebCore::CSSParser::consumeStyleBlock):
(WebCore::ruleDoesNotAllowImportant):
* Source/WebCore/css/parser/CSSParser.h:
(WebCore::CSSParser::isStyleNestedContext const):
(WebCore::CSSParser::isFunctionNestedContext const):
* Source/WebCore/css/parser/CSSParserEnum.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):
(WebCore::consumeFunctionDescriptor):
* Source/WebCore/css/query/MediaQueryParser.h:

Canonical link: <a href="https://commits.webkit.org/299544@main">https://commits.webkit.org/299544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/825bab3953c62034cbbb25c6f4bf778f48e8f269

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71288 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f8c51d7-429f-4321-954f-8dd601fa7fb5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90580 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59940 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9203166-95b0-4c15-9214-77dd61110d51) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70989 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3709a776-d62c-4c99-9ac5-d0375660c523) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69103 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128466 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99140 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98915 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25175 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44385 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42711 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51684 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->