### PR TITLE
[JSC] Use CountingLock for CalleeGroup

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -51,6 +51,7 @@ Ref<CalleeGroup> CalleeGroup::createFromExisting(MemoryMode mode, const CalleeGr
 CalleeGroup::CalleeGroup(MemoryMode mode, const CalleeGroup& other)
     : m_calleeCount(other.m_calleeCount)
     , m_mode(mode)
+    , m_upperTierCallees(m_calleeCount)
     , m_ipintCallees(other.m_ipintCallees)
     , m_jsEntrypointCallees(other.m_jsEntrypointCallees)
     , m_callers(m_calleeCount)
@@ -65,6 +66,7 @@ CalleeGroup::CalleeGroup(MemoryMode mode, const CalleeGroup& other)
 CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInformation, RefPtr<IPIntCallees> ipintCallees)
     : m_calleeCount(moduleInformation.internalFunctionCount())
     , m_mode(mode)
+    , m_upperTierCallees(m_calleeCount)
     , m_ipintCallees(ipintCallees)
     , m_callers(m_calleeCount)
 {
@@ -142,23 +144,28 @@ void CalleeGroup::compileAsync(VM& vm, AsyncCompilationCallback&& task)
 }
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
-RefPtr<BBQCallee> CalleeGroup::tryGetBBQCalleeForLoopOSR(const AbstractLocker&, VM& vm, FunctionCodeIndex functionIndex)
+RefPtr<BBQCallee> CalleeGroup::tryGetBBQCalleeForLoopOSR(VM& vm, FunctionCodeIndex functionIndex)
 {
-    if (m_bbqCallees.isEmpty())
-        return nullptr;
+    RefPtr<BBQCallee> released;
+    auto callee = m_lock.doOptimizedRead(
+        [&]() -> RefPtr<BBQCallee> {
+            auto& maybeCallee = m_upperTierCallees[functionIndex].m_bbqCallee;
+            RefPtr bbqCallee = maybeCallee.get();
+            if (!bbqCallee)
+                return nullptr;
 
-    auto& maybeCallee = m_bbqCallees[functionIndex];
-    RefPtr bbqCallee = maybeCallee.get();
-    if (!bbqCallee)
-        return nullptr;
+            if (maybeCallee.isStrong())
+                return bbqCallee;
 
-    if (maybeCallee.isStrong())
-        return bbqCallee;
-
-    // This means this callee has been released but hasn't yet been destroyed. We're safe to use it
-    // as long as this VM knows to look for it the next time it scans for conservative roots.
-    vm.heap.reportWasmCalleePendingDestruction(Ref { *bbqCallee });
-    return bbqCallee;
+            released = bbqCallee;
+            return bbqCallee;
+        });
+    if (released) {
+        // This means this callee has been released but hasn't yet been destroyed. We're safe to use it
+        // as long as this VM knows to look for it the next time it scans for conservative roots.
+        vm.heap.reportWasmCalleePendingDestruction(Ref { *released });
+    }
+    return callee;
 }
 
 void CalleeGroup::releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex functionIndex)
@@ -175,11 +182,9 @@ void CalleeGroup::releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex func
     // We could have triggered a tier up from a BBQCallee has MemoryMode::BoundsChecking
     // but is currently running a MemoryMode::Signaling memory. In that case there may
     // be nothing to release.
-    if (!m_bbqCallees.isEmpty()) [[likely]] {
-        if (RefPtr bbqCallee = m_bbqCallees[functionIndex].convertToWeak()) {
-            bbqCallee->reportToVMsForDestruction();
-            return;
-        }
+    if (RefPtr bbqCallee = m_upperTierCallees[functionIndex].m_bbqCallee.convertToWeak()) {
+        bbqCallee->reportToVMsForDestruction();
+        return;
     }
 
     ASSERT(mode() == MemoryMode::Signaling);
@@ -220,11 +225,10 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
 
     auto handleCallerIndex = [&](size_t caller) {
         auto callerIndex = FunctionCodeIndex(caller);
-        assertIsHeld(m_lock);
 #if ENABLE(WEBASSEMBLY_BBQJIT)
         // This callee could be weak but we still need to update it since it could call our BBQ callee
         // that we're going to want to destroy.
-        if (RefPtr<BBQCallee> bbqCallee = m_bbqCallees[callerIndex].get()) {
+        if (RefPtr bbqCallee = m_upperTierCallees[callerIndex].m_bbqCallee.get()) {
             collectCallsites(bbqCallee.get());
             ASSERT(!bbqCallee->osrEntryCallee() || m_osrEntryCallees.find(callerIndex) != m_osrEntryCallees.end());
         }
@@ -286,7 +290,6 @@ void CalleeGroup::reportCallees(const AbstractLocker&, JITCallee* caller, const 
     for (uint32_t calleeIndex : callees) {
         WTF::switchOn(m_callers[calleeIndex],
             [&](SparseCallers& callers) {
-                assertIsHeld(m_lock);
                 callers.add(callerIndex.rawIndex());
                 // FIXME: We should do this when we would resize to be bigger than the bitvectors count rather than after we've already resized.
                 if (callers.memoryUse() >= DenseCallers::outOfLineMemoryUse(m_calleeCount)) {
@@ -312,7 +315,7 @@ TriState CalleeGroup::calleeIsReferenced(const AbstractLocker&, Wasm::Callee* ca
 #if ENABLE(WEBASSEMBLY_BBQJIT)
     case CompilationMode::BBQMode: {
         FunctionCodeIndex index = toCodeIndex(callee->index());
-        auto& calleeHandle = m_bbqCallees.at(index);
+        auto& calleeHandle = m_upperTierCallees[index].m_bbqCallee;
         RefPtr bbqCallee = calleeHandle.get();
         if (calleeHandle.isWeak())
             return bbqCallee ? TriState::Indeterminate : TriState::False;
@@ -320,13 +323,15 @@ TriState CalleeGroup::calleeIsReferenced(const AbstractLocker&, Wasm::Callee* ca
     }
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-    case CompilationMode::OMGMode:
-        return triState(m_omgCallees.at(toCodeIndex(callee->index())).get());
+    case CompilationMode::OMGMode: {
+        FunctionCodeIndex index = toCodeIndex(callee->index());
+        return triState(m_upperTierCallees[index].m_omgCallee.get());
+    }
     case CompilationMode::OMGForOSREntryMode: {
         FunctionCodeIndex index = toCodeIndex(callee->index());
         if (m_osrEntryCallees.get(index).get()) {
             // The BBQCallee really owns the OMGOSREntryCallee so as long as that's around the OMGOSREntryCallee is referenced.
-            if (m_bbqCallees.at(index).get())
+            if (m_upperTierCallees[index].m_bbqCallee.get())
                 return TriState::True;
             return TriState::Indeterminate;
         }

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/MemoryMode.h>
 #include <JavaScriptCore/WasmCallee.h>
 #include <JavaScriptCore/WasmJS.h>
+#include <wtf/CountingLock.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/FixedBitVector.h>
 #include <wtf/FixedVector.h>
@@ -52,6 +53,15 @@ struct UnlinkedWasmToWasmCall;
 
 class CalleeGroup final : public ThreadSafeRefCounted<CalleeGroup> {
 public:
+    struct UpperTierCallee {
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+        RefPtr<OMGCallee> m_omgCallee;
+#endif
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+        ThreadSafeWeakOrStrongPtr<BBQCallee> m_bbqCallee;
+#endif
+    };
+
     typedef void CallbackType(Ref<CalleeGroup>&&, bool);
     using AsyncCompilationCallback = RefPtr<WTF::SharedTask<CallbackType>>;
     static Ref<CalleeGroup> createFromIPInt(VM&, MemoryMode, ModuleInformation&, RefPtr<IPIntCallees>);
@@ -100,28 +110,45 @@ public:
         return *callee;
     }
 
-    RefPtr<JITCallee> replacement(const AbstractLocker&, FunctionSpaceIndex functionIndexSpace) WTF_REQUIRES_LOCK(m_lock)
+    RefPtr<JITCallee> replacement(FunctionSpaceIndex functionIndexSpace)
     {
         ASSERT(runnable());
         ASSERT(functionIndexSpace >= functionImportCount());
         unsigned calleeIndex = functionIndexSpace - functionImportCount();
-        UNUSED_PARAM(calleeIndex);
+        return m_lock.doOptimizedRead(
+            [&]() -> RefPtr<JITCallee> {
+                auto& callees = m_upperTierCallees[calleeIndex];
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-        if (!m_omgCallees.isEmpty()) {
-            if (RefPtr callee = m_omgCallees[calleeIndex])
-                return callee;
-        }
+                if (RefPtr callee = callees.m_omgCallee)
+                    return callee;
 #endif
 #if ENABLE(WEBASSEMBLY_BBQJIT)
-        if (!m_bbqCallees.isEmpty()) {
-            if (RefPtr callee = m_bbqCallees[calleeIndex].get())
-                return callee;
-        }
+                if (RefPtr callee = callees.m_bbqCallee.get())
+                    return callee;
 #endif
+                return nullptr;
+            });
+    }
+
+    RefPtr<JITCallee> replacement(const AbstractLocker&, FunctionSpaceIndex functionIndexSpace)
+    {
+        ASSERT(runnable());
+        ASSERT(functionIndexSpace >= functionImportCount());
+        unsigned calleeIndex = functionIndexSpace - functionImportCount();
+        auto& callees = m_upperTierCallees[calleeIndex];
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+        if (RefPtr callee = callees.m_omgCallee)
+            return callee;
+#endif
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+        if (RefPtr callee = callees.m_bbqCallee.get())
+            return callee;
+#endif
+        UNUSED_PARAM(callees);
         return nullptr;
     }
 
-    Ref<Callee> wasmEntrypointCalleeFromFunctionIndexSpace(const AbstractLocker& locker, FunctionSpaceIndex functionIndexSpace) WTF_REQUIRES_LOCK(m_lock)
+    Ref<Callee> wasmEntrypointCalleeFromFunctionIndexSpace(const AbstractLocker& locker, FunctionSpaceIndex functionIndexSpace)
     {
 
         if (RefPtr replacement = this->replacement(locker, functionIndexSpace))
@@ -130,7 +157,7 @@ public:
         return m_ipintCallees->at(calleeIndex).get();
     }
 
-    Ref<IPIntCallee> ipintCalleeFromFunctionIndexSpace(const AbstractLocker&, FunctionSpaceIndex functionIndexSpace) const WTF_REQUIRES_LOCK(m_lock)
+    Ref<IPIntCallee> ipintCalleeFromFunctionIndexSpace(const AbstractLocker&, FunctionSpaceIndex functionIndexSpace) const
     {
         ASSERT(functionIndexSpace >= functionImportCount());
         unsigned calleeIndex = functionIndexSpace - functionImportCount();
@@ -138,40 +165,32 @@ public:
     }
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
-    RefPtr<BBQCallee> bbqCallee(const AbstractLocker&, FunctionCodeIndex functionIndex) WTF_REQUIRES_LOCK(m_lock)
+    RefPtr<BBQCallee> bbqCallee(const AbstractLocker&, FunctionCodeIndex functionIndex)
     {
-        if (m_bbqCallees.isEmpty())
-            return nullptr;
-        return m_bbqCallees[functionIndex].get();
+        return m_upperTierCallees[functionIndex].m_bbqCallee.get();
     }
 
-    void setBBQCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, Ref<BBQCallee>&& callee) WTF_REQUIRES_LOCK(m_lock)
+    void setBBQCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, Ref<BBQCallee>&& callee)
     {
-        if (m_bbqCallees.isEmpty())
-            m_bbqCallees = FixedVector<ThreadSafeWeakOrStrongPtr<BBQCallee>>(m_calleeCount);
-        m_bbqCallees[functionIndex] = WTFMove(callee);
+        m_upperTierCallees[functionIndex].m_bbqCallee = WTFMove(callee);
     }
 
-    RefPtr<BBQCallee> tryGetBBQCalleeForLoopOSR(const AbstractLocker&, VM&, FunctionCodeIndex) WTF_REQUIRES_LOCK(m_lock);
-    void releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex) WTF_REQUIRES_LOCK(m_lock);
+    RefPtr<BBQCallee> tryGetBBQCalleeForLoopOSR(VM&, FunctionCodeIndex);
+    void releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex);
 #endif
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-    OMGCallee* omgCallee(const AbstractLocker&, FunctionCodeIndex functionIndex) WTF_REQUIRES_LOCK(m_lock)
+    OMGCallee* omgCallee(const AbstractLocker&, FunctionCodeIndex functionIndex)
     {
-        if (m_omgCallees.isEmpty())
-            return nullptr;
-        return m_omgCallees[functionIndex].get();
+        return m_upperTierCallees[functionIndex].m_omgCallee.get();
     }
 
-    void setOMGCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, Ref<OMGCallee>&& callee) WTF_REQUIRES_LOCK(m_lock)
+    void setOMGCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, Ref<OMGCallee>&& callee)
     {
-        if (m_omgCallees.isEmpty())
-            m_omgCallees = FixedVector<RefPtr<OMGCallee>>(m_calleeCount);
-        m_omgCallees[functionIndex] = WTFMove(callee);
+        m_upperTierCallees[functionIndex].m_omgCallee = WTFMove(callee);
     }
 
-    void recordOMGOSREntryCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, OMGOSREntryCallee& callee) WTF_REQUIRES_LOCK(m_lock)
+    void recordOMGOSREntryCallee(const AbstractLocker&, FunctionCodeIndex functionIndex, OMGOSREntryCallee& callee)
     {
         auto result = m_osrEntryCallees.add(functionIndex, callee);
         ASSERT_UNUSED(result, result.isNewEntry);
@@ -202,12 +221,12 @@ public:
     MemoryMode mode() const { return m_mode; }
 
 #if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
-    void updateCallsitesToCallUs(const AbstractLocker&, CodeLocationLabel<WasmEntryPtrTag> entrypoint, FunctionCodeIndex functionIndex) WTF_REQUIRES_LOCK(m_lock);
-    void reportCallees(const AbstractLocker&, JITCallee* caller, const FixedBitVector& callees) WTF_REQUIRES_LOCK(m_lock);
+    void updateCallsitesToCallUs(const AbstractLocker&, CodeLocationLabel<WasmEntryPtrTag> entrypoint, FunctionCodeIndex functionIndex);
+    void reportCallees(const AbstractLocker&, JITCallee* caller, const FixedBitVector& callees);
 #endif
 
     // TriState::Indeterminate means weakly referenced.
-    TriState calleeIsReferenced(const AbstractLocker&, Wasm::Callee*) const WTF_REQUIRES_LOCK(m_lock);
+    TriState calleeIsReferenced(const AbstractLocker&, Wasm::Callee*) const;
 
     ~CalleeGroup();
 private:
@@ -226,17 +245,12 @@ private:
 
     unsigned m_calleeCount;
     MemoryMode m_mode;
-#if ENABLE(WEBASSEMBLY_OMGJIT)
-    FixedVector<RefPtr<OMGCallee>> m_omgCallees WTF_GUARDED_BY_LOCK(m_lock);
-#endif
-#if ENABLE(WEBASSEMBLY_BBQJIT)
-    FixedVector<ThreadSafeWeakOrStrongPtr<BBQCallee>> m_bbqCallees WTF_GUARDED_BY_LOCK(m_lock);
-#endif
-    RefPtr<IPIntCallees> m_ipintCallees WTF_GUARDED_BY_LOCK(m_lock);
+    FixedVector<UpperTierCallee> m_upperTierCallees;
+    RefPtr<IPIntCallees> m_ipintCallees;
     UncheckedKeyHashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsEntrypointCallees;
 #if ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
     // FIXME: We should probably find some way to prune dead entries periodically.
-    UncheckedKeyHashMap<uint32_t, ThreadSafeWeakPtr<OMGOSREntryCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_osrEntryCallees WTF_GUARDED_BY_LOCK(m_lock);
+    UncheckedKeyHashMap<uint32_t, ThreadSafeWeakPtr<OMGOSREntryCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_osrEntryCallees;
 #endif
 
     // functionCodeIndex -> functionCodeIndex of internal functions that have direct JIT callsites to the lhs.
@@ -245,7 +259,7 @@ private:
     // FIXME: This should be a WTF class and we should use it in the JIT Plans.
     using SparseCallers = UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     using DenseCallers = BitVector;
-    FixedVector<Variant<SparseCallers, DenseCallers>> m_callers WTF_GUARDED_BY_LOCK(m_lock);
+    FixedVector<Variant<SparseCallers, DenseCallers>> m_callers;
     FixedVector<CodePtr<WasmEntryPtrTag>> m_wasmIndirectCallEntryPoints;
     FixedVector<RefPtr<Wasm::IPIntCallee>> m_wasmIndirectCallWasmCallees;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToWasmExitStubs;
@@ -253,7 +267,7 @@ private:
     std::atomic<bool> m_compilationFinished { false };
     String m_errorMessage;
 public:
-    Lock m_lock;
+    CountingLock m_lock;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -111,10 +111,9 @@ static inline RefPtr<Wasm::JITCallee> jitCompileAndSetHeuristics(Wasm::IPIntCall
     ASSERT(instance->memoryMode() == memoryMode);
     ASSERT(memoryMode == calleeGroup.mode());
     auto getReplacement = [&] () -> RefPtr<Wasm::JITCallee> {
-        Locker locker { calleeGroup.m_lock };
         if (osrFor == OSRFor::Call)
-            return calleeGroup.replacement(locker, callee.index());
-        return calleeGroup.tryGetBBQCalleeForLoopOSR(locker, instance->vm(), callee.functionIndex());
+            return calleeGroup.replacement(callee.index());
+        return calleeGroup.tryGetBBQCalleeForLoopOSR(instance->vm(), callee.functionIndex());
     };
 
     if (RefPtr replacement = getReplacement()) {
@@ -163,12 +162,9 @@ static inline Expected<RefPtr<Wasm::JITCallee>, Wasm::CompilationError> jitCompi
 
     MemoryMode memoryMode = instance->memory()->mode();
     Wasm::CalleeGroup& calleeGroup = *instance->calleeGroup();
-    {
-        Locker locker { calleeGroup.m_lock };
-        if (RefPtr replacement = calleeGroup.replacement(locker, callee.index()))  {
-            dataLogLnIf(Options::verboseOSR(), "\tSIMD code was already compiled.");
-            return replacement;
-        }
+    if (RefPtr replacement = calleeGroup.replacement(callee.index()))  {
+        dataLogLnIf(Options::verboseOSR(), "\tSIMD code was already compiled.");
+        return replacement;
     }
 
     bool compile = false;
@@ -187,8 +183,7 @@ static inline Expected<RefPtr<Wasm::JITCallee>, Wasm::CompilationError> jitCompi
             // Besides we're outside the critical section.
             locker.unlockEarly();
             {
-                Locker locker { calleeGroup.m_lock };
-                RefPtr replacement = calleeGroup.replacement(locker, callee.index());
+                RefPtr replacement = calleeGroup.replacement(callee.index());
                 RELEASE_ASSERT(replacement);
                 return replacement;
             }
@@ -211,8 +206,7 @@ static inline Expected<RefPtr<Wasm::JITCallee>, Wasm::CompilationError> jitCompi
         RELEASE_ASSERT(tierUpCounter.compilationStatus(memoryMode) == Wasm::IPIntTierUpCounter::CompilationStatus::Compiled);
     }
 
-    Locker locker { calleeGroup.m_lock };
-    RefPtr replacement = calleeGroup.replacement(locker, callee.index());
+    RefPtr replacement = calleeGroup.replacement(callee.index());
     RELEASE_ASSERT(replacement);
     return replacement;
 }


### PR DESCRIPTION
#### 1ec7365000bafc71324f49efe84a68a93e53695b
<pre>
[JSC] Use CountingLock for CalleeGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=298137">https://bugs.webkit.org/show_bug.cgi?id=298137</a>
<a href="https://rdar.apple.com/159488896">rdar://159488896</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
(JSC::Wasm::CalleeGroup::tryGetBBQCalleeForLoopOSR):
(JSC::Wasm::CalleeGroup::releaseBBQCallee):
(JSC::Wasm::CalleeGroup::updateCallsitesToCallUs):
(JSC::Wasm::CalleeGroup::reportCallees):
(JSC::Wasm::CalleeGroup::calleeIsReferenced const):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::jitCompileSIMDFunction):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ec7365000bafc71324f49efe84a68a93e53695b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70779 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f51fdc0-988d-4b60-99d9-fb3a03783861) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90102 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59625 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4862c6d6-43bf-42bd-b47c-3405987ca08d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70608 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c0cc554-f6d8-4b16-9e97-f8afb05ec7d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24552 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68561 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110837 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127958 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117233 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98746 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98528 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21974 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42134 "Hash 1ec73650 for PR 50099 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45496 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51174 "Found 2 new failures in wasm/WasmCalleeGroup.cpp, wasm/WasmCalleeGroup.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145929 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44960 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37523 "Found 1 new JSC binary failure: testapi, Found 18581 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48306 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->