### PR TITLE
Resync `mathml` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005-expected.html
@@ -1,11 +1,22 @@
 <!DOCTYPE html>
 <title>&lt;semantics&gt; - mozilla bug 21479 (reference)</title>
 <meta charset="utf-8"/>
+<style>
+@font-face {
+  font-family: operators;
+  src: url("/fonts/math/operators.woff");
+}
+math, math * {
+  font-family: operators;
+  font-size: 32px;
+  color: purple;
+}
+</style>
 <p>
   <math xmlns="http://www.w3.org/1998/Math/MathML">
     <mover>
-      <mspace width="300px" height="10px" mathbackground="black"></mspace>
-      <mo>&#xaf;</mo>
+      <mspace width="300px" height="10px" mathbackground="blue"></mspace>
+      <mo>&#x21AC;<!-- Rightwards Arrow With Loop --></mo>
     </mover>
   </math>
 </p>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005-ref.html
@@ -1,11 +1,22 @@
 <!DOCTYPE html>
 <title>&lt;semantics&gt; - mozilla bug 21479 (reference)</title>
 <meta charset="utf-8"/>
+<style>
+@font-face {
+  font-family: operators;
+  src: url("/fonts/math/operators.woff");
+}
+math, math * {
+  font-family: operators;
+  font-size: 32px;
+  color: purple;
+}
+</style>
 <p>
   <math xmlns="http://www.w3.org/1998/Math/MathML">
     <mover>
-      <mspace width="300px" height="10px" mathbackground="black"></mspace>
-      <mo>&#xaf;</mo>
+      <mspace width="300px" height="10px" mathbackground="blue"></mspace>
+      <mo>&#x21AC;<!-- Rightwards Arrow With Loop --></mo>
     </mover>
   </math>
 </p>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005.html
@@ -3,13 +3,24 @@
 <meta charset="utf-8"/>
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=21479">
 <link rel="help" href="https://w3c.github.io/mathml-core/#semantics-and-presentation">
+<style>
+@font-face {
+  font-family: operators;
+  src: url("/fonts/math/operators.woff");
+}
+math, math * {
+  font-family: operators;
+  font-size: 32px;
+  color: purple;
+}
+</style>
 <link rel="match" href="semantics-005-ref.html">
 <meta name="assert" content="The embellished operator made of a single mo inside a semantics element is treated the same as the mo alone.">
 <p>
   <math xmlns="http://www.w3.org/1998/Math/MathML">
     <mover>
-      <mspace width="300px" height="10px" mathbackground="black"></mspace>
-      <semantics><mo>&#xaf;</mo></semantics>
+      <mspace width="300px" height="10px" mathbackground="blue"></mspace>
+      <semantics><mo>&#x21AC;<!-- Rightwards Arrow With Loop --></mo></semantics>
     </mover>
   </math>
 </p>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-default-font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-default-font-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Operators using largeop should be bigger
+∫
+∫
+
+∑
+∑
+
+⋁
+⋁
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-default-font.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-default-font.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>DisplayOperatorMinHeight with default font</title>
+    <link
+      rel="help"
+      href="https://w3c.github.io/mathml-core/#layout-of-operators"
+    >
+    <meta
+      name="assert"
+      content="Operators using largeop should be bigger"
+    >
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script src="/mathml/support/fonts.js"></script>
+
+    <style>
+      math {
+        font-size: 16px;
+      }
+    </style>
+
+    <script>
+      // Small factor to ensure that the largeop version is bigger
+      const delta = 1.2;
+
+      var t = async_test("Operators using largeop should be bigger");
+      window.addEventListener("load", () => {
+        loadAllFonts().then(
+          t.step_func_done(function () {
+            document.querySelectorAll("math").forEach(
+              (math, i) => {
+                children = math.children;
+                regular = children[0].getBoundingClientRect();
+                largeop = children[1].getBoundingClientRect();
+                assert_greater_than(
+                  largeop.height,
+                  regular.height * delta,
+                  `Test ${children[0].textContent}`,
+                );
+              },
+            );
+          }),
+        );
+      });
+    </script>
+  </head>
+
+  <body>
+    <div id="log"></div>
+    <math displaystyle="true">
+      <mo largeop="false">&#x222B;</mo>
+      <mo largeop="true">&#x222B;</mo>
+    </math>
+    <math displaystyle="true">
+      <mo largeop="false">&#x2211;</mo>
+      <mo largeop="true">&#x2211;</mo>
+    </math>
+    <math displaystyle="true">
+      <mo largeop="false">&#x22C1;</mo>
+      <mo largeop="true">&#x22C1;</mo>
+    </math>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-no-workaround-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-no-workaround-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL DisplayOperatorMinHeight is not modified assert_approx_equals: Using the small variant expected 40 +/- 3.2 but got 0
+⫿
+⫿

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-no-workaround.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-no-workaround.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>DisplayOperatorMinHeight with custom font</title>
+    <link
+      rel="help"
+      href="https://w3c.github.io/mathml-core/#layout-of-operators"
+    >
+    <meta
+      name="assert"
+      content="Laying out operators should respect the font's DisplayOperatorMinHeight"
+    >
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script src="/mathml/support/fonts.js"></script>
+
+    <style>
+      /* This font has a DisplayOperatorMinHeight of 1.25em and two variants of the 0x2AFF
+      character, one with a height of 1.25em and the other with 2em. */
+      @font-face {
+        font-family: largeop-displayoperatorminheight1250;
+        src: url("/fonts/math/largeop-displayoperatorminheight1250.woff");
+      }
+      math {
+        font-family: largeop-displayoperatorminheight1250;
+        font-size: 32px;
+        color: green;
+      }
+      math > mo:first-child {
+        color: blue;
+      }
+    </style>
+
+    <script>
+      const font_size = 32;
+      const small_variant = 1.25 * font_size;
+      // Needs to be less than the difference between the two variants (2em - 1.25em)
+      const epsilon = 0.1 * font_size;
+
+      // Some browser engines had a minimum for DisplayOperatorMinHeight of sqrt(2) times
+      // the base glyph size (~1.41 * 1em in this case).
+      // This test checks that the constant is not modified and the variant measuring 1.25em
+      // is picked instead of the bigger one measuring 2em.
+      var t = async_test("DisplayOperatorMinHeight is not modified");
+      window.addEventListener("load", () => {
+        loadAllFonts().then(
+          t.step_func_done(function () {
+            const math = document.querySelector("math");
+            children = math.children;
+            largeop = children[1].getBoundingClientRect();
+            assert_approx_equals(
+              largeop.height,
+              small_variant,
+              epsilon,
+              "Using the small variant",
+            );
+          }),
+        );
+      });
+    </script>
+  </head>
+
+  <body>
+    <div id="log"></div>
+    <math display="block">
+      <mo largeop="false">&#x2AFF;</mo>
+      <mo largeop="true">&#x2AFF;</mo>
+    </math>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/w3c-import.log
@@ -15,6 +15,8 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/character-level-mirroring.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-default-font.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-no-workaround.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-op-1-2-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-op-1-2-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-op-1-2.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/cramped-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/cramped-001-expected.txt
@@ -13,7 +13,7 @@ PASS child of munderover (non-accent overscript)
 PASS accent child of mover (accent overscript)
 PASS accent child of munderover (accent overscript)
 PASS mmultiscripts
-PASS element with specified CSS math-style
+PASS element with specified CSS math-shift
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/cramped-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/cramped-001.html
@@ -145,7 +145,7 @@
           assert_cramped("css-002", true);
           assert_cramped("css-003", true);
           assert_cramped("css-004", false);
-      }, "element with specified CSS math-style");
+      }, "element with specified CSS math-shift");
 
       done();
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-computed-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Property math-depth value '0' assert_true: math-depth doesn't seem to be supported in the computed style expected true got false
+FAIL Property math-depth value '1' assert_true: math-depth doesn't seem to be supported in the computed style expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-depth with computed values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-script-level-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<math id="target"></math>
+<script>
+  test_computed_value("math-depth", "0");
+  test_computed_value("math-depth", "1");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-invalid-expected.txt
@@ -1,0 +1,12 @@
+
+PASS e.style['math-depth'] = "auto" should not set the property value
+PASS e.style['math-depth'] = "invalid" should not set the property value
+PASS e.style['math-depth'] = "add" should not set the property value
+PASS e.style['math-depth'] = "add(0.5)" should not set the property value
+PASS e.style['math-depth'] = "add(1px)" should not set the property value
+PASS e.style['math-depth'] = "0.5" should not set the property value
+PASS e.style['math-depth'] = "1px" should not set the property value
+PASS e.style['math-depth'] = "auto-add add(1)" should not set the property value
+PASS e.style['math-depth'] = "auto-add 1" should not set the property value
+PASS e.style['math-depth'] = "add(1) 1" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-invalid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-depth with invalid values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-script-level-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+  test_invalid_value("math-depth", "auto");
+  test_invalid_value("math-depth", "invalid");
+  test_invalid_value("math-depth", "add");
+  test_invalid_value("math-depth", "add(0.5)");
+  test_invalid_value("math-depth", "add(1px)");
+  test_invalid_value("math-depth", "0.5");
+  test_invalid_value("math-depth", "1px");
+  test_invalid_value("math-depth", "auto-add add(1)");
+  test_invalid_value("math-depth", "auto-add 1");
+  test_invalid_value("math-depth", "add(1) 1");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-valid-expected.txt
@@ -1,0 +1,7 @@
+
+FAIL e.style['math-depth'] = "auto-add" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['math-depth'] = "add(0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['math-depth'] = "add(1)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['math-depth'] = "0" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['math-depth'] = "1" should set the property value assert_not_equals: property should be set got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-depth with valid values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-script-level-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+  test_valid_value("math-depth", "auto-add");
+  test_valid_value("math-depth", "add(0)");
+  test_valid_value("math-depth", "add(1)");
+  test_valid_value("math-depth", "0");
+  test_valid_value("math-depth", "1");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-computed-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Property math-shift value 'normal'
+PASS Property math-shift value 'compact'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-shift with computed values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-shift">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<math id="target"></math>
+<script>
+  test_computed_value("math-shift", "normal");
+  test_computed_value("math-shift", "compact");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-invalid-expected.txt
@@ -1,0 +1,5 @@
+
+PASS e.style['math-shift'] = "auto" should not set the property value
+PASS e.style['math-shift'] = "invalid" should not set the property value
+PASS e.style['math-shift'] = "normal compact" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-shift with invalid values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-shift">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+  test_invalid_value("math-shift", "auto");
+  test_invalid_value("math-shift", "invalid");
+  test_invalid_value("math-shift", "normal compact");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-valid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['math-shift'] = "normal" should set the property value
+PASS e.style['math-shift'] = "compact" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-valid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-shift with valid values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-shift">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+  test_valid_value("math-shift", "normal");
+  test_valid_value("math-shift", "compact");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-computed-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Property math-style value 'normal'
+PASS Property math-style value 'compact'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-style with computed values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-style-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<math id="target"></math>
+<script>
+  test_computed_value("math-style", "normal");
+  test_computed_value("math-style", "compact");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-invalid-expected.txt
@@ -1,0 +1,5 @@
+
+PASS e.style['math-style'] = "auto" should not set the property value
+PASS e.style['math-style'] = "invalid" should not set the property value
+PASS e.style['math-style'] = "normal compact" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-style with invalid values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-style-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+  test_invalid_value("math-style", "auto");
+  test_invalid_value("math-style", "invalid");
+  test_invalid_value("math-style", "normal compact");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-valid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['math-style'] = "normal" should set the property value
+PASS e.style['math-style'] = "compact" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-valid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MathML Core: parsing math-style with valid values</title>
+<link rel="author" title="Eri Pazos" href="mailto:eri@igalia.com">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-math-style-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+  test_valid_value("math-style", "normal");
+  test_valid_value("math-style", "compact");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/w3c-import.log
@@ -1,0 +1,25 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-valid.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/tools/largeop.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/tools/largeop.py
@@ -81,3 +81,16 @@ f[nAryWhiteVerticalBarCodePoint].verticalComponents = \
      )
 f[nAryWhiteVerticalBarCodePoint].verticalComponentItalicCorrection = v2
 mathfont.save(f)
+
+v1 = int(1.25 * mathfont.em)
+f = mathfont.create("largeop-displayoperatorminheight%d" % v1,
+                    "Copyright (c) 2025 Igalia S.L.")
+f.math.DisplayOperatorMinHeight = v1
+f.math.AxisHeight = int(v1 / 2)
+mathfont.createSquareGlyph(f, nAryWhiteVerticalBarCodePoint)
+g = f.createChar(-1, "uni2AFF.v1")
+mathfont.drawRectangleGlyph(g, mathfont.em, v1, 0)
+g = f.createChar(-1, "uni2AFF.v2")
+mathfont.drawRectangleGlyph(g, mathfont.em, 2 * mathfont.em, 0)
+f[nAryWhiteVerticalBarCodePoint].verticalVariants = "uni2AFF uni2AFF.v1 uni2AFF.v2"
+mathfont.save(f)


### PR DESCRIPTION
#### 35208586d748409bbca90e3aa5430801e98ef257
<pre>
Resync `mathml` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=298193">https://bugs.webkit.org/show_bug.cgi?id=298193</a>

Reviewed by Frédéric Wang.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/ef5ef5e2aa577e020f9022294dbf9f900f20cd34">https://github.com/web-platform-tests/wpt/commit/ef5ef5e2aa577e020f9022294dbf9f900f20cd34</a>

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-005.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-default-font-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-default-font.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-no-workaround-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/display-operator-min-height-no-workaround.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/cramped-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/cramped-001.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-depth-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-shift-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/math-style-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/parsing/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/tools/largeop.py:

Canonical link: <a href="https://commits.webkit.org/299403@main">https://commits.webkit.org/299403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748ad9045b32e0aa85314526e5d83f7e0e0e1ee7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70967 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a14fa6bc-7ef4-45be-b38c-4096da1af4a0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90235 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c13e46b1-5656-46b6-aa8c-fa09a4fd0f44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70741 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d70b0297-15b5-4aa1-badc-0df5c65484c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68756 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128144 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98894 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98674 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25080 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42376 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45681 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46831 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->