### PR TITLE
[JSC] emit `op_typeof_is_undefined` for `typeof x>"u"`

### DIFF
--- a/JSTests/microbenchmarks/minified-typeof-undefined.js
+++ b/JSTests/microbenchmarks/minified-typeof-undefined.js
@@ -1,0 +1,8 @@
+function test(x) {
+    return typeof x > "u";
+}
+noInline(test);
+
+for (let i = 0; i < 1e6; i++) {
+    test(i % 2 === 0 ? undefined : i);
+}

--- a/JSTests/stress/minified-typeof-undefined.js
+++ b/JSTests/stress/minified-typeof-undefined.js
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(x) {
+    return typeof x > "u";
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(test(undefined), true);
+    shouldBe(test(), true);
+
+    shouldBe(test(null), false);
+    shouldBe(test(1), false);
+    shouldBe(test("foo"), false);
+    shouldBe(test({}), false);
+    shouldBe(test(function () {}), false);
+    shouldBe(test(Symbol("test")), false);
+    shouldBe(test(1n), false);
+}


### PR DESCRIPTION
#### a937882ba69b59b6fc4f7aa42e1dfc9d6674712d
<pre>
[JSC] emit `op_typeof_is_undefined` for `typeof x&gt;&quot;u&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298148">https://bugs.webkit.org/show_bug.cgi?id=298148</a>

Reviewed by Keith Miller and Yusuke Suzuki.

esbuild minifies `typeof x === &quot;undefined&quot;` to `typeof x&gt;&quot;u&quot;`[1]. This reduces
code size but is slower in JSC.

This patch makes `typeof x&gt;&quot;u&quot;` emit `op_typeof_is_undefined` just like
`typeof x === &quot;undefined&quot;`.

[1]: <a href="https://esbuild.github.io/try/#dAAwLjI1LjkALS1taW5pZnkAdHlwZW9mIHggPT09ICJ1bmRlZmluZWQi">https://esbuild.github.io/try/#dAAwLjI1LjkALS1taW5pZnkAdHlwZW9mIHggPT09ICJ1bmRlZmluZWQi</a>

                                   TipOfTree                  Patched

minified-typeof-undefined        4.4291+-0.2282     ^      1.8605+-0.0225        ^ definitely 2.3805x faster

* JSTests/microbenchmarks/minified-typeof-undefined.js: Added.
(test):
* JSTests/stress/minified-typeof-undefined.js: Added.
(shouldBe):
(test):
(i.shouldBe.test):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitBinaryOp):

Canonical link: <a href="https://commits.webkit.org/299368@main">https://commits.webkit.org/299368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4feb968e1d3b4d4e1b380326a21d56db81ec6af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90118 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24568 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68582 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110856 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127977 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117252 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98762 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98544 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25060 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21990 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42157 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51193 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145948 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44979 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37530 "Found 1 new JSC binary failure: testapi, Found 18599 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->