### PR TITLE
[WTF] Upstream runtime checks for 2024-aligned releases

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -225,6 +225,16 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::SupportGameControllerEventInteractionAPI);
     }
 
+    if (linkedBefore(dyld_2024_SU_C_os_versions, DYLD_IOS_VERSION_18_2, DYLD_MACOSX_VERSION_15_2))
+        disableBehavior(SDKAlignedBehavior::BlobFileAccessEnforcementAndNetworkProcessRoundTrip);
+
+    if (linkedBefore(dyld_2024_SU_E_os_versions, DYLD_IOS_VERSION_18_4, DYLD_MACOSX_VERSION_15_4)) {
+        disableBehavior(SDKAlignedBehavior::DevolvableWidgets);
+        disableBehavior(SDKAlignedBehavior::SetSelectionRangeCachesSelectionIfNotFocusedOrSelected);
+        disableBehavior(SDKAlignedBehavior::DispatchFocusEventBeforeNotifyingClient);
+        disableBehavior(SDKAlignedBehavior::BlobFileAccessEnforcement);
+    }
+
     if (linkedBefore(dyld_2024_SU_F_os_versions, DYLD_IOS_VERSION_18_5, DYLD_MACOSX_VERSION_15_5))
         disableBehavior(SDKAlignedBehavior::NavigationActionSourceFrameNonNull);
 

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -163,6 +163,14 @@ DECLARE_SYSTEM_HEADER
 #define DYLD_MACOSX_VERSION_15_0 0x000f0000
 #endif
 
+#ifndef DYLD_MACOSX_VERSION_15_2
+#define DYLD_MACOSX_VERSION_15_2 0x000f0200
+#endif
+
+#ifndef DYLD_MACOSX_VERSION_15_4
+#define DYLD_MACOSX_VERSION_15_4 0x000f0400
+#endif
+
 #ifndef DYLD_MACOSX_VERSION_15_5
 #define DYLD_MACOSX_VERSION_15_5 0x000f0500
 #endif
@@ -201,6 +209,8 @@ typedef struct {
 #define DYLD_IOS_VERSION_17_2 0x00110200
 #define DYLD_IOS_VERSION_17_4 0x00110400
 #define DYLD_IOS_VERSION_18_0 0x00120000
+#define DYLD_IOS_VERSION_18_2 0x00120200
+#define DYLD_IOS_VERSION_18_4 0x00120400
 #define DYLD_IOS_VERSION_18_5 0x00120500
 
 #define DYLD_MACOSX_VERSION_10_10 0x000A0A00
@@ -223,6 +233,8 @@ typedef struct {
 #define DYLD_MACOSX_VERSION_14_2 0x000e0200
 #define DYLD_MACOSX_VERSION_14_4 0x000e0400
 #define DYLD_MACOSX_VERSION_15_0 0x000f0000
+#define DYLD_MACOSX_VERSION_15_2 0x000f0200
+#define DYLD_MACOSX_VERSION_15_4 0x000f0400
 #define DYLD_MACOSX_VERSION_15_5 0x000f0500
 
 #endif
@@ -315,6 +327,14 @@ WTF_EXTERN_C_BEGIN
 
 #ifndef dyld_fall_2024_os_versions
 #define dyld_fall_2024_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_2024_SU_C_os_versions
+#define dyld_2024_SU_C_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_2024_SU_E_os_versions
+#define dyld_2024_SU_E_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 #ifndef dyld_2024_SU_F_os_versions


### PR DESCRIPTION
#### be89683dec269fb21ca36d47b47f02bd2fa4df94
<pre>
[WTF] Upstream runtime checks for 2024-aligned releases
<a href="https://bugs.webkit.org/show_bug.cgi?id=298169">https://bugs.webkit.org/show_bug.cgi?id=298169</a>
<a href="https://rdar.apple.com/159548694">rdar://159548694</a>

Reviewed by Aditya Keerthi.

Upstream checks for 18.2 and 18.4 releases.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/spi/darwin/dyldSPI.h:

Canonical link: <a href="https://commits.webkit.org/299444@main">https://commits.webkit.org/299444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ebcb6ca53d17e22244cc7e08c69bfb06ffdddf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124991 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70865 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c6bf27e-244d-45b5-9332-48d551924896) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90166 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59676 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3998d4e8-6540-494f-97ef-3683d6fb3922) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6f2f263-c796-43be-924a-1d072a3ae0de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68651 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110921 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128042 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117317 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98816 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102735 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98598 "Found 1 new API test failure: TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42250 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51258 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146013 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45045 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37553 "Found 1 new JSC binary failure: testapi, Found 18603 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48390 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46730 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->