### PR TITLE
REGRESSION(299129@main): [ iOS Debug ]ASSERTION FAILED: !isInAuxiliaryProcess() || MediaSessionHelper::sharedHelper().presentedApplicationPID()

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8258,8 +8258,6 @@ webkit.org/b/297984 [ Release ] imported/w3c/web-platform-tests/html/cross-origi
 
 webkit.org/b/298042 [ Release ] http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html [ Pass Failure ]
 
-webkit.org/b/298106 [ Debug ] http/wpt/mediasession/gpuProcessCrash-voiceDetection.html [ Crash ]
-
 webkit.org/b/298125 imported/w3c/web-platform-tests/mediacapture-streams/parallel-capture-requests.https.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/css/css-break/block-in-inline-012.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
@@ -105,7 +105,7 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
     // means that AVAudioSession may synchronously unduck previously ducked clients. Activation needs to complete before this method
     // returns, so do it synchronously on the same serial queue.
     if (active) {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) && !ENABLE(EXTENSION_CAPABILITIES)
         ASSERT(!isInAuxiliaryProcess() || MediaSessionHelper::sharedHelper().presentedApplicationPID());
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -271,6 +271,10 @@ public:
     RemoteAudioSessionProxy& audioSessionProxy();
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+    void providePresentingApplicationPID(WebCore::PageIdentifier) const;
+#endif
+
 private:
     GPUConnectionToWebProcess(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
 

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
@@ -77,6 +77,9 @@ public:
 #if ENABLE(EXTENSION_CAPABILITIES)
         virtual bool setCurrentMediaEnvironment(WebCore::PageIdentifier) { return false; };
 #endif
+#if PLATFORM(IOS_FAMILY)
+        virtual void providePresentingApplicationPID(WebCore::PageIdentifier) const = 0;
+#endif
         virtual void startProducingData(WebCore::CaptureDevice::DeviceType, WebCore::PageIdentifier) { }
         virtual RemoteVideoFrameObjectHeap* remoteVideoFrameObjectHeap() { return nullptr; }
 


### PR DESCRIPTION
#### 9b38c49f37039062b25d12d8b4e7be2589f193e5
<pre>
REGRESSION(299129@main): [ iOS Debug ]ASSERTION FAILED: !isInAuxiliaryProcess() || MediaSessionHelper::sharedHelper().presentedApplicationPID()
<a href="https://bugs.webkit.org/show_bug.cgi?id=298131">https://bugs.webkit.org/show_bug.cgi?id=298131</a>
<a href="https://rdar.apple.com/159478772">rdar://159478772</a>

Reviewed by Youenn Fablet.

The assertion added to AudioSessionCocoa::tryToSetActiveInternal in 299129@main is invalid on
platforms where media capability grants are enabled, since in that case it is expected for
presentedApplicationPID to not be set. Since it&apos;s not possible to check the value of a web
preference in AudioSession, restricted the assertion at compile time to platforms where
ENABLE(EXTENSION_CAPABILITIES) is false.

However, this assertion did expose a bug in 299129@main where
UserMediaCaptureManagerProxySourceProxy would activate the AudioSession without first setting a
presentedApplicationPID (on platforms where that&apos;s necessary). Resolved that by setting a Function
on UserMediaCaptureManagerProxySourceProxy that is called prior to activating the audio session.
UserMediaCaptureManagerProxy sets the function to a lamda that calls
GPUConnectionToWebProcess::providePresentingApplicationPID with the proxy&apos;s pageIdentifier.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::tryToSetActiveInternal):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::providePresentingApplicationPID const):
(WebKit::providePresentingApplicationPID): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
(WebKit::UserMediaCaptureManagerProxy::clone):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/299430@main">https://commits.webkit.org/299430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb27aeab969d97de14fe3888032057a99b6df9ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61fccacf-7aab-4312-aee8-96420ab54b8a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90256 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59771 "Found 1 new test failure: workers/btoa-oom.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b1fb26d-b987-4f55-80df-fa356dfcc71c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70761 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c2a56e2-ca4b-4d69-8885-6f50d8a5e85e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24741 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68784 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128171 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98917 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22153 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42403 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45708 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51386 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45174 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48518 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46858 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->