### PR TITLE
Add supports for scenarios where WebCoreDecompression can't be used to AudioVideoRendererAVFObjC

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -115,6 +115,9 @@ public:
 
     virtual ~TracksRendererManager() = default;
 
+    virtual void setPreferences(VideoMediaSampleRendererPreferences) { }
+    virtual void setHasProtectedVideoContent(bool) { }
+
     virtual TrackIdentifier addTrack(TrackType) = 0;
     virtual void removeTrack(TrackIdentifier) = 0;
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -88,6 +88,7 @@ public:
 #endif
 
     void flush();
+    void shutdown();
 
     void expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime&);
 


### PR DESCRIPTION
#### 2ee09856dcfda8b1b4237947f991ff7d8f77894b
<pre>
Add supports for scenarios where WebCoreDecompression can&apos;t be used to AudioVideoRendererAVFObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=298177">https://bugs.webkit.org/show_bug.cgi?id=298177</a>
<a href="https://rdar.apple.com/159572175">rdar://159572175</a>

Reviewed by Jer Noble and Youenn Fablet.

When the WebCoreDecompressionSession isn&apos;t in used in the VideoMediaSampleRenderer,
operations such as switching from protected&lt;-&gt;clear, docking the video
or switching from an AVSampleBufferDisplayLayer to AVSampleBufferVideoRenderer
requires to first flush the renderer and re-enqueue content.
This change handles those scenarios. It is similar to what the
MediaPlayerPrivateMediaSourceAVFObjC is already doing but we allow for
simplifications as the AudioVideoRenderer only has to deal with a single
VideoMediaSampleRenderer.

Manually tested by disabling the decompressionsession in the WebM player.

No change in observable behaviour.

* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::TracksRendererManager::setPreferences):
(WebCore::TracksRendererManager::setHasProtectedVideoContent):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::setPreferences):
(WebCore::AudioVideoRendererAVFObjC::setHasProtectedVideoContent):
(WebCore::AudioVideoRendererAVFObjC::notifyWhenHasAvailableVideoFrame):
(WebCore::AudioVideoRendererAVFObjC::setVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::canUseDecompressionSession const):
(WebCore::AudioVideoRendererAVFObjC::isUsingDecompressionSession const):
(WebCore::AudioVideoRendererAVFObjC::willUseDecompressionSessionIfNeeded const):
(WebCore::AudioVideoRendererAVFObjC::stageVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::flushVideo):
(WebCore::AudioVideoRendererAVFObjC::notifyRequiresFlushToResume):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::play):
(WebCore::MediaPlayerPrivateWebM::flushVideoIfNeeded):
(WebCore::MediaPlayerPrivateWebM::setLayerRequiresFlush):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::~VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::changeRenderer):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::shutdown):

Canonical link: <a href="https://commits.webkit.org/299875@main">https://commits.webkit.org/299875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e63894af6c6af6a9216665108be0de0cfa6cc229

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72614 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6aa725c-f2c8-49e1-aa57-3b9be2f7a521) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48810 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91546 "Failed to checkout and rebase branch from PR 50162") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17d03ec9-980e-4b19-ab95-ce011e39ae63) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72097 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/630cdaef-4f7a-4a19-8fde-c0976e588428) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70532 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129800 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36022 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25385 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45450 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47322 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46790 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48477 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->