### PR TITLE
<view> elements should apply to the root element

### DIFF
--- a/LayoutTests/svg/as-image/resources/view-in-inner-svg.svg
+++ b/LayoutTests/svg/as-image/resources/view-in-inner-svg.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="100" width="100" height="100" fill="green"/>
+  <svg>
+    <view id="innerview" viewBox="100 0 100 100"/>
+    <rect width="100" height="100" fill="red"/>
+  </svg>
+</svg>

--- a/LayoutTests/svg/as-image/view-in-inner-svg-expected.html
+++ b/LayoutTests/svg/as-image/view-in-inner-svg-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/as-image/view-in-inner-svg.html
+++ b/LayoutTests/svg/as-image/view-in-inner-svg.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<img src="resources/view-in-inner-svg.svg#innerview" width="100">

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -700,7 +700,11 @@ RefPtr<SVGViewElement> SVGSVGElement::findViewAnchor(StringView fragmentIdentifi
 
 SVGSVGElement* SVGSVGElement::findRootAnchor(const SVGViewElement* viewElement) const
 {
-    return dynamicDowncast<SVGSVGElement>(SVGLocatable::nearestViewportElement(viewElement));
+    if (!viewElement)
+        return nullptr;
+
+    auto& document = viewElement->document();
+    return dynamicDowncast<SVGSVGElement>(document.documentElement());
 }
 
 SVGSVGElement* SVGSVGElement::findRootAnchor(StringView fragmentIdentifier) const
@@ -743,9 +747,9 @@ bool SVGSVGElement::scrollToFragment(StringView fragmentIdentifier)
     }
 
     // Spec: If the SVG fragment identifier addresses a "view" element within an SVG document (e.g., MyDrawing.svg#MyView)
-    // then the closest ancestor "svg" element is displayed in the viewport.
+    // then the root 'svg' element is displayed in the SVG viewport.
     // Any view specification attributes included on the given "view" element override the corresponding view specification
-    // attributes on the closest ancestor "svg" element.
+    // attributes on the root 'svg' element.
     if (RefPtr viewElement = findViewAnchor(fragmentIdentifier)) {
         if (RefPtr rootElement = findRootAnchor(viewElement.get())) {
             if (rootElement->m_currentViewElement) {


### PR DESCRIPTION
#### 1018cb1de959c7f012cbfe369964d8e6b0e0b101
<pre>
&lt;view&gt; elements should apply to the root element
<a href="https://bugs.webkit.org/show_bug.cgi?id=298206">https://bugs.webkit.org/show_bug.cgi?id=298206</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Inspired by: <a href="https://chromium.googlesource.com/chromium/src.git/+/17ee10504ffe050b3926fa4be7262f8a21ac4e2d">https://chromium.googlesource.com/chromium/src.git/+/17ee10504ffe050b3926fa4be7262f8a21ac4e2d</a>

As the comment here indicates, it wasn&apos;t clear which &lt;svg&gt; a &lt;view&gt;
element should apply to. This was clarified in SVG2 [1] to be the &quot;root
&apos;svg&apos; element&quot;, which is the same as for a &quot;svgView(...)&quot; fragment.
The comment is updated to reflect the new spec text and &apos;findRootAnchor&apos;
was updated to align with specification.

[1] <a href="https://svgwg.org/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions">https://svgwg.org/svg2-draft/linking.html#SVGFragmentIdentifiersDefinitions</a>

* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::findRootAnchor const):
(WebCore::SVGSVGElement::scrollToFragment):
* LayoutTests/svg/as-image/resources/view-in-inner-svg.svg: Added.
* LayoutTests/svg/as-image/view-in-inner-svg-expected.html: Added.
* LayoutTests/svg/as-image/view-in-inner-svg.html: Added.

Canonical link: <a href="https://commits.webkit.org/299459@main">https://commits.webkit.org/299459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/775e8a689abaa705144bbfd2956c8e0689094342

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71144 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88bfa68c-eb9c-43bb-b9f8-6887382a23cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47344 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90416 "Found 1 new test failure: http/wpt/service-workers/service-worker-spinning-activate.https.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4b08f50-8884-4a71-9fbf-c8988b428720) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70877 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6410f450-8e7f-4861-826c-1339faa80fa9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24867 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68948 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128322 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98811 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/25118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22272 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45858 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51537 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45325 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47010 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->