### PR TITLE
[Tools][WPE] Plug run-mvt-tests script into webkitpy display-server

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1259,8 +1259,7 @@ class RunBuiltinsTests(shell.TestNewStyle):
 
 
 class RunMVTTests(shell.TestNewStyle):
-    command = ["Tools/Scripts/run-mvt-tests", WithProperties("--%(configuration)s"),
-               WithProperties("--%(fullPlatform)s"), "--headless"]
+    command = ["Tools/Scripts/run-mvt-tests", WithProperties("--%(configuration)s"), WithProperties("--%(fullPlatform)s")]
     name = "MVT-tests"
     description = ["MVT tests running"]
     descriptionDone = ["MVT tests"]

--- a/Tools/Scripts/run-mvt-tests
+++ b/Tools/Scripts/run-mvt-tests
@@ -38,6 +38,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from urllib3.exceptions import HTTPError, ReadTimeoutError
+from webkitpy.common.host import Host
 
 top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -89,7 +90,11 @@ def parse_args(argument_list):
     parser.add_argument("--retry-webdriver-timeouts", type=restricted_int_range(0,2000), help="Number of times to retry when the connection with WebDriver times out. Pass 0 to disable.", default=3)
     parser.add_argument("--timeout-to-load", type=restricted_int_range(30,2000), help="Number of seconds to wait for load/ready requests.",  default=60)
     parser.add_argument("--timeout-to-run", type=restricted_int_range(120,2000), help="Number of seconds to wait for any MVT test to finish.", default=600)
-    parser.add_argument("--headless", action='store_true', help="Enable headless mode if available")
+    parser.add_argument("--headless", action='store_true', help=argparse.SUPPRESS) # FIXME: this doesn't have any effect, delete it once the build master restarts.
+    parser.add_argument("--display-server", choices=['xvfb', 'xorg', 'weston', 'wayland', 'headless'], default=argparse.SUPPRESS,
+                        help='"xvfb": Use a virtualized X11 server. "xorg": Use the current X11 session. '
+                             '"weston": Use a virtualized Weston server. "wayland": Use the current wayland session. '
+                             '"headless": Headless mode in current session. (default: xvfb for gtk and headless for wpe)')
     parser.add_argument("--browser-name", choices=['MiniBrowser', 'cog'], default='MiniBrowser', help="Select the browser to use via 'run-minibrowser'.")
     parser.add_argument('--log-level', dest='log_level', choices=['minimal', 'info', 'debug'], default='info')
     parser.add_argument('--', dest='extra_browser_args', help='Pass extra arguments to the browser (run-minibrowser) after two dashes (--)')
@@ -103,13 +108,14 @@ def parse_args(argument_list):
         argument_list = argument_list[:dashes_ind]
     args = parser.parse_args(argument_list)
     args.extra_browser_args = extra_browser_args
-
+    if not hasattr(args, 'display_server'):
+        args.display_server = 'xvfb' if args.platform == 'gtk' else 'headless'
     return args
 
 
 class MVTWebDriverRunner():
 
-    def __init__(self, platform, configuration, extra_browser_args, mvt_instance_address, browser_name, max_retries_if_timeout, timeout_to_load, timeout_to_run):
+    def __init__(self, port, platform, configuration, extra_browser_args, mvt_instance_address, browser_name, max_retries_if_timeout, timeout_to_load, timeout_to_run):
         self.mvt_instance_address = mvt_instance_address
         if platform == "gtk":
             from selenium.webdriver import WebKitGTKOptions as WebKitOptions
@@ -121,6 +127,7 @@ class MVTWebDriverRunner():
             from selenium.webdriver import WPEWebKit as WebKitDriver
         else:
             raise NotImplementedError(f"Unknown platform {platform}")
+        self.environ_for_test = self.start_display_server(port)
         self._max_retries_if_timeout = max_retries_if_timeout
         self.timeout_to_load = timeout_to_load
         self.timeout_to_run = timeout_to_run
@@ -143,11 +150,23 @@ class MVTWebDriverRunner():
         self.driver = None
         _log.info(f'Starting WebDriver MVT runner for platform {self.platform.upper()}')
 
+    def start_display_server(self, port):
+        self._display_driver = port._driver_class()(port, worker_number=0, pixel_tests=False, no_timeout=True)
+        if not self._display_driver.check_driver(port):
+            raise RuntimeError("Failed to check driver %s" % self._display_driver.__class__.__name__)
+        _log.info(f'Using display server: {self._display_driver.__class__.__name__}')
+        return self._display_driver._setup_environ_for_test()
+
+    def stop_display_server(self):
+        if self._display_driver:
+            self._display_driver.stop()
+        self._display_driver = None
+
     def start_driver(self, retry_if_failure_to_start=True):
         if retry_if_failure_to_start:
             return self._retry_if_timeout(self.start_driver, None, False)
         # Start the service (WebDriver) in its own process group to ensure cleaning everything at stop_driver()
-        self.driver_service = self.driver_service_class(executable_path=self._run_webdriver_script_path,
+        self.driver_service = self.driver_service_class(executable_path=self._run_webdriver_script_path, env=self.environ_for_test,
                           service_args=[f"--{self.configuration}", f"--{self.platform}"], popen_kw={"process_group": 0})
         self.driver = self.driver_class(options=self.driver_options, service=self.driver_service)
         self.driver.maximize_window()
@@ -530,23 +549,22 @@ def main(argument_list):
     else:
         raise NotImplementedError(f'Unknown platform {args.platform}')
 
-    # Enable headless mode if requested
-    if args.headless:
-        if args.platform == 'gtk':
-            _log.warning('Headless mode not available for WebKitGTK. Try to run this script with "xvfb-run"')
-        elif args.platform == 'wpe':
-            if args.browser_name == 'MiniBrowser':
-                args.extra_browser_args.append("--headless")
-            elif args.browser_name == 'cog':
-                os.environ['COG_PLATFORM_NAME'] = 'headless'
-            else:
-                raise NotImplementedError(f'Unknown wpe browser: {browser_name}')
+    # Enable WPE headless mode
+    if args.platform == 'wpe' and args.display_server == 'headless':
+        if args.browser_name == 'MiniBrowser':
+            args.extra_browser_args.append("--headless")
+        elif args.browser_name == 'cog':
+            os.environ['COG_PLATFORM_NAME'] = 'headless'
+        else:
+            raise NotImplementedError(f'Unknown wpe browser: {browser_name}')
 
     # Set a default timeout for all the urllib3 requests (avoid hangs)
     set_urllib3_request_default_timeout(args.timeout_to_load)
     exit_code = -1
+    mvtwebdriver_runner = None
     try:
-        mvtwebdriver_runner = MVTWebDriverRunner(args.platform, args.configuration.lower(), args.extra_browser_args, args.mvt_instance_address, args.browser_name, args.retry_webdriver_timeouts, args.timeout_to_load, args.timeout_to_run)
+        port = Host().port_factory.get(args.platform, args)
+        mvtwebdriver_runner = MVTWebDriverRunner(port, args.platform, args.configuration.lower(), args.extra_browser_args, args.mvt_instance_address, args.browser_name, args.retry_webdriver_timeouts, args.timeout_to_load, args.timeout_to_run)
         mvtwebdriver_runner.start_driver()
         mvtresultsexpectations_parser = MVTResultsExpectationsParser(args.platform, args.configuration, args.update_expectations, args.reset_expectations)
         suites = TEST_SUITES if args.suite is None else [args.suite]
@@ -562,7 +580,9 @@ def main(argument_list):
     except:
         traceback.print_exc()
     finally:
-        mvtwebdriver_runner.stop_driver()
+        if mvtwebdriver_runner:
+            mvtwebdriver_runner.stop_driver()
+            mvtwebdriver_runner.stop_display_server()
         return exit_code
 
 

--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
@@ -73,11 +73,11 @@ class WebDriverTestRunner(object):
         self._port = port
         _log.info('Using port %s' % self._port.name())
         _log.info('Test configuration: %s' % self._port.test_configuration())
-        _log.info('Using display server %s' % (self._port._display_server))
 
         self._display_driver = self._port._driver_class()(self._port, worker_number=0, pixel_tests=False, no_timeout=True)
         if not self._display_driver.check_driver(self._port):
             raise RuntimeError("Failed to check driver %s" % self._display_driver.__class__.__name__)
+        _log.info('Using display server %s' % (self._display_driver.__class__.__name__))
 
         driver = create_driver(self._port)
         _log.info('Using driver at %s' % (driver.binary_path()))


### PR DESCRIPTION
#### cdc8fbebc0e6cd018c6ae165c3aea628f4c28df3
<pre>
[Tools][WPE] Plug run-mvt-tests script into webkitpy display-server
<a href="https://bugs.webkit.org/show_bug.cgi?id=298108">https://bugs.webkit.org/show_bug.cgi?id=298108</a>

Reviewed by Nikolas Zimmermann.

This plugs the script run-mvt-tests into the webkitpy display-server facility.
That way it becomes easier to run the tests headless in GTK (via the xvfb
display-server) and allows also to run the tests with WPE on any of the wayland
or headless display-servers.

* Tools/Scripts/run-mvt-tests:
(parse_args):
* Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py:
(WebDriverTestRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/299387@main">https://commits.webkit.org/299387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d2329d3c9ba9792a0ea1d295932d50fcf3c1992

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90051 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59594 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70556 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/118013 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24491 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127891 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98687 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/118077 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98471 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42064 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18931 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45430 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->