### PR TITLE
Don't use m_shader cache and create a new one for each draw https://bugs.webkit.org/show_bug.cgi?id=298220

### DIFF
--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -132,10 +132,6 @@ private:
     std::optional<GradientRendererCG> m_platformRenderer;
 #endif
 
-#if USE(SKIA)
-    sk_sp<SkShader> m_shader;
-#endif
-
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Gradient&);

--- a/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
@@ -42,7 +42,6 @@ namespace WebCore {
 
 void Gradient::stopsChanged()
 {
-    m_shader = { };
 }
 
 inline SkScalar webCoreDoubleToSkScalar(double d)
@@ -103,9 +102,6 @@ static SkGradientShader::Interpolation toSkiaInterpolation(const ColorInterpolat
 
 sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradientSpaceTransform)
 {
-    if (m_shader)
-        return m_shader;
-
     Vector<SkColor4f, 8> colors;
     colors.reserveInitialCapacity(stops().size());
     Vector<SkScalar, 8> positions;
@@ -147,7 +143,7 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
     auto interpolation = toSkiaInterpolation(colorInterpolationMethod());
     SkMatrix matrix = gradientSpaceTransform;
 
-    m_shader = WTF::switchOn(
+    auto shader = WTF::switchOn(
         m_data,
         [&](const LinearData& data) {
             SkPoint points[] = { SkPoint::Make(data.point0.x(), data.point0.y()), SkPoint::Make(data.point1.x(), data.point1.y()) };
@@ -172,7 +168,7 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
             return SkGradientShader::MakeSweep(data.point0.x(), data.point0.y(), colors.span().data(), nullptr, positions.span().data(), colors.size(), tileMode, 0, 360, interpolation, &matrix);
         });
 
-    return m_shader;
+    return shader;
 }
 
 void Gradient::fill(GraphicsContext& context, const FloatRect& rect)


### PR DESCRIPTION
#### 22cffb4048e746966d59fec45cc83170cee8a44c
<pre>
Don&apos;t use m_shader cache and create a new one for each draw <a href="https://bugs.webkit.org/show_bug.cgi?id=298220">https://bugs.webkit.org/show_bug.cgi?id=298220</a>

Reviewed by Carlos Garcia Campos.

The usage of `m_shader` doesn&apos;t seem to be safe. It seems to me that a Gradient
might be used by different threads. They both can check that the shader is
not set and then try to create it. The first one creates it and then tries to
use it and the second one will then create a new one and free the first one.
I could see two threads that use `WebCore::Gradient::fill()` which ended
up in `SkShaderBase::makeContext()` crash.

This commit removes the `m_shader` cache and always creates a new shader for
each draw. This is probably more expensive, but maybe not that much.

If I remove the use of the shader cache, the crash goes away.

* Source/WebCore/platform/graphics/Gradient.h:
* Source/WebCore/platform/graphics/skia/GradientSkia.cpp:
(Gradient::shader): Modified

Canonical link: <a href="https://commits.webkit.org/299797@main">https://commits.webkit.org/299797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3b0ecf9a11d3226cabdb8ffcd54d24260464c58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72172 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91211 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60518 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25790 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129352 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25326 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23147 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43650 "The change is no longer eligible for processing.") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/19102 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52587 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->