### PR TITLE
AX: Add AccessibilityObjectInlines.h to guarantee the inlining of hot functions like AccessibilityObject::axObjectCache()

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -844,6 +844,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AXNotifications.h
     accessibility/AXObjectCache.h
     accessibility/AXObjectCacheInlines.h
+    accessibility/AXObjectRareData.h
     accessibility/AXSearchManager.h
     accessibility/AXTextMarker.h
     accessibility/AXTextRun.h
@@ -855,6 +856,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AccessibilityMockObject.h
     accessibility/AccessibilityNodeObject.h
     accessibility/AccessibilityObject.h
+    accessibility/AccessibilityObjectInlines.h
     accessibility/AccessibilityRenderObject.h
     accessibility/AccessibilityRole.h
     accessibility/AccessibilityScrollView.h

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -48,6 +48,7 @@
 #include "AccessibilityMenuList.h"
 #include "AccessibilityMenuListOption.h"
 #include "AccessibilityMenuListPopup.h"
+#include "AccessibilityObjectInlines.h"
 #include "AccessibilityProgressIndicator.h"
 #include "AccessibilityRenderObject.h"
 #include "AccessibilitySVGObject.h"

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityImageMapLink.h"
 
 #include "AXObjectCacheInlines.h"
+#include "AccessibilityObjectInlines.h"
 #include "ContainerNodeInlines.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "HTMLImageElement.h"

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -32,6 +32,7 @@
 
 #include "AXObjectCacheInlines.h"
 #include "AXUtilities.h"
+#include "AccessibilityObjectInlines.h"
 #include "MathMLNames.h"
 #include "NodeInlines.h"
 #include "RenderStyleInlines.h"

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -39,6 +39,7 @@
 #include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"
 #include "AccessibilityMediaHelpers.h"
+#include "AccessibilityObjectInlines.h"
 #include "AccessibilitySpinButton.h"
 #include "AccessibilityTableCell.h"
 #include "AccessibilityTableColumn.h"

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/AXObjectCache.h>
+#include <WebCore/AXObjectRareData.h>
+#include <WebCore/AXTextMarker.h>
+#include <WebCore/AXUtilities.h>
+#include <WebCore/AccessibilityObject.h>
+#include <WebCore/Color.h>
+#include <WebCore/Document.h>
+#include <WebCore/Element.h>
+#include <WebCore/HTMLParserIdioms.h>
+#include <WebCore/LocalFrame.h>
+#include <WebCore/RenderInline.h>
+#include <WebCore/RenderLayer.h>
+#include <WebCore/SimpleRange.h>
+#include <WebCore/TextIterator.h>
+
+namespace WebCore {
+
+inline void AccessibilityObject::init()
+{
+    m_role = determineAccessibilityRole();
+
+    if (needsRareData())
+        ensureRareData();
+}
+
+inline AXObjectCache* AccessibilityObject::axObjectCache() const
+{
+    return m_axObjectCache.get();
+}
+
+inline bool AccessibilityObject::isDetached() const
+{
+    return !wrapper();
+}
+
+inline bool AccessibilityObject::isNonNativeTextControl() const
+{
+    return (isARIATextControl() || hasContentEditableAttributeSet()) && !isNativeTextControl();
+}
+
+inline AXTextMarkerRange AccessibilityObject::textMarkerRange() const
+{
+    return simpleRange();
+}
+
+inline LocalFrame* AccessibilityObject::frame() const
+{
+    Node* node = this->node();
+    return node ? node->document().frame() : nullptr;
+}
+
+inline bool AccessibilityObject::hasRowGroupTag() const
+{
+    auto elementName = this->elementName();
+    return elementName == ElementName::HTML_thead || elementName == ElementName::HTML_tbody || elementName == ElementName::HTML_tfoot;
+}
+
+inline bool AccessibilityObject::hasElementName(ElementName name) const
+{
+    return elementName() == name;
+}
+
+inline RefPtr<Document> AccessibilityObject::protectedDocument() const
+{
+    return document();
+}
+
+inline SRGBA<uint8_t> AccessibilityObject::colorValue() const
+{
+    return Color::black;
+}
+
+inline bool AccessibilityObject::isInlineText() const
+{
+    return is<RenderInline>(renderer());
+}
+
+inline Element* AccessibilityObject::element() const
+{
+    return dynamicDowncast<Element>(node());
+}
+
+inline CommandType AccessibilityObject::commandType() const
+{
+    return CommandType::Invalid;
+}
+
+inline bool AccessibilityObject::hasDatalist() const
+{
+    RefPtr input = dynamicDowncast<HTMLInputElement>(element());
+    return input && input->hasDataList();
+}
+
+inline TextIterator AccessibilityObject::textIteratorIgnoringFullSizeKana(const SimpleRange& range)
+{
+    return TextIterator(range, { TextIteratorBehavior::IgnoresFullSizeKana });
+}
+
+inline bool AccessibilityObject::isIgnoredByDefault() const
+{
+    return defaultObjectInclusion() == AccessibilityObjectInclusion::IgnoreObject;
+}
+
+inline bool AccessibilityObject::isRenderHidden() const
+{
+    CheckedPtr style = this->style();
+    return WebCore::isRenderHidden(style.get());
+}
+
+inline ElementName AccessibilityObject::elementName() const
+{
+    RefPtr element = this->element();
+    return element ? element->elementName() : ElementName::Unknown;
+}
+
+inline bool AccessibilityObject::isFigureElement() const
+{
+    return elementName() == ElementName::HTML_figure;
+}
+
+inline bool AccessibilityObject::isOutput() const
+{
+    return elementName() == ElementName::HTML_output;
+}
+
+inline AXObjectRareData& AccessibilityObject::ensureRareData()
+{
+    if (!hasRareData())
+        m_rareDataWithBitfields.setPointer(makeUnique<AXObjectRareData>());
+    return *rareData();
+}
+
+inline void AccessibilityObject::setLastKnownIsIgnoredValue(bool isIgnored)
+{
+    m_lastKnownIsIgnoredValue = isIgnored ? AccessibilityObjectInclusion::IgnoreObject : AccessibilityObjectInclusion::IncludeObject;
+}
+
+inline bool AccessibilityObject::ignoredFromPresentationalRole() const
+{
+    return role() == AccessibilityRole::Presentational || inheritsPresentationalRole();
+}
+
+inline void AccessibilityObject::scrollToMakeVisible() const
+{
+    scrollToMakeVisible({ SelectionRevealMode::Reveal, ScrollAlignment::alignCenterIfNeeded, ScrollAlignment::alignCenterIfNeeded, ShouldAllowCrossOriginScrolling::Yes });
+}
+
+inline bool AccessibilityObject::supportsChecked() const
+{
+    switch (role()) {
+    case AccessibilityRole::Checkbox:
+    case AccessibilityRole::MenuItemCheckbox:
+    case AccessibilityRole::MenuItemRadio:
+    case AccessibilityRole::RadioButton:
+    case AccessibilityRole::Switch:
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline bool AccessibilityObject::supportsRowCountChange() const
+{
+    switch (role()) {
+    case AccessibilityRole::Tree:
+    case AccessibilityRole::TreeGrid:
+    case AccessibilityRole::Grid:
+    case AccessibilityRole::Table:
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline String AccessibilityObject::datetimeAttributeValue() const
+{
+    return getAttribute(HTMLNames::datetimeAttr);
+}
+
+inline String AccessibilityObject::linkRelValue() const
+{
+    return getAttribute(HTMLNames::relAttr);
+}
+
+inline bool AccessibilityObject::supportsKeyShortcuts() const
+{
+    return hasAttribute(HTMLNames::aria_keyshortcutsAttr);
+}
+
+inline String AccessibilityObject::keyShortcuts() const
+{
+    return getAttribute(HTMLNames::aria_keyshortcutsAttr);
+}
+
+inline int AccessibilityObject::integralAttribute(const QualifiedName& attributeName) const
+{
+    return parseHTMLInteger(getAttribute(attributeName)).value_or(0);
+}
+
+inline bool AccessibilityObject::supportsCurrent() const
+{
+    return hasAttribute(HTMLNames::aria_currentAttr);
+}
+
+inline bool AccessibilityObject::ariaIsMultiline() const
+{
+    return equalLettersIgnoringASCIICase(getAttribute(HTMLNames::aria_multilineAttr), "true"_s);
+}
+
+inline const AccessibilityObject::AccessibilityChildrenVector& AccessibilityObject::children(bool updateChildrenIfNeeded)
+{
+    if (updateChildrenIfNeeded)
+        updateChildrenIfNecessary();
+
+    return m_children;
+}
+
+inline bool AccessibilityObject::supportsCheckedState() const
+{
+    auto role = this->role();
+    return isCheckboxOrRadio()
+    || role == AccessibilityRole::MenuItemCheckbox
+    || role == AccessibilityRole::MenuItemRadio
+    || role == AccessibilityRole::Switch
+    || isToggleButton();
+}
+
+inline bool AccessibilityObject::supportsAutoComplete() const
+{
+    return (isComboBox() || isARIATextControl()) && hasAttribute(HTMLNames::aria_autocompleteAttr);
+}
+
+inline bool AccessibilityObject::isARIATextControl() const
+{
+    auto role = ariaRoleAttribute();
+    return role == AccessibilityRole::TextArea || role == AccessibilityRole::TextField || role == AccessibilityRole::SearchField;
+}
+
+// https://github.com/w3c/aria/pull/1860
+// If accname cannot be derived from content or author, accname can be derived on permitted roles
+// from the first descendant element node with a heading role.
+inline bool AccessibilityObject::accessibleNameDerivesFromHeading() const
+{
+    switch (role()) {
+    case AccessibilityRole::ApplicationAlertDialog:
+    case AccessibilityRole::ApplicationDialog:
+    case AccessibilityRole::DocumentArticle:
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline void AccessibilityObject::initializeAncestorFlags(const OptionSet<AXAncestorFlag>& flags)
+{
+    m_ancestorFlags.set(AXAncestorFlag::FlagsInitialized, true);
+    m_ancestorFlags.add(flags);
+}
+
+inline std::optional<AXID> AccessibilityObject::treeID() const
+{
+    auto* cache = axObjectCache();
+    return cache ? std::optional { cache->treeID() } : std::nullopt;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -31,6 +31,7 @@
 
 #include "AXObjectCacheInlines.h"
 #include "AXUtilities.h"
+#include "AccessibilityObjectInlines.h"
 #include "AccessibilityTableRow.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLTableCellElement.h"

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -24,6 +24,7 @@
 #include "AXCoreObject.h"
 #include "AXObjectCache.h"
 #include "AccessibilityAtspiInterfaces.h"
+#include "AccessibilityObjectInlines.h"
 #include "AccessibilityRootAtspi.h"
 #include "AccessibilityTableCell.h"
 #include "ElementInlines.h"

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -28,6 +28,7 @@
 
 #import "AXObjectCache.h"
 #import "AXTreeStoreInlines.h"
+#import "AccessibilityObjectInlines.h"
 #import "ColorCocoa.h"
 #import "RenderObjectInlines.h"
 #import "WebAccessibilityObjectWrapperBase.h"

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -25,7 +25,7 @@
  */
 
 #import "config.h"
-#import "AccessibilityObject.h"
+#import "AccessibilityObjectInlines.h"
 
 #if PLATFORM(COCOA)
 

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "AccessibilityObject.h"
+#import "AccessibilityObjectInlines.h"
 
 #if PLATFORM(IOS_FAMILY)
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -38,6 +38,7 @@
 #include "AXTreeStoreInlines.h"
 #include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"
+#include "AccessibilityObjectInlines.h"
 #include "AccessibilityTableCell.h"
 #include "AccessibilityTableRow.h"
 #include "DocumentInlines.h"

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "AccessibilityObject.h"
+#import "AccessibilityObjectInlines.h"
 
 #import "AXObjectCacheInlines.h"
 #import "AXRemoteFrame.h"

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -41,6 +41,7 @@
 #import "AXTextMarker.h"
 #import "AXTreeStore.h"
 #import "AXTreeStoreInlines.h"
+#import "AccessibilityObjectInlines.h"
 #import "AccessibilityProgressIndicator.h"
 #import "AccessibilityRenderObject.h"
 #import "AccessibilityScrollView.h"

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -30,6 +30,7 @@
 #include "AXCoreObject.h"
 #include "AXObjectCacheInlines.h"
 #include "AccessibilityNodeObject.h"
+#include "AccessibilityObjectInlines.h"
 #include "ContainerNode.h"
 #include "Document.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -33,6 +33,7 @@
 
 #include "AXObjectCacheInlines.h"
 #include "AccessibilityNodeObject.h"
+#include "AccessibilityObjectInlines.h"
 #include "AddEventListenerOptionsInlines.h"
 #include "Attr.h"
 #include "AudioTrack.h"


### PR DESCRIPTION
#### abbdd705cb616d8c06a93b1efe784d8c7766a14a
<pre>
AX: Add AccessibilityObjectInlines.h to guarantee the inlining of hot functions like AccessibilityObject::axObjectCache()
<a href="https://bugs.webkit.org/show_bug.cgi?id=298162">https://bugs.webkit.org/show_bug.cgi?id=298162</a>
<a href="https://rdar.apple.com/159531037">rdar://159531037</a>

Reviewed by Joshua Hoffman.

Inline various small and frequently called functions.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::init): Deleted.
(WebCore::AccessibilityObject::axObjectCache const): Deleted.
(WebCore::AccessibilityObject::treeID const): Deleted.
(WebCore::AccessibilityObject::isDetached const): Deleted.
(WebCore::AccessibilityObject::initializeAncestorFlags): Deleted.
(WebCore::AccessibilityObject::accessibleNameDerivesFromHeading const): Deleted.
(WebCore::AccessibilityObject::isARIATextControl const): Deleted.
(WebCore::AccessibilityObject::isNonNativeTextControl const): Deleted.
(WebCore::AccessibilityObject::textMarkerRange const): Deleted.
(WebCore::AccessibilityObject::frame const): Deleted.
(WebCore::AccessibilityObject::hasRowGroupTag const): Deleted.
(WebCore::AccessibilityObject::supportsCheckedState const): Deleted.
(WebCore::AccessibilityObject::supportsAutoComplete const): Deleted.
(WebCore::AccessibilityObject::protectedDocument const): Deleted.
(WebCore::AccessibilityObject::children): Deleted.
(WebCore::AccessibilityObject::ariaIsMultiline const): Deleted.
(WebCore::AccessibilityObject::supportsCurrent const): Deleted.
(WebCore::AccessibilityObject::hasElementName const): Deleted.
(WebCore::AccessibilityObject::integralAttribute const): Deleted.
(WebCore::AccessibilityObject::colorValue const): Deleted.
(WebCore::AccessibilityObject::datetimeAttributeValue const): Deleted.
(WebCore::AccessibilityObject::linkRelValue const): Deleted.
(WebCore::AccessibilityObject::isInlineText const): Deleted.
(WebCore::AccessibilityObject::supportsKeyShortcuts const): Deleted.
(WebCore::AccessibilityObject::keyShortcuts const): Deleted.
(WebCore::AccessibilityObject::element const): Deleted.
(WebCore::AccessibilityObject::commandType const): Deleted.
(WebCore::AccessibilityObject::hasDatalist const): Deleted.
(WebCore::AccessibilityObject::supportsChecked const): Deleted.
(WebCore::AccessibilityObject::supportsRowCountChange const): Deleted.
(WebCore::AccessibilityObject::setLastKnownIsIgnoredValue): Deleted.
(WebCore::AccessibilityObject::ignoredFromPresentationalRole const): Deleted.
(WebCore::AccessibilityObject::textIteratorIgnoringFullSizeKana): Deleted.
(WebCore::AccessibilityObject::isIgnoredByDefault const): Deleted.
(WebCore::AccessibilityObject::isRenderHidden const): Deleted.
(WebCore::AccessibilityObject::elementName const): Deleted.
(WebCore::AccessibilityObject::isFigureElement const): Deleted.
(WebCore::AccessibilityObject::isOutput const): Deleted.
(WebCore::AccessibilityObject::ensureRareData): Deleted.
* Source/WebCore/accessibility/AccessibilityObjectInlines.h: Added.
(WebCore::AccessibilityObject::init):
(WebCore::AccessibilityObject::axObjectCache const):
(WebCore::AccessibilityObject::isDetached const):
(WebCore::AccessibilityObject::isNonNativeTextControl const):
(WebCore::AccessibilityObject::textMarkerRange const):
(WebCore::AccessibilityObject::frame const):
(WebCore::AccessibilityObject::hasRowGroupTag const):
(WebCore::AccessibilityObject::hasElementName const):
(WebCore::AccessibilityObject::protectedDocument const):
(WebCore::AccessibilityObject::colorValue const):
(WebCore::AccessibilityObject::isInlineText const):
(WebCore::AccessibilityObject::element const):
(WebCore::AccessibilityObject::commandType const):
(WebCore::AccessibilityObject::hasDatalist const):
(WebCore::AccessibilityObject::textIteratorIgnoringFullSizeKana):
(WebCore::AccessibilityObject::isIgnoredByDefault const):
(WebCore::AccessibilityObject::isRenderHidden const):
(WebCore::AccessibilityObject::elementName const):
(WebCore::AccessibilityObject::isFigureElement const):
(WebCore::AccessibilityObject::isOutput const):
(WebCore::AccessibilityObject::ensureRareData):
(WebCore::AccessibilityObject::setLastKnownIsIgnoredValue):
(WebCore::AccessibilityObject::ignoredFromPresentationalRole const):
(WebCore::AccessibilityObject::scrollToMakeVisible const):
(WebCore::AccessibilityObject::supportsChecked const):
(WebCore::AccessibilityObject::supportsRowCountChange const):
(WebCore::AccessibilityObject::datetimeAttributeValue const):
(WebCore::AccessibilityObject::linkRelValue const):
(WebCore::AccessibilityObject::supportsKeyShortcuts const):
(WebCore::AccessibilityObject::keyShortcuts const):
(WebCore::AccessibilityObject::integralAttribute const):
(WebCore::AccessibilityObject::supportsCurrent const):
(WebCore::AccessibilityObject::ariaIsMultiline const):
(WebCore::AccessibilityObject::children):
(WebCore::AccessibilityObject::supportsCheckedState const):
(WebCore::AccessibilityObject::supportsAutoComplete const):
(WebCore::AccessibilityObject::isARIATextControl const):
(WebCore::AccessibilityObject::accessibleNameDerivesFromHeading const):
(WebCore::AccessibilityObject::initializeAncestorFlags):
(WebCore::AccessibilityObject::treeID const):
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:

Canonical link: <a href="https://commits.webkit.org/299468@main">https://commits.webkit.org/299468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a3af920e39f78c051bf00da639d527efc3abd9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71112 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da2541a1-3ce1-41af-bedd-fe9d2f41ab7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90393 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3183f29d-e720-40de-bc17-1365ad46bf2c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70853 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afeb2495-3065-4841-b08d-31201cc81172) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24844 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68912 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128290 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45956 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34727 "Found 1 new test failure: imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99014 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42535 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51505 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45293 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46978 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->