### PR TITLE
[GStreamer][Debug] ASSERT in imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-insertDTMF.https.html

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -54,8 +54,9 @@ public:
     RealtimeOutgoingAudioSourceGStreamer* audioSource()
     {
         return WTF::switchOn(m_source,
-            [] (Ref<RealtimeOutgoingAudioSourceGStreamer>& source) { return source.ptr(); },
-            [] (const auto&) -> RealtimeOutgoingAudioSourceGStreamer* { return nullptr; }
+            [](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) { return source.ptr(); },
+            [](Ref<RealtimeOutgoingVideoSourceGStreamer>&) -> RealtimeOutgoingAudioSourceGStreamer* { return nullptr; },
+            [](std::nullptr_t&) -> RealtimeOutgoingAudioSourceGStreamer* { return nullptr; }
         );
     }
 
@@ -63,24 +64,20 @@ public:
     {
         return WTF::switchOn(m_source,
             [](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) -> ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> { return source.get(); },
-            [](const auto&) -> ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> { return nullptr; });
+            [](Ref<RealtimeOutgoingVideoSourceGStreamer>&) -> ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> { return nullptr; },
+            [](std::nullptr_t&) -> ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> { return nullptr; });
     }
 
     RealtimeOutgoingVideoSourceGStreamer* videoSource()
     {
         return WTF::switchOn(m_source,
-            [] (Ref<RealtimeOutgoingVideoSourceGStreamer>& source) { return source.ptr(); },
-            [] (const auto&) -> RealtimeOutgoingVideoSourceGStreamer* { return nullptr; }
+            [](Ref<RealtimeOutgoingVideoSourceGStreamer>& source) { return source.ptr(); },
+            [](Ref<RealtimeOutgoingAudioSourceGStreamer>&) -> RealtimeOutgoingVideoSourceGStreamer* { return nullptr; },
+            [](std::nullptr_t&) -> RealtimeOutgoingVideoSourceGStreamer* { return nullptr; }
         );
     }
 
-    bool hasSource() const
-    {
-        return WTF::switchOn(m_source,
-            [] (const std::nullptr_t&) { return false; },
-            [] (const auto&) { return true; }
-        );
-    }
+    bool hasSource() const { return !std::holds_alternative<std::nullptr_t>(m_source); }
 
     void setSource(Source&&);
     void takeSource(GStreamerRtpSenderBackend&);


### PR DESCRIPTION
#### a14305e8fd8388cab3f61a9621672f4a11f34a5b
<pre>
[GStreamer][Debug] ASSERT in imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-insertDTMF.https.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=298166">https://bugs.webkit.org/show_bug.cgi?id=298166</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h: Use
std::holds_alternative() in hasSource(). Visiting the variant for this method was overkill and
triggering a bad variant access assertion in mpark. Driving-by, make variant visit callback
parameters a bit more explicit to improve readability.

Canonical link: <a href="https://commits.webkit.org/299385@main">https://commits.webkit.org/299385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81f98779551c3e81bca86856e9b9598c88ed1cf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90164 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59669 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70669 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24625 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68647 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98594 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22045 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42245 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45576 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51254 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->