### PR TITLE
Resync `cookies/partitioned-cookies` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7873,3 +7873,4 @@ imported/w3c/web-platform-tests/page-lifecycle/child-display-none.tentative.html
 imported/w3c/web-platform-tests/page-lifecycle/child-out-of-viewport.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/page-lifecycle/worker-dispay-none.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/page-lifecycle/set-composited-layer-position.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Setting Partitioned cookie on top-level site and embedding a cross-site iframe
+PASS Embed same-site embed in cross-site
+FAIL Same-site embed with a cross-site parent partitioned cookie access assert_false: expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<head>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<meta name="help" href="https://github.com/WICG/CHIPS#chips-cookies-having-independent-partitioned-state">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>
+<title>Test partitioned cookies consider ancestor chain</title>
+</head>
+<body>
+<script>
+  // This test is sets up an A1->B->A2 frame tree, where the top-level site is embedded
+  // in a cross-site embed. If the partitionKey of the cookie has a cross-site ancestor bit,
+  // the cookie set on site A1 will not be accessible on site A2.
+  promise_test(async() => {
+    assert_equals(document.cookie, "");
+
+    const partitionedCookie = "ancestor=chain";
+    const partitionedCookieAttributes =
+        "; Secure; Path=/; SameSite=None; Partitioned";
+    const partitionedCookieLine =
+        partitionedCookie + partitionedCookieAttributes;
+    document.cookie = partitionedCookieLine;
+
+    assert_true(document.cookie.includes(partitionedCookie));
+
+    const iframe = document.createElement("iframe");
+    const url = new URL(
+      "/cookies/partitioned-cookies/resources/" +
+          "ancestor-chain-cross-site-embed.html",
+          get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
+
+    iframe.src = url.href;
+    document.body.appendChild(iframe);
+
+    await fetch_tests_from_window(iframe.contentWindow);
+    erase_cookie_from_js("ancestor", "Secure; Path=/; SameSite=None; Partitioned");
+  }, "Setting Partitioned cookie on top-level site and embedding a cross-site iframe");
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Partitioned cookies are sent in embedded cross-site to same-site redirects
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<meta name="help" href="https://github.com/WICG/CHIPS#chips-cookies-having-independent-partitioned-state">
+<title>Test partitioned cookies cross-site sub-resource redirect to same-site</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>
+
+<body>
+<script>
+  promise_test(async () => {
+  assert_equals(document.cookie, "");
+  const partitionedCookie = "ancestor=chain";
+  const partitionedCookieAttributes =
+      "; Secure; Path=/; SameSite=None; Partitioned";
+  const partitionedCookieLine =
+      partitionedCookie + partitionedCookieAttributes;
+  // Add partitioned cookie to top-level site.
+  document.cookie = partitionedCookieLine;
+  assert_true(document.cookie.includes(partitionedCookie));
+
+  //Create cross-site url for iframe.
+  const cross_site_url = new URL(
+    './resources/partitioned-cookies-empty-embed.html',
+    get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
+
+  // Create cross-site iframe and wait for it to load.
+  const iframe = document.createElement("iframe");
+  iframe.src = cross_site_url.href;
+  document.body.appendChild(iframe);
+  await new Promise(r => iframe.onload = r);
+
+  // Confirm that the iframe is cross-site.
+  let iframe_url = new URL(iframe.src);
+  assert_not_equals(window.location.hostname, iframe_url.hostname);
+
+  //Create same-site url for iframe.
+  const same_site_url = new URL(
+    './resources/partitioned-cookies-empty-embed.html',
+    get_host_info().ORIGIN + self.location.pathname);
+
+  // Redirect iframe by using redirect-and-echo-cookie-header.py to append the
+  // http cookie header to the url query params for testing.
+  iframe.src = `./resources/redirect-and-echo-cookie-header.py?location=${same_site_url.href}`;
+  await new Promise(r => iframe.onload = r);
+
+  iframe_url = new URL(iframe.src);
+  assert_equals(window.location.hostname, iframe_url.hostname);
+
+  // Confirm that the cookie was in http header of the redirect request
+  assert_true(iframe.contentWindow.location.href
+    .includes(partitionedCookie));
+  assert_true(iframe.contentDocument.cookie
+      .includes(partitionedCookie));
+  erase_cookie_from_js("ancestor", "Secure; Path=/; SameSite=None; Partitioned");
+    }, "Partitioned cookies are sent in embedded cross-site to same-site redirects");
+</script>
+</body>
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Partitioned cookies set in same-site contexts are available in other same-site documents. assert_true: partitionedCookie=cookie expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<head>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<meta name="help" href="https://github.com/WICG/CHIPS#chips-cookies-having-independent-partitioned-state">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>
+<title>Test partitioned cookies behavior in parallel same-site iframes</title>
+</head>
+<body>
+<script>
+
+function waitForIframeToLoad(frame) {
+  return new Promise((resolve, reject) => {
+    frame.onload = resolve;
+    frame.onerror = reject;
+ });
+}
+
+promise_test( async() => {
+  // Set up document containing two same-site iframes.
+  const sameSiteIframeUrl = new URL(
+      "/cookies/partitioned-cookies/resources/" +
+          "partitioned-cookies-empty-embed.html",
+          get_host_info().HTTPS_ORIGIN + self.location.pathname);
+
+  const iframe = document.createElement("iframe");
+  const iframe2 = document.createElement("iframe");
+
+  iframe.src = sameSiteIframeUrl.href;
+  iframe2.src = sameSiteIframeUrl.href;
+
+  let loadCompleted = Promise.all([waitForIframeToLoad(iframe), waitForIframeToLoad(iframe2)]);
+
+  document.body.appendChild(iframe);
+  document.body.appendChild(iframe2);
+
+  await loadCompleted;
+
+  // Confirm that partitioned cookies set in iframes are made available to other same-site
+  // documents that exist before the cookie is set.
+  const partitionedCookieName = "partitionedCookie";
+  const partitionedCookie = partitionedCookieName+ "=cookie";
+  const partitionedCookieAttributes =
+        ";Secure; Path=/; SameSite=None; Partitioned";
+
+  iframe.contentWindow.document.cookie = partitionedCookie + partitionedCookieAttributes;
+
+  assert_true(document.cookie.includes(partitionedCookie), document.cookie);
+  assert_true(iframe.contentWindow.document.cookie.includes(partitionedCookie),
+      iframe.contentWindow.document.cookie);
+  assert_true(iframe2.contentWindow.document.cookie.includes(partitionedCookie),
+      iframe2.contentWindow.document.cookie);
+
+  // Confirm that partitioned cookies are available to iframes that are added after the
+  // cookie has been set.
+  const iframe3 = document.createElement("iframe");
+  loadCompleted = waitForIframeToLoad(iframe3);
+
+  iframe3.src = sameSiteIframeUrl.href;
+
+  loadCompleted = waitForIframeToLoad(iframe3);
+
+  document.body.appendChild(iframe3);
+
+  await loadCompleted;
+
+  assert_true(iframe3.contentWindow.document.cookie.includes(partitionedCookie));
+
+  // Confirm that a partitioned cookie set in one iframe, is accessible in all other same site
+  // documents.
+  const secondPartitionedCookie = "second=cookie";
+
+  iframe.contentWindow.document.cookie = secondPartitionedCookie + partitionedCookieAttributes;
+
+  assert_true(iframe.contentWindow.document.cookie.includes(secondPartitionedCookie),
+      iframe.contentWindow.document.cookie);
+  assert_true(iframe2.contentWindow.document.cookie.includes(secondPartitionedCookie),
+      iframe2.contentWindow.document.cookie);
+  assert_true(iframe3.contentWindow.document.cookie.includes(secondPartitionedCookie),
+      iframe3.contentWindow.document.cookie);
+  assert_true(document.cookie.includes(secondPartitionedCookie), document.cookie);
+
+  // Confirm that changes made to a partitioned cookie in one iframe will impact the cookie
+  // in other documents.
+  const changedPartitionedCookie = partitionedCookieName+ "=newValue";
+
+  iframe.contentWindow.document.cookie = changedPartitionedCookie + partitionedCookieAttributes;
+
+  assert_true(iframe.contentWindow.document.cookie.includes(changedPartitionedCookie),
+      iframe.contentWindow.document.cookie);
+  assert_true(iframe2.contentWindow.document.cookie.includes(changedPartitionedCookie),
+      iframe2.contentWindow.document.cookie);
+  assert_true(document.cookie.includes(changedPartitionedCookie), document.cookie);
+
+  assert_false(document.cookie.includes(partitionedCookie), document.cookie);
+  assert_false(iframe.contentWindow.document.cookie.includes(partitionedCookie),
+      iframe.contentWindow.document.cookie);
+  assert_false(iframe2.contentWindow.document.cookie.includes(partitionedCookie),
+      iframe2.contentWindow.document.cookie);
+
+  erase_cookie_from_js("partitionedCookie", "Secure; Path=/; SameSite=None; Partitioned");
+  erase_cookie_from_js("second", "Secure; Path=/; SameSite=None; Partitioned");
+
+}, "Partitioned cookies set in same-site contexts are available in other same-site documents.");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Partitioned cookies are not sent in embedded same-site to cross-site redirects
+PASS Cross-site embed partitioned cookie access
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<meta name="help" href="https://github.com/WICG/CHIPS#chips-cookies-having-independent-partitioned-state">
+<title>Test partitioned cookies same-site sub-resource redirect to cross-site</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>
+
+<body>
+<script>
+promise_test(async () => {
+  //Add partitioned cookie to top-level site.
+  assert_equals(document.cookie, "");
+  const partitionedCookie = "ancestor=chain";
+  const partitionedCookieAttributes =
+      "; Secure; Path=/; SameSite=None; Partitioned";
+  const partitionedCookieLine =
+      partitionedCookie + partitionedCookieAttributes;
+
+  document.cookie = partitionedCookieLine;
+
+  assert_true(document.cookie.includes(partitionedCookie));
+
+  const resourceDir = "./resources/";
+  const embedUrl = new URL(resourceDir +
+    "ancestor-chain-same-site-to-cross-site-embed.html",
+    get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
+  const redirectUrl = new URL(resourceDir +
+    "redirect-and-echo-cookie-header.py?location=" + embedUrl,
+    get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
+
+  const iframe = document.createElement("iframe");
+  iframe.src = new URL(resourceDir + "ancestor-chain-empty-embed.html",
+                        get_host_info().ORIGIN + self.location.pathname);
+  document.body.appendChild(iframe);
+  await new Promise(r => iframe.onload = r);
+
+  // Confirm that the iframe is same-site to the top-level site.
+  let iframeUrl = new URL(iframe.src);
+  let iframeHost = iframeUrl.hostname;
+  assert_equals(window.location.hostname, iframeHost);
+
+  iframe.src = redirectUrl;
+  await new Promise(r => iframe.onload = r);
+
+  await fetch_tests_from_window(iframe.contentWindow);
+
+  // Confirm that the iframe is cross-site to the top-level site.
+  iframeUrl = new URL(iframe.src);
+  iframeHost = iframeUrl.hostname;
+  assert_not_equals(window.location.hostname, iframeHost);
+
+  erase_cookie_from_js("ancestor", "Secure; Path=/; SameSite=None; Partitioned");
+
+}, "Partitioned cookies are not sent in embedded same-site to cross-site redirects");
+</script>
+</body>
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS In top-level contexts, partitioned cookies default to the same SameSite attribute as unpartitioned cookies.
+PASS In top-level contexts, partitioned cookies can be set with all SameSite attributes.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="timeout" content="long" />
+  <meta
+    name="help"
+    href="https://github.com/WICG/CHIPS#chips-cookies-having-independent-partitioned-state"
+  />
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <title>Test SameSite attribute behavior for partitioned cookies</title>
+</head>
+<body>
+  <script>
+    document.body.onload = async () => {
+      const iframe = document.createElement("iframe");
+      iframe.src = new URL(
+        "resources/partitioned-cookies-samesite-attributes-embed.html",
+        get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname,
+      );
+      document.body.appendChild(iframe);
+      await new Promise(r => iframe.onload = r);
+      await fetch_tests_from_window(iframe.contentWindow);
+    };
+
+    promise_test(async (t) => {
+      t.add_cleanup(test_driver.delete_all_cookies);
+
+      document.cookie = "testPartitioned=0; Secure; Partitioned;";
+      document.cookie = "testUnpartitioned=1; Secure;";
+      const partitionedCookie = await test_driver.get_named_cookie("testPartitioned");
+      const unpartitionedCookie = await test_driver.get_named_cookie("testUnpartitioned");
+
+      // Browsers have not aligned on a common SameSite attribute default yet.
+      assert_any(assert_equals, partitionedCookie["sameSite"], ["Strict", "Lax", "None"]);
+      assert_equals(partitionedCookie["sameSite"], unpartitionedCookie["sameSite"]);
+    }, "In top-level contexts, partitioned cookies default to the same SameSite attribute as unpartitioned cookies.");
+
+    promise_test(async (t) => {
+      t.add_cleanup(test_driver.delete_all_cookies);
+
+      document.cookie = "testStrict=0; Secure; Partitioned; SameSite=Strict;";
+      let cookie = await test_driver.get_named_cookie("testStrict");
+      assert_equals(cookie["sameSite"], "Strict");
+
+      document.cookie = "testLax=0; Secure; Partitioned; SameSite=Lax;";
+      cookie = await test_driver.get_named_cookie("testLax");
+      assert_equals(cookie["sameSite"], "Lax");
+
+      document.cookie = "testNone=0; Secure; Partitioned; SameSite=None;";
+      cookie = await test_driver.get_named_cookie("testNone");
+      assert_equals(cookie["sameSite"], "None");
+    }, "In top-level contexts, partitioned cookies can be set with all SameSite attributes.");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Partitioned Cookies are available in top-level cross-site to same-site redirects
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<meta name="help" href="https://github.com/WICG/CHIPS#chips-cookies-having-independent-partitioned-state">
+<title>Test partitioned cookies redirect top-level site to cross-site and back</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>
+
+<body>
+<script>
+
+  const partitionedCookie = "ancestor=chain";
+  // Cross-site html file will add query param 'redirect=true'
+  // to indicate that redirect has been initiated. This is done
+  // to allow for the redirect to return the window to this site.
+  // This is needed to prevent a timeout in the test harness.
+  if(!window.location.href.includes("redirect=true")){
+    const partitionedCookieAttributes =
+      "; Secure; Path=/; SameSite=None; Partitioned";
+    const partitionedCookieLine =
+      partitionedCookie + partitionedCookieAttributes;
+    // Set partitioned cookie to top-level site.
+    document.cookie = partitionedCookieLine;
+
+    // Confirm that cookie has been set.
+    assert_true(document.cookie.includes(partitionedCookie));
+
+    //Create cross-site url and navigate to it.
+    const crossSiteUrl = new URL(
+      './resources/partitioned-cookies-top-level-redirect.html?location='
+      +`${window.location.href}`,
+      get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
+
+    window.location=crossSiteUrl.href;
+  }
+
+  // Confirm that the partitioned cookie is available after redirect
+  // back from cross-site in document and http headers.
+  test(() => {
+      assert_true(document.cookie.includes(partitionedCookie));
+      assert_true(window.location.href.includes(partitionedCookie));
+
+      erase_cookie_from_js("ancestor", "Secure; Path=/; SameSite=None; Partitioned");
+    }
+  ,"Partitioned Cookies are available in top-level cross-site to same-site redirects");
+
+
+</script>
+</body>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html
@@ -65,7 +65,11 @@ document.body.onload = async () => {
           encodeURIComponent(self.origin)}`,
       get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
   const popup = window.open(crossSiteUrl);
-  fetch_tests_from_window(popup);
+  await fetch_tests_from_window(popup);
+
+  for (const cookieName of cookieNames) {
+    erase_cookie_from_js(cookieName, "Secure; Path=/; SameSite=None; Partitioned");
+  }
 };
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<head>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/cookies/resources/testharness-helpers.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<title>Test partitioned cookies ancestor chain: cross site embed</title>
+</head>
+<body>
+<script>
+
+promise_test(async () => {
+  assert_false(document.cookie.includes("ancestor=chain"));
+
+  const iframe = document.createElement("iframe");
+    const url = new URL(
+    "./ancestor-chain-same-site-embed.html",
+    get_host_info().ORIGIN + self.location.pathname);
+
+  iframe.src = url.href;
+  document.body.appendChild(iframe);
+  await new Promise(r => iframe.onload = r);
+
+ await fetch_tests_from_window(iframe.contentWindow);
+
+}, "Embed same-site embed in cross-site");
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-embed.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<head>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/cookies/resources/testharness-helpers.js"></script>
+<title>Test partitioned cookies ancestor chain: same site embed</title>
+</head>
+<body>
+<script>
+
+test(() => {
+  // The cookie set on the top-level site has no cross-site ancestor in and this embed has a
+  // cross-site ancestor. So the partitioned cookie should not be accessible.
+  assert_false(document.cookie.includes("ancestor=chain"));
+}, "Same-site embed with a cross-site parent partitioned cookie access");
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-to-cross-site-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-to-cross-site-embed.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<head>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/cookies/resources/testharness-helpers.js"></script>
+<title>Test partitioned cookies ancestor chain: cross-site embed</title>
+</head>
+<body>
+<script>
+
+promise_test(async t => {
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  const partitionedCookie = "ancestor=chain";
+  assert_false(window.location.href.includes(partitionedCookie));
+  assert_false(document.cookie.includes(partitionedCookie));
+}, "Cross-site embed partitioned cookie access");
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-empty-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-empty-embed.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<head>
+<title>Empty site</title>
+</head>
+<body></body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-samesite-attributes-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-samesite-attributes-embed.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long" />
+<title>Partitioned cookie SameSite test site embedded in a cross-site context</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body>
+<script>
+promise_test(async t => {
+  test_driver.set_test_context(window.top);
+  t.add_cleanup(test_driver.delete_all_cookies);
+
+  document.cookie = "testUnset=0; Secure; Partitioned;";
+  document.cookie = "testStrict=0; Secure; Partitioned; SameSite=Strict;";
+  document.cookie = "testLax=0; Secure; Partitioned; SameSite=Lax;";
+  let cookies = await test_driver.get_all_cookies();
+  assert_equals(cookies.length, 0);
+
+  document.cookie = "testNone=0; Secure; Partitioned; SameSite=None;";
+  cookies = await test_driver.get_all_cookies();
+  assert_equals(cookies.length, 1);
+  const cookie = cookies[0];
+  assert_equals(cookie["name"], "testNone");
+  assert_equals(cookie["value"], "0");
+  assert_equals(cookie["sameSite"], "None");
+
+}, "In embedded cross-site contexts, partitioned cookies can only be set with explicit SameSite=None");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-top-level-redirect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-top-level-redirect.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<meta name="timeout" content="long">
+<title>Test partitioned cookie top level cross-site</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>
+
+<script>
+    const partitionedCookie = "ancestor=chain";
+    assert_false(document.cookie.includes(partitionedCookie));
+
+    //Redirect the page back to the same-site.
+    const params = new URLSearchParams(new URL(window.location.href).search);
+    const original_site = params.get('location');
+    // Use redirect-and-echo-cookie-header.py to make the http cookie
+    // headers available on the redirect.
+    const sameSiteUrl = new URL(`./redirect-and-echo-cookie-header.py?`
+        + `location=${original_site}?redirect=true`,
+        get_host_info().ORIGIN + self.location.pathname);
+
+    window.location=sameSiteUrl.href;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/redirect-and-echo-cookie-header.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/redirect-and-echo-cookie-header.py
@@ -1,0 +1,8 @@
+def main(request, response):
+    # Performs a redirect to the location provided. Appends
+    # the cookie headers to the url as query parameters.
+    response.status = 302
+    location = request.GET.first(b"location")
+    cookies = b"?cookies=" + request.headers.get(b"cookie", b"")
+
+    response.headers.set(b"Location", location + cookies)

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/w3c-import.log
@@ -14,6 +14,13 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-embed.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-to-cross-site-embed.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-cross-site-embed.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-cross-site-window.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-empty-embed.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-samesite-attributes-embed.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-top-level-redirect.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/redirect-and-echo-cookie-header.py
 /LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/test-helpers.js

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/w3c-import.log
@@ -14,4 +14,10 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3297,3 +3297,5 @@ webkit.org/b/300050 imported/w3c/web-platform-tests/infrastructure/server/wpt-se
 webkit.org/b/301065 imported/w3c/web-platform-tests/upgrade-insecure-requests/gen [ Skip ]
 
 webkit.org/b/301198 [ Sonoma ] imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek.html [ Failure ]
+webkit.org/b/299137 imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor.html [ Failure ]
+imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https.html [ Failure Pass ]

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt
@@ -1,0 +1,10 @@
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/resources/testharness.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/cookies/resources/testharness-helpers.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/cookies/resources/cookie-helper.sub.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/common/get-host-info.sub.js from asking for credentials because it is a cross-origin request.
+
+
+PASS Setting Partitioned cookie on top-level site and embedding a cross-site iframe
+PASS Embed same-site embed in cross-site
+FAIL Same-site embed with a cross-site parent partitioned cookie access assert_false: expected false got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/resources/testharness.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/cookies/resources/testharness-helpers.js from asking for credentials because it is a cross-origin request.
+
+
+PASS Partitioned cookies are not sent in embedded same-site to cross-site redirects
+PASS Cross-site embed partitioned cookie access
+

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS In top-level contexts, partitioned cookies default to the same SameSite attribute as unpartitioned cookies.
+FAIL In top-level contexts, partitioned cookies can be set with all SameSite attributes. assert_equals: expected "Strict" but got "None"
+

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -1769,13 +1769,25 @@
     "imported/w3c/web-platform-tests/cookies/ordering/resources/ordering-child.sub.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-cross-site-embed.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-cross-site-window.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/cookies/path/match.html": [


### PR DESCRIPTION
#### 630e5f79e1c982ab52beda01559334eb9f8fd23b
<pre>
Resync `cookies/partitioned-cookies` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=298120">https://bugs.webkit.org/show_bug.cgi?id=298120</a>
<a href="https://rdar.apple.com/159469732">rdar://159469732</a>

Reviewed by Tim Nguyen and Matthew Finkel.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8539bf6cb4b87d36ceef4cee1b951f203cfda2e8">https://github.com/web-platform-tests/wpt/commit/8539bf6cb4b87d36ceef4cee1b951f203cfda2e8</a>

* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/w3c-import.log:
* LayoutTests/tests-options.json:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-cross-site-subresource-to-same-site-redirect.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-parallel-iframes.embed.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-embed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-to-cross-site-embed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-empty-embed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-samesite-attributes-embed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/partitioned-cookies-top-level-redirect.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/redirect-and-echo-cookie-header.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/w3c-import.log:
* LayoutTests/tests-options.json
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-same-site-subresource-to-cross-site-redirect.tentative.https-expected.txt: Added.
* LayoutTests/TestExpectations:
* LayoutTests/platform/win/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-samesite-attribute.https-expected.txt: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/302371@main">https://commits.webkit.org/302371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e28a353497c639aa3c62e6752a4d8186dc40f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80218 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f42b3a8c-975f-4f3c-89b9-77ad653a2dcb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98093 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66015 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9b4d1a14-c80a-4167-9fa1-46d025d13b05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131793 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/800 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78707 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8e388371-f20a-4506-aaa5-72841c04dfa5) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/728 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79509 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109169 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34030 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138690 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/890 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106634 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 87 flakes 97 failures; Uploaded test results; 26 flakes 64 failures; Running compile-webkit-without-change") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/755 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30291 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/53374 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/988 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/894 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/929 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | | 
<!--EWS-Status-Bubble-End-->