### PR TITLE
Click and auxclick event targeting does not follow pointer capture target override

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_capture_mouse-auxclick-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_capture_mouse-auxclick-expected.txt
@@ -1,8 +1,8 @@
 
 PASS pointerdown/up at child1, no capture
 PASS pointerdown/up at child1, capture at child1
-FAIL pointerdown/up at child1, capture at child2 assert_equals: expected "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,auxclick@child2" but got "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,auxclick@child1"
+PASS pointerdown/up at child1, capture at child2
 PASS pointerdown at child1, pointerup at child2, no capture
-FAIL pointerdown at child1, pointerup at child2, capture at child1 assert_equals: expected "pointerdown@child1,gotpointercapture@child1,pointerup@child1,lostpointercapture@child1,auxclick@child1" but got "pointerdown@child1,gotpointercapture@child1,pointerup@child1,lostpointercapture@child1,auxclick@parent"
-FAIL pointerdown at child1, pointerup at child2, capture at child2 assert_equals: expected "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,auxclick@child2" but got "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,auxclick@parent"
+PASS pointerdown at child1, pointerup at child2, capture at child1
+PASS pointerdown at child1, pointerup at child2, capture at child2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_capture_mouse-click-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_capture_mouse-click-expected.txt
@@ -1,8 +1,8 @@
 
 PASS pointerdown/up at child1, no capture
 PASS pointerdown/up at child1, capture at child1
-FAIL pointerdown/up at child1, capture at child2 assert_equals: expected "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,click@child2" but got "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,click@child1"
+PASS pointerdown/up at child1, capture at child2
 PASS pointerdown at child1, pointerup at child2, no capture
-FAIL pointerdown at child1, pointerup at child2, capture at child1 assert_equals: expected "pointerdown@child1,gotpointercapture@child1,pointerup@child1,lostpointercapture@child1,click@child1" but got "pointerdown@child1,gotpointercapture@child1,pointerup@child1,lostpointercapture@child1,click@parent"
-FAIL pointerdown at child1, pointerup at child2, capture at child2 assert_equals: expected "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,click@child2" but got "pointerdown@child1,gotpointercapture@child2,pointerup@child2,lostpointercapture@child2,click@parent"
+PASS pointerdown at child1, pointerup at child2, capture at child1
+PASS pointerdown at child1, pointerup at child2, capture at child2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=-expected.txt
@@ -7,6 +7,6 @@ PASS Test in the topmost document: "pointerdown" event should be fired on expect
 PASS Test in the topmost document: "mousedown" event should be fired on expected target
 PASS Test in the topmost document: "pointerup" event should be fired on expected target
 PASS Test in the topmost document: "mouseup" event should be fired on expected target
-FAIL Test in the topmost document: "click" event should be fired on expected target assert_array_equals: lengths differ, expected array ["<div id=\"parent\">", "<body>", "<html>", Document node with 2 children, object "[object Window]"] length 5, got ["<div id=\"target\">", "<div id=\"parent\">", "<body>", "<html>", Document node with 2 children, object "[object Window]"] length 6
+PASS Test in the topmost document: "click" event should be fired on expected target
 FAIL Test in the iframe: all expected events should be fired assert_array_equals: lengths differ, expected array ["pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 5, got [] length 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=pointerdown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&preventDefault=pointerdown-expected.txt
@@ -5,6 +5,6 @@ PASS Test in the iframe
 PASS Test in the topmost document: all expected events should be fired
 PASS Test in the topmost document: "pointerdown" event should be fired on expected target
 PASS Test in the topmost document: "pointerup" event should be fired on expected target
-FAIL Test in the topmost document: "click" event should be fired on expected target assert_array_equals: lengths differ, expected array ["<div id=\"parent\">", "<body>", "<html>", Document node with 2 children, object "[object Window]"] length 5, got ["<div id=\"target\">", "<div id=\"parent\">", "<body>", "<html>", Document node with 2 children, object "[object Window]"] length 6
+PASS Test in the topmost document: "click" event should be fired on expected target
 FAIL Test in the iframe: all expected events should be fired assert_array_equals: lengths differ, expected array ["pointerdown", "pointerup", "click"] length 3, got [] length 0
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -482,6 +482,7 @@ private:
 
     MouseEventWithHitTestResults prepareMouseEvent(const HitTestRequest&, const PlatformMouseEvent&);
 
+    bool dispatchAnyClickEvent(const AtomString& eventType, Node* target, int clickCount, const PlatformMouseEvent&);
     bool dispatchMouseEvent(const AtomString& eventType, Node* target, int clickCount, const PlatformMouseEvent&, FireMouseOverOut);
 
     enum class IgnoreAncestorNodesForClickEvent : bool { No, Yes };
@@ -676,6 +677,7 @@ private:
 
     RefPtr<Node> m_lastTouchedNode;
     RefPtr<Node> m_clickNode;
+    RefPtr<Element> m_clickCaptureElement;
     RefPtr<HTMLFrameSetElement> m_frameSetBeingResized;
 
     LayoutSize m_offsetFromResizeCorner; // In the coords of m_resizeLayer.


### PR DESCRIPTION
#### 69700fdc39ef56aa2131e7ad0065d63626e6de8d
<pre>
Click and auxclick event targeting does not follow pointer capture target override
<a href="https://bugs.webkit.org/show_bug.cgi?id=298130">https://bugs.webkit.org/show_bug.cgi?id=298130</a>
<a href="https://rdar.apple.com/159477637">rdar://159477637</a>

Reviewed by Richard Robinson and Lily Spiniolas.

When an element has pointer capture, [aux]click events should (also) be
dispatched to the pointer capture target override rather than the hit
tested node under the pointer, refer to
<a href="https://www.w3.org/TR/pointerevents/#">https://www.w3.org/TR/pointerevents/#</a>:~:text=even%20though%20the%20lostpointercapture%20event%20with%20the%20same%20pointerId%20has%20been%20dispatched%20already

In this patch, we add a new m_clickCaptureElement member to
EventHandler. This stores the element when pointer capture is
established during a pointer event sequence. Note that we choose to not
override m_clickNode because it is used for general event dispatch
logic, too.

The swallowAnyClickEvent() method now checks for this captured element
first when determining the target for click events.

The patch fixes (and updates expectations for) the failing tests:
- pointerevent_click_during_capture_mouse-click.html
- pointerevent_click_during_capture_mouse-auxclick.html

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_capture_mouse-auxclick-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_capture_mouse-click-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&amp;preventDefault=-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture_pointerType=mouse&amp;preventDefault=pointerdown-expected.txt:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::clear):
(WebCore::EventHandler::nodeWillBeRemoved):
(WebCore::EventHandler::invalidateClick):
(WebCore::targetNodeForClickEvent):
(WebCore::EventHandler::swallowAnyClickEvent):
(WebCore::EventHandler::pointerCaptureElementDidChange):
(WebCore::EventHandler::updateMouseEventTargetNode):
(WebCore::EventHandler::dispatchAnyClickEvent):
* Source/WebCore/page/EventHandler.h:

Canonical link: <a href="https://commits.webkit.org/299567@main">https://commits.webkit.org/299567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdf17c2f5f69e8ac1407317d2a686642902735ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71463 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c76e8150-4354-4dec-9215-c127e2e89ba2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90723 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60038 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59681d2e-2b4c-409d-8e73-4dc855aeedba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107047 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71190 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d714182-18e6-4b14-9a11-dd72edbeaded) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69295 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128637 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99299 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99101 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22541 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42877 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19000 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51873 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45638 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->