### PR TITLE
[GStreamer][WebAudio] Garbled rendering when the internal audio mixer is enabled

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h
@@ -33,8 +33,10 @@ public:
     static GStreamerAudioMixer& singleton();
 
     void ensureState(GstStateChange);
-    GRefPtr<GstPad> registerProducer(GstElement*);
+    GRefPtr<GstPad> registerProducer(GstElement*, std::optional<int> forcedSampleRate);
     void unregisterProducer(const GRefPtr<GstPad>&);
+
+    void configureSourcePeriodTime(StringView sourceName, uint64_t periodTime);
 
 private:
     GStreamerAudioMixer();

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1026,14 +1026,12 @@ IGNORE_WARNINGS_END
 
 GstElement* /* (transfer floating) */ createPlatformAudioSink(const String& role)
 {
-    GstElement* audioSink = webkitAudioSinkNew();
+    GstElement* audioSink = webkitAudioSinkNew(role);
     if (!audioSink) {
         // This means the WebKit audio sink configuration failed. It can happen for the following reasons:
         // - audio mixing was not requested using the WEBKIT_GST_ENABLE_AUDIO_MIXER
         // - audio mixing was requested using the WEBKIT_GST_ENABLE_AUDIO_MIXER but the audio mixer
         //   runtime requirements are not fullfilled.
-        // - the sink was created for the WPE port, audio mixing was not requested and no
-        //   WPEBackend-FDO audio receiver has been registered at runtime.
         audioSink = createAutoAudioSink(role);
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h
@@ -48,6 +48,6 @@ GType webkit_audio_sink_get_type(void);
 
 G_END_DECLS
 
-GstElement* webkitAudioSinkNew();
+GstElement* webkitAudioSinkNew(const String&);
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -168,7 +168,7 @@ GstElement* GStreamerQuirksManager::createWebAudioSink()
     }
 
     GST_DEBUG("Quirks didn't specify a WebAudioSink, falling back to default sink");
-    return createPlatformAudioSink("music"_s);
+    return createPlatformAudioSink("webaudio"_s);
 }
 
 GstElement* GStreamerQuirksManager::createHolePunchVideoSink(bool isLegacyPlaybin, const MediaPlayer* player)


### PR DESCRIPTION
#### a1f6b0bee5a43b8757f15988d9f0585cd7444b6b
<pre>
[GStreamer][WebAudio] Garbled rendering when the internal audio mixer is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=298235">https://bugs.webkit.org/show_bug.cgi?id=298235</a>

Reviewed by Xabier Rodriguez-Calvar.

When the WEBKIT_GST_ENABLE_AUDIO_MIXER=1 environment variable is set, audio buffers are sent to a
separate pipeline using interaudiosink. That process-wide singleton pipeline is then in charge of
audio mixing and rendering to an actual audio device.

For WebAudio it wasn&apos;t working properly, leading to garbled rendering, due to the audiomixer sink
pad corresponding to the WebAudio source not using the same sample rate and also interaudiosrc using
a sample period-size too big. We now align these values between the WebAudio sink and its matching
interaudiosrc audiomixer branch.

The Rialto WebAudio sink configuration was also moved to the Rialto quirk and the version check
removed (I couldn&apos;t find the reasoning behind that).

* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp:
(WebCore::GStreamerAudioMixer::registerProducer):
(WebCore::GStreamerAudioMixer::configureSourcePeriodTime):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::createPlatformAudioSink):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkConfigure):
(webKitAudioSinkChangeState):
(webKitAudioSinkConstructed):
(webkitAudioSinkNew):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp:
(WebCore::GStreamerQuirkRialto::createWebAudioSink):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::createWebAudioSink):

Canonical link: <a href="https://commits.webkit.org/299489@main">https://commits.webkit.org/299489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c583ef16dbc002a5a4db155a4d4fae9780cea89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125228 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71086 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90373 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70834 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24824 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128264 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98994 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98773 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25136 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51478 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->