### PR TITLE
macOS context menus displays 'show media stats' instead of 'show media statistics'

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1360,8 +1360,8 @@
 /* Show fonts context menu item */
 "Show Fonts" = "Show Fonts";
 
-/* Media stats context menu item */
-"Show Media Stats" = "Show Media Stats";
+/* Media statistics context menu item */
+"Show Media Statistics" = "Show Media Statistics";
 
 /* menu item title */
 "Show Spelling and Grammar" = "Show Spelling and Grammar";

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -1485,7 +1485,7 @@ String addAudioTrackKindCommentarySuffix(const String& text)
 
 String contextMenuItemTagShowMediaStats()
 {
-    return WEB_UI_STRING("Show Media Stats", "Media stats context menu item");
+    return WEB_UI_STRING("Show Media Statistics", "Media statistics context menu item");
 }
 
 #endif // ENABLE(VIDEO)


### PR DESCRIPTION
#### 850751e4cdd81ed0d67e70456e0bbb456d033129
<pre>
macOS context menus displays &apos;show media stats&apos; instead of &apos;show media statistics&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=298268">https://bugs.webkit.org/show_bug.cgi?id=298268</a>
<a href="https://rdar.apple.com/149900101">rdar://149900101</a>

Reviewed by Andy Estes.

Update media stats menu item text to &quot;Show Media Statistics&quot;.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemTagShowMediaStats):

Canonical link: <a href="https://commits.webkit.org/299512@main">https://commits.webkit.org/299512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b899428a1fcd799b942673d3b9a4324f9ae596a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71181 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b90bc7b-ffcf-435e-bfdd-66b3578f7bb8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90452 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59869 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2b20ee1-795c-427f-9e1d-df2197cd260a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70899 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffcdd0c9-8456-4506-a74e-ca3feae5b4a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46025 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34775 "Found 1 new test failure: imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99061 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98841 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25152 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44295 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22293 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42604 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51575 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48708 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47047 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->