### PR TITLE
[Performance] Media controls ask for localized, sorted list of text tracks, only to check to see if the list is empty

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/tracks-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/tracks-support.js
@@ -69,13 +69,13 @@ class TracksSupport extends MediaControllerSupport
 
     _canPickAudioTracks()
     {
-        const audioTracks = this._audioTracks();
+        const audioTracks = this.mediaController.media.audioTracks;
         return audioTracks && audioTracks.length > 1;
     }
 
     _canPickTextTracks()
     {
-        const textTracks = this._textTracks();
+        const textTracks = this.mediaController.media.textTracks;
         return textTracks && textTracks.length > 0;
     }
 


### PR DESCRIPTION
#### 21a8c47f4202c17fa5801a519b191dc60f521c54
<pre>
[Performance] Media controls ask for localized, sorted list of text tracks, only to check to see if the list is empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=298133">https://bugs.webkit.org/show_bug.cgi?id=298133</a>
<a href="https://rdar.apple.com/159479269">rdar://159479269</a>

Reviewed by Ryan Reno.

As a follow up to 299347@main, much of the CPU time spent by the main thread in the
Media/VideoElementAddManyTextTracks.html test is spent generating a sorted, localized list of text
tracks for use by the media controls. However the media controls don&apos;t actually use that sorted
list for anything other than checking whether it&apos;s empty. Instead, the controls can just check
whether the media element&apos;s textTracks or audioTracks lists are empty.

This change further increases the performance of the VideoElementAddManyTextTracks.html peformance
test; the a median iteration time is now 7.5ms, which is over 100x faster than prior to
299347@main.

* Source/WebCore/Modules/modern-media-controls/media/tracks-support.js:
(TracksSupport.prototype._canPickAudioTracks):
(TracksSupport.prototype._canPickTextTracks):

Canonical link: <a href="https://commits.webkit.org/299351@main">https://commits.webkit.org/299351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6247557d52b82d77aa91914a4b4d309d75e74e3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70763 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73e3808b-903e-4287-81e3-1b332eff6b98) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90088 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c6827a3-36c8-472a-92d7-0fea604ab7bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70594 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e876548-bd20-4567-8b89-ad4766110408) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68542 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127942 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98729 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98512 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/25049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42118 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45480 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51158 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44944 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->