### PR TITLE
Drag image includes text elements below/adjacent to the dragged element

### DIFF
--- a/LayoutTests/fast/snapshot/positioned-static-with-composited-expected.html
+++ b/LayoutTests/fast/snapshot/positioned-static-with-composited-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+    position: relative;
+}
+.dropdown {
+    background-color: rebeccapurple;
+    position: absolute;
+    top: 100%;
+    left: 20px;
+}
+</style>
+</head>
+<body>
+    <div id="box">
+        Is this included?
+        <div class="dropdown">am I also included in the snapshot?</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/positioned-static-with-composited.html
+++ b/LayoutTests/fast/snapshot/positioned-static-with-composited.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+    position: relative;
+}
+#secondBox {
+    width: 100px;
+    height: 100px;
+    background-color: gold;
+    color: black;
+}
+.dropdown {
+    background-color: rebeccapurple;
+    position: absolute;
+    top: 100%;
+    left: 20px;
+}
+</style>
+<script type="text/javascript" src="../../resources/snapshot-helper.js"></script>
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-950" />
+</head>
+<body>
+    <div id="box" style="transform: translateZ(0);">
+        Is this included?
+        <div class="dropdown">am I also included in the snapshot?</div>
+    </div>
+    <div id="secondBox">Am I included too?</div>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+async function main() {
+    if (!window.internals) {
+        console.log('FAIL: window.internals is not available');
+        return;
+    }
+    
+    const box = document.getElementById('box');
+    const secondBox = document.getElementById('secondBox');
+
+    const canvas = await SnapshotHelper.takeSnapshot(box);
+
+    box.remove();
+    secondBox.remove();
+
+    document.body.appendChild(canvas);
+
+    if (window.testRunner) {
+        testRunner.notifyDone();
+    }
+}
+
+window.addEventListener('load', main, false);
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3768,13 +3768,17 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
     };
 
     if (paintingInfo.paintBehavior.contains(PaintBehavior::DraggableSnapshot) && paintingInfo.subtreePaintRoot) {
-        if (paintingInfo.subtreePaintRoot->hasLayer()) {
-            CheckedPtr subtreeRootLayer = paintingInfo.subtreePaintRoot->enclosingLayer();
-            bool isLayerInSubtree = (this == subtreeRootLayer) || isDescendantOf(*subtreeRootLayer);
+        auto isNotSelfReference = paintingInfo.subtreePaintRoot != &renderer();
+        auto hasLayer = paintingInfo.subtreePaintRoot->hasLayer();
 
-            if (isLayerInSubtree && (paintingInfo.subtreePaintRoot != &renderer() && shouldExcludeBasedOnContainingBlock()))
-                shouldPaintContent = false;
-        } else if (renderer().isAbsolutelyPositioned() && paintingInfo.subtreePaintRoot != &renderer() && shouldExcludeBasedOnContainingBlock()) {
+        CheckedPtr subtreeRootLayer = hasLayer ? paintingInfo.subtreePaintRoot->enclosingLayer() : nullptr;
+        bool isLayerInSubtree = subtreeRootLayer && ((this == subtreeRootLayer) || isDescendantOf(*subtreeRootLayer));
+
+        if (hasLayer && !isLayerInSubtree && isNotSelfReference) {
+            shouldPaintContent = false;
+        } else if (hasLayer && isLayerInSubtree && isNotSelfReference && shouldExcludeBasedOnContainingBlock()) {
+            shouldPaintContent = false;
+        } else if (!hasLayer && renderer().isAbsolutelyPositioned() && isNotSelfReference && shouldExcludeBasedOnContainingBlock()) {
             shouldPaintContent = false;
         }
     }


### PR DESCRIPTION
#### 012c833ae7f0
<pre>
Drag image includes text elements below/adjacent to the dragged element
<a href="https://bugs.webkit.org/show_bug.cgi?id=297687">https://bugs.webkit.org/show_bug.cgi?id=297687</a>
<a href="https://rdar.apple.com/158802441">rdar://158802441</a>

Reviewed by NOBODY (OOPS!).

CSS transforms applied on draggable elements (e.g translateZ(0)) create new
stacking contexts that alter the layer tree hierarchy. This may cause sibling
elements to become composited if they&apos;re overlapping and breaks
the layer ancestry checks in paintLayerContents, allowing unrelated
content to appear in drag snapshots.

The fix adds early exclusion logic for DraggableSnapshot paint behavior
that excludes layers not in the drag subtree based on layer ancestry.

LayoutTests/fast/snapshot/positioned-static-with-composited-expected.html: Added.
LayoutTests/fast/snapshot/positioned-static-with-composited.html: Added.
Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/012c833ae7f06df2d9bfea9cc0536bfb9e3fd8c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71294 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2510e86e-fb53-4062-bfd0-087fb5eb3e52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47493 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90579 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/crashtests/inline-float-parallel-flow.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53d43d1c-9d68-4aec-bab1-69ddee0d3523) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70988 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e18d808-1887-4bf0-ad21-ee347e82050d) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/118589 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69106 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128472 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99145 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98919 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42716 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51690 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45474 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48824 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->