### PR TITLE
[JSC] Add fast path for iteration on Map

### DIFF
--- a/JSTests/microbenchmarks/iterator-prototype-forEach-map.js
+++ b/JSTests/microbenchmarks/iterator-prototype-forEach-map.js
@@ -1,0 +1,17 @@
+function test(mapIter) {
+    let sum = 0;
+    Iterator.prototype.forEach.call(mapIter, function(value) {
+        sum += value;
+    });
+    return sum;
+}
+
+const map = new Map();
+for (let i = 0; i < 12; i++) {
+    map.set(i, i * 2);
+}
+
+let r;
+for (let i = 0; i < testLoopCount; i++) {
+    r = test(map.values());
+}

--- a/JSTests/microbenchmarks/iterator-prototype-toArray-map.js
+++ b/JSTests/microbenchmarks/iterator-prototype-toArray-map.js
@@ -1,0 +1,13 @@
+function test(mapIter) {
+    return Iterator.prototype.toArray.call(mapIter);
+}
+
+const map = new Map();
+for (let i = 0; i < 12; i++) {
+    map.set(i, i * 2);
+}
+
+let r;
+for (let i = 0; i < testLoopCount; i++) {
+    r = test(map.values());
+}

--- a/JSTests/stress/aggregate-error-constructor-broken-map.js
+++ b/JSTests/stress/aggregate-error-constructor-broken-map.js
@@ -1,0 +1,71 @@
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+function shouldThrow(fn, errorMessage) {
+    let thrown = false;
+    try {
+        fn();
+    } catch (e) {
+        thrown = true;
+        if (errorMessage && e.message !== errorMessage) {
+            throw new Error(`Expected error message "${errorMessage}" but got "${e.message}"`);
+        }
+    }
+    if (!thrown) {
+        throw new Error('Expected to throw but did not');
+    }
+}
+
+// Test AggregateError constructor with Map values
+{
+    const map = new Map([['error1', 'Error 1'], ['error2', 'Error 2'], ['error3', 'Error 3']]);
+    const aggregateError = new AggregateError(map.values(), 'Multiple errors');
+    shouldBe(aggregateError.errors.length, 3);
+    shouldBe(aggregateError.errors[0], 'Error 1');
+    shouldBe(aggregateError.errors[1], 'Error 2');
+    shouldBe(aggregateError.errors[2], 'Error 3');
+    shouldBe(aggregateError.message, 'Multiple errors');
+}
+
+// Test with broken Map Symbol.iterator
+{
+    const map = new Map([['key1', 'value1'], ['key2', 'value2']]);
+    const oldIterator = map[Symbol.iterator];
+    map[Symbol.iterator] = function() {
+        throw new Error('Custom iterator error');
+    };
+    
+    // Should still work because it uses fast path for map.values()
+    const aggregateError = new AggregateError(map.values(), 'Test message');
+    shouldBe(aggregateError.errors.length, 2);
+    shouldBe(aggregateError.errors[0], 'value1');
+    shouldBe(aggregateError.errors[1], 'value2');
+    
+    map[Symbol.iterator] = oldIterator;
+}
+
+// Test with broken Map Iterator next method
+{
+    const map = new Map([['key1', 'value1'], ['key2', 'value2']]);
+    const mapIterator = map.values();
+    mapIterator.next = function() {
+        throw new Error('Iterator next error');
+    };
+    
+    shouldThrow(function() {
+        new AggregateError(mapIterator, 'Test message');
+    }, 'Iterator next error');
+}
+
+// Test normal case
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    const aggregateError = new AggregateError(map.keys(), 'Test');
+    shouldBe(aggregateError.errors.length, 3);
+    shouldBe(aggregateError.errors[0], 1);
+    shouldBe(aggregateError.errors[1], 2);
+    shouldBe(aggregateError.errors[2], 3);
+}

--- a/JSTests/stress/iterator-prototype-forEach-map.js
+++ b/JSTests/stress/iterator-prototype-forEach-map.js
@@ -1,0 +1,62 @@
+function test(mapIterator, fn) {
+    return Iterator.prototype.forEach.call(mapIterator, fn);
+}
+
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+// Test with values iterator
+{
+    const map = new Map([[1, 10], [2, 20], [3, 30]]);
+    let sum = 0;
+    test(map.values(), function(value) {
+        sum += value;
+    });
+    shouldBe(sum, 60);
+}
+
+// Test with keys iterator
+{
+    const map = new Map([[1, 10], [2, 20], [3, 30]]);
+    let sum = 0;
+    test(map.keys(), function(key) {
+        sum += key;
+    });
+    shouldBe(sum, 6);
+}
+
+// Test with entries iterator
+{
+    const map = new Map([[1, 10], [2, 20]]);
+    let keySum = 0;
+    let valueSum = 0;
+    test(map.entries(), function(entry) {
+        keySum += entry[0];
+        valueSum += entry[1];
+    });
+    shouldBe(keySum, 3);
+    shouldBe(valueSum, 30);
+}
+
+// Test with modified map prototype
+{
+    const oldNext = Map.prototype[Symbol.iterator];
+    let nextCalled = false;
+    Map.prototype[Symbol.iterator] = function() {
+        nextCalled = true;
+        return oldNext.call(this);
+    };
+    
+    const map = new Map([[1, 10], [2, 20]]);
+    let sum = 0;
+    test(map.values(), function(value) {
+        sum += value;
+    });
+    shouldBe(sum, 30);
+    shouldBe(nextCalled, false); // Fast path should not call Symbol.iterator
+    
+    Map.prototype[Symbol.iterator] = oldNext;
+}

--- a/JSTests/stress/iterator-prototype-toArray-broken-map-iterator.js
+++ b/JSTests/stress/iterator-prototype-toArray-broken-map-iterator.js
@@ -1,0 +1,62 @@
+function test(mapIterator) {
+    return Iterator.prototype.toArray.call(mapIterator);
+}
+
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+function shouldThrow(fn, errorMessage) {
+    let thrown = false;
+    try {
+        fn();
+    } catch (e) {
+        thrown = true;
+        if (errorMessage && e.message !== errorMessage) {
+            throw new Error(`Expected error message "${errorMessage}" but got "${e.message}"`);
+        }
+    }
+    if (!thrown) {
+        throw new Error('Expected to throw but did not');
+    }
+}
+
+// Test with broken iterator (modified next method)
+{
+    const map = new Map([[1, 10], [2, 20], [3, 30]]);
+    const mapIterator = map.values();
+    mapIterator.next = function() {
+        throw new Error('Custom error');
+    };
+    
+    shouldThrow(function() {
+        test(mapIterator);
+    }, 'Custom error');
+}
+
+// Test with broken iterator (modified prototype)
+{
+    const map = new Map([[1, 10], [2, 20]]);
+    const mapIterator = map.values();
+    const oldProto = Object.getPrototypeOf(mapIterator);
+    const newProto = Object.create(oldProto);
+    newProto.next = function() {
+        throw new Error('Proto error');
+    };
+    Object.setPrototypeOf(mapIterator, newProto);
+    
+    shouldThrow(function() {
+        test(mapIterator);
+    }, 'Proto error');
+}
+
+// Test normal case after broken iterator tests
+{
+    const map = new Map([[1, 10], [2, 20]]);
+    const arr = test(map.values());
+    shouldBe(arr.length, 2);
+    shouldBe(arr[0], 10);
+    shouldBe(arr[1], 20);
+}

--- a/JSTests/stress/iterator-prototype-toArray-map.js
+++ b/JSTests/stress/iterator-prototype-toArray-map.js
@@ -1,0 +1,58 @@
+function test(mapIterator) {
+    return Iterator.prototype.toArray.call(mapIterator);
+}
+
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+// Test with values iterator
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c'], [4, 'd'], [5, 'e']]);
+    const arr = test(map.values());
+    shouldBe(arr.length, 5);
+    shouldBe(arr[0], 'a');
+    shouldBe(arr[1], 'b');
+    shouldBe(arr[2], 'c');
+    shouldBe(arr[3], 'd');
+    shouldBe(arr[4], 'e');
+}
+
+// Test with keys iterator
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c'], [4, 'd'], [5, 'e']]);
+    const arr = test(map.keys());
+    shouldBe(arr.length, 5);
+    shouldBe(arr[0], 1);
+    shouldBe(arr[1], 2);
+    shouldBe(arr[2], 3);
+    shouldBe(arr[3], 4);
+    shouldBe(arr[4], 5);
+}
+
+// Test with entries iterator
+{
+    const map = new Map([[1, 'a'], [2, 'b']]);
+    const arr = test(map.entries());
+    shouldBe(arr.length, 2);
+    shouldBe(arr[0].length, 2);
+    shouldBe(arr[0][0], 1);
+    shouldBe(arr[0][1], 'a');
+    shouldBe(arr[1][0], 2);
+    shouldBe(arr[1][1], 'b');
+}
+
+// Test with partially consumed iterator
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c'], [4, 'd'], [5, 'e']]);
+    const mapIter = map.values();
+    mapIter.next();
+    const arr = test(mapIter);
+    shouldBe(arr.length, 4);
+    shouldBe(arr[0], 'b');
+    shouldBe(arr[1], 'c');
+    shouldBe(arr[2], 'd');
+    shouldBe(arr[3], 'e');
+}

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1191,6 +1191,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSMap.h
     runtime/JSMapInlines.h
     runtime/JSMapIterator.h
+    runtime/MapIteratorPrototype.h
+    runtime/MapIteratorPrototypeInlines.h
     runtime/JSMicrotask.h
     runtime/JSModuleEnvironment.h
     runtime/JSModuleNamespaceObject.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -851,10 +851,10 @@
 		276B387B2A71D11800252F4E /* JSONObjectInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38782A71D11700252F4E /* JSONObjectInlines.h */; };
 		276B387C2A71D11800252F4E /* JSRemoteFunctionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38792A71D11700252F4E /* JSRemoteFunctionInlines.h */; };
 		276B387D2A71D11800252F4E /* JSPropertyNameEnumeratorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B387A2A71D11700252F4E /* JSPropertyNameEnumeratorInlines.h */; };
-		276B38822A71D12B00252F4E /* MapIteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B387E2A71D12A00252F4E /* MapIteratorPrototypeInlines.h */; };
+		276B38822A71D12B00252F4E /* MapIteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B387E2A71D12A00252F4E /* MapIteratorPrototypeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		276B38832A71D12B00252F4E /* MathObjectInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B387F2A71D12A00252F4E /* MathObjectInlines.h */; };
 		276B38842A71D12B00252F4E /* MapConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38802A71D12B00252F4E /* MapConstructorInlines.h */; };
-		276B38852A71D12B00252F4E /* MapPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38812A71D12B00252F4E /* MapPrototypeInlines.h */; };
+		276B38852A71D12B00252F4E /* MapPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38812A71D12B00252F4E /* MapPrototypeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		276B38882A71D14500252F4E /* AggregateErrorConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38862A71D14500252F4E /* AggregateErrorConstructorInlines.h */; };
 		276B38892A71D14500252F4E /* ArrayConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B38872A71D14500252F4E /* ArrayConstructorInlines.h */; };
 		276B388B2A71D16F00252F4E /* ArrayIteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 276B388A2A71D16E00252F4E /* ArrayIteratorPrototypeInlines.h */; };
@@ -1660,7 +1660,7 @@
 		A741017F179DAF80002EB8BA /* DFGSaneStringGetByValSlowPathGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = A741017E179DAF80002EB8BA /* DFGSaneStringGetByValSlowPathGenerator.h */; };
 		A7482B9311671147003B0712 /* JSWeakObjectMapRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A7482B791166CDEA003B0712 /* JSWeakObjectMapRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A7482E93116A7CAD003B0712 /* JSWeakObjectMapRefInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A7482E37116A697B003B0712 /* JSWeakObjectMapRefInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A74DEF94182D991400522C22 /* MapIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A74DEF8E182D991400522C22 /* MapIteratorPrototype.h */; };
+		A74DEF94182D991400522C22 /* MapIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A74DEF8E182D991400522C22 /* MapIteratorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A74DEF96182D991400522C22 /* JSMapIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A74DEF90182D991400522C22 /* JSMapIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A75EE9B218AAB7E200AAD043 /* BuiltinNames.h in Headers */ = {isa = PBXBuildFile; fileRef = A75EE9B018AAB7E200AAD043 /* BuiltinNames.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A766B44F0EE8DCD1009518CA /* ExecutableAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B48DB50EE74CFC00DCBDB6 /* ExecutableAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/JavaScriptCore/runtime/JSMap.cpp
+++ b/Source/JavaScriptCore/runtime/JSMap.cpp
@@ -54,25 +54,4 @@ bool JSMap::isSetFastAndNonObservable(Structure* structure)
     return true;
 }
 
-bool JSMap::isIteratorProtocolFastAndNonObservable()
-{
-    JSGlobalObject* globalObject = this->globalObject();
-    if (!globalObject->isMapPrototypeIteratorProtocolFastAndNonObservable())
-        return false;
-
-    VM& vm = globalObject->vm();
-    Structure* structure = this->structure();
-    // This is the fast case. Many maps will be an original map.
-    if (structure == globalObject->mapStructure())
-        return true;
-
-    if (getPrototypeDirect() != globalObject->mapPrototype())
-        return false;
-
-    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
-        return false;
-
-    return true;
-}
-
 }

--- a/Source/JavaScriptCore/runtime/JSMap.h
+++ b/Source/JavaScriptCore/runtime/JSMap.h
@@ -59,7 +59,7 @@ public:
     ALWAYS_INLINE void set(JSGlobalObject*, JSValue key, JSValue);
 
     static bool isSetFastAndNonObservable(Structure*);
-    bool isIteratorProtocolFastAndNonObservable();
+    ALWAYS_INLINE bool isIteratorProtocolFastAndNonObservable();
     JSMap* clone(JSGlobalObject*, VM&, Structure*);
 
 private:

--- a/Source/JavaScriptCore/runtime/JSMapInlines.h
+++ b/Source/JavaScriptCore/runtime/JSMapInlines.h
@@ -39,4 +39,25 @@ ALWAYS_INLINE void JSMap::set(JSGlobalObject* globalObject, JSValue key, JSValue
     add(globalObject, key, value);
 }
 
+ALWAYS_INLINE bool JSMap::isIteratorProtocolFastAndNonObservable()
+{
+    JSGlobalObject* globalObject = this->globalObject();
+    if (!globalObject->isMapPrototypeIteratorProtocolFastAndNonObservable())
+        return false;
+
+    VM& vm = globalObject->vm();
+    Structure* structure = this->structure();
+    // This is the fast case. Many maps will be an original map.
+    if (structure == globalObject->mapStructure())
+        return true;
+
+    if (getPrototypeDirect() != globalObject->mapPrototype())
+        return false;
+
+    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
+        return false;
+
+    return true;
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/MapIteratorPrototype.h
+++ b/Source/JavaScriptCore/runtime/MapIteratorPrototype.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSObject.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h
@@ -25,9 +25,29 @@
 
 #pragma once
 
-#include "MapIteratorPrototype.h"
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/JSMapIterator.h>
+#include <JavaScriptCore/MapIteratorPrototype.h>
 
 namespace JSC {
+
+ALWAYS_INLINE bool mapIteratorProtocolIsFastAndNonObservable(VM& vm, JSMapIterator* mapIterator)
+{
+    JSGlobalObject* globalObject = mapIterator->globalObject();
+
+    if (!globalObject->isMapPrototypeIteratorProtocolFastAndNonObservable())
+        return false;
+
+    if (mapIterator->getPrototypeDirect() != globalObject->mapIteratorPrototype())
+        return false;
+
+    if (mapIterator->hasCustomProperties()) {
+        if (mapIterator->getDirectOffset(vm, vm.propertyNames->next) != invalidOffset)
+            return false;
+    }
+
+    return true;
+}
 
 inline Structure* MapIteratorPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {


### PR DESCRIPTION
#### 38df8fb7a13a27c7305fb927e6d7094b12f22ef2
<pre>
[JSC] Add fast path for iteration on Map
<a href="https://bugs.webkit.org/show_bug.cgi?id=298171">https://bugs.webkit.org/show_bug.cgi?id=298171</a>

Reviewed by Keith Miller.

This patch changes to apply the same optimization as commits.webkit.org/299358@main
to Map.

                                        TipOfTree                  Patched

iterator-prototype-forEach-map        4.6865+-0.1369     ^      0.9110+-0.0499        ^ definitely 5.1442x faster

* JSTests/microbenchmarks/iterator-prototype-forEach-map.js: Added.
(test):
* JSTests/microbenchmarks/iterator-prototype-toArray-map.js: Added.
(test):
* JSTests/stress/aggregate-error-constructor-broken-map.js: Added.
(shouldBe):
(shouldThrow):
(throw.new.Error):
(shouldBe.map.Symbol.iterator):
(mapIterator.next):
(new.AggregateError):
* JSTests/stress/iterator-prototype-forEach-map.js: Added.
(test):
(shouldBe):
(throw.new.Error):
(shouldBe.Map.prototype.Symbol.iterator):
* JSTests/stress/iterator-prototype-toArray-broken-map-iterator.js: Added.
(test):
(shouldBe):
(shouldThrow):
(throw.new.Error.mapIterator.next):
(throw.new.Error):
(newProto.next):
* JSTests/stress/iterator-prototype-toArray-map.js: Added.
(test):
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInMapStorage):
(JSC::forEachInIterable):
(JSC::forEachInIteratorProtocol):
* Source/JavaScriptCore/runtime/JSMap.cpp:
(JSC::JSMap::isIteratorProtocolFastAndNonObservable): Deleted.
* Source/JavaScriptCore/runtime/JSMap.h:
* Source/JavaScriptCore/runtime/JSMapInlines.h:
(JSC::JSMap::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/MapIteratorPrototype.h:
* Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h:
(JSC::mapIteratorProtocolIsFastAndNonObservable):

Canonical link: <a href="https://commits.webkit.org/299751@main">https://commits.webkit.org/299751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ce4fa5f0e61f4d98793c10992e4af13265aa5ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72081 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48278 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91133 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60448 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69977 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112133 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129258 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118524 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99751 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99596 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25300 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43549 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46790 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52496 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147223 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46256 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37831 "Found 1 new JSC binary failure: testapi, Found 18665 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->