### PR TITLE
[JSC] Avoid dangling pointers in WeakBlock list

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2706,6 +2706,7 @@ bool Heap::shouldDoFullCollection()
 
 void Heap::addLogicallyEmptyWeakBlock(WeakBlock* block)
 {
+    RELEASE_ASSERT(!block->next() && !block->prev());
     m_logicallyEmptyWeakBlocks.append(block);
 }
 
@@ -2724,6 +2725,7 @@ bool Heap::sweepNextLogicallyEmptyWeakBlock()
         return false;
 
     WeakBlock* block = m_logicallyEmptyWeakBlocks[m_indexOfNextLogicallyEmptyWeakBlockToSweep];
+    RELEASE_ASSERT(!block->next() && !block->prev());
 
     block->sweep();
     if (block->isEmpty()) {

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -400,16 +400,6 @@ void MarkedSpace::freeBlock(MarkedBlock::Handle* block)
     delete block;
 }
 
-void MarkedSpace::freeOrShrinkBlock(MarkedBlock::Handle* block)
-{
-    if (!block->isEmpty()) {
-        block->shrink();
-        return;
-    }
-
-    freeBlock(block);
-}
-
 void MarkedSpace::shrink()
 {
     forEachDirectory(

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -133,7 +133,6 @@ public:
 
     void shrink();
     void freeBlock(MarkedBlock::Handle*);
-    void freeOrShrinkBlock(MarkedBlock::Handle*);
 
     void didAddBlock(MarkedBlock::Handle*);
     void didConsumeFreeList(MarkedBlock::Handle*);

--- a/Source/JavaScriptCore/heap/WeakBlock.cpp
+++ b/Source/JavaScriptCore/heap/WeakBlock.cpp
@@ -47,6 +47,7 @@ WeakBlock* WeakBlock::create(JSC::Heap& heap, CellContainer container)
 
 void WeakBlock::destroy(JSC::Heap& heap, WeakBlock* block)
 {
+    RELEASE_ASSERT(!block->next() && !block->prev());
     block->~WeakBlock();
     WeakBlockMalloc::free(block);
     heap.didFreeBlock(WeakBlock::blockSize);

--- a/Source/JavaScriptCore/heap/WeakSet.cpp
+++ b/Source/JavaScriptCore/heap/WeakSet.cpp
@@ -37,12 +37,9 @@ WeakSet::~WeakSet()
         remove();
     
     JSC::Heap& heap = *this->heap();
-    WeakBlock* next = nullptr;
-    for (WeakBlock* block = m_blocks.head(); block; block = next) {
-        next = block->next();
+    while (WeakBlock* block = m_blocks.removeHead())
         WeakBlock::destroy(heap, block);
-    }
-    m_blocks.clear();
+    ASSERT(m_blocks.isEmpty());
 }
 
 void WeakSet::sweep()

--- a/Source/WTF/wtf/DoublyLinkedList.h
+++ b/Source/WTF/wtf/DoublyLinkedList.h
@@ -41,8 +41,8 @@ public:
 
 template<typename T> inline DoublyLinkedListNode<T>::DoublyLinkedListNode()
 {
-    setPrev(0);
-    setNext(0);
+    setPrev(nullptr);
+    setNext(nullptr);
 }
 
 template<typename T> inline void DoublyLinkedListNode<T>::setPrev(T* prev)
@@ -92,8 +92,8 @@ private:
 };
 
 template<typename T> inline DoublyLinkedList<T>::DoublyLinkedList()
-    : m_head(0)
-    , m_tail(0)
+    : m_head(nullptr)
+    , m_tail(nullptr)
 {
 }
 
@@ -128,37 +128,33 @@ template<typename T> inline T* DoublyLinkedList<T>::tail() const
 
 template<typename T> inline void DoublyLinkedList<T>::push(T* node)
 {
+    ASSERT(!node->prev() && !node->next());
     if (!m_head) {
         ASSERT(!m_tail);
         m_head = node;
         m_tail = node;
-        node->setPrev(0);
-        node->setNext(0);
         return;
     }
 
     ASSERT(m_tail);
     m_head->setPrev(node);
     node->setNext(m_head);
-    node->setPrev(0);
     m_head = node;
 }
 
 template<typename T> inline void DoublyLinkedList<T>::append(T* node)
 {
+    ASSERT(!node->prev() && !node->next());
     if (!m_tail) {
         ASSERT(!m_head);
         m_head = node;
         m_tail = node;
-        node->setPrev(0);
-        node->setNext(0);
         return;
     }
 
     ASSERT(m_head);
     m_tail->setNext(node);
     node->setPrev(m_tail);
-    node->setNext(0);
     m_tail = node;
 }
 
@@ -177,10 +173,10 @@ template<typename T> inline DoublyLinkedList<T> DoublyLinkedList<T>::splitAt(siz
     DoublyLinkedList<T> newList { };
     newList.m_head = p->next();
     newList.m_tail = m_tail;
-    newList.m_head->setPrev(0);
+    newList.m_head->setPrev(nullptr);
 
     m_tail = p;
-    m_tail->setNext(0);
+    m_tail->setNext(nullptr);
 
     return newList;
 }
@@ -202,6 +198,8 @@ template<typename T> inline void DoublyLinkedList<T>::remove(T* node)
         ASSERT(node == m_tail);
         m_tail = node->prev();
     }
+    node->setNext(nullptr);
+    node->setPrev(nullptr);
 }
 
 template<typename T> inline T* DoublyLinkedList<T>::removeHead()


### PR DESCRIPTION
#### c90e64eec92dad9dfa49801778997c6e449ce1c6
<pre>
[JSC] Avoid dangling pointers in WeakBlock list
<a href="https://bugs.webkit.org/show_bug.cgi?id=298236">https://bugs.webkit.org/show_bug.cgi?id=298236</a>
<a href="https://rdar.apple.com/157587352">rdar://157587352</a>

Reviewed by Keith Miller.

Before this change, DoublyLinkedList leaves the next/prev pointers
in a dangling state when removing a node from the list. Then,
if the node is re-added, the next/prev pointers are reset when necessary.

Let&apos;s make a stronger invariant: if the node is not in the list,
then the prev/next pointers are nullptr. (Note that the converse
is not true for single element lists.)

Then, add some asserts to verify the WeakSet&apos;s WeakBlock list lifecycle
to try to help track down a mysterious crash. The WeakBlock ownership
can be transferred from the WeakSet to the Heap, at which point
the prev/next should be nulled out and, after this change, no longer
dangling.

Bonus: remove MarkedSpace::freeOrShrinkBlock() since it&apos;s never called.
Canonical link: <a href="https://commits.webkit.org/299454@main">https://commits.webkit.org/299454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9d77baab2ad768bcbd8bfe5204052f6009315b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71100 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9f7115f-3c4c-4794-b564-d62f01f93097) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5335f072-948d-47f7-91f0-965ae5318e44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70850 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/417c32c1-85f2-46af-80e6-ccdeb89c6914) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24835 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68898 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111155 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128278 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117552 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99005 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98784 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22242 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42523 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51493 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146250 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45281 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37620 "Found 11 new JSC stress test failures: wasm.yaml/wasm/lowExecutableMemory/executable-memory-oom.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-jit-to-llint.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-no-cjit ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->