### PR TITLE
[Cocoa] Adding many text tracks to a video element is extremely slow

### DIFF
--- a/PerformanceTests/Media/VideoElementAddManyTextTracks.html
+++ b/PerformanceTests/Media/VideoElementAddManyTextTracks.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<script>
+    window.addEventListener('load', event => {
+        const numberOfIterations = 20;
+        const numberOfItems = 100;
+
+        const subtitles = [
+            {kind:"captions",label:"Zulu (CC)",language:"zu"},
+            {kind:"captions",label:"Chinese (Traditional) (CC)",language:"zh-TW"},
+            {kind:"captions",label:"Chinese (Traditional - Hong Kong) (CC)",language:"zh-HK"},
+            {kind:"captions",label:"Chinese (Simplified) (CC)",language:"zh"},
+            {kind:"captions",label:"Xhosa (CC)",language:"xh"},
+            {kind:"captions",label:"Vietnamese (CC)",language:"vi"},
+            {kind:"captions",label:"Ukranian (CC)",language:"uk"},
+            {kind:"captions",label:"Turkish (CC)",language:"tr"},
+            {kind:"captions",label:"Tagalog (CC)",language:"fil"},
+            {kind:"captions",label:"Thai (CC)",language:"th"},
+            {kind:"captions",label:"Swahili (CC)",language:"sw"},
+            {kind:"captions",label:"Swedish (CC)",language:"sv"},
+            {kind:"captions",label:"Montenegrin (CC)",language:"sr-ME"},
+            {kind:"captions",label:"Serbian (CC)",language:"sr"},
+            {kind:"captions",label:"Albanian (CC)",language:"sq"},
+            {kind:"captions",label:"Slovenian (CC)",language:"sl"},
+            {kind:"captions",label:"Slovakian (CC)",language:"sk"},
+            {kind:"captions",label:"Russian (CC)",language:"ru"},
+            {kind:"captions",label:"Romanian (CC)",language:"ro"},
+            {kind:"captions",label:"Portuguese (Portugal) (CC)",language:"pt-PT"},
+            {kind:"captions",label:"Portuguese (CC)",language:"pt"},
+            {kind:"captions",label:"Polish (CC)",language:"pl"},
+            {kind:"captions",label:"Norwegian (CC)",language:"no"},
+            {kind:"captions",label:"Dutch (CC)",language:"nl"},
+            {kind:"captions",label:"Maltese (CC)",language:"mt"},
+            {kind:"captions",label:"Malay (CC)",language:"ms"},
+            {kind:"captions",label:"Macedonian (CC)",language:"mk"},
+            {kind:"captions",label:"Latvian (CC)",language:"lv"},
+            {kind:"captions",label:"Lithuanian (CC)",language:"lt"},
+            {kind:"captions",label:"Korean (CC)",language:"ko"},
+            {kind:"captions",label:"Georgian (CC)",language:"ka"},
+            {kind:"captions",label:"Japanese (CC)",language:"ja"},
+            {kind:"captions",label:"Italian (CC)",language:"it"},
+            {kind:"captions",label:"Icelandic (CC)",language:"is"},
+            {kind:"captions",label:"Indonesian (CC)",language:"id"},
+            {kind:"captions",label:"Armenian (CC)",language:"hy"},
+            {kind:"captions",label:"Hungarian (CC)",language:"hu"},
+            {kind:"captions",label:"Croatian (CC)",language:"hr"},
+            {kind:"captions",label:"Hebrew (CC)",language:"he"},
+            {kind:"captions",label:"Irish (CC)",language:"ga"},
+            {kind:"captions",label:"French (Canada) (CC)",language:"fr-CA"},
+            {kind:"captions",label:"French (CC)",language:"fr"},
+            {kind:"captions",label:"Finnish (CC)",language:"fi"},
+            {kind:"captions",label:"Estonian (CC)",language:"et"},
+            {kind:"captions",label:"Spanish (Latin America) (CC)",language:"es-XL"},
+            {kind:"captions",label:"Spanish (Mexican Speaking) (CC)",language:"es-MX"},
+            {kind:"captions",label:"Spanish (CC)",language:"es"},
+            {kind:"captions",label:"Spanish (Argentina) (CC)",language:"es-AR"},
+            {kind:"captions",label:"English (CC)",language:"en"},
+            {kind:"captions",label:"English (United Kingdom) (CC)",language:"en-GB"},
+            {kind:"captions",label:"English (Canada) (CC)",language:"en-CA"},
+            {kind:"captions",label:"English (Australia) (CC)",language:"en-AU"},
+            {kind:"captions",label:"Greek (CC)",language:"el"},
+            {kind:"captions",label:"German (CC)",language:"de"},
+            {kind:"captions",label:"Danish (CC)",language:"da"},
+            {kind:"captions",label:"Czech (CC)",language:"cs"},
+            {kind:"captions",label:"Catalan (CC)",language:"ca"},
+            {kind:"captions",label:"Bosnian (CC)",language:"bs"},
+            {kind:"captions",label:"Bulgarian (CC)",language:"bg"},
+            {kind:"captions",label:"Azerbaijani (CC)",language:"az"},
+            {kind:"captions",label:"Arabic (CC)",language:"ar"}
+        ];
+
+        function waitFor(object, event) {
+            return new Promise(resolve => {
+                object.addEventListener(event, resolve, {once: true});
+            })
+        }
+
+        PerfTestRunner.prepareToMeasureValuesAsync({
+            customIterationCount: numberOfIterations,
+            unit: 'ms',
+            done: function () {
+                PerfTestRunner.gc();
+            }
+        });
+
+        function startIteration()
+        {
+            testGenerator = runIteration();
+            testGenerator.next();
+        }
+
+        async function *runIteration()
+        {
+            let target = document.createElement('div');
+            document.body.appendChild(target);
+
+            var startTime = PerfTestRunner.now();
+
+            let video = document.createElement('video');
+            video.controls = true;
+            target.appendChild(video);
+            for (subtitle of subtitles) {
+                let track = video.addTextTrack(subtitle.kind, subtitle.label, subtitle.language);
+                track.mode = 'disabled';
+            };
+
+            for (subtitle of subtitles)
+                await waitFor(video.textTracks, 'change');
+
+            if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime)) {
+                document.body.removeChild(target);
+                return;
+            }
+
+            document.body.removeChild(target);
+            PerfTestRunner.gc();
+            setTimeout(startIteration, 0);
+        }
+
+        startIteration();
+    })
+</script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
#### bbf46ab941a84a573ad4b742e35bda3b698c374c
<pre>
[Cocoa] Adding many text tracks to a video element is extremely slow
<a href="https://rdar.apple.com/147072548">rdar://147072548</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298122">https://bugs.webkit.org/show_bug.cgi?id=298122</a>

Reviewed by Eric Carlson.

When TextTracks are added to a video element with its controls enabled, the controls ask
for the current available TextTracks to be sorted, and that sort operation is of course O(n^2).
In the sort algorithm itself, the same properties are re-calculated many times, multiplying
that inefficiency.

Rather than re-calculating the properties needed by the sort algorithim for each comparison,
generate a side data structure initialized with pre-calculated values. There&apos;s still an O(n^2)
complexity to the sort, but the algorithm now just compares bools and strings; the cost is
now mostly linear with the number of tracks.

Added a performance test to validate this fix. The perf test adds 60 caption tracks and measures
the amount of time taken before all these tracks &quot;change&quot; events fire. On this change, the median
time requried to complete each iteration has dropped from 1.30s to 200ms; a 6x speed increase.

* PerformanceTests/Media/VideoElementAddManyTextTracks.html
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::trackDisplayName):
(WebCore::CaptionUserPreferencesMediaAF::displayNameForTrack const):
(WebCore::CaptionUserPreferencesMediaAF::sortedTrackListForMenu):
(WebCore::textTrackCompare): Deleted.

Canonical link: <a href="https://commits.webkit.org/299347@main">https://commits.webkit.org/299347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/272ff6f1c4e4f1ddcd36d4de2d4e131a2fc3a21c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118681 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70741 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7effdfc-e43b-4488-869a-27532322ec84) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90072 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72871958-ecfd-4bab-96e7-e4846dd079d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70578 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2dff1474-2495-4be7-9954-4413cba538de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68518 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98713 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25045 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21943 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51136 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44922 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48268 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->