### PR TITLE
Remove zoom on font-relative units when resolving SVGLengthValue

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7702,7 +7702,6 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/letter-spacing.html [ Imag
 imported/w3c/web-platform-tests/css/css-viewport/zoom/line-height.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/list-style-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/relative-units-from-parent.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/svg.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-stroke-width.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units-expected.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<link rel="stylesheet" href="/fonts/ahem.css"/>
+<style>
+  :root {
+    font: 10px/1 Ahem;
+  }
+  body { margin: 0 }
+  .container {
+    font-size: 20px;
+  }
+  line {
+    stroke-width: 8px;
+    stroke: lime;
+  }
+  svg {
+    background-color: black;
+  }
+</style>
+<div class="container">
+  <svg width=400 height=400>
+    <line y1=40  y2=40  x1=0 x2=80 />
+    <line y1=120 y2=120 x1=0 x2=80 />
+    <line y1=140 y2=140 x1=0 x2=80 />
+    
+    <line y1=220 y2=220 x1=0 x2=40  />
+    <line y1=240 y2=240 x1=0 x2=40 />
+    <line y1=280 y2=280 x1=0 x2=40 />
+    <line y1=300 y2=300 x1=0 x2=40 />
+  </svg>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<link rel="stylesheet" href="/fonts/ahem.css"/>
+<style>
+  :root {
+    font: 10px/1 Ahem;
+  }
+  body { margin: 0 }
+  .container {
+    font-size: 20px;
+  }
+  line {
+    stroke-width: 8px;
+    stroke: lime;
+  }
+  svg {
+    background-color: black;
+  }
+</style>
+<div class="container">
+  <svg width=400 height=400>
+    <line y1=40  y2=40  x1=0 x2=80 />
+    <line y1=120 y2=120 x1=0 x2=80 />
+    <line y1=140 y2=140 x1=0 x2=80 />
+    
+    <line y1=220 y2=220 x1=0 x2=40  />
+    <line y1=240 y2=240 x1=0 x2=40 />
+    <line y1=280 y2=280 x1=0 x2=40 />
+    <line y1=300 y2=300 x1=0 x2=40 />
+  </svg>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="svg-font-relative-units-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+  :root {
+    font: 10px/1 Ahem;
+    zoom: 2;
+  }
+  body { margin: 0 }
+  .container {
+    font-size: 20px;
+  }
+  .child {
+    zoom: 2;
+  }
+  line {
+    stroke-width: 2px;
+    stroke: lime;
+  }
+  svg {
+    background-color: black;
+  }
+</style>
+<div class="container">
+  <div class="child">
+    <svg width=100 height=100>
+      <!-- Font-relative units -->
+      <line y1=10  y2=10  x1=0 x2=1em />
+      <line y1=30  y2=30  x1=0 x2=1ch /> 
+      <line y1=35  y2=35  x1=0 x2=1ic />
+      
+      <!-- Root font-relative units -->
+      <line y1=55  y2=55  x1=0 x2=1rch />
+      <line y1=60 y2=60 x1=0 x2=1rem />
+      <line y1=70 y2=70 x1=0 x2=1ric />
+      <line y1=75 y2=75 x1=0 x2=1rlh />
+    </svg>
+  </div>
+</div>

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -97,6 +97,7 @@ private:
 
     std::optional<FloatSize> computeViewportSize() const;
     float computeNonCalcLength(float, CSS::LengthUnit) const;
+    float removeZoomFromFontOrRootFontRelativeLength(float value, CSS::LengthUnit) const;
 
     std::optional<CSSToLengthConversionData> cssConversionData() const;
     RefPtr<const SVGElement> protectedContext() const;


### PR DESCRIPTION
#### ea6f87ed951e23583099f071feac8f878454f948
<pre>
Remove zoom on font-relative units when resolving SVGLengthValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=298102">https://bugs.webkit.org/show_bug.cgi?id=298102</a>
<a href="https://rdar.apple.com/159448970">rdar://159448970</a>

Reviewed by Tim Nguyen.

Currently, when resolving SVGLengthValue, somewhere in the callstack
we call computeUnzoomedNonCalcLengthDouble to get user units as the
final value. This value can sometimes be resolved against the computed
font size, which may or may not include zoom when units are
font-relative or root font-relative.

In SVG contexts when using font-relative units, we expect these values
to be unzoomed because SVG applies zoom during layout-time
at viewport level. (see RenderSVGViewportContainer)

Ideally, a routine named &quot;computeUnzoomed*&quot; should guarantee
non-zoomed values, but this isn&apos;t the case.

This PR removes the applied zoom for font-relative or root
font-relative units in SVG length context.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-font-relative-units.html: Added.
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::computeNonCalcLength const):
(WebCore::SVGLengthContext::removeZoomFromFontOrRootFontRelativeLength const):
* Source/WebCore/svg/SVGLengthContext.h:

Canonical link: <a href="https://commits.webkit.org/299637@main">https://commits.webkit.org/299637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8d0a7ecff5982195ce844f350bbb160efa29601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71718 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca781931-2732-4a8f-9dc5-967d3e3a38a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90874 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ccb5dc96-a9e9-4fd4-9a92-7e71803c1200) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71389 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04d68731-b8cf-47f4-a6c2-7ea38ca5c517) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25385 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69576 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128892 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46566 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35280 "Found 1 new test failure: http/tests/cache/disk-cache/disk-cache-302-status-code.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99473 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25232 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22764 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43130 "Hash e8d0a7ec for PR 50067 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52134 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45894 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->