### PR TITLE
REGRESSION (macOS 15.4): Eclipse crashes in BackForwardCache::markPagesForContentsSizeChanged

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -616,6 +616,9 @@ void BackForwardCache::prune(PruningReason pruningReason)
 {
     while (pageCount() > maxSize()) {
         auto oldestItem = m_items.takeFirst();
+
+        // Take the CachedPage before calling set() so ~CachedPage doesn’t find itself in m_cachedPageMap.
+        auto cachedPage = m_cachedPageMap.take(oldestItem);
         m_cachedPageMap.set(oldestItem, pruningReason);
         RELEASE_LOG(BackForwardCache, "BackForwardCache::prune removing item: %s, size: %u / %u", oldestItem.toString().utf8().data(), pageCount(), maxSize());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -1215,6 +1215,27 @@ TEST(WTF_HashMap, Clear_Reenter)
     EXPECT_TRUE(map.isEmpty());
 }
 
+TEST(WTF_HashMap, Set_Reenter)
+{
+    HashMap<uint64_t, Variant<std::unique_ptr<TestObjectWithCustomDestructor>, int>> map;
+    map.add(1, makeUnique<TestObjectWithCustomDestructor>([&map] {
+        auto it = map.find(1);
+        EXPECT_TRUE(std::holds_alternative<std::unique_ptr<TestObjectWithCustomDestructor>>(it->value));
+    }));
+    map.set(1, 1);
+}
+
+TEST(WTF_HashMap, Take_Set_Reenter)
+{
+    HashMap<uint64_t, Variant<std::unique_ptr<TestObjectWithCustomDestructor>, int>> map;
+    map.add(1, makeUnique<TestObjectWithCustomDestructor>([&map] {
+        auto it = map.find(1);
+        EXPECT_FALSE(std::holds_alternative<std::unique_ptr<TestObjectWithCustomDestructor>>(it->value));
+    }));
+    auto value = map.take(1);
+    map.set(1, 1);
+}
+
 TEST(WTF_HashMap, Ensure_Translator)
 {
     HashMap<String, unsigned> map;


### PR DESCRIPTION
#### 3b9e70010b835f477b09ae4125ca352d301365c7
<pre>
REGRESSION (macOS 15.4): Eclipse crashes in BackForwardCache::markPagesForContentsSizeChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=290985">https://bugs.webkit.org/show_bug.cgi?id=290985</a>
<a href="https://rdar.apple.com/157132323">rdar://157132323</a>

Reviewed by Michael Catanzaro.

In WebKitLegacy, m_cachedPageMap can be iterated while cached pages are being pruned. When this happens,
the std::unique_ptr&lt;CachedPage&gt; remains in the map during ~CachedPage, but the unique_ptr is nulled,
which can lead to a crash in the CachedPage destructor. We can avoid this by ensuring that the CachedPage
is removed from the HashMap before its destructor is executed, which this change does.

I’ve had trouble creating a layout test that hit this crash, but I have added tests that shows the
HashMap behavior that leads to it.

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::prune):
* Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp:
(TestWebKitAPI::TEST(WTF_HashMap, Set_Reenter)):
(TestWebKitAPI::TEST(WTF_HashMap, Take_Set_Reenter)):

Canonical link: <a href="https://commits.webkit.org/299363@main">https://commits.webkit.org/299363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98314d5f3b3fbcaa8c6842b2bf6c6e92bdc53ba5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70768 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4b5622b-5ee0-430b-b491-eaa84208e8e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90093 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d88906e-fff5-4438-8b63-f7d4f8e5abdb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70599 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d988babd-e9f3-49de-ab56-2dcbf5f50d59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24541 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68550 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127947 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98736 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98519 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42123 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18921 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51163 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->