### PR TITLE
Convert testRunner stopLoading and dumpFullScreenCallbacks from testRunner.idl to testRunnerJS

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -58,7 +58,6 @@ interface TestRunner {
     undefined dumpEditingCallbacks();
     undefined dumpSelectionRect();
     undefined dumpTitleChanges();
-    undefined dumpFullScreenCallbacks();
     undefined dumpFrameLoadCallbacks();
     undefined dumpProgressFinishedCallback();
     undefined dumpResourceLoadCallbacks();
@@ -96,7 +95,6 @@ interface TestRunner {
     undefined setCacheModel(long model);
     undefined setAsynchronousSpellCheckingEnabled(boolean value);
     undefined setPrinting();
-    undefined stopLoading();
 
     // Special DOM functions.
     Promise<undefined> clearBackForwardList();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -912,16 +912,6 @@ void TestRunner::queueLoadHTMLString(JSStringRef content, JSStringRef baseURL, J
     InjectedBundle::singleton().queueLoadHTMLString(toWK(content).get(), baseURLWK.get(), unreachableURLWK.get());
 }
 
-void TestRunner::stopLoading()
-{
-    postPageMessage("StopLoading");
-}
-
-void TestRunner::dumpFullScreenCallbacks()
-{
-    postPageMessage("DumpFullScreenCallbacks");
-}
-
 void TestRunner::queueReload()
 {
     InjectedBundle::singleton().queueReload();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -125,7 +125,6 @@ public:
     void dumpEditingCallbacks() { m_dumpEditingCallbacks = true; }
     void dumpSelectionRect() { m_dumpSelectionRect = true; }
     void dumpTitleChanges() { m_dumpTitleChanges = true; }
-    void dumpFullScreenCallbacks();
     void dumpFrameLoadCallbacks() { setShouldDumpFrameLoadCallbacks(true); }
     void dumpProgressFinishedCallback() { setShouldDumpProgressFinishedCallback(true); }
     void dumpResourceLoadCallbacks() { m_dumpResourceLoadCallbacks = true; }
@@ -361,8 +360,6 @@ public:
     JSValueRef failNextNewCodeBlock(JSContextRef);
     JSValueRef numberOfDFGCompiles(JSContextRef, JSValueRef function);
     JSValueRef neverInlineFunction(JSContextRef, JSValueRef function);
-
-    void stopLoading();
 
     bool didCancelClientRedirect() const { return m_didCancelClientRedirect; }
     void setDidCancelClientRedirect(bool value) { m_didCancelClientRedirect = value; }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1940,6 +1940,8 @@ if (window.testRunner) {
     testRunner.setHandlesAuthenticationChallenges = value => post(['SetHandlesAuthenticationChallenges', value]);
     testRunner.setShouldLogCanAuthenticateAgainstProtectionSpace = value => post(['SetShouldLogCanAuthenticateAgainstProtectionSpace', value]);
     testRunner.setBlockAllPlugins = value => post(['SetBlockAllPlugins', value]);
+    testRunner.stopLoading = () => post(['StopLoading']);
+    testRunner.dumpFullScreenCallbacks = () => post(['DumpFullScreenCallbacks']);
 }
 )testRunnerJS";
 
@@ -2040,6 +2042,16 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
 
     if (WKStringIsEqualToUTF8CString(command, "RequestExitFullscreenFromUIProcess")) {
         requestExitFullscreenFromUIProcess();
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "DumpFullScreenCallbacks")) {
+        dumpFullScreenCallbacks();
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "StopLoading")) {
+        WKPageStopLoading(mainWebView()->page());
         return completionHandler(nullptr);
     }
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -599,14 +599,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "StopLoading"))
-        return WKPageStopLoading(TestController::singleton().mainWebView()->page());
-
-    if (WKStringIsEqualToUTF8CString(messageName, "DumpFullScreenCallbacks")) {
-        TestController::singleton().dumpFullScreenCallbacks();
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "ShowWebInspector")) {
         WKPageShowWebInspectorForTesting(TestController::singleton().mainWebView()->page());
         return;


### PR DESCRIPTION
#### 7c873dd916d30f73fe9942c3e76e81e488bfd996
<pre>
Convert testRunner stopLoading and dumpFullScreenCallbacks from testRunner.idl to testRunnerJS
<a href="https://rdar.apple.com/159702859">rdar://159702859</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298272">https://bugs.webkit.org/show_bug.cgi?id=298272</a>

Reviewed by Alex Christensen.

Moves testRunner.stopLoading and testRunner.dumpFullScreenCallbacks from testRunner.idl to testRunnerJS

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::stopLoading): Deleted.
(WTR::TestRunner::dumpFullScreenCallbacks): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::dumpTitleChanges):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::if):
(WTR::CompletionHandler&lt;void):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/299535@main">https://commits.webkit.org/299535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced06ef8d64cccb2e5e1bb0a06e31adb4e2ba59b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90646 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106956 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25066 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69185 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128543 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22460 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46079 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45544 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->