### PR TITLE
resolve conflicts for cpp file

### DIFF
--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,7 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle}}
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle}}
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,7 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
-        FeatureEvaluationContext
+        FeatureEvaluationContext context { *document, {}}
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,7 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get(), nullptr, document->renderView() } }
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get(), nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,6 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
+        FeatureEvaluationContext
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,7 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
-        FeatureEvaluationContext context { *document, {}}
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle}}
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,7 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get()}}
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get(), nullptr}}
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -82,7 +82,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
+//        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -82,7 +82,6 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-//        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
         FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get(), nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,7 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get(), nullptr}}
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get(), nullptr, document->renderView() } }
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -83,7 +83,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
             return EvaluationResult::Unknown;
 
 //        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle}}
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle.get()}}
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -50,7 +50,6 @@ public:
 private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
-//    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
     CheckedPtr<const RenderStyle> m_rootElementStyle;
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -51,7 +51,7 @@ private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
 //    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
-CheckedPtr
+CheckedPtr<const RenderStyle>
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -51,6 +51,7 @@ private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
 //    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
+    
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -50,7 +50,7 @@ public:
 private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
-    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
+//    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -50,12 +50,7 @@ public:
 private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
-<<<<<<< HEAD
     CheckedPtr<const RenderStyle> m_rootElementStyle;
-=======
-//    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
-    const CheckedPtr<const RenderStyle> m_rootElementStyle;
->>>>>>> 45d1bcbab140 (added const to m_rootElementStyle - no reassign)
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -51,7 +51,7 @@ private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
 //    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
-    const CheckedPtr<const RenderStyle> m_rootElementStyle;
+    CheckedPtr<const RenderStyle> m_rootElementStyle;
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -51,7 +51,7 @@ private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
 //    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
-CheckedPtr<const RenderStyle>
+    CheckedPtr<const RenderStyle> m_rootElementStyle;
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -51,7 +51,7 @@ private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
 //    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
-    
+CheckedPtr
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -51,7 +51,7 @@ private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
 //    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
-    CheckedPtr<const RenderStyle> m_rootElementStyle;
+    const CheckedPtr<const RenderStyle> m_rootElementStyle;
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -50,7 +50,12 @@ public:
 private:
     AtomString m_mediaType;
     WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
+<<<<<<< HEAD
     CheckedPtr<const RenderStyle> m_rootElementStyle;
+=======
+//    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
+    const CheckedPtr<const RenderStyle> m_rootElementStyle;
+>>>>>>> 45d1bcbab140 (added const to m_rootElementStyle - no reassign)
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme
@@ -39,8 +39,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      internalIOSLaunchStyle = "2">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -723,9 +723,9 @@
 		A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */; };
 		A170E3AA2ABA7857009EA799 /* VectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A170E3A22ABA7857009EA799 /* VectorCocoa.mm */; };
 		A17191AD2CD2DB090088944E /* WKWebViewLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17191AC2CD2DB090088944E /* WKWebViewLogging.mm */; };
-		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1798B7F22431D2B000764BD /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */; };
 		A1798B8522433647000764BD /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
 		A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17991861E1C994E00A505ED /* SharedBuffer.mm */; };


### PR DESCRIPTION
#### c235aad478e862fd7f40bba935fc4dbaa2d73db2
<pre>
resolve conflicts for cpp file
</pre>
----------------------------------------------------------------------
#### 2648fc2e908492ffda6e6efba9868018a1839e9f
<pre>
resolve conflicts for cpp file
</pre>
----------------------------------------------------------------------
#### b1243210bf025c4599983816c2ae4757cb980278
<pre>
safely removed comments
</pre>
----------------------------------------------------------------------
#### 2ca9826b42ab73d20e13ad9cd0230fb3a1a627f9
<pre>
safely removed comments
</pre>
----------------------------------------------------------------------
#### 53080cd01c4b3142b8bbb03ace61df036e06b325
<pre>
added removed for assignable MQ in Style Resolver
</pre>
----------------------------------------------------------------------
#### 97f9bba8cc82eecbfe7689f72e87939926f5caca
<pre>
added const to m_rootElementStyle - no reassign
</pre>
----------------------------------------------------------------------
#### 508738a5c3b3aecb88f61e9bbc2d6f79f3e0f074
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### e4777a2702f1a3c7730d03c4fab282deb3fa98be
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### 60b542a9f03936820fe1e3faf28c2dcafbbb0e69
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### 409c3d68740dbb51042031890d290e2f43dcdc21
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### 6ec188eac3b2172e308e0ecebe55da315c612821
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### e2f3180f5866aa4804e277fffe75e1184644811a
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### 7c16338c3f17c3344403d77e3457949541b270c2
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### 33468d20048a675ea71f09339e799e9dbdcc6650
<pre>
added get() for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### da3a5a4207201fcc373bb0fee596a7071ad30254
<pre>
marked for deletion
</pre>
----------------------------------------------------------------------
#### 3b421e69785babaf57c1d60dfd9e5e4217d50b64
<pre>
add CheckedPtr for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### f4ed6f790ab1b6a86254336c13486fdb8c8acac7
<pre>
add CheckedPtr for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### a7a5ea0f9c7f1cc182e9fc6cc9f2f90891bc7036
<pre>
add CheckedPtr for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### e3559440bb8d64344e6e4b310dd9360171da8e62
<pre>
add CheckedPtr for m_rootElementStyle
</pre>
----------------------------------------------------------------------
#### 0fcfceb939b3ce0d7d7145fdbe377ba32ff6ad55
<pre>
marked for deletion
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c235aad478e862fd7f40bba935fc4dbaa2d73db2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38536 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29187 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47118 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90203 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 500 failures. 500 tests run. 1 flakes 500 failures; Uploaded test results; Running layout-tests-repeat-failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121808 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31269 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/106561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70710 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30331 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/24675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68703 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100712 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/24862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128095 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45762 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34561 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 60 tests run. 1 flakes 60 failures; Uploaded test results; Exiting early after 60 failures. 60 tests run. 1 flakes 60 failures; Running compile-webkit-without-change") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98862 "Failure limit exceed. At least found 495 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46128 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/102781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98642 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 252 api tests failed or timed out; 252 api tests failed or timed out; Compiled WebKit; Running run-api-tests-without-change") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/44088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/22092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42326 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45632 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51310 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Running scan-build") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48442 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->