### PR TITLE
Command-click to open a link in a new tab navigates the current tab on some websites

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3083,6 +3083,10 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
 {
     Ref frame = m_frame.get();
 
+    if (eventType == eventNames().clickEvent) {
+        if (RefPtr window = frame->window())
+            window->updateLastUserClickEvent(platformMouseEvent.modifiers());
+    }
     updateMouseEventTargetNode(eventType, targetNode, platformMouseEvent, fireMouseOverOut);
 
     bool isMouseDownEvent = eventType == eventNames().mousedownEvent;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -200,7 +200,7 @@ static std::optional<Seconds>& transientActivationDurationOverrideForTesting()
     return overrideForTesting;
 }
 
-static Seconds transientActivationDuration()
+Seconds LocalDOMWindow::transientActivationDuration()
 {
     if (auto override = transientActivationDurationOverrideForTesting())
         return *override;
@@ -1589,6 +1589,19 @@ bool LocalDOMWindow::consumeHistoryActionUserActivation()
     }
 
     return true;
+}
+
+void LocalDOMWindow::updateLastUserClickEvent(OptionSet<PlatformEventModifier> modifiers)
+{
+    m_lastUserClickEvent = ClickEventData {
+        MonotonicTime::now(),
+        modifiers
+    };
+}
+
+std::optional<LocalDOMWindow::ClickEventData> LocalDOMWindow::consumeLastUserClickEvent()
+{
+    return std::exchange(m_lastUserClickEvent, std::nullopt);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#activation-notification

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -65,6 +65,7 @@ class LocalFrame;
 struct ScrollToOptions;
 struct WindowPostMessageOptions;
 
+enum class PlatformEventModifier : uint8_t;
 using ReducedResolutionSeconds = Seconds;
 
 template<typename> class ExceptionOr;
@@ -152,6 +153,14 @@ public:
     WEBCORE_EXPORT bool consumeTransientActivation();
     WEBCORE_EXPORT bool hasHistoryActionActivation() const;
     WEBCORE_EXPORT bool consumeHistoryActionUserActivation();
+    WEBCORE_EXPORT static Seconds transientActivationDuration();
+
+    struct ClickEventData {
+        MonotonicTime time;
+        OptionSet<PlatformEventModifier> modifiers;
+    };
+    void updateLastUserClickEvent(OptionSet<PlatformEventModifier>);
+    WEBCORE_EXPORT std::optional<ClickEventData> consumeLastUserClickEvent();
 
     DOMSelection* getSelection();
 
@@ -487,6 +496,8 @@ private:
     // value is positive infinity.
     MonotonicTime m_lastActivationTimestamp { MonotonicTime::infinity() };
     MonotonicTime m_lastHistoryActionActivationTimestamp { MonotonicTime::infinity() };
+
+    std::optional<ClickEventData> m_lastUserClickEvent;
 
     bool m_wasWrappedWithoutInitializedSecurityOrigin { false };
     bool m_mayReuseForNavigation { true };


### PR DESCRIPTION
#### 79fdcdf3166524609b3412c7da7bbee86ed72096
<pre>
Command-click to open a link in a new tab navigates the current tab on some websites
<a href="https://bugs.webkit.org/show_bug.cgi?id=298213">https://bugs.webkit.org/show_bug.cgi?id=298213</a>
<a href="https://rdar.apple.com/57216935">rdar://57216935</a>

Reviewed by Brady Eidson and Alexey Proskuryakov.

Command-click to open a link in a new tab navigates the current tab on some websites.
The reason for this is that these sites intercept the click event on the element,
do some processing (e.g. link click analytics), then &quot;clone&quot; the click event and
dispatch the cloned event.

The issue with this is that the &quot;cloned&quot; click event is no longer a trusted event
and WebKit decided to ignore modifiers for navigations triggered by untrusted
events in r197150. The issue was that sites could add items to Safari&apos;s reading
list by simulating clicks with the &quot;Shift&quot; modifier set.

To address the issue while maintaining the security benefits from r197150, we now
keep track of the last user click event on any given window object. When a frame is
navigated by an untrusted event, we now check if there was a user click in this frame
in the last 5 seconds and maintain the modifiers that are common to the untrusted
event and the last (trusted) user click. We also consume the last user click so that
it can only be used to maintain modifiers on a single untrusted event.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchMouseEvent):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::transientActivationDuration):
(WebCore::LocalDOMWindow::updateLastUserClickEvent):
(WebCore::LocalDOMWindow::consumeLastUserClickEvent):
(WebCore::transientActivationDuration): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebKit/Shared/WebEventModifier.cpp:
(WebKit::modifiersForNavigationAction):
* Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm:
(TestWebKitAPI::runModifierIsKeptWhenJSInterceptsClickTest):
(TestWebKitAPI::TEST(MouseEventTests, CmdModifierIsKeptWhenJSInterceptsClick)):
(TestWebKitAPI::TEST(MouseEventTests, ShiftModifierIsKeptWhenJSInterceptsClick)):
(TestWebKitAPI::TEST(MouseEventTests, AltModifierIsKeptWhenJSInterceptsClick)):
(TestWebKitAPI::TEST(MouseEventTests, CmdShiftModifierIsKeptWhenJSInterceptsClick)):

Canonical link: <a href="https://commits.webkit.org/299537@main">https://commits.webkit.org/299537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b4787c3c03869a284d9e70c3f47afc9d8124467

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71230 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a886e10-62ee-426b-9229-e99855ee82b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90524 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59899 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d120679f-39f3-4cdc-a409-f6e8bca042a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f0baf88-e9bd-4f7e-8ece-91aac89ea2c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24937 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69042 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128408 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99087 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22335 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42653 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51624 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45411 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47103 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->