### PR TITLE
[Build Speed] Remove NodeInlines.h from LiveNodeList.h

### DIFF
--- a/Source/WebCore/dom/ClassCollection.h
+++ b/Source/WebCore/dom/ClassCollection.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "CachedHTMLCollection.h"
+#include "Document.h"
 #include "Element.h"
 #include "SpaceSplitString.h"
 

--- a/Source/WebCore/dom/LiveNodeList.h
+++ b/Source/WebCore/dom/LiveNodeList.h
@@ -25,16 +25,16 @@
 
 #include <WebCore/CollectionIndexCache.h>
 #include <WebCore/CollectionTraversal.h>
-#include <WebCore/Document.h>
-#include <WebCore/HTMLNames.h>
-#include <WebCore/NodeInlines.h>
+#include <WebCore/DocumentEnums.h>
 #include <WebCore/NodeList.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
+class Document;
 class Element;
+class QualifiedName;
 
 inline bool shouldInvalidateTypeOnAttributeChange(NodeListInvalidationType, const QualifiedName&);
 
@@ -50,7 +50,7 @@ public:
     ContainerNode& ownerNode() const { return m_ownerNode; }
     void invalidateCacheForAttribute(const QualifiedName& attributeName) const;
     virtual void invalidateCacheForDocument(Document&) const = 0;
-    void invalidateCache() const { invalidateCacheForDocument(protectedDocument().get()); }
+    inline void invalidateCache() const;
 
     bool isRegisteredForInvalidationAtDocument() const { return m_isRegisteredForInvalidationAtDocument; }
     void setRegisteredForInvalidationAtDocument(bool isRegistered) { m_isRegisteredForInvalidationAtDocument = isRegistered; }
@@ -58,8 +58,8 @@ public:
 protected:
     LiveNodeList(ContainerNode& ownerNode, NodeListInvalidationType);
 
-    Document& document() const { return m_ownerNode->document(); }
-    Ref<Document> protectedDocument() const { return document(); }
+    inline Document& document() const;
+    inline Ref<Document> protectedDocument() const;
     ContainerNode& rootNode() const;
 
 private:
@@ -75,7 +75,7 @@ template <class NodeListType>
 class CachedLiveNodeList : public LiveNodeList {
     WTF_MAKE_TZONE_OR_ISO_NON_HEAP_ALLOCATABLE(CachedLiveNodeList);
 public:
-    virtual ~CachedLiveNodeList();
+    inline virtual ~CachedLiveNodeList();
 
     inline unsigned length() const final;
     inline Node* item(unsigned offset) const final;
@@ -108,18 +108,5 @@ private:
 
     mutable CollectionIndexCache<NodeListType, Iterator> m_indexCache;
 };
-
-template <class NodeListType>
-CachedLiveNodeList<NodeListType>::CachedLiveNodeList(ContainerNode& ownerNode, NodeListInvalidationType invalidationType)
-    : LiveNodeList(ownerNode, invalidationType)
-{
-}
-
-template <class NodeListType>
-CachedLiveNodeList<NodeListType>::~CachedLiveNodeList()
-{
-    if (m_indexCache.hasValidCache())
-        protectedDocument()->unregisterNodeListForInvalidation(*this);
-}
 
 } // namespace WebCore

--- a/Source/WebCore/html/CachedHTMLCollection.h
+++ b/Source/WebCore/html/CachedHTMLCollection.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/CollectionTraversal.h>
+#include <WebCore/Document.h>
 #include <WebCore/HTMLCollection.h>
 #include <WebCore/HTMLElement.h>
 #include <wtf/TZoneMalloc.h>


### PR DESCRIPTION
#### b58677801fc6cdc87a34da6349bb13c6b4c39684
<pre>
[Build Speed] Remove NodeInlines.h from LiveNodeList.h
<a href="https://rdar.apple.com/159675881">rdar://159675881</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298241">https://bugs.webkit.org/show_bug.cgi?id=298241</a>

Reviewed by Andy Estes.

* Source/WebCore/dom/ClassCollection.h:
* Source/WebCore/dom/LiveNodeList.h:
(WebCore::LiveNodeList::invalidateCache const): Deleted.
(WebCore::LiveNodeList::document const): Deleted.
(WebCore::LiveNodeList::protectedDocument const): Deleted.
* Source/WebCore/dom/LiveNodeListInlines.h:
(WebCore::LiveNodeList::invalidateCache const):
(WebCore::LiveNodeList::document const):
(WebCore::LiveNodeList::protectedDocument const):

Canonical link: <a href="https://commits.webkit.org/299469@main">https://commits.webkit.org/299469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11d5ffc575b8c291ceed678eecfd2411966ab973

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71155 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/417c1197-ffcc-418a-afd9-348d1fcb918a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90423 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/066a4220-9e84-4c02-a161-057c983e18b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70883 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/559b1d29-5cd3-44a5-b33e-5def06f2f5ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68959 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99042 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98822 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25124 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22279 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45869 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51549 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45336 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/48682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47021 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->