### PR TITLE
AX: Prefer the Node& version of getOrCreate over the RenderObject& version when possible as it's more performant

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1335,7 +1335,7 @@ Element* AccessibilityNodeObject::anchorElement() const
     // search up the DOM tree for an anchor element
     // NOTE: this assumes that any non-image with an anchor is an HTMLAnchorElement
     for ( ; node; node = node->parentNode()) {
-        if (is<HTMLAnchorElement>(*node) || (node->renderer() && cache->getOrCreate(node->renderer())->isLink()))
+        if (is<HTMLAnchorElement>(*node) || (node->renderer() && cache->getOrCreate(*node)->isLink()))
             return downcast<Element>(node).get();
     }
 
@@ -2502,7 +2502,7 @@ String AccessibilityNodeObject::textForLabelElements(Vector<Ref<HTMLElement>>&& 
 
     WeakPtr cache = axObjectCache();
     for (auto& labelElement : labelElements) {
-        RefPtr label = cache ? cache->getOrCreate(labelElement.ptr()) : nullptr;
+        RefPtr label = cache ? cache->getOrCreate(labelElement.get()) : nullptr;
         if (!label)
             continue;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -633,7 +633,7 @@ AccessibilityObject* firstAccessibleObjectFromNode(const Node* node, NOESCAPE co
     if (!cache)
         return nullptr;
 
-    RefPtr accessibleObject = cache->getOrCreate(axNode->renderer());
+    RefPtr accessibleObject = cache->getOrCreate(const_cast<Node&>(*axNode));
     while (accessibleObject && !isAccessible(*accessibleObject)) {
         axNode = NodeTraversal::next(*axNode);
 
@@ -643,7 +643,7 @@ AccessibilityObject* firstAccessibleObjectFromNode(const Node* node, NOESCAPE co
         if (!axNode)
             return nullptr;
 
-        accessibleObject = cache->getOrCreate(axNode->renderer());
+        accessibleObject = cache->getOrCreate(const_cast<Node&>(*axNode));
     }
 
     return accessibleObject.get();
@@ -2321,9 +2321,9 @@ AccessibilityObject* AccessibilityObject::anchorElementForNode(Node& node)
         return nullptr;
 
     WeakPtr cache = renderer->document().axObjectCache();
-    RefPtr axObject = cache ? cache->getOrCreate(renderer.get()) : nullptr;
+    RefPtr axObject = cache ? cache->getOrCreate(node) : nullptr;
     RefPtr anchor = axObject ? axObject->anchorElement() : nullptr;
-    return anchor ? cache->getOrCreate(anchor->renderer()) : nullptr;
+    return anchor ? cache->getOrCreate(*anchor) : nullptr;
 }
 
 AccessibilityObject* AccessibilityObject::headingElementForNode(Node* node)
@@ -2335,7 +2335,7 @@ AccessibilityObject* AccessibilityObject::headingElementForNode(Node* node)
     if (!renderObject)
         return nullptr;
 
-    RefPtr axObject = renderObject->document().axObjectCache()->getOrCreate(*renderObject);
+    RefPtr axObject = renderObject->document().axObjectCache()->getOrCreate(*node);
 
     return Accessibility::findAncestor<AccessibilityObject>(*axObject, true, [] (const AccessibilityObject& object) {
         return object.role() == AccessibilityRole::Heading;
@@ -3086,7 +3086,7 @@ bool AccessibilityObject::isTabItemSelected() const
 
     auto elements = elementsFromAttribute(aria_controlsAttr);
     for (auto& element : elements) {
-        RefPtr tabPanel = cache->getOrCreate(element.ptr());
+        RefPtr tabPanel = cache->getOrCreate(element.get());
 
         // A tab item should only control tab panels.
         if (!tabPanel || tabPanel->role() != AccessibilityRole::TabPanel)

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -147,7 +147,7 @@ RetainPtr<NSArray> AccessibilityObject::contentForRange(const SimpleRange& range
         } else {
             if (RefPtr replacedNode = it.node()) {
                 auto* cache = axObjectCache();
-                if (RefPtr object = cache ? cache->getOrCreate(replacedNode->renderer()) : nullptr)
+                if (RefPtr object = cache ? cache->getOrCreate(*replacedNode) : nullptr)
                     addObjectWrapperToArray(*object, result.get());
             }
         }

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -496,7 +496,7 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node& node, StringView text
         return nil;
 
     auto* cache = renderer->document().axObjectCache();
-    RefPtr object = cache ? cache->getOrCreate(*renderer) : nullptr;
+    RefPtr object = cache ? cache->getOrCreate(node) : nullptr;
     if (!object)
         return nil;
 


### PR DESCRIPTION
#### 8f51070fb0cb7fc0df7c7e2f5bb5f2dc9abb7ac5
<pre>
AX: Prefer the Node&amp; version of getOrCreate over the RenderObject&amp; version when possible as it&apos;s more performant
<a href="https://bugs.webkit.org/show_bug.cgi?id=298161">https://bugs.webkit.org/show_bug.cgi?id=298161</a>
<a href="https://rdar.apple.com/159528971">rdar://159528971</a>

Reviewed by Joshua Hoffman.

Now that objects key their identity and lifetime based on `Node`s rather than `RenderObject`s, AXObjectCache::getOrCreate(RenderObject&amp;)
requires several extra branches to call into the `Node&amp;` version to check that first. In contexts where we have a `Node`,
use that instead of `getOrCreate`ing the renderer.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::anchorElement const):
(WebCore::AccessibilityNodeObject::textForLabelElements const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::firstAccessibleObjectFromNode):
(WebCore::AccessibilityObject::anchorElementForNode):
(WebCore::AccessibilityObject::headingElementForNode):
(WebCore::AccessibilityObject::isTabItemSelected const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::parentObject const):
(WebCore::AccessibilityRenderObject::anchorElement const):
(WebCore::AccessibilityRenderObject::documentLinks):
(WebCore::AccessibilityRenderObject::accessibilityHitTest const):
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::AccessibilityObject::contentForRange const):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::attributedStringCreate):

Canonical link: <a href="https://commits.webkit.org/299429@main">https://commits.webkit.org/299429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e83500aa46e1df269bfa196eb1e2c80e33f05dd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70831 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35fea2ad-bc09-4b1b-85ac-0bffb5b6cda0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90142 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59652 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee271af9-089e-4e0b-a04f-de97ee88d31e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70648 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbc675a5-b4f3-4812-96af-bc39f0a25647) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68614 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128009 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98789 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98571 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25096 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42210 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45011 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48357 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->