### PR TITLE
AX: Optimize hot functions AXObjectCache::{get(Node&), getOrCreate(Node&)} by inlining get inside getOrCreate and eliminating one hashmap lookup

### DIFF
--- a/Source/WebCore/accessibility/AXListHelpers.cpp
+++ b/Source/WebCore/accessibility/AXListHelpers.cpp
@@ -29,7 +29,7 @@
 #include "config.h"
 #include "AXListHelpers.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXUtilities.h"
 #include "AccessibilityObject.h"
 #include "AccessibilityRenderObject.h"

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -29,7 +29,8 @@
 #pragma once
 
 #include "AXGeometryManager.h"
-#include <wtf/text/MakeString.h>
+#include "AXIsolatedTree.h"
+#include "AXObjectCache.h"
 
 namespace WebCore {
 
@@ -66,6 +67,20 @@ inline Node* AXObjectCache::nodeForID(std::optional<AXID> axID) const
 
     RefPtr object = m_objects.get(*axID);
     return object ? object->node() : nullptr;
+}
+
+inline AccessibilityObject* AXObjectCache::getOrCreate(Node& node, IsPartOfRelation isPartOfRelation)
+{
+    if (RefPtr object = get(node))
+        return object.get();
+    return getOrCreateSlow(node, isPartOfRelation);
+}
+
+inline AccessibilityObject* AXObjectCache::getOrCreate(Element& element, IsPartOfRelation isPartOfRelation)
+{
+    if (RefPtr object = get(element))
+        return object.get();
+    return getOrCreateSlow(element, isPartOfRelation);
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -27,7 +27,7 @@
 
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AccessibilityObject.h"
 #include "Logging.h"
 #include "TextIterator.h"

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -29,7 +29,7 @@
 #include "config.h"
 #include "AccessibilityImageMapLink.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "ContainerNodeInlines.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "HTMLImageElement.h"

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -29,7 +29,7 @@
 #include "config.h"
 #include "AccessibilityListBoxOption.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "ContainerNodeInlines.h"
 #include "ElementInlines.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -30,7 +30,7 @@
 #if ENABLE(MATHML)
 #include "AccessibilityMathMLElement.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXUtilities.h"
 #include "MathMLNames.h"
 #include "NodeInlines.h"

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "AccessibilityMenuListOption.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AccessibilityMenuListPopup.h"
 #include "Document.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -27,7 +27,7 @@
 #include "AccessibilityMenuListPopup.h"
 
 #include "AXNotifications.h"
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AccessibilityMenuList.h"
 #include "AccessibilityMenuListOption.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -34,7 +34,7 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXNotifications.h"
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXTableHelpers.h"
 #include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -35,7 +35,6 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXNotifications.h"
-#include "AXObjectCache.h"
 #include "AXObjectCacheInlines.h"
 #include "AXObjectRareData.h"
 #include "AXRemoteFrame.h"

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -33,7 +33,7 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXNotifications.h"
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"
 #include "AccessibilityMediaHelpers.h"
@@ -452,7 +452,7 @@ AccessibilityObject* AccessibilityRenderObject::nextSibling() const
     if (nextSibling->node() && nextSibling->node() == m_renderer->node()) {
         if (RefPtr nextObject = cache->getOrCreate(*nextSibling)) {
             if (nextObject.get() == this) {
-                // WebKit accessibility objects use DOM nodes as the "primary key" (i.e. in m_nodeObjectMapping).
+                // WebKit accessibility objects use DOM nodes as the "primary key" (i.e. in m_nodeIdMapping).
                 // This can cause a bit of trouble for continuations, which result in multiple renderers being associated
                 // with the same node. That can cause us to get into this branch — if nextSibling or us is a continuation,
                 // we will be different renderers with the same node, and thus `nextObject` will be us.

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -28,7 +28,7 @@
 #include "config.h"
 #include "AccessibilitySVGObject.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXUtilities.h"
 #include "ElementChildIteratorInlines.h"
 #include "ElementInlines.h"

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "AccessibilityScrollView.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXRemoteFrame.h"
 #include "AccessibilityScrollbar.h"
 #include "ContainerNodeInlines.h"

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -29,7 +29,7 @@
 #include "config.h"
 #include "AccessibilityTableCell.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXUtilities.h"
 #include "AccessibilityTableRow.h"
 #include "HTMLParserIdioms.h"

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -29,7 +29,7 @@
 
 #if PLATFORM(COCOA)
 
-#import "AXObjectCache.h"
+#import "AXObjectCacheInlines.h"
 #import "TextIterator.h"
 #import "WebAccessibilityObjectWrapperBase.h"
 #import <wtf/cocoa/TypeCastsCocoa.h>

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -31,7 +31,6 @@
 #import "AXAttributeCacheScope.h"
 #import "AXLogger.h"
 #import "AXNotifications.h"
-#import "AXObjectCache.h"
 #import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
 #import "AXUtilities.h"

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -32,7 +32,6 @@
 #include "AXIsolatedTree.h"
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
-#include "AXObjectCache.h"
 #include "AXObjectCacheInlines.h"
 #include "AXSearchManager.h"
 #include "AXTextMarker.h"

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -33,6 +33,7 @@
 #include "AXIsolatedObject.h"
 #include "AXLogger.h"
 #include "AXNotifications.h"
+#include "AXObjectCacheInlines.h"
 #include "AXTreeStore.h"
 #include "AXTreeStoreInlines.h"
 #include "AXUtilities.h"

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "AccessibilityObject.h"
 
-#import "AXObjectCache.h"
+#import "AXObjectCacheInlines.h"
 #import "AXRemoteFrame.h"
 #import "ColorCocoa.h"
 #import "CompositionHighlight.h"

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -30,7 +30,6 @@
 #import "WebAccessibilityObjectWrapperMac.h"
 
 #import "AXIsolatedTree.h"
-#import "AXObjectCache.h"
 #import "AXObjectCacheInlines.h"
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -29,7 +29,6 @@
 #include "Document.h"
 
 #include "AXIsolatedTree.h"
-#include "AXObjectCache.h"
 #include "AXObjectCacheInlines.h"
 #include "AnimationTimelinesController.h"
 #include "ApplicationManifest.h"

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -28,7 +28,7 @@
 #include "InspectorAuditAccessibilityObject.h"
 
 #include "AXCoreObject.h"
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AccessibilityNodeObject.h"
 #include "ContainerNode.h"
 #include "Document.h"

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -30,7 +30,7 @@
 #include "config.h"
 #include "InspectorOverlay.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AccessibilityObject.h"
 #include "CSSGridAutoRepeatValue.h"
 #include "CSSGridIntegerRepeatValue.h"

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -31,7 +31,7 @@
 #include "config.h"
 #include "InspectorDOMAgent.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AccessibilityNodeObject.h"
 #include "AddEventListenerOptionsInlines.h"
 #include "Attr.h"

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -22,7 +22,6 @@
 
 #include "AXIsolatedTree.h"
 #include "AXLogger.h"
-#include "AXObjectCache.h"
 #include "AXObjectCacheInlines.h"
 #include "ActivityStateChangeObserver.h"
 #include "AdvancedPrivacyProtections.h"

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -22,7 +22,6 @@
 #include "PrintContext.h"
 
 #include "AXIsolatedTree.h"
-#include "AXObjectCache.h"
 #include "AXObjectCacheInlines.h"
 #include "CommonAtomStrings.h"
 #include "ContainerNodeInlines.h"

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -27,7 +27,7 @@
 #include "config.h"
 #include "Internals.h"
 
-#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AddEventListenerOptionsInlines.h"
 #include "AnimationTimeline.h"
 #include "AnimationTimelinesController.h"
@@ -7769,7 +7769,7 @@ AccessibilityObject* Internals::axObjectForElement(Element& element) const
 
     if (CheckedPtr cache = document->axObjectCache()) {
         cache->performDeferredCacheUpdate(ForceLayout::No);
-        return cache->getOrCreate(element);
+        return cache->exportedGetOrCreate(element);
     }
     return nullptr;
 }

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -367,7 +367,7 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
         // the accessibility object for this element will not be created (because it doesn't yet have its renderer).
         axObjectCache->performDeferredCacheUpdate(ForceLayout::Yes);
 
-        if (RefPtr<WebCore::AccessibilityObject> axObject = axObjectCache->getOrCreate(coreElement.get()))
+        if (RefPtr<WebCore::AccessibilityObject> axObject = axObjectCache->exportedGetOrCreate(*coreElement))
             return axObject.get();
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -143,7 +143,7 @@ static const int defaultScrollMagnitudeThresholdForPageFlip = 20;
     if (!protectedSelf->_parent) {
         callOnMainRunLoopAndWait([&protectedSelf] {
             if (auto* axObjectCache = protectedSelf->_pdfPlugin->axObjectCache()) {
-                if (RefPtr pluginAxObject = axObjectCache->getOrCreate(RefPtr { protectedSelf->_pluginElement.get() }.get()))
+                if (RefPtr pluginAxObject = axObjectCache->exportedGetOrCreate(RefPtr { protectedSelf->_pluginElement.get() }.get()))
                     protectedSelf->_parent = pluginAxObject->wrapper();
             }
         });
@@ -286,7 +286,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     if (RefPtr activeAnnotation = _pdfPlugin->activeAnnotation()) {
         if (WebCore::AXObjectCache* existingCache = _pdfPlugin->axObjectCache()) {
-            if (RefPtr object = existingCache->getOrCreate(activeAnnotation->protectedElement().get()))
+            if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->protectedElement().get()))
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                 return [object->wrapper() accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -304,7 +304,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     id wrapper = nil;
     callOnMainRunLoopAndWait([activeAnnotation, protectedSelf = retainPtr(self), &wrapper] {
         if (auto* axObjectCache = protectedSelf->_pdfPlugin->axObjectCache()) {
-            if (RefPtr annotationElementAxObject = axObjectCache->getOrCreate(activeAnnotation->protectedElement().get()))
+            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(activeAnnotation->protectedElement().get()))
                 wrapper = annotationElementAxObject->wrapper();
         }
     });

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -3812,7 +3812,7 @@ id UnifiedPDFPlugin::accessibilityHitTestInPageForIOS(WebCore::FloatPoint point)
 WebCore::AXCoreObject* UnifiedPDFPlugin::accessibilityCoreObject()
 {
     if (CheckedPtr cache = axObjectCache())
-        return cache->getOrCreate(m_element.get());
+        return cache->exportedGetOrCreate(m_element.get());
     return nullptr;
 }
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -163,7 +163,7 @@
     if (RefPtr plugin = _pdfPlugin.get()) {
         if (RefPtr activeAnnotation = plugin->activeAnnotation()) {
             if (CheckedPtr existingCache = plugin->axObjectCache()) {
-                if (RefPtr object = existingCache->getOrCreate(activeAnnotation->protectedElement().get())) {
+                if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->protectedElement().get())) {
                 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                     return [object->wrapper() accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
                 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -225,7 +225,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!protectedSelf->_parent) {
         callOnMainRunLoopAndWait([protectedSelf] {
             if (CheckedPtr axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
-                if (RefPtr pluginAxObject = axObjectCache->getOrCreate(RefPtr { protectedSelf->_pluginElement.get() }.get()))
+                if (RefPtr pluginAxObject = axObjectCache->exportedGetOrCreate(RefPtr { protectedSelf->_pluginElement.get() }.get()))
                     protectedSelf->_parent = pluginAxObject->wrapper();
             }
         });
@@ -326,7 +326,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return;
 
         if (CheckedPtr axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
-            if (RefPtr annotationElementAxObject = axObjectCache->getOrCreate(activeAnnotation->protectedElement().get()))
+            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(activeAnnotation->protectedElement().get()))
                 wrapper = annotationElementAxObject->wrapper();
         }
     });


### PR DESCRIPTION
#### fd8b56688bda9cfc9527916226d9854a756ef727
<pre>
AX: Optimize hot functions AXObjectCache::{get(Node&amp;), getOrCreate(Node&amp;)} by inlining get inside getOrCreate and eliminating one hashmap lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=298158">https://bugs.webkit.org/show_bug.cgi?id=298158</a>
<a href="https://rdar.apple.com/159526201">rdar://159526201</a>

Reviewed by Joshua Hoffman.

This commit implements three optimizations to make AXObjectCache::get and AXObjectCache::getOrCreate faster:

  1. Rename existing data structure AXObjectCache::m_nodeObjectMapping to AXObjectCache::m_nodeIdMapping, and make a
     new data structure with the name AXObjectCache::m_nodeObjectMapping that points from a Node&amp; directly to an Ref&lt;AccessibilityObject&gt;.
     This removes one HashMap lookup in AXObjectCache::get. m_renderObjectMapping and m_widgetObjectMapping were renamed
     to m_renderObjectIdMapping and m_widgetIdMapping to stay consistent with m_nodeIdMapping. The cost of this new
     data structure is very small on most sites, and even in the most extreme case of html.spec.whatwg.org, only adds
     0.56mb extra memory usage. I believe this is worth the cost for what we get (results below).

  2. Inline the `get` part of `getOrCreate(Node&amp;)`, and move the non-inlined part to new method `getOrCreateSlow`.
     Based on 60 seconds of using VoiceOver on html.spec.whatwg.org, we hit this new inlined fast path 98.9% of the
     time (~51,114,000 fast path hits vs. `590,000` slow-path hits). This required creation of a new method called
     exportedGetOrCreate which is outlined for consumers outside WebCore, as inlined functions cannot be exported.

  3. Add a new `AXObjectCache::getOrCreate(Element&amp;)` method, allowing us to skip an `is&lt;Document&gt;` check in contexts
     where we&apos;ve already casted a `Node` into an `Element`.

This eliminates 1532 samples (1.5 seconds) of main-thread time based on 60 seconds of using VoiceOver on html.spec.whatwg.org.

Places that used `getOrCreate` are now changed to import `AXObjectCacheInlines.h` instead of `AXObjectCache.h`.

* Source/WebCore/accessibility/AXListHelpers.cpp:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::cacheAndInitializeWrapper):
(WebCore::AXObjectCache::exportedGetOrCreate):
(WebCore::AXObjectCache::getOrCreateSlow):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::onPaint const):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/accessibility/AXSearchManager.cpp:
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
* Source/WebCore/accessibility/AccessibilityMenuListOption.cpp:
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::nextSibling const):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/page/Page.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::axObjectForElement const):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getAccessibilityObjectForNode):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFPluginAccessibilityObject parent]):
(-[WKPDFPluginAccessibilityObject accessibilityFocusedUIElement]):
(-[WKPDFPluginAccessibilityObject accessibilityAssociatedControlForAnnotation:]):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::accessibilityCoreObject):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityParent]):
(-[WKAccessibilityPDFDocumentObject accessibilityAssociatedControlForAnnotation:]):

Canonical link: <a href="https://commits.webkit.org/299439@main">https://commits.webkit.org/299439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32fc2b3a779a89abdc9b90b43b46cbeb8535705c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70830 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90141 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59651 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70647 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68613 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128008 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98788 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25105 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42207 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45546 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51224 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48356 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->