### PR TITLE
Port WebExtensionContext Permissions to C++

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -270,6 +270,18 @@ public:
         BackgroundContentFailedToLoad
     };
 
+    enum class PermissionNotification : uint8_t {
+        None = 0,
+        PermissionsWereGranted,
+        PermissionsWereDenied,
+        GrantedPermissionsWereRemoved,
+        DeniedPermissionsWereRemoved,
+        PermissionMatchPatternsWereGranted,
+        PermissionMatchPatternsWereDenied,
+        GrantedPermissionMatchPatternsWereRemoved,
+        DeniedPermissionMatchPatternsWereRemoved,
+    };
+
     enum class PermissionState : int8_t {
         DeniedExplicitly    = -3,
         DeniedImplicitly    = -2,
@@ -665,16 +677,14 @@ private:
     void determineInstallReasonDuringLoad();
     void moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&&);
 
-    void permissionsDidChange(NSString *notificationName, const PermissionsSet&);
-    void permissionsDidChange(NSString *notificationName, const MatchPatternSet&);
+    void permissionsDidChange(PermissionNotification, const PermissionsSet&);
+    void permissionsDidChange(PermissionNotification, const MatchPatternSet&);
 
-    bool removePermissions(PermissionsMap&, PermissionsSet&, WallTime& nextExpirationDate, NSString *notificationName);
-    bool removePermissionMatchPatterns(PermissionMatchPatternsMap&, MatchPatternSet&, EqualityOnly, WallTime& nextExpirationDate, NSString *notificationName);
+    bool removePermissions(PermissionsMap&, PermissionsSet&, WallTime& nextExpirationDate, PermissionNotification = PermissionNotification::None);
+    bool removePermissionMatchPatterns(PermissionMatchPatternsMap&, MatchPatternSet&, EqualityOnly, WallTime& nextExpirationDate, PermissionNotification = PermissionNotification::None);
 
-#if PLATFORM(COCOA)
-    PermissionsMap& removeExpired(PermissionsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
-    PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
-#endif
+    PermissionsMap& removeExpired(PermissionsMap&, WallTime& nextExpirationDate, PermissionNotification = PermissionNotification::None);
+    PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, WallTime& nextExpirationDate, PermissionNotification = PermissionNotification::None);
 
     void populateWindowsAndTabs();
 


### PR DESCRIPTION
#### 23fb371328cf3c54930b21696a19a8f9acda0056
<pre>
Port WebExtensionContext Permissions to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=298204">https://bugs.webkit.org/show_bug.cgi?id=298204</a>

Reviewed by Timothy Hatcher.

Moves and updates permission code to C++, and creates a new enum to specify notifications, allowing for most functions to not worry about how notifications will be handled per-platform, with the exception of functions emitting notifications via the platform-specific system such as NSNotificationCenter.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::permissionNotification):
(WebKit::WebExtensionContext::permissionsDidChange):
(WebKit::WebExtensionContext::hasPermissionToSendWebRequestEvent):
(WebKit::WebExtensionContext::addItemsToContextMenu):
(WebKit::WebExtensionContext::userGesturePerformed):
(WebKit::WebExtensionContext::clearUserGesture):
(WebKit::WebExtensionContext::webViewConfiguration):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::handleContentRuleListMatchedRule):
(WebKit::WebExtensionContext::handleContentRuleListNotificationForTab):
(WebKit::WebExtensionContext::quotaForStorageType):
(WebKit::WebExtensionContext::grantedPermissions): Deleted.
(WebKit::WebExtensionContext::setGrantedPermissions): Deleted.
(WebKit::WebExtensionContext::deniedPermissions): Deleted.
(WebKit::WebExtensionContext::setDeniedPermissions): Deleted.
(WebKit::WebExtensionContext::grantedPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::setGrantedPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::deniedPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::setDeniedPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::grantPermissions): Deleted.
(WebKit::WebExtensionContext::denyPermissions): Deleted.
(WebKit::WebExtensionContext::grantPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::denyPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::removeGrantedPermissions): Deleted.
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::removeDeniedPermissions): Deleted.
(WebKit::WebExtensionContext::removeDeniedPermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::removePermissions): Deleted.
(WebKit::WebExtensionContext::removePermissionMatchPatterns): Deleted.
(WebKit::WebExtensionContext::removeExpired): Deleted.
(WebKit::WebExtensionContext::needsPermission): Deleted.
(WebKit::WebExtensionContext::hasPermission): Deleted.
(WebKit::WebExtensionContext::hasPermissions): Deleted.
(WebKit::WebExtensionContext::permissionState): Deleted.
(WebKit::WebExtensionContext::setPermissionState): Deleted.
(WebKit::WebExtensionContext::clearCachedPermissionStates): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::grantedPermissions):
(WebKit::WebExtensionContext::setGrantedPermissions):
(WebKit::WebExtensionContext::deniedPermissions):
(WebKit::WebExtensionContext::setDeniedPermissions):
(WebKit::WebExtensionContext::grantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::setGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::setDeniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::deniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::grantPermissions):
(WebKit::WebExtensionContext::denyPermissions):
(WebKit::WebExtensionContext::grantPermissionMatchPatterns):
(WebKit::WebExtensionContext::denyPermissionMatchPatterns):
(WebKit::WebExtensionContext::removePermissions):
(WebKit::WebExtensionContext::removePermissionMatchPatterns):
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeGrantedPermissions):
(WebKit::WebExtensionContext::removeDeniedPermissions):
(WebKit::WebExtensionContext::removeDeniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeExpired):
(WebKit::WebExtensionContext::needsPermission):
(WebKit::WebExtensionContext::hasPermission):
(WebKit::WebExtensionContext::hasPermissions):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::setPermissionState):
(WebKit::WebExtensionContext::clearCachedPermissionStates):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/300065@main">https://commits.webkit.org/300065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b67368ba9bdd3af21facc53f0efa6b6ea9bee92e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92082 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32249 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100679 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24041 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44839 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53716 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->