### PR TITLE
gamepad/gamepad-visibility-1.html is failing

### DIFF
--- a/LayoutTests/gamepad/gamepad-visibility-1.html
+++ b/LayoutTests/gamepad/gamepad-visibility-1.html
@@ -42,8 +42,11 @@ function runTest() {
 
     // Connecting the gamepad and changing axis values should *not* make it visible.
     // Only button presses should expose it.
-    testRunner.setMockGamepadDetails(0, "Test Joystick", "", 2, 2, false);
+    const gamepadWasConnected = true;
+    testRunner.setMockGamepadDetails(0, "Test Joystick", "", 2, 2, false, gamepadWasConnected);
+
     testRunner.connectMockGamepad(0);
+
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3536,8 +3536,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-elemen
 # Remove console message: 'Navigator.getGamepads() will be removed from insecure contexts in a future release'.
 imported/w3c/web-platform-tests/gamepad/gamepad-secure-context.html [ DumpJSConsoleLogInStdErr ]
 
-webkit.org/b/259104 gamepad/gamepad-visibility-1.html [ Failure ]
-
 # ENABLE(DRAGGABLE_REGION) is disabled
 Bug(GLIB) fast/css/draggable-region-parser.html [ Failure ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -774,7 +774,6 @@ webkit.org/b/160042 accessibility/mac/value-change/value-change-user-info-conten
 webkit.org/b/160309 fast/dom/Window/child-window-focus.html [ Pass Failure ]
 
 webkit.org/b/161148 gamepad/gamepad-timestamp.html [ Pass Failure ]
-webkit.org/b/167517 gamepad/gamepad-visibility-1.html [ Pass Failure ]
 
 webkit.org/b/161633 [ Debug ] storage/indexeddb/objectstore-cursor.html [ Pass Timeout ]
 

--- a/Source/WebCore/testing/MockGamepad.cpp
+++ b/Source/WebCore/testing/MockGamepad.cpp
@@ -30,14 +30,14 @@
 
 namespace WebCore {
 
-MockGamepad::MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
+MockGamepad::MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected)
     : PlatformGamepad(index)
 {
     m_connectTime = m_lastUpdateTime = MonotonicTime::now();
-    updateDetails(gamepadID, mapping, axisCount, buttonCount, supportsDualRumble);
+    updateDetails(gamepadID, mapping, axisCount, buttonCount, supportsDualRumble, wasConnected);
 }
 
-void MockGamepad::updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
+void MockGamepad::updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected)
 {
     m_id = gamepadID;
     m_mapping = mapping;
@@ -52,6 +52,7 @@ void MockGamepad::updateDetails(const String& gamepadID, const String& mapping, 
         m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
     else
         m_supportedEffectTypes.remove(GamepadHapticEffectType::DualRumble);
+    m_wasConnected = wasConnected;
 }
 
 bool MockGamepad::setAxisValue(unsigned index, double value)

--- a/Source/WebCore/testing/MockGamepad.h
+++ b/Source/WebCore/testing/MockGamepad.h
@@ -33,18 +33,20 @@ namespace WebCore {
 
 class MockGamepad : public PlatformGamepad {
 public:
-    MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
+    MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
 
     const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
     const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
 
-    void updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
+    void updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
     bool setAxisValue(unsigned index, double value);
     bool setButtonValue(unsigned index, double value);
+    bool wasConnected() { return m_wasConnected; }
 
 private:
     Vector<SharedGamepadValue> m_axisValues;
     Vector<SharedGamepadValue> m_buttonValues;
+    bool m_wasConnected;
 };
 
 }

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -49,7 +49,7 @@ public:
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
     void clearGamepadsForTesting() final;
 
-    void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
+    void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
     bool setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);
     bool setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
     bool connectMockGamepad(unsigned index);

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -195,10 +195,10 @@ void disconnectMockGamepad(unsigned gamepadIndex)
 #endif
 }
 
-void setMockGamepadDetails(unsigned gamepadIndex, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
+void setMockGamepadDetails(unsigned gamepadIndex, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected)
 {
 #if ENABLE(GAMEPAD)
-    MockGamepadProvider::singleton().setMockGamepadDetails(gamepadIndex, gamepadID, mapping, axisCount, buttonCount, supportsDualRumble);
+    MockGamepadProvider::singleton().setMockGamepadDetails(gamepadIndex, gamepadID, mapping, axisCount, buttonCount, supportsDualRumble, wasConnected);
 #else
     UNUSED_PARAM(gamepadIndex);
     UNUSED_PARAM(gamepadID);
@@ -206,6 +206,7 @@ void setMockGamepadDetails(unsigned gamepadIndex, const String& gamepadID, const
     UNUSED_PARAM(axisCount);
     UNUSED_PARAM(buttonCount);
     UNUSED_PARAM(supportsDualRumble);
+    UNUSED_PARAM(wasConnected);
 #endif
 }
 

--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -66,7 +66,7 @@ TEST_SUPPORT_EXPORT void setLinkedOnOrAfterEverythingForTesting();
 TEST_SUPPORT_EXPORT void installMockGamepadProvider();
 TEST_SUPPORT_EXPORT void connectMockGamepad(unsigned index);
 TEST_SUPPORT_EXPORT void disconnectMockGamepad(unsigned index);
-TEST_SUPPORT_EXPORT void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
+TEST_SUPPORT_EXPORT void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
 TEST_SUPPORT_EXPORT void setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);
 TEST_SUPPORT_EXPORT void setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -268,7 +268,7 @@ interface TestRunner {
     undefined setAllowedMenuActions(object actions);
 
     // Gamepad
-    undefined setMockGamepadDetails(unsigned long index, DOMString id, DOMString mapping, unsigned long axisCount, unsigned long buttonCount, boolean supportsDualRumble);
+    undefined setMockGamepadDetails(unsigned long index, DOMString id, DOMString mapping, unsigned long axisCount, unsigned long buttonCount, boolean supportsDualRumble, boolean wasConnected);
     undefined setMockGamepadAxisValue(unsigned long index, unsigned long axisIndex, double value);
     undefined setMockGamepadButtonValue(unsigned long index, unsigned long buttonIndex, double value);
     undefined connectMockGamepad(unsigned long index);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1549,7 +1549,7 @@ void TestRunner::disconnectMockGamepad(unsigned index)
     postSynchronousMessage("DisconnectMockGamepad", index);
 }
 
-void TestRunner::setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
+void TestRunner::setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected)
 {
     postSynchronousMessage("SetMockGamepadDetails", createWKDictionary({
         { "GamepadID", toWK(gamepadID) },
@@ -1558,6 +1558,7 @@ void TestRunner::setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JS
         { "AxisCount", adoptWK(WKUInt64Create(axisCount)) },
         { "ButtonCount", adoptWK(WKUInt64Create(buttonCount)) },
         { "SupportsDualRumble", adoptWK(WKBooleanCreate(supportsDualRumble)) },
+        { "WasConnected", adoptWK(WKBooleanCreate(wasConnected)) },
     }));
 }
 
@@ -1589,7 +1590,7 @@ void TestRunner::disconnectMockGamepad(unsigned)
 {
 }
 
-void TestRunner::setMockGamepadDetails(unsigned, JSStringRef, JSStringRef, unsigned, unsigned, bool)
+void TestRunner::setMockGamepadDetails(unsigned, JSStringRef, JSStringRef, unsigned, unsigned, bool, bool)
 {
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -376,7 +376,7 @@ public:
     // Gamepads
     void connectMockGamepad(unsigned index);
     void disconnectMockGamepad(unsigned index);
-    void setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
+    void setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
     void setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);
     void setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
     

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -846,7 +846,8 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         auto axisCount = uint64Value(messageBodyDictionary, "AxisCount");
         auto buttonCount = uint64Value(messageBodyDictionary, "ButtonCount");
         bool supportsDualRumble = booleanValue(messageBodyDictionary, "SupportsDualRumble");
-        WebCoreTestSupport::setMockGamepadDetails(gamepadIndex, toWTFString(gamepadID), toWTFString(mapping), axisCount, buttonCount, supportsDualRumble);
+        bool wasConnected = booleanValue(messageBodyDictionary, "WasConnected");
+        WebCoreTestSupport::setMockGamepadDetails(gamepadIndex, toWTFString(gamepadID), toWTFString(mapping), axisCount, buttonCount, supportsDualRumble, wasConnected);
         return nullptr;
     }
 


### PR DESCRIPTION
#### 2a2bdc0d50dab2388f3b8d908aa577081e3a0314
<pre>
gamepad/gamepad-visibility-1.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=259104">https://bugs.webkit.org/show_bug.cgi?id=259104</a>

Reviewed by Adrian Perez de Castro.

This test was failing in all platforms. The test connects a mock gamepad and
changes axis values.  The test expects that none of these events should
emit a &apos;gamepadconnect&apos; event. However, the method &apos;connectMockGamepad&apos; always
emits a &apos;gamepadconnect&apos; event, which makes the test fail.

To fix the test, I added an extra argument &apos;wasConnected&apos; to &apos;setMockGamepadDetails&apos;,
so when &apos;connectMockGamepad&apos; is called the method doesn&apos;t emit a &apos;gamepadconnect&apos;
event.  This allows to implement a scenario similar to when a page is loaded and
there&apos;s a gamepad already connected.

* LayoutTests/gamepad/gamepad-visibility-1.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/testing/MockGamepad.cpp:
(WebCore::MockGamepad::MockGamepad):
(WebCore::MockGamepad::updateDetails):
* Source/WebCore/testing/MockGamepad.h:
(WebCore::MockGamepad::wasConnected):
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::setMockGamepadDetails):
(WebCore::MockGamepadProvider::connectMockGamepad):
* Source/WebCore/testing/MockGamepadProvider.h:
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::setMockGamepadDetails):
* Source/WebCore/testing/js/WebCoreTestSupport.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setMockGamepadDetails):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/299621@main">https://commits.webkit.org/299621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d63583e10837fcba2bf832d401f5fe66196bd25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90401 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59844 "Found 1 new test failure: http/tests/navigation/ping-attribute/anchor-cookie.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30504 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24852 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68926 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45967 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34735 "Found 1 new test failure: http/tests/cache/disk-cache/speculative-validation/cacheable-redirect.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98797 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42546 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19027 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51516 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->