### PR TITLE
Adopt safer CPP in PlatformMediaSessionManager.cpp and WebMediaSessionManager.cpp

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
@@ -84,7 +84,9 @@ protected:
 private:
 
     WebCore::MediaPlaybackTargetPicker& targetPicker();
+    CheckedRef<WebCore::MediaPlaybackTargetPicker> checkedTargetPicker();
     WebCore::MediaPlaybackTargetPickerMock& mockPicker();
+    CheckedRef<WebCore::MediaPlaybackTargetPickerMock> checkedMockPicker();
 
     // MediaPlaybackTargetPicker::Client
     void setPlaybackTarget(Ref<WebCore::MediaPlaybackTarget>&&) final;

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.h
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(APPLE_PAY)
 
+#include "ExceptionOr.h"
 #include <WebCore/ApplePaySessionPaymentRequest.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>

--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.h
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.h
@@ -28,11 +28,10 @@
 #if ENABLE(APPLE_PAY)
 
 #include "ApplePaySessionPaymentRequest.h"
+#include "ExceptionOr.h"
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
-
-template<typename> class ExceptionOr;
 
 class PaymentRequestValidator {
 public:

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -22,7 +22,6 @@ Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
 Modules/WebGPU/Implementation/WebGPUTextureViewImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp
-Modules/airplay/WebMediaSessionManager.cpp
 Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
 Modules/indexeddb/IDBDatabase.h
 Modules/mediastream/RTCPeerConnection.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,4 +1,3 @@
-Modules/airplay/WebMediaSessionManager.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
 Modules/indexeddb/IDBCursor.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,7 +2,6 @@ EventNames.h
 Modules/ShapeDetection/BarcodeDetector.cpp
 Modules/ShapeDetection/FaceDetector.cpp
 Modules/ShapeDetection/TextDetector.cpp
-Modules/airplay/WebMediaSessionManager.cpp
 Modules/applepay/ApplePaySession.cpp
 Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -85,7 +85,7 @@ Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
 Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
 Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
 Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
-Modules/airplay/WebMediaSessionManager.cpp
+Modules/airplay/WebMediaSessionManager.mm
 Modules/applepay/ApplePayCouponCodeChangedEvent.cpp
 Modules/applepay/ApplePayCancelEvent.cpp
 Modules/applepay/ApplePayContactField.cpp

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -116,10 +116,10 @@ WeakPtr<PlatformMediaSessionInterface> PlatformMediaSessionManager::bestEligible
     if (eligibleAudioVideoSessions.isEmpty()) {
         if (eligibleWebAudioSessions.isEmpty())
             return nullptr;
-        return eligibleWebAudioSessions[0]->selectBestMediaSession(eligibleWebAudioSessions, purpose);
+        return WeakPtr { eligibleWebAudioSessions[0].get() }->selectBestMediaSession(eligibleWebAudioSessions, purpose);
     }
 
-    return eligibleAudioVideoSessions[0]->selectBestMediaSession(eligibleAudioVideoSessions, purpose);
+    return WeakPtr { eligibleAudioVideoSessions[0].get() }->selectBestMediaSession(eligibleAudioVideoSessions, purpose);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 27505b8e701f3d03575f3c7ccee0aa2c3686b166
<pre>
Adopt safer CPP in PlatformMediaSessionManager.cpp and WebMediaSessionManager.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298121">https://bugs.webkit.org/show_bug.cgi?id=298121</a>
<a href="https://rdar.apple.com/159484220">rdar://159484220</a>

Reviewed by Brady Eidson and Per Arne Vollan.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/Modules/airplay/WebMediaSessionManager.h:
* Source/WebCore/Modules/airplay/WebMediaSessionManager.mm: Renamed from Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp.
(WebCore::ClientState::ClientState):
(WebCore::ClientState::operator== const):
(WebCore::flagsAreSet):
(WebCore::mediaProducerStateString):
(WebCore::WebMediaSessionLogger::create):
(WebCore::WebMediaSessionLogger::logAlways const):
(WebCore::WebMediaSessionLogger::WebMediaSessionLogger):
(WebCore::WebMediaSessionManager::logger):
(WebCore::WebMediaSessionManager::alwaysOnLoggingAllowed const):
(WebCore::WebMediaSessionManager::setMockMediaPlaybackTargetPickerEnabled):
(WebCore::WebMediaSessionManager::setMockMediaPlaybackTargetPickerState):
(WebCore::WebMediaSessionManager::mockMediaPlaybackTargetPickerDismissPopup):
(WebCore::WebMediaSessionManager::mockPicker):
(WebCore::WebMediaSessionManager::checkedMockPicker):
(WebCore::WebMediaSessionManager::targetPicker):
(WebCore::WebMediaSessionManager::checkedTargetPicker):
(WebCore::WebMediaSessionManager::WebMediaSessionManager):
(WebCore::WebMediaSessionManager::addPlaybackTargetPickerClient):
(WebCore::WebMediaSessionManager::removePlaybackTargetPickerClient):
(WebCore::WebMediaSessionManager::removeAllPlaybackTargetPickerClients):
(WebCore::WebMediaSessionManager::showPlaybackTargetPicker):
(WebCore::WebMediaSessionManager::clientStateDidChange):
(WebCore::WebMediaSessionManager::setPlaybackTarget):
(WebCore::WebMediaSessionManager::externalOutputDeviceAvailableDidChange):
(WebCore::WebMediaSessionManager::playbackTargetPickerWasDismissed):
(WebCore::WebMediaSessionManager::configureNewClients):
(WebCore::WebMediaSessionManager::configurePlaybackTargetClients):
(WebCore::WebMediaSessionManager::configurePlaybackTargetMonitoring):
(WebCore::WebMediaSessionManager::scheduleDelayedTask):
(WebCore::WebMediaSessionManager::taskTimerFired):
(WebCore::WebMediaSessionManager::find):
(WebCore::WebMediaSessionManager::configureWatchdogTimer):
(WebCore::WebMediaSessionManager::watchdogTimerFired):
* Source/WebCore/Modules/applepay/PaymentCoordinator.h:
* Source/WebCore/Modules/applepay/PaymentRequestValidator.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::bestEligibleSessionForRemoteControls):

Canonical link: <a href="https://commits.webkit.org/299504@main">https://commits.webkit.org/299504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42d79d21a854f9231559361e5105de2fa146af63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119054 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71117 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/282e5d98-0064-45ea-bd75-0ae377dd6b57) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90397 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59841 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58e8bbf8-f6d8-4c7a-80fa-873215a6ab17) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70857 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be6eb70c-1275-40d6-b0d7-bf95a1457f06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24848 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68919 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128295 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99015 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98794 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42540 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18978 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51510 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48643 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46983 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->