### PR TITLE
[Liquid Glass] [macOS] Music app: hard scroll pocket appears in iTune Stores after resizing the window

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1566,9 +1566,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_setTopContentInset:(CGFloat)inset
 {
-    auto insets = _impl->obscuredContentInsets();
-    insets.setTop(static_cast<float>(inset));
-    _impl->setObscuredContentInsets(insets);
+    [self _setTopContentInset:inset immediate:NO];
 }
 
 - (CGFloat)_topContentInset
@@ -1591,6 +1589,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [NSException raise:NSInvalidArgumentException format:@"Obscured insets cannot be negative: {%f, %f, %f, %f}", insets.top, insets.left, insets.bottom, insets.right];
         return;
     }
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    _impl->setCanInstallScrollPocket();
+#endif
 
     _impl->setObscuredContentInsets(coreBoxExtentsFromEdgeInsets(insets));
 
@@ -1616,6 +1618,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_setOverflowHeightForTopScrollEdgeEffect:(CGFloat)height
 {
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    _impl->setCanInstallScrollPocket();
+#endif
+
     if (_page->overflowHeightForTopScrollEdgeEffect() == height)
         return;
 
@@ -1636,6 +1642,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_setOverrideTopScrollEdgeEffectColor:(NSColor *)color
 {
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    _impl->setCanInstallScrollPocket();
+#endif
+
     if (_overrideTopScrollEdgeEffectColor == color || [_overrideTopScrollEdgeEffectColor isEqual:color])
         return;
 
@@ -1659,6 +1669,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_setUsesAutomaticContentInsetBackgroundFill:(BOOL)value
 {
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    _impl->setCanInstallScrollPocket();
+#endif
+
     if (_usesAutomaticContentInsetBackgroundFill == value)
         return;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -805,6 +805,7 @@ public:
     void updateTopScrollPocketCaptureColor();
     void updateTopScrollPocketStyle();
     void updatePrefersSolidColorHardPocket();
+    void setCanInstallScrollPocket();
 #endif
 
 private:
@@ -1089,6 +1090,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     RetainPtr<NSScrollPocket> m_topScrollPocket;
     RetainPtr<NSHashTable<NSView *>> m_viewsAboveScrollPocket;
+    bool m_canInstallScrollPocket { false };
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7066,6 +7066,15 @@ void WebViewImpl::fulfillDeferredImageAnalysisOverlayViewHierarchyTask()
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
+void WebViewImpl::setCanInstallScrollPocket()
+{
+    if (m_canInstallScrollPocket)
+        return;
+
+    m_canInstallScrollPocket = true;
+    updateScrollPocket();
+}
+
 void WebViewImpl::updatePrefersSolidColorHardPocket()
 {
     static bool canSetPrefersSolidColorHardPocket = [NSScrollPocket instancesRespondToSelector:@selector(setPrefersSolidColorHardPocket:)];
@@ -7095,10 +7104,14 @@ void WebViewImpl::updateScrollPocket()
     if (m_windowIsEnteringOrExitingFullScreen)
         return;
 
+    Ref page = m_page.get();
+    if (!m_canInstallScrollPocket)
+        return;
+
     RetainPtr view = m_view.get();
     CGFloat topContentInset = obscuredContentInsets().top();
-    CGFloat additionalHeight = m_page->overflowHeightForTopScrollEdgeEffect();
-    bool needsTopView = m_page->preferences().contentInsetBackgroundFillEnabled()
+    CGFloat additionalHeight = page->overflowHeightForTopScrollEdgeEffect();
+    bool needsTopView = page->preferences().contentInsetBackgroundFillEnabled()
         && view
         && !view->_reasonsToHideTopScrollPocket
         && (topContentInset > 0 || additionalHeight > 0);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
@@ -317,6 +317,21 @@ TEST(ObscuredContentInsets, TopScrollPocketKVO)
     EXPECT_EQ([observer changeCount], 2u);
 }
 
+TEST(ObscuredContentInsets, NonObscuredTopContentInset)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+    EXPECT_NULL([webView _topScrollPocket]);
+
+    [webView _setTopContentInset:50];
+    [webView waitForNextPresentationUpdate];
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    EXPECT_NULL([webView _topScrollPocket]);
+
+    [webView _setOverrideTopScrollEdgeEffectColor:NSColor.redColor];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_NOT_NULL([webView _topScrollPocket]);
+}
+
 TEST(ObscuredContentInsets, AdjustedColorForTopContentInsetColor)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);


### PR DESCRIPTION
#### 0d38c8510a6ac78bd7390c26c6b61770df090aea
<pre>
[Liquid Glass] [macOS] Music app: hard scroll pocket appears in iTune Stores after resizing the window
<a href="https://bugs.webkit.org/show_bug.cgi?id=298134">https://bugs.webkit.org/show_bug.cgi?id=298134</a>
<a href="https://rdar.apple.com/156118454">rdar://156118454</a>

Reviewed by Tim Horton.

Currently, in macOS 26, using `-_setTopContentInset:` to set a nonzero top content inset for the web
view automatically installs a scroll pocket as well. This is because in Safari (and various other
system apps), the top content inset represents the area near the top of the web view, where UI
overlaps the content while scrolling (e.g. the navigation bar). While this SPI existed long before
macOS 26, it was recently generalized to all 4 rect edges, and additionally renamed to
`-setObscuredContentInsets:` to clarify the fact that these insets represent the dimensions of UI
that obscures the webpage.

However, the Music app (and possibly others) have always used `-_setTopContentInset:` to represent
a *non-obscuring* part of the UI that sits above the web view; as such, they&apos;re setting a top
content inset only to ensure that there&apos;s ~70px of additional scrollable content height above the
web view, when scrolled to the very top. Note that while this is technically incorrect due to the
fact that setting top content inset also shrinks the layout viewport for fixed-position elements, it
ultimately works out in the Music app&apos;s case, which doesn&apos;t have any fixed elements in their web
view anyways.

To fix the Music app while allowing Safari and other &quot;obscured top content inset&quot; clients to
automatically install a top scroll pocket, we require the client to use either:

1.  `-_setObscuredContentInsets:immediate:` or `-setObscuredContentInsets:` to set a top inset value
2.  `-_setTopContentInset:` in combination with any of the other SPIs that customizes the appearance
    or behavior of the top scroll pocket

...in order for WebKit to automatically create and install a scroll pocket at the top of the web
view. If only `-_setTopContentInset:` is used and (as far as WebKit can tell) the client doesn&apos;t
otherwise indicate that it requires a scroll pocket, we fall back to shipping behavior and avoid
installing the scroll pocket.

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setTopContentInset:]):
(-[WKWebView _setObscuredContentInsets:immediate:]):
(-[WKWebView _setOverflowHeightForTopScrollEdgeEffect:]):
(-[WKWebView _setOverrideTopScrollEdgeEffectColor:]):
(-[WKWebView _setUsesAutomaticContentInsetBackgroundFill:]):

Implicitly opt into showing the magic pocket when using any of the other macOS web view SPIs for
customizing the pocket appearance, even if only a top content inset is set. This is necessary to
keep other system web views that use only `-_setTopContentInset:` from breaking, e.g. AMSUI&apos;s web
views.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateScrollPocket):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, NonObscuredTopContentInset)):

Canonical link: <a href="https://commits.webkit.org/299408@main">https://commits.webkit.org/299408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52d0bbb6f3972ac325891945bc18fadba6a618c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70784 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25887323-a7a7-48d6-bfab-fd4927e1cc23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90106 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59628 "Found 1 new test failure: fast/css/vertical-align-rem-on-root.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fcab986-5332-462f-8621-4ed818eff2fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70612 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e8fa1e0-1a0c-4d73-8bd8-c4103ee3d98a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68566 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127963 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98750 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98532 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42139 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45501 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51179 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44965 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48311 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->