### PR TITLE
REGRESSION(298023@main): Newly enabled TestWebKitAPI.UnifiedPDF.PDFHUDMoveIFrame is broken

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -369,10 +369,16 @@ UNIFIED_PDF_TEST(SetPageZoomFactorDoesNotBailIncorrectly)
     EXPECT_EQ(scaleAfterResetting, 1.0);
 }
 
-static void checkFrame(NSRect frame, CGFloat x, CGFloat y, CGFloat width, CGFloat height)
+static void checkFrame(NSRect frame, CGFloat x, CGFloat y, CGFloat width, CGFloat height, std::optional<CGFloat> frameOriginTolerance = { })
 {
-    EXPECT_EQ(frame.origin.x, x);
-    EXPECT_EQ(frame.origin.y, y);
+    if (frameOriginTolerance) {
+        auto tolerance = *frameOriginTolerance;
+        EXPECT_TRUE(std::abs(frame.origin.x - x) <= tolerance) << "Expected frameOrigin.x to be around " << x << ", got " << frame.origin.x;
+        EXPECT_TRUE(std::abs(frame.origin.y - y) <= tolerance) << "Expected frameOrigin.y to be around " << y << ", got " << frame.origin.y;
+    } else {
+        EXPECT_EQ(frame.origin.x, x);
+        EXPECT_EQ(frame.origin.y, y);
+    }
     EXPECT_EQ(frame.size.width, width);
     EXPECT_EQ(frame.size.height, height);
 }
@@ -463,7 +469,7 @@ UNIFIED_PDF_TEST(PDFHUDMoveIFrame)
     while ([webView _pdfHUDs].anyObject.frame.size.width != 560)
         TestWebKitAPI::Util::spinRunLoop();
     EXPECT_EQ([webView _pdfHUDs].count, 1u);
-    checkFrame([webView _pdfHUDs].anyObject.frame, 14, 40, 560, 210);
+    checkFrame([webView _pdfHUDs].anyObject.frame, 13, 40, 560, 210, 1);
 }
 
 UNIFIED_PDF_TEST(PDFHUDNestedIFrames)


### PR DESCRIPTION
#### 779c9d723c65f44c82fc48a5d87b03f22e46f1b6
<pre>
REGRESSION(298023@main): Newly enabled TestWebKitAPI.UnifiedPDF.PDFHUDMoveIFrame is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=298259">https://bugs.webkit.org/show_bug.cgi?id=298259</a>
<a href="https://rdar.apple.com/159695000">rdar://159695000</a>

Reviewed by Wenson Hsieh and Aditya Keerthi.

It turns out that in certain configurations, the test is failing with a
tiny diff:

```
11:41:58.050 10802 /Volumes/Data/worker/Apple-Sequoia-Release-Build/build/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:374
11:41:58.050 10802 Expected equality of these values:
11:41:58.050 10802   frame.origin.x
11:41:58.050 10802     Which is: 13
11:41:58.050 10802   x
11:41:58.050 10802     Which is: 14
11:41:58.050 10802
11:41:58.050 10802
11:41:58.050 10802
11:41:58.050 10802 /Volumes/Data/worker/Apple-Sequoia-Release-Build/build/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:375
11:41:58.050 10802 Expected equality of these values:
11:41:58.050 10802   frame.origin.y
11:41:58.050 10802     Which is: 39
11:41:58.050 10802   y
11:41:58.050 10802     Which is: 40
```

This patch makes the test robust to this small variance by introducing a
frame origin tolerance that tests can optionally provide when checking
the PDF HUD frame properties. We then adopt a tolerance of 1.0 in
PDFHUDMoveIframe.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::checkFrame):
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/299473@main">https://commits.webkit.org/299473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41a68ee3fe8b426e70a423cfea30e4b388f96b95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71162 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15b99821-6223-4f5f-b3c1-5783f7405b08) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90426 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed1c9203-15d1-479e-90ec-a178e4adccc0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70886 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ad1cba4-d86f-4a5d-a1c9-9ec7bbe331f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68966 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128340 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98821 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22283 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18962 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45876 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45343 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48689 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47028 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->