### PR TITLE
[Fullscreen] Crash under WebKit::WebFullScreenManager::didExitFullScreen() in WebCore::Page::localMainFrame()

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4668,7 +4668,7 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
         else if (document->isTextDocument())
             m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::textDocumentParameters());
 #if ENABLE(PDF_PLUGIN)
-        else if (m_page->settings().unifiedPDFEnabled() && document->isPluginDocument())
+        else if (m_page && m_page->settings().unifiedPDFEnabled() && document->isPluginDocument())
             m_viewportConfiguration.setDefaultConfiguration(UnifiedPDFPlugin::viewportParameters());
 #endif
         else
@@ -4816,12 +4816,16 @@ void WebPage::shrinkToFitContent(ZoomToInitialScale zoomToInitialScale)
 
 bool WebPage::shouldIgnoreMetaViewport() const
 {
+    if (!m_page)
+        return false;
+
     RefPtr localMainFrame = m_page->localMainFrame();
-    if (auto* mainDocument = localMainFrame ? localMainFrame->document() : nullptr) {
-        auto* loader = mainDocument->loader();
+    if (RefPtr mainDocument = localMainFrame ? localMainFrame->document() : nullptr) {
+        RefPtr loader = mainDocument->loader();
         if (loader && loader->metaViewportPolicy() == WebCore::MetaViewportPolicy::Ignore)
             return true;
     }
+
     return m_page->settings().shouldIgnoreMetaViewport();
 }
 


### PR DESCRIPTION
#### ab689ba5638ba779006c108dc2f11af3e8dd0bbd
<pre>
[Fullscreen] Crash under WebKit::WebFullScreenManager::didExitFullScreen() in WebCore::Page::localMainFrame()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=298172">https://bugs.webkit.org/show_bug.cgi?id=298172</a>&gt;
&lt;<a href="https://rdar.apple.com/153638900">rdar://153638900</a>&gt;

Reviewed by Tim Nguyen.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::resetViewportDefaultConfiguration):
- Add `nullptr` check for `WebPage::m_page` which is in the call stack
  for the crash.
(WebKit::WebPage::shouldIgnoreMetaViewport const):
- Add nullptr check of `WebPage::m_page` to avoid the crash.
- Replace raw pointers with RefPtr while we&apos;re here.

Canonical link: <a href="https://commits.webkit.org/299377@main">https://commits.webkit.org/299377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37853e345badf9cf1a0220181b2cfd46478a221e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70890 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdbdae1a-cd4c-4790-9467-b6a2b99029b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90180 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/911fe5b9-bf2a-4cd7-b502-6ff7b3931699) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7470380-bc35-4181-a7f7-1c8e89c3e310) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30305 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68676 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128067 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98833 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98614 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42284 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18927 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51283 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45070 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48415 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46755 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->