### PR TITLE
Swap `isFirstInComplexSelector` and `isLastInComplexSelector`

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -359,14 +359,14 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElementName(St
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-const CSSSelector* CSSSelector::firstInCompound() const
+const CSSSelector* CSSSelector::lastInCompound() const
 {
     auto* selector = this;
-    while (!selector->isFirstInComplexSelector()) {
-        auto* previousSelector = selector - 1;
-        if (previousSelector->relation() != Relation::Subselector)
+    while (!selector->isLastInComplexSelector()) {
+        auto* next = selector - 1;
+        if (next->relation() != Relation::Subselector)
             break;
-        selector = previousSelector;
+        selector = next;
     }
     return selector;
 }

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -133,12 +133,12 @@ public:
     static const ASCIILiteral nameForUserAgentPartLegacyAlias(StringView);
 
     // Selectors are kept in an array by CSSSelectorList.
-    // The next component of the selector is the next item in the array.
+    // The left component of the selector is the next item in the array.
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    const CSSSelector* precedingInComplexSelector() const { return m_isLastInComplexSelector ? nullptr : this + 1; }
+    const CSSSelector* precedingInComplexSelector() const { return m_isFirstInComplexSelector ? nullptr : this + 1; }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    const CSSSelector* firstInCompound() const;
+    const CSSSelector* lastInCompound() const;
 
     const QualifiedName& tagQName() const;
     const AtomString& tagLowercaseLocalName() const;
@@ -217,8 +217,11 @@ private:
     mutable unsigned m_pseudoType : 8 { 0 }; // PseudoType.
     // 17 bits
     unsigned m_isLastInSelectorList : 1 { false };
+
+    // These are in logical order, which is reversed from the memory order.
     unsigned m_isFirstInComplexSelector : 1 { true };
     unsigned m_isLastInComplexSelector : 1 { true };
+
     unsigned m_hasRareData : 1 { false };
     unsigned m_isForPage : 1 { false };
     unsigned m_tagIsForNamespaceRule : 1 { false };

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -83,7 +83,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const_iterator& operator++()
         {
             // Skip subparts of compound selectors.
-            while (!m_ptr->isLastInComplexSelector())
+            while (!m_ptr->isFirstInComplexSelector())
                 ++m_ptr;
             m_ptr = m_ptr->isLastInSelectorList() ? nullptr : m_ptr + 1;
             return *this;

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1550,7 +1550,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
         if (relation == CSSSelector::Relation::Subselector)
             continue;
 
-        if ((relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant) && !selector->isLastInComplexSelector())
+        if ((relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant) && !selector->isFirstInComplexSelector())
             return FunctionType::CannotCompile;
 
         if (relation == CSSSelector::Relation::ShadowSlotted)

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -50,17 +50,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SelectorQueryCache);
 #if ASSERT_ENABLED
 static bool isSingleTagNameSelector(const CSSSelector& selector)
 {
-    return selector.isLastInComplexSelector() && selector.match() == CSSSelector::Match::Tag;
+    return selector.isFirstInComplexSelector() && selector.match() == CSSSelector::Match::Tag;
 }
 
 static bool isSingleClassNameSelector(const CSSSelector& selector)
 {
-    return selector.isLastInComplexSelector() && selector.match() == CSSSelector::Match::Class;
+    return selector.isFirstInComplexSelector() && selector.match() == CSSSelector::Match::Class;
 }
 
 static bool isSingleAttributeExactSelector(const CSSSelector& selector)
 {
-    return selector.isLastInComplexSelector() && selector.match() == CSSSelector::Match::Exact;
+    return selector.isFirstInComplexSelector() && selector.match() == CSSSelector::Match::Exact;
 }
 
 #endif // ASSERT_ENABLED
@@ -132,7 +132,7 @@ SelectorDataList::SelectorDataList(const CSSSelectorList& selectorList)
 
     if (selectorCount == 1) {
         const CSSSelector& selector = *m_selectors.first().selector;
-        if (selector.isLastInComplexSelector()) {
+        if (selector.isFirstInComplexSelector()) {
             switch (selector.match()) {
             case CSSSelector::Match::Tag:
                 m_matchType = TagNameMatch;

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -386,7 +386,7 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
     AtomString attributeName;
     AtomString className;
     AtomString tagName;
-    for (auto* simpleSelector = selector.firstInCompound(); simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
+    for (auto* simpleSelector = selector.lastInCompound(); simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
         if (simpleSelector->match() == CSSSelector::Match::Id)
             return makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Id, simpleSelector->value());
 


### PR DESCRIPTION
#### 8f719fa47034a9e9bc8f572ef4f9b4ce443c61ad
<pre>
Swap `isFirstInComplexSelector` and `isLastInComplexSelector`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298173">https://bugs.webkit.org/show_bug.cgi?id=298173</a>
<a href="https://rdar.apple.com/159557880">rdar://159557880</a>

Reviewed by Antti Koivisto.

The meaning is reversed since the rename from `tagHistory` to `inComplexSelector` in 299193@main.

`tagHistory` uses memory order, `inComplexSelector` uses logical order which is reversed from the memory order.

Also rename `CSSSelector::firstInCompound` to `CSSSelector::lastInCompound` to reflect what it actually represents.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::lastInCompound const):
(WebCore::CSSSelector::firstInCompound const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::precedingInComplexSelector const):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::listSize const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::const_iterator::operator++):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::isSingleTagNameSelector):
(WebCore::isSingleClassNameSelector):
(WebCore::isSingleAttributeExactSelector):
(WebCore::SelectorDataList::SelectorDataList):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::makePseudoClassInvalidationKey):

Canonical link: <a href="https://commits.webkit.org/299397@main">https://commits.webkit.org/299397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5f9592d8446488eabd319a70049dd4ae858ce75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70951 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a01047d9-3108-414d-a6d2-6f9a70c8dd31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/adb9de3e-08be-4818-83d1-bb921caf9755) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121841 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/31296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/106589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/70731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4333add-78dc-4ad9-ba13-08035781bad3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/24703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68740 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/100739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/24890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128128 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45795 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/98885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46161 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/102809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/98665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/44113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/22120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51343 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45131 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->