### PR TITLE
Fix some Safer C++ lambda capture issues in WebCore/dom

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -37,12 +37,9 @@ css/CSSPendingSubstitutionValue.cpp
 css/CSSValue.cpp
 css/CSSVariableReferenceValue.cpp
 css/StyleRule.cpp
-dom/BroadcastChannel.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
-dom/Document.cpp
 dom/RejectedPromiseTracker.cpp
-dom/Subscriber.cpp
 editing/Editor.cpp
 html/FormAssociatedCustomElement.cpp
 html/track/TrackBase.cpp

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -128,7 +128,7 @@ void BroadcastChannel::MainThreadBridge::ensureOnMainThread(Function<void(Page*)
 
 void BroadcastChannel::MainThreadBridge::registerChannel()
 {
-    ensureOnMainThread([this, contextIdentifier = m_broadcastChannel->scriptExecutionContext()->identifier()](auto* page) mutable {
+    ensureOnMainThread([this, protectedThis = Ref { *this }, contextIdentifier = m_broadcastChannel->scriptExecutionContext()->identifier()](auto* page) mutable {
         if (page)
             page->protectedBroadcastChannelRegistry()->registerChannel(m_origin, m_name, identifier());
         channelToContextIdentifier().add(identifier(), contextIdentifier);
@@ -137,7 +137,7 @@ void BroadcastChannel::MainThreadBridge::registerChannel()
 
 void BroadcastChannel::MainThreadBridge::unregisterChannel()
 {
-    ensureOnMainThread([this](auto* page) {
+    ensureOnMainThread([this, protectedThis = Ref { *this }](auto* page) {
         if (page)
             page->protectedBroadcastChannelRegistry()->unregisterChannel(m_origin, m_name, identifier());
         channelToContextIdentifier().remove(identifier());
@@ -146,7 +146,7 @@ void BroadcastChannel::MainThreadBridge::unregisterChannel()
 
 void BroadcastChannel::MainThreadBridge::postMessage(Ref<SerializedScriptValue>&& message)
 {
-    ensureOnMainThread([this, message = WTFMove(message)](auto* page) mutable {
+    ensureOnMainThread([this, protectedThis = Ref { *this }, message = WTFMove(message)](auto* page) mutable {
         if (!page)
             return;
 

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -31,18 +31,18 @@
 #include "ScriptWrappable.h"
 #include "SubscribeOptions.h"
 #include "VoidCallback.h"
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class ScriptExecutionContext;
 
-class Subscriber final : public ActiveDOMObject, public ScriptWrappable, public RefCounted<Subscriber> {
+class Subscriber final : public ActiveDOMObject, public ScriptWrappable, public RefCountedAndCanMakeWeakPtr<Subscriber> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Subscriber);
 
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const final { RefCountedAndCanMakeWeakPtr::ref(); }
+    void deref() const final { RefCountedAndCanMakeWeakPtr::deref(); }
 
     void next(JSC::JSValue);
     void complete();


### PR DESCRIPTION
#### fb7ca044092d1152852a83c4d8f156f672357759
<pre>
Fix some Safer C++ lambda capture issues in WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=298127">https://bugs.webkit.org/show_bug.cgi?id=298127</a>
<a href="https://rdar.apple.com/159475468">rdar://159475468</a>

Reviewed by Geoffrey Garen.

Apply SaferCPP rules for lambda captures to some files in WebCore/dom.

* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/dom/BroadcastChannel.cpp:
* Source/WebCore/dom/Document.cpp:
    This one is actually safe for the Document but passing a Ref to the Document
    in to the lambda helps us sidestep any problems with the Settings raw pointer
    being passed into functions not necessarily visible from this scope.
* Source/WebCore/dom/Subscriber.cpp:
    We may need to create a RefPtr if we run the AbortSignal&apos;s algorithm
    installed in Subscriber::followSignal immediately during object
    construction. In that case we will hit a debug assert in RefCounted since
    we haven&apos;t finished adoption yet. We can safely relax the adoption requirement
    here since we aren&apos;t at risk of forgetting to adopt the reference.

Canonical link: <a href="https://commits.webkit.org/299365@main">https://commits.webkit.org/299365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e8e54d6aba28597bbeacc5b3ccc0e516b935906

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70822 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/543735c4-2d92-433f-af18-8032509b6ced) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90135 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1cd3418-1f7c-41ee-b1fb-4b01b12603bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70641 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8ed0606-da83-479f-877f-98d9f58626a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24589 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68606 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128001 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98782 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42194 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51217 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45003 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46689 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->