### PR TITLE
Refactor TextDecorationLineFlags into TextDecorationLine::Flag

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1728,7 +1728,7 @@ LineDecorationStyle::LineDecorationStyle(RenderObject& renderer)
 {
     const CheckedRef style = renderer.style();
     auto decor = style->textDecorationLineInEffect();
-    if (decor.containsAny({ TextDecorationLineFlags::Underline, TextDecorationLineFlags::LineThrough })) {
+    if (decor.containsAny({ Style::TextDecorationLine::Flag::Underline, Style::TextDecorationLine::Flag::LineThrough })) {
         auto decorationStyles = TextDecorationPainter::stylesForRenderer(renderer, decor);
         if (decor.hasUnderline()) {
             hasUnderline = true;

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -47,6 +47,7 @@
 #include <WebCore/ScrollAxis.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/StyleScrollBehavior.h>
+#include <WebCore/StyleTextDecorationLine.h>
 #include <WebCore/StyleWebKitOverflowScrolling.h>
 #include <WebCore/StyleWebKitTouchCallout.h>
 #include <WebCore/TextFlags.h>
@@ -1222,7 +1223,7 @@ template<> constexpr TextJustify fromCSSValueID(CSSValueID valueID)
     return TextJustify::Auto;
 }
 
-#define TYPE TextDecorationLineFlags
+#define TYPE Style::TextDecorationLine::Flag
 #define FOR_EACH(CASE) CASE(Underline) CASE(Overline) CASE(LineThrough) CASE(Blink)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1027,7 +1027,7 @@ static float logicalBottomForTextDecorationContent(const InlineDisplay::Boxes& b
             logicalBottom = logicalBottom ? std::max(*logicalBottom, contentLogicalBottom) : contentLogicalBottom;
         }
     }
-    // This function is not called unless there's at least one run on the line with TextDecorationLineFlags::Underline.
+    // This function is not called unless there's at least one run on the line with Style::TextDecorationLine::Flag::Underline.
     ASSERT(logicalBottom);
     return logicalBottom.value_or(0.f);
 }

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -607,8 +607,8 @@ static inline bool isDecoratingBoxForBackground(const InlineIterator::InlineBox&
         // <font> and <a> are always considered decorating boxes.
         return true;
     }
-    return styleToUse.textDecorationLine().containsAny({ TextDecorationLineFlags::Underline, TextDecorationLineFlags::Overline })
-        || (inlineBox.isRootInlineBox() && styleToUse.textDecorationLineInEffect().containsAny({ TextDecorationLineFlags::Underline, TextDecorationLineFlags::Overline }));
+    return styleToUse.textDecorationLine().containsAny({ Style::TextDecorationLine::Flag::Underline, Style::TextDecorationLine::Flag::Overline })
+        || (inlineBox.isRootInlineBox() && styleToUse.textDecorationLineInEffect().containsAny({ Style::TextDecorationLine::Flag::Underline, Style::TextDecorationLine::Flag::Overline }));
 }
 
 void TextBoxPainter::collectDecoratingBoxesForBackgroundPainting(DecoratingBoxList& decoratingBoxList, const InlineIterator::TextBoxIterator& textBox, FloatPoint textBoxLocation, const TextDecorationPainter::Styles& overrideDecorationStyle)

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -199,7 +199,7 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
 
         if (underlineStyle == TextDecorationStyle::Wavy)
             strokeWavyTextDecoration(m_context, rect, m_isPrinting, decorationGeometry.wavyStrokeParameters, strokeStyle);
-        else if (decoration == TextDecorationLineFlags::Underline || decoration == TextDecorationLineFlags::Overline) {
+        else if (decoration == Style::TextDecorationLine::Flag::Underline || decoration == Style::TextDecorationLine::Flag::Overline) {
             if ((style.textDecorationSkipInk() == TextDecorationSkipInk::Auto
                 || style.textDecorationSkipInk() == TextDecorationSkipInk::All)
                 && !m_writingMode.isVerticalTypographic()) {
@@ -256,9 +256,9 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
 
     auto draw = [&](const Style::TextShadow* shadow) {
         if (decorationType.hasUnderline() && !underlineRect.isEmpty())
-            paintDecoration(TextDecorationLineFlags::Underline, decorationStyle.underline.decorationStyle, decorationStyle.underline.color, underlineRect);
+            paintDecoration(Style::TextDecorationLine::Flag::Underline, decorationStyle.underline.decorationStyle, decorationStyle.underline.color, underlineRect);
         if (decorationType.hasOverline() && !overlineRect.isEmpty())
-            paintDecoration(TextDecorationLineFlags::Overline, decorationStyle.overline.decorationStyle, decorationStyle.overline.color, overlineRect);
+            paintDecoration(Style::TextDecorationLine::Flag::Overline, decorationStyle.overline.decorationStyle, decorationStyle.overline.color, overlineRect);
         // We only want to paint the shadow, hence the transparent color, not the actual line-through,
         // which will be painted in paintForegroundDecorations().
         if (shadow && decorationType.hasLineThrough())
@@ -316,24 +316,24 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
 static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
 {
     auto extractDecorations = [&] (const RenderStyle& style, Style::TextDecorationLine decorations) {
-        if (!decorations.containsAny({ TextDecorationLineFlags::Underline, TextDecorationLineFlags::Overline, TextDecorationLineFlags::LineThrough }))
+        if (!decorations.containsAny({ Style::TextDecorationLine::Flag::Underline, Style::TextDecorationLine::Flag::Overline, Style::TextDecorationLine::Flag::LineThrough }))
             return;
 
         auto color = TextDecorationPainter::decorationColor(style, paintBehavior);
         auto decorationStyle = style.textDecorationStyle();
 
         if (decorations.hasUnderline()) {
-            remainingDecorations.remove(TextDecorationLineFlags::Underline);
+            remainingDecorations.remove(Style::TextDecorationLine::Flag::Underline);
             result.underline.color = color;
             result.underline.decorationStyle = decorationStyle;
         }
         if (decorations.hasOverline()) {
-            remainingDecorations.remove(TextDecorationLineFlags::Overline);
+            remainingDecorations.remove(Style::TextDecorationLine::Flag::Overline);
             result.overline.color = color;
             result.overline.decorationStyle = decorationStyle;
         }
         if (decorations.hasLineThrough()) {
-            remainingDecorations.remove(TextDecorationLineFlags::LineThrough);
+            remainingDecorations.remove(Style::TextDecorationLine::Flag::LineThrough);
             result.linethrough.color = color;
             result.linethrough.decorationStyle = decorationStyle;
         }
@@ -397,13 +397,13 @@ auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Styl
 
 Style::TextDecorationLine TextDecorationPainter::textDecorationsInEffectForStyle(const TextDecorationPainter::Styles& style)
 {
-    OptionSet<TextDecorationLineFlags> decorations;
+    OptionSet<Style::TextDecorationLine::Flag> decorations;
     if (style.underline.color.isValid())
-        decorations.add(TextDecorationLineFlags::Underline);
+        decorations.add(Style::TextDecorationLine::Flag::Underline);
     if (style.overline.color.isValid())
-        decorations.add(TextDecorationLineFlags::Overline);
+        decorations.add(Style::TextDecorationLine::Flag::Overline);
     if (style.linethrough.color.isValid())
-        decorations.add(TextDecorationLineFlags::LineThrough);
+        decorations.add(Style::TextDecorationLine::Flag::LineThrough);
     return decorations;
 }
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1187,17 +1187,6 @@ TextStream& operator<<(TextStream& ts, TextCombine textCombine)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, TextDecorationLineFlags line)
-{
-    switch (line) {
-    case TextDecorationLineFlags::Underline: ts << "underline"_s; break;
-    case TextDecorationLineFlags::Overline: ts << "overline"_s; break;
-    case TextDecorationLineFlags::LineThrough: ts << "line-through"_s; break;
-    case TextDecorationLineFlags::Blink: ts << "blink"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, TextDecorationSkipInk skip)
 {
     switch (skip) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -656,13 +656,6 @@ enum class TextTransform : uint8_t {
 };
 constexpr auto maxTextTransformValue = TextTransform::FullWidth;
 
-enum class TextDecorationLineFlags : uint8_t {
-    Underline     = 1 << 0,
-    Overline      = 1 << 1,
-    LineThrough   = 1 << 2,
-    Blink         = 1 << 3,
-};
-
 enum class TextDecorationStyle : uint8_t {
     Solid,
     Double,
@@ -1340,7 +1333,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, TableLayoutType);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignLast);
 WTF::TextStream& operator<<(WTF::TextStream&, TextCombine);
-WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationLineFlags);
 WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationSkipInk);
 WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisFill);

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -221,9 +221,9 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
         // Spec: All text decorations except line-through should be drawn before the text is filled and stroked; thus, the text is rendered on top of these decorations.
         auto decorations = style.textDecorationLineInEffect();
         if (decorations.hasUnderline())
-            paintDecoration(TextDecorationLineFlags::Underline, fragment);
+            paintDecoration(Style::TextDecorationLine::Flag::Underline, fragment);
         if (decorations.hasOverline())
-            paintDecoration(TextDecorationLineFlags::Overline, fragment);
+            paintDecoration(Style::TextDecorationLine::Flag::Overline, fragment);
 
         for (auto type : RenderStyle::paintTypesForPaintOrder(style.paintOrder())) {
             switch (type) {
@@ -248,7 +248,7 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
 
         // Spec: Line-through should be drawn after the text is filled and stroked; thus, the line-through is rendered on top of the text.
         if (decorations.hasLineThrough())
-            paintDecoration(TextDecorationLineFlags::LineThrough, fragment);
+            paintDecoration(Style::TextDecorationLine::Flag::LineThrough, fragment);
 
         m_paintingResourceMode = { };
     }
@@ -401,11 +401,11 @@ static inline float positionOffsetForDecoration(Style::TextDecorationLine decora
     // FIXME: For SVG Fonts we need to use the attributes defined in the <font-face> if specified.
     // Compatible with Batik/Opera.
     const float ascent = fontMetrics.ascent();
-    if (decoration == TextDecorationLineFlags::Underline)
+    if (decoration == Style::TextDecorationLine::Flag::Underline)
         return ascent + thickness * 1.5f;
-    if (decoration == TextDecorationLineFlags::Overline)
+    if (decoration == Style::TextDecorationLine::Flag::Overline)
         return thickness;
-    if (decoration == TextDecorationLineFlags::LineThrough)
+    if (decoration == Style::TextDecorationLine::Flag::LineThrough)
         return ascent * 5 / 8.0f;
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp
@@ -35,6 +35,17 @@
 #include <wtf/Assertions.h>
 
 namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, Style::TextDecorationLine::Flag flag)
+{
+    switch (flag) {
+    case Style::TextDecorationLine::Flag::Underline: ts << "underline"_s; break;
+    case Style::TextDecorationLine::Flag::Overline: ts << "overline"_s; break;
+    case Style::TextDecorationLine::Flag::LineThrough: ts << "line-through"_s; break;
+    case Style::TextDecorationLine::Flag::Blink: ts << "blink"_s; break;
+    }
+    return ts;
+}
 namespace Style {
 
 uint8_t TextDecorationLine::addOrReplaceIfNotNone(const TextDecorationLine& value)
@@ -48,7 +59,7 @@ uint8_t TextDecorationLine::addOrReplaceIfNotNone(const TextDecorationLine& valu
         [&](CSS::Keyword::GrammarError) {
             setGrammarError();
         },
-        [&](const OptionSet<TextDecorationLineFlags>& newValue) {
+        [&](const OptionSet<TextDecorationLine::Flag>& newValue) {
             setFlags(newValue);
         }
     );
@@ -81,7 +92,7 @@ auto CSSValueConversion<TextDecorationLine>::operator()(BuilderState& state, con
     }
 
     if (RefPtr valueList = dynamicDowncast<CSSValueList>(value)) {
-        OptionSet<TextDecorationLineFlags> flags;
+        OptionSet<TextDecorationLine::Flag> flags;
 
         for (Ref item : *valueList) {
             RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, item);
@@ -90,16 +101,16 @@ auto CSSValueConversion<TextDecorationLine>::operator()(BuilderState& state, con
 
             switch (primitiveValue->valueID()) {
             case CSSValueUnderline:
-                flags.add(TextDecorationLineFlags::Underline);
+                flags.add(TextDecorationLine::Flag::Underline);
                 break;
             case CSSValueOverline:
-                flags.add(TextDecorationLineFlags::Overline);
+                flags.add(TextDecorationLine::Flag::Overline);
                 break;
             case CSSValueLineThrough:
-                flags.add(TextDecorationLineFlags::LineThrough);
+                flags.add(TextDecorationLine::Flag::LineThrough);
                 break;
             case CSSValueBlink:
-                flags.add(TextDecorationLineFlags::Blink);
+                flags.add(TextDecorationLine::Flag::Blink);
                 break;
             default:
                 return invalidValue();
@@ -115,30 +126,30 @@ auto CSSValueConversion<TextDecorationLine>::operator()(BuilderState& state, con
     return invalidValue();
 }
 
-Ref<CSSValue> CSSValueCreation<OptionSet<TextDecorationLineFlags>>::operator()(CSSValuePool&, const RenderStyle&, const OptionSet<TextDecorationLineFlags>& value)
+Ref<CSSValue> CSSValueCreation<OptionSet<TextDecorationLine::Flag>>::operator()(CSSValuePool&, const RenderStyle&, const OptionSet<TextDecorationLine::Flag>& value)
 {
     ASSERT(!value.isEmpty());
 
     CSSValueListBuilder list;
-    if (value.contains(TextDecorationLineFlags::Underline))
+    if (value.contains(TextDecorationLine::Flag::Underline))
         list.append(CSSPrimitiveValue::create(CSSValueUnderline));
-    if (value.contains(TextDecorationLineFlags::Overline))
+    if (value.contains(TextDecorationLine::Flag::Overline))
         list.append(CSSPrimitiveValue::create(CSSValueOverline));
-    if (value.contains(TextDecorationLineFlags::LineThrough))
+    if (value.contains(TextDecorationLine::Flag::LineThrough))
         list.append(CSSPrimitiveValue::create(CSSValueLineThrough));
-    if (value.contains(TextDecorationLineFlags::Blink))
+    if (value.contains(TextDecorationLine::Flag::Blink))
         list.append(CSSPrimitiveValue::create(CSSValueBlink));
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 // MARK: - Serialization
 
-void Serialize<OptionSet<TextDecorationLineFlags>>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle&, const OptionSet<TextDecorationLineFlags>& value)
+void Serialize<OptionSet<TextDecorationLine::Flag>>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle&, const OptionSet<TextDecorationLine::Flag>& value)
 {
     ASSERT(!value.isEmpty());
 
     bool needsSpace = false;
-    auto appendOption = [&](TextDecorationLineFlags option, CSSValueID valueID) {
+    auto appendOption = [&](TextDecorationLine::Flag option, CSSValueID valueID) {
         if (value.contains(option)) {
             if (needsSpace)
                 builder.append(' ');
@@ -146,11 +157,11 @@ void Serialize<OptionSet<TextDecorationLineFlags>>::operator()(StringBuilder& bu
             needsSpace = true;
         }
     };
-    appendOption(TextDecorationLineFlags::Underline, CSSValueUnderline);
-    appendOption(TextDecorationLineFlags::Overline, CSSValueOverline);
-    appendOption(TextDecorationLineFlags::LineThrough, CSSValueLineThrough);
+    appendOption(TextDecorationLine::Flag::Underline, CSSValueUnderline);
+    appendOption(TextDecorationLine::Flag::Overline, CSSValueOverline);
+    appendOption(TextDecorationLine::Flag::LineThrough, CSSValueLineThrough);
     // Blink value is ignored for rendering but not for the computed value.
-    appendOption(TextDecorationLineFlags::Blink, CSSValueBlink);
+    appendOption(TextDecorationLine::Flag::Blink, CSSValueBlink);
 }
 
 // MARK: - Logging
@@ -167,9 +178,9 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const TextDecorationLine& decor
         [&](CSS::Keyword::GrammarError) {
             ts << "grammar-error";
         },
-        [&](const OptionSet<TextDecorationLineFlags>& flags) {
+        [&](const OptionSet<TextDecorationLine::Flag>& flags) {
             bool needsSpace = false;
-            auto streamFlag = [&](TextDecorationLineFlags flag, CSSValueID valueID) {
+            auto streamFlag = [&](TextDecorationLine::Flag flag, CSSValueID valueID) {
                 if (flags.contains(flag)) {
                     if (needsSpace)
                         ts << ' ';
@@ -177,10 +188,10 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const TextDecorationLine& decor
                     needsSpace = true;
                 }
             };
-            streamFlag(TextDecorationLineFlags::Underline, CSSValueUnderline);
-            streamFlag(TextDecorationLineFlags::Overline, CSSValueOverline);
-            streamFlag(TextDecorationLineFlags::LineThrough, CSSValueLineThrough);
-            streamFlag(TextDecorationLineFlags::Blink, CSSValueBlink);
+            streamFlag(TextDecorationLine::Flag::Underline, CSSValueUnderline);
+            streamFlag(TextDecorationLine::Flag::Overline, CSSValueOverline);
+            streamFlag(TextDecorationLine::Flag::LineThrough, CSSValueLineThrough);
+            streamFlag(TextDecorationLine::Flag::Blink, CSSValueBlink);
         }
     );
     return ts;

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
@@ -62,11 +62,18 @@ struct TextDecorationLine {
         GrammarError
     };
 
+    enum class Flag : uint8_t {
+        Underline     = 1 << 0,
+        Overline      = 1 << 1,
+        LineThrough   = 1 << 2,
+        Blink         = 1 << 3,
+    };
+
     // Values when Type is Flags
-    static constexpr uint8_t UnderlineBit   = static_cast<uint8_t>(TextDecorationLineFlags::Underline);
-    static constexpr uint8_t OverlineBit    = static_cast<uint8_t>(TextDecorationLineFlags::Overline);
-    static constexpr uint8_t LineThroughBit = static_cast<uint8_t>(TextDecorationLineFlags::LineThrough);
-    static constexpr uint8_t BlinkBit       = static_cast<uint8_t>(TextDecorationLineFlags::Blink);
+    static constexpr uint8_t UnderlineBit   = static_cast<uint8_t>(TextDecorationLine::Flag::Underline);
+    static constexpr uint8_t OverlineBit    = static_cast<uint8_t>(TextDecorationLine::Flag::Overline);
+    static constexpr uint8_t LineThroughBit = static_cast<uint8_t>(TextDecorationLine::Flag::LineThrough);
+    static constexpr uint8_t BlinkBit       = static_cast<uint8_t>(TextDecorationLine::Flag::Blink);
 
     static constexpr uint8_t SingleValueNone          = static_cast<uint8_t>(Type::SingleValue) | static_cast<uint8_t>(SingleValue::None);
     static constexpr uint8_t SingleValueSpellingError = static_cast<uint8_t>(Type::SingleValue) | static_cast<uint8_t>(SingleValue::SpellingError);
@@ -94,13 +101,13 @@ struct TextDecorationLine {
     {
     }
 
-    TextDecorationLine(OptionSet<TextDecorationLineFlags> flags)
+    TextDecorationLine(OptionSet<TextDecorationLine::Flag> flags)
         : m_packed(flags.isEmpty() ? SingleValueNone : packFlags(flags))
     {
     }
 
-    TextDecorationLine(TextDecorationLineFlags flag)
-        : TextDecorationLine(OptionSet<TextDecorationLineFlags>(flag))
+    TextDecorationLine(TextDecorationLine::Flag flag)
+        : TextDecorationLine(OptionSet<TextDecorationLine::Flag>(flag))
     {
     }
 
@@ -130,21 +137,21 @@ struct TextDecorationLine {
         return (isFlags()) && (m_packed & BlinkBit);
     }
 
-    bool containsAny(OptionSet<TextDecorationLineFlags> options) const
+    bool containsAny(OptionSet<TextDecorationLine::Flag> options) const
     {
         if (!isFlags())
             return false;
         return (m_packed & packFlags(options));
     }
 
-    bool contains(TextDecorationLineFlags option) const
+    bool contains(TextDecorationLine::Flag option) const
     {
         if (!isFlags())
             return false;
         return (m_packed & packFlagValue(option));
     }
 
-    void remove(TextDecorationLineFlags option)
+    void remove(TextDecorationLine::Flag option)
     {
         if (type() == Type::Flags) {
             m_packed &= ~packFlagValue(option);
@@ -179,7 +186,7 @@ struct TextDecorationLine {
     void setNone() { m_packed = SingleValueNone; }
     void setSpellingError() { m_packed = SingleValueSpellingError; }
     void setGrammarError() { m_packed = SingleValueGrammarError; }
-    void setFlags(OptionSet<TextDecorationLineFlags> flags)
+    void setFlags(OptionSet<TextDecorationLine::Flag> flags)
     {
         if (isFlags())
             m_packed |= packFlags(flags);
@@ -191,16 +198,16 @@ struct TextDecorationLine {
     bool operator==(const TextDecorationLine& other) const { return m_packed == other.m_packed; }
 
     uint8_t toRaw() const { return m_packed; }
-    static constexpr uint8_t packFlags(OptionSet<TextDecorationLineFlags> flags)
+    static constexpr uint8_t packFlags(OptionSet<TextDecorationLine::Flag> flags)
     {
         uint8_t result = static_cast<uint8_t>(Type::Flags);
-        if (flags.contains(TextDecorationLineFlags::Underline))
+        if (flags.contains(TextDecorationLine::Flag::Underline))
             result |= UnderlineBit;
-        if (flags.contains(TextDecorationLineFlags::Overline))
+        if (flags.contains(TextDecorationLine::Flag::Overline))
             result |= OverlineBit;
-        if (flags.contains(TextDecorationLineFlags::LineThrough))
+        if (flags.contains(TextDecorationLine::Flag::LineThrough))
             result |= LineThroughBit;
-        if (flags.contains(TextDecorationLineFlags::Blink))
+        if (flags.contains(TextDecorationLine::Flag::Blink))
             result |= BlinkBit;
         return result;
     }
@@ -210,34 +217,34 @@ private:
     inline uint8_t rawValue() const { return m_packed & ValuesMask; }
 
     // Note that this function packs only the 'Value' bit, ignoring the Type. This is useful for bitwise operations.
-    static constexpr uint8_t packFlagValue(TextDecorationLineFlags flag)
+    static constexpr uint8_t packFlagValue(TextDecorationLine::Flag flag)
     {
         switch (flag) {
-        case TextDecorationLineFlags::Underline:
+        case TextDecorationLine::Flag::Underline:
             return UnderlineBit;
-        case TextDecorationLineFlags::Overline:
+        case TextDecorationLine::Flag::Overline:
             return OverlineBit;
-        case TextDecorationLineFlags::LineThrough:
+        case TextDecorationLine::Flag::LineThrough:
             return LineThroughBit;
-        case TextDecorationLineFlags::Blink:
+        case TextDecorationLine::Flag::Blink:
             return BlinkBit;
         }
         ASSERT_NOT_REACHED();
         return 0;
     }
 
-    OptionSet<TextDecorationLineFlags> unpackFlags() const
+    OptionSet<TextDecorationLine::Flag> unpackFlags() const
     {
         ASSERT(isFlags());
-        OptionSet<TextDecorationLineFlags> flags;
+        OptionSet<TextDecorationLine::Flag> flags;
         if (m_packed & UnderlineBit)
-            flags.add(TextDecorationLineFlags::Underline);
+            flags.add(TextDecorationLine::Flag::Underline);
         if (m_packed & OverlineBit)
-            flags.add(TextDecorationLineFlags::Overline);
+            flags.add(TextDecorationLine::Flag::Overline);
         if (m_packed & LineThroughBit)
-            flags.add(TextDecorationLineFlags::LineThrough);
+            flags.add(TextDecorationLine::Flag::LineThrough);
         if (m_packed & BlinkBit)
-            flags.add(TextDecorationLineFlags::Blink);
+            flags.add(TextDecorationLine::Flag::Blink);
         return flags;
     }
 
@@ -250,19 +257,22 @@ template<> struct CSSValueConversion<TextDecorationLine> {
     auto operator()(BuilderState&, const CSSValue&) -> TextDecorationLine;
 };
 
-template<> struct CSSValueCreation<OptionSet<TextDecorationLineFlags>> {
-    auto operator()(CSSValuePool&, const RenderStyle&, const  OptionSet<TextDecorationLineFlags>&) -> Ref<CSSValue>;
+template<> struct CSSValueCreation<OptionSet<TextDecorationLine::Flag>> {
+    auto operator()(CSSValuePool&, const RenderStyle&, const  OptionSet<TextDecorationLine::Flag>&) -> Ref<CSSValue>;
 };
 
 // MARK: Serialization
 
-template<> struct Serialize<OptionSet<TextDecorationLineFlags>> {
-    void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const OptionSet<TextDecorationLineFlags>&);
+template<> struct Serialize<OptionSet<TextDecorationLine::Flag>> {
+    void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const OptionSet<TextDecorationLine::Flag>&);
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const TextDecorationLine&);
 
 } // namespace Style
+
+WTF::TextStream& operator<<(WTF::TextStream&, Style::TextDecorationLine::Flag);
+
 } // namespace WebCore
 
 DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextDecorationLine)


### PR DESCRIPTION
#### a1433b9ad2b2a4e2f50d6f064db5642fe29b0cfa
<pre>
Refactor TextDecorationLineFlags into TextDecorationLine::Flag
<a href="https://rdar.apple.com/159463269">rdar://159463269</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298115">https://bugs.webkit.org/show_bug.cgi?id=298115</a>

Reviewed by Tim Nguyen and Brent Fulgham.

Since TextDecorationLine is now converted to its own strong type,
it makes sense to refactor TextDecorationLineFlags into a nested
enum class &quot;Flag&quot; under TextDecorationLine.

Note that we also changed it from &quot;Flags&quot; to &quot;Flag&quot;,
as per Sammy&apos;s feedback at <a href="https://github.com/WebKit/WebKit/pull/49911">https://github.com/WebKit/WebKit/pull/49911</a>

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::LineDecorationStyle::LineDecorationStyle):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::logicalBottomForTextDecorationContent):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::isDecoratingBoxForBackground):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::paintBackgroundDecorations):
(WebCore::collectStylesForRenderer):
(WebCore::TextDecorationPainter::textDecorationsInEffectForStyle):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::paint):
(WebCore::positionOffsetForDecoration):
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::Style::TextDecorationLine::addOrReplaceIfNotNone):
(WebCore::Style::CSSValueConversion&lt;TextDecorationLine&gt;::operator):
(WebCore::Style::CSSValueCreation&lt;OptionSet&lt;TextDecorationLine::Flag&gt;&gt;::operator):
(WebCore::Style::Serialize&lt;OptionSet&lt;TextDecorationLine::Flag&gt;&gt;::operator):
(WebCore::Style::operator&lt;&lt;):
(WebCore::Style::CSSValueCreation&lt;OptionSet&lt;TextDecorationLineFlags&gt;&gt;::operator): Deleted.
(WebCore::Style::Serialize&lt;OptionSet&lt;TextDecorationLineFlags&gt;&gt;::operator): Deleted.
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h:
(WebCore::Style::TextDecorationLine::TextDecorationLine):
(WebCore::Style::TextDecorationLine::containsAny const):
(WebCore::Style::TextDecorationLine::contains const):
(WebCore::Style::TextDecorationLine::remove):
(WebCore::Style::TextDecorationLine::setFlags):
(WebCore::Style::TextDecorationLine::packFlags):
(WebCore::Style::TextDecorationLine::packFlagValue):
(WebCore::Style::TextDecorationLine::unpackFlags const):

Canonical link: <a href="https://commits.webkit.org/299349@main">https://commits.webkit.org/299349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f8cd1511b8e7b2b2600df1c62529874d340a335

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38347 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/29551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70726 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f49378db-3352-4337-86cc-dc522cb0a52b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90060 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ec574f1-376b-4ddc-8799-09e4f6cdb117) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31104 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/29551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70566 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f7c3cfc-63eb-4381-803d-000d2203e72b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30161 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/29551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/69094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100543 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/29551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127904 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45937 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/29551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98484 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25043 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43927 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/29551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42078 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51121 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44907 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46593 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->