### PR TITLE
[WTF] Make use of __unsafe_unretained in TypeCastsCocoa.h for trivial, inline Objective-C methods to make ARC and non-ARC implementations the same

### DIFF
--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -87,10 +87,10 @@ inline RetainPtr<id> bridge_id_cast(RetainPtr<CFTypeRef>&& object)
 template <typename ExpectedType>
 struct ObjCTypeCastTraits {
 public:
-    static bool isType(id object) { return [object isKindOfClass:[ExpectedType class]]; }
+    static bool isType(__unsafe_unretained id object) { return [object isKindOfClass:[ExpectedType class]]; }
 
     template <typename ArgType>
-    static bool isType(const ArgType *object) { return [object isKindOfClass:[ExpectedType class]]; }
+    static bool isType(__unsafe_unretained const ArgType *object) { return [object isKindOfClass:[ExpectedType class]]; }
 };
 
 #define SPECIALIZE_OBJC_TYPE_TRAITS(ClassName, ClassExpresssion) \
@@ -98,13 +98,19 @@ namespace WTF { \
 template <> \
 class ObjCTypeCastTraits<ClassName> { \
 public: \
-    static bool isType(id object) { return [object isKindOfClass:(ClassExpresssion)]; } \
-    static bool isType(const NSObject *object) { return [object isKindOfClass:(ClassExpresssion)]; } \
+    static bool isType(__unsafe_unretained id object) { return [object isKindOfClass:(ClassExpresssion)]; } \
+    static bool isType(__unsafe_unretained const NSObject *object) { return [object isKindOfClass:(ClassExpresssion)]; } \
 }; \
 }
 
+template <typename ExpectedType>
+inline bool is_objc(__unsafe_unretained id source)
+{
+    return source && ObjCTypeCastTraits<ExpectedType>::isType(source);
+}
+
 template <typename ExpectedType, typename ArgType>
-inline bool is_objc(ArgType * source)
+inline bool is_objc(__unsafe_unretained ArgType * source)
 {
     return source && ObjCTypeCastTraits<ExpectedType>::isType(source);
 }


### PR DESCRIPTION
#### f991ef4e8f4ac7a07748de85e6511b4dbb7473c3
<pre>
[WTF] Make use of __unsafe_unretained in TypeCastsCocoa.h for trivial, inline Objective-C methods to make ARC and non-ARC implementations the same
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=298252">https://bugs.webkit.org/show_bug.cgi?id=298252</a>&gt;
&lt;<a href="https://rdar.apple.com/159684159">rdar://159684159</a>&gt;

Reviewed by NOBODY (OOPS!).

Add `__unsafe_unretained` to arguments with ObjC types to avoid needless
retain/release churn for trivial, inline functions.

* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
(WTF::ObjCTypeCastTraits::isType):
(WTF::is_objc):
- Add an overload for `WTF::is_objc(id)` since it won&apos;t work with the
  existing template definition.  This matches what
  `WTF::ObjCTypeCastTraits::isType()` does.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f991ef4e8f4ac7a07748de85e6511b4dbb7473c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e77b4b79-a771-45aa-91d8-0267c6b1017b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90398 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59851 "Found 1 new test failure: workers/btoa-oom.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad6348c3-ab6e-4e98-9c42-fd1ae2ea0162) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70858 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e3c806f-8d3e-4263-b872-d9b23c0380af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24849 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68927 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111173 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128296 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117570 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99016 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98795 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42541 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45832 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51511 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146268 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45299 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37625 "Found 11 new JSC stress test failures: wasm.yaml/wasm/lowExecutableMemory/executable-memory-oom.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-jit-to-llint.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins.js.wasm-no-cjit ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48644 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->