### PR TITLE
[GLIB] WebKit doesn't build with -DENABLE_MALLOC_HEAP_BREAKDOWN=ON

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -49,6 +49,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FetchLoaderClient);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchLoader);
 
 void FetchLoader::start(ScriptExecutionContext& context, const Blob& blob)
 {

--- a/Source/WebCore/Modules/fetch/FetchLoader.h
+++ b/Source/WebCore/Modules/fetch/FetchLoader.h
@@ -43,6 +43,7 @@ class FetchRequest;
 class ScriptExecutionContext;
 class FragmentedSharedBuffer;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchLoader);
 class WEBCORE_EXPORT FetchLoader final : public RefCounted<FetchLoader>, public ThreadableLoaderClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FetchLoader, FetchLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FetchLoader);

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -44,6 +44,7 @@ namespace WebCore {
 // https://notifications.spec.whatwg.org/#resources
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NotificationResourcesLoader);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceLoader);
 
 NotificationResourcesLoader::NotificationResourcesLoader(Notification& notification)
     : m_notification(notification)

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -42,6 +42,7 @@ class NotificationResources;
 class ResourceError;
 class ResourceResponse;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceLoader);
 class NotificationResourcesLoader {
     WTF_MAKE_TZONE_ALLOCATED(NotificationResourcesLoader);
 public:

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -236,7 +236,7 @@ private:
     CSSSelector(CSSSelector&&) = delete;
 
     struct RareData : public RefCounted<RareData> {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSSelectorRareData, RareData);
+        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSSelectorRareData, CSSSelectorRareData);
         static Ref<RareData> create(AtomString);
         WEBCORE_EXPORT ~RareData();
 

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -34,6 +34,7 @@
 #include "CSSParserObserverWrapper.h"
 #include "CSSParserTokenRange.h"
 #include "CSSTokenizerInputStream.h"
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/unicode/CharacterNames.h>

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
@@ -32,6 +32,8 @@
 
 #include "CSSTokenizer.h"
 
+#include <wtf/NeverDestroyed.h>
+
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizerInputStream);
 

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -49,6 +49,7 @@
 #include "ThreadableBlobRegistry.h"
 #include "ThreadableLoader.h"
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
@@ -57,6 +58,8 @@
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FileReaderLoader);
 
 const int defaultBufferLength = 32768;
 

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -53,6 +53,7 @@ class ScriptExecutionContext;
 class TextResourceDecoder;
 class ThreadableLoader;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FileReaderLoader);
 class FileReaderLoader final : public ThreadableLoaderClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FileReaderLoader, FileReaderLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FileReaderLoader);

--- a/Source/WebCore/loader/LoaderMalloc.cpp
+++ b/Source/WebCore/loader/LoaderMalloc.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "LoaderMalloc.h"
 
+#include <wtf/NeverDestroyed.h>
+
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Loader);
 }

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -85,7 +85,7 @@
 
 namespace WebCore {
 
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceLoader);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CoreResourceLoader);
 
 ResourceLoader::ResourceLoader(LocalFrame& frame, ResourceLoaderOptions options)
     : m_frame { &frame }

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -65,9 +65,9 @@ class NetworkLoadMetrics;
 class ResourceMonitor;
 #endif
 
-DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceLoader);
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CoreResourceLoader);
 class ResourceLoader : public RefCountedAndCanMakeWeakPtr<ResourceLoader>, protected ResourceHandleClient {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ResourceLoader, ResourceLoader);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ResourceLoader, CoreResourceLoader);
 public:
     virtual ~ResourceLoader() = 0;
 

--- a/Source/WebCore/page/PerformanceEntry.cpp
+++ b/Source/WebCore/page/PerformanceEntry.cpp
@@ -31,6 +31,8 @@
 #include "config.h"
 #include "PerformanceEntry.h"
 
+#include <wtf/NeverDestroyed.h>
+
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PerformanceEntry);

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -42,7 +42,7 @@
 
 namespace WebCore::Style::Interpolation {
 
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Animation);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInterpolationWrapperBase);
 // MARK: - Standard property interpolation support
 
 static void interpolateStandardProperty(CSSPropertyID property, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation compositeOperation, IterationCompositeOperation iterationCompositeOperation, double currentIteration, const Client& client)

--- a/Source/WebCore/style/StyleInterpolationWrapperBase.h
+++ b/Source/WebCore/style/StyleInterpolationWrapperBase.h
@@ -44,10 +44,10 @@ namespace Style::Interpolation {
 
 struct Context;
 
-DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Animation);
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInterpolationWrapperBase);
 class WrapperBase {
     WTF_MAKE_NONCOPYABLE(WrapperBase);
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation, WrapperBase);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(WrapperBase, StyleInterpolationWrapperBase);
 public:
     explicit WrapperBase(CSSPropertyID property)
         : m_property(property)

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -105,7 +105,7 @@ private:
     std::optional<ResolvedStyle> resolveAncestorFirstLetterPseudoElement(Element&, const ElementUpdate&, ResolutionContext&);
 
     struct Scope : RefCounted<Scope> {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(TreeResolverScope, Scope);
+        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(TreeResolverScope, TreeResolverScope);
         Ref<Resolver> resolver;
         SelectorMatchingState selectorMatchingState;
         RefPtr<ShadowRoot> shadowRoot;

--- a/Source/bmalloc/bmalloc/SystemHeap.cpp
+++ b/Source/bmalloc/bmalloc/SystemHeap.cpp
@@ -42,7 +42,7 @@ SystemHeap* systemHeapCache { nullptr };
 
 DEFINE_STATIC_PER_PROCESS_STORAGE(SystemHeap);
 
-#if BOS(DARWIN)
+#if BENABLE(MALLOC_HEAP_BREAKDOWN) || BOS(DARWIN)
 
 static bool shouldUseDefaultMallocZone()
 {

--- a/Source/bmalloc/bmalloc/SystemHeap.h
+++ b/Source/bmalloc/bmalloc/SystemHeap.h
@@ -64,7 +64,7 @@ public:
     static SystemHeap* tryGet();
     static SystemHeap* getExisting();
 
-#if BOS(DARWIN)
+#if BENABLE(MALLOC_HEAP_BREAKDOWN) || BOS(DARWIN)
     malloc_zone_t* zone() const { return m_zone; };
 #endif
 


### PR DESCRIPTION
#### f5f08704ee110d47da47f6d5cda78145594439f6
<pre>
[GLIB] WebKit doesn&apos;t build with -DENABLE_MALLOC_HEAP_BREAKDOWN=ON
<a href="https://bugs.webkit.org/show_bug.cgi?id=298223">https://bugs.webkit.org/show_bug.cgi?id=298223</a>

Reviewed by Michael Catanzaro.

There were a few issues here:

 * Commit 37d4a6880db95ef5abd introduced a new argument to the
   WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER()
   macro, but didn&apos;t update all places accordingly

 * There&apos;s a conflicting symbol with the ResourceLoader expansion,
   so rename it.

 * The heap identifier in StyleInterpolationWrapperBase.h was misnamed,
   probably a copy-paste mistake.

 * In FastMalloc.{cpp,h}, relevant parts of the code were compiled
   out due to not having a BENABLE(MALLOC_HEAP_BREAKDOWN) check. Add
   them.

* Source/WebCore/Modules/fetch/FetchLoader.cpp:
* Source/WebCore/Modules/fetch/FetchLoader.h:
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.h:
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/parser/CSSTokenizer.cpp:
* Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
* Source/WebCore/fileapi/FileReaderLoader.cpp:
* Source/WebCore/fileapi/FileReaderLoader.h:
* Source/WebCore/loader/LoaderMalloc.cpp:
* Source/WebCore/loader/ResourceLoader.cpp:
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/page/PerformanceEntry.cpp:
* Source/WebCore/style/StyleInterpolation.cpp:
* Source/WebCore/style/StyleInterpolationWrapperBase.h:
* Source/WebCore/style/StyleTreeResolver.h:
* Source/bmalloc/bmalloc/SystemHeap.cpp:
* Source/bmalloc/bmalloc/SystemHeap.h:

Canonical link: <a href="https://commits.webkit.org/299555@main">https://commits.webkit.org/299555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2148527333f49bc44f774b1e0141b0a29c035f38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90388 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59837 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24837 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68902 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111159 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128282 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117556 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44245 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42527 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51497 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146254 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45285 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37622 "Found 11 new JSC stress test failures: wasm.yaml/wasm/lowExecutableMemory/executable-memory-oom.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-jit-to-llint.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-no-cjit ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->