### PR TITLE
Non-Unified Build Fixes August 2025 (part 2)

### DIFF
--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.cpp
@@ -28,6 +28,10 @@
 
 #if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
+#include "JSWebAssemblyInstance.h"
+#include "WasmBinding.h"
+#include "WasmOperations.h"
+
 namespace JSC {
 namespace Wasm {
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.h
@@ -35,6 +35,8 @@
 namespace JSC {
 namespace Wasm {
 
+enum class BindingFailure;
+
 Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> generateWasmBuiltinTrampoline(const WebAssemblyBuiltin&);
 
 } // namespace Wasm

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
@@ -33,6 +33,7 @@
 #include "JSRTCEncodedVideoFrame.h"
 #include "ReadableStreamSource.h"
 #include "WritableStreamSink.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/StyleRuleFunction.cpp
+++ b/Source/WebCore/css/StyleRuleFunction.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "StyleRuleFunction.h"
 
+#include "StyleProperties.h"
+
 namespace WebCore {
 
 Ref<StyleRuleFunction> StyleRuleFunction::create(const AtomString& name, Vector<Parameter>&& parameters, CSSCustomPropertySyntax&& returnType, Vector<Ref<StyleRuleBase>>&& rules)

--- a/Source/WebCore/css/query/MediaQueryParser.h
+++ b/Source/WebCore/css/query/MediaQueryParser.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "GenericMediaQueryParser.h"
+#include "MediaQuery.h"
 #include "MediaQueryParserContext.h"
 
 namespace WebCore {

--- a/Source/WebCore/html/MediaError.h
+++ b/Source/WebCore/html/MediaError.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO)
 
 #include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/ResizeObserverSize.h
+++ b/Source/WebCore/page/ResizeObserverSize.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "RenderBlockFlow.h"
 
+#include "AXObjectCache.h"
 #include "BlockStepSizing.h"
 #include "Editor.h"
 #include "ElementInlines.h"

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -31,6 +31,7 @@
 
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "HTMLNames.h"
 #include "RuleSet.h"
 #include "StyleRule.h"
 


### PR DESCRIPTION
#### 22a05c42d57c8e3f1e261ac10174d39dbee30c07
<pre>
Non-Unified Build Fixes August 2025 (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=297747">https://bugs.webkit.org/show_bug.cgi?id=297747</a>

Unreviewed non-unified source build fix.

* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.h:
* Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp:
* Source/WebCore/css/StyleRuleFunction.cpp:
* Source/WebCore/css/query/MediaQueryParser.h:
* Source/WebCore/html/MediaError.h:
* Source/WebCore/page/ResizeObserverSize.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/style/RuleFeature.cpp:

Canonical link: <a href="https://commits.webkit.org/299369@main">https://commits.webkit.org/299369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1749572fa073c3f33c389bf6622c24d66b27061

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70847 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47048 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70656 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24610 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68633 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/110903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128024 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117299 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34497 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98580 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42229 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18922 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51240 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145995 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45026 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37547 "Found 1 new JSC binary failure: testapi, Found 18567 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug724121.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->