### PR TITLE
Resync `the-canvas-element` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/imagedata-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/imagedata-expected.txt
@@ -5,10 +5,5 @@ PASS ImageData(w, h), exposed attributes check
 PASS ImageData(buffer, w), the buffer size must be a multiple of 4
 PASS ImageData(buffer, w), buffer size must be a multiple of the image width
 PASS ImageData(buffer, w, h), buffer.length == 4 * w * h must be true
-FAIL ImageData(buffer, w, opt h), Uint8ClampedArray argument type check assert_throws_js: function "function() {
-        new ImageData(new Int8Array(1), 1);
-    }" threw object "IndexSizeError: The index is not in the allowed range." ("IndexSizeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
 PASS ImageData(buffer, w, opt h), exposed attributes check
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/imagedata.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/imagedata.html
@@ -43,12 +43,6 @@ test(function() {
 }, "ImageData(buffer, w, h), buffer.length == 4 * w * h must be true");
 
 test(function() {
-    assert_throws_js(TypeError, function() {
-        new ImageData(new Int8Array(1), 1);
-    });
-}, "ImageData(buffer, w, opt h), Uint8ClampedArray argument type check");
-
-test(function() {
     var imageData = new ImageData(new Uint8ClampedArray(24), 2);
     assert_equals(imageData.width, 2);
     assert_equals(imageData.height, 3);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.html
@@ -20,6 +20,11 @@ async_test(t => {
     const canvas = frames[0].document.querySelector("canvas");
     canvas.toBlob(new frames[1].Function(`throw new parent.frames[2].Error("PASS");`));
 
+    // Wait until at least one `onerror` fires.
+    t.step_wait_func(() => onerrorCalls.length != 0);
+
+    // Wait for 25ms more in case one other `onerror` fires.  This is inherently
+    // flaky...
     t.step_timeout(() => {
       assert_array_equals(onerrorCalls, ["frame1"]);
       t.done();


### PR DESCRIPTION
#### 012b8d2be44b8278f140438b1a09088c6dfc5c83
<pre>
Resync `the-canvas-element` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=298198">https://bugs.webkit.org/show_bug.cgi?id=298198</a>
<a href="https://rdar.apple.com/159611849">rdar://159611849</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/ef5ef5e2aa577e020f9022294dbf9f900f20cd34">https://github.com/web-platform-tests/wpt/commit/ef5ef5e2aa577e020f9022294dbf9f900f20cd34</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/imagedata-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/imagedata.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.html:

Canonical link: <a href="https://commits.webkit.org/299406@main">https://commits.webkit.org/299406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23e6247cea72f5f96719379e918a02dd91a9a474

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70978 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/358a619d-8d2f-4093-a0cb-1d0ff54ef085) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90243 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59761 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fc56ee7-ed73-4de0-bcbd-763c44051de8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cebe30bd-efc8-4bf3-a53d-b46166830b5b) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68767 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128155 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98904 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98684 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25083 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42387 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45692 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48502 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->