### PR TITLE
[Experimental] Expose roll angle of Apple Pencil for `twist` Pointer Event attribute

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -389,6 +389,7 @@ platform/ios/ios/fast/forms/range-input-container-touches.html [ Skip ]
 platform/ios/ios/fast/forms/range-input-readonly-and-disabled.html [ Skip ]
 platform/ios/ios/fast/forms/range-input-touches.html [ Skip ]
 platform/ios/ios/touch [ Skip ]
+pointerevents/pointer-event-twist-on-tap-or-click.html [ Skip ]
 media/modern-media-controls/css/pointer-events-none.html [ Skip ]
 
 # Calls into the Opportunistic Task Scheduler which is currently disabled on IOS

--- a/LayoutTests/pointerevents/ios/pointer-event-twist-on-stylus-down-expected.txt
+++ b/LayoutTests/pointerevents/ios/pointer-event-twist-on-stylus-down-expected.txt
@@ -1,0 +1,5 @@
+PASS twist is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/pointerevents/ios/pointer-event-twist-on-stylus-down.html
+++ b/LayoutTests/pointerevents/ios/pointer-event-twist-on-stylus-down.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+</head>
+<script>
+    jsTestIsAsync = true;
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+
+        document.addEventListener("pointerdown", function (e) {
+            twist = e.twist;
+            shouldBe("twist", "0");
+            finishJSTest();
+        });
+
+        UIHelper.stylusTapAt(10, 10);
+    }
+</script>
+</html>

--- a/LayoutTests/pointerevents/pointer-event-constructors-twist-expected.txt
+++ b/LayoutTests/pointerevents/pointer-event-constructors-twist-expected.txt
@@ -1,0 +1,6 @@
+PASS event.twist is 0
+PASS event.twist is 50
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/pointerevents/pointer-event-constructors-twist.html
+++ b/LayoutTests/pointerevents/pointer-event-constructors-twist.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+
+        event = new PointerEvent('pointerdown');
+        shouldBe("event.twist", "0");
+
+        event = new PointerEvent('pointerdown', { twist: 50 });
+        shouldBe("event.twist", "50");
+        testRunner.notifyDone();
+    }
+</script>
+</html>

--- a/LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click-expected.txt
+++ b/LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click-expected.txt
@@ -1,0 +1,5 @@
+PASS twist is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click.html
+++ b/LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<script>
+    jsTestIsAsync = true;
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+
+        document.addEventListener("pointerdown", function (e) {
+            twist = e.twist;
+            shouldBe("twist", "0");
+            finishJSTest();
+        });
+
+        UIHelper.activateAt(10, 10);
+    }
+</script>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2759,6 +2759,21 @@ ExposeDefaultSpeakerAsSpecificDeviceEnabled:
     WebCore:
       default: true
 
+ExposeRollAngleAsTwistEnabled:
+  type: bool
+  status: unstable
+  category: dom
+  humanReadableName: "Expose Apple Pencil rotation for twist PointerEvent Property"
+  humanReadableDescription: "Expose Apple Pencil rotation for the `twist` PointerEvent Property"
+  condition: PLATFORM(IOS_FAMILY)
+  defaultValue:
+    WebKitLegacy:
+     default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ExposeSpeakersEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/dom/Touch.cpp
+++ b/Source/WebCore/dom/Touch.cpp
@@ -56,7 +56,7 @@ static DoublePoint scaledLocation(LocalFrame* frame, const DoublePoint& pagePosi
     return pagePosition.scaled(scaleFactor);
 }
 
-Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, const DoublePoint& screenPosition, const DoublePoint& pagePosition, const DoubleSize& radius, float rotationAngle, float force)
+Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, const DoublePoint& screenPosition, const DoublePoint& pagePosition, const DoubleSize& radius, float rotationAngle, double twist, float force)
     : m_target(target)
     , m_identifier(identifier)
     , m_clientPosition(DoublePoint(pagePosition - contentsOffset(frame)))
@@ -64,12 +64,13 @@ Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, const Doubl
     , m_pagePosition(pagePosition)
     , m_radius(radius)
     , m_rotationAngle(rotationAngle)
+    , m_twist(twist)
     , m_force(force)
     , m_absoluteLocation(scaledLocation(frame, pagePosition))
 {
 }
 
-Touch::Touch(EventTarget* target, int identifier, const DoublePoint& clientPosition, const DoublePoint& screenPosition, const DoublePoint& pagePosition, const DoubleSize& radius, float rotationAngle, float force, DoublePoint absoluteLocation)
+Touch::Touch(EventTarget* target, int identifier, const DoublePoint& clientPosition, const DoublePoint& screenPosition, const DoublePoint& pagePosition, const DoubleSize& radius, float rotationAngle, double twist, float force, DoublePoint absoluteLocation)
     : m_target(target)
     , m_identifier(identifier)
     , m_clientPosition(clientPosition)
@@ -77,6 +78,7 @@ Touch::Touch(EventTarget* target, int identifier, const DoublePoint& clientPosit
     , m_pagePosition(pagePosition)
     , m_radius(radius)
     , m_rotationAngle(rotationAngle)
+    , m_twist(twist)
     , m_force(force)
     , m_absoluteLocation(absoluteLocation)
 {
@@ -86,7 +88,7 @@ Touch::~Touch() = default;
 
 Ref<Touch> Touch::cloneWithNewTarget(EventTarget* eventTarget) const
 {
-    return adoptRef(*new Touch(eventTarget, m_identifier, m_clientPosition, m_screenPosition, m_pagePosition, m_radius, m_rotationAngle, m_force, m_absoluteLocation));
+    return adoptRef(*new Touch(eventTarget, m_identifier, m_clientPosition, m_screenPosition, m_pagePosition, m_radius, m_rotationAngle, m_twist, m_force, m_absoluteLocation));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Touch.h
+++ b/Source/WebCore/dom/Touch.h
@@ -43,10 +43,10 @@ class Touch : public RefCounted<Touch> {
 public:
     static Ref<Touch> create(LocalFrame* frame, EventTarget* target,
         int identifier, const DoublePoint& screenPos, const DoublePoint& pagePos,
-        const DoubleSize& radius, float rotationAngle, float force)
+        const DoubleSize& radius, float rotationAngle, float force, double twist = 0)
     {
         return adoptRef(
-            *new Touch(frame, target, identifier, screenPos, pagePos, radius, rotationAngle, force));
+            *new Touch(frame, target, identifier, screenPos, pagePos, radius, rotationAngle, twist, force));
     }
 
     ~Touch();
@@ -62,6 +62,7 @@ public:
     double webkitRadiusX() const { return m_radius.width(); }
     double webkitRadiusY() const { return m_radius.height(); }
     float webkitRotationAngle() const { return m_rotationAngle; }
+    double twist() const { return m_twist; }
     float webkitForce() const { return m_force; }
     const DoublePoint& absoluteLocation() const { return m_absoluteLocation; }
     Ref<Touch> cloneWithNewTarget(EventTarget*) const;
@@ -69,11 +70,11 @@ public:
 private:
     Touch(LocalFrame*, EventTarget*, int identifier,
         const DoublePoint& screenPosition, const DoublePoint& pagePosition,
-        const DoubleSize& radius, float rotationAngle, float force);
+        const DoubleSize& radius, float rotationAngle, double twist, float force);
 
     Touch(EventTarget*, int identifier, const DoublePoint& clientPosition,
         const DoublePoint& screenPosition, const DoublePoint& pagePosition,
-        const DoubleSize& radius, float rotationAngle, float force, DoublePoint absoluteLocation);
+        const DoubleSize& radius, float rotationAngle, double twist, float force, DoublePoint absoluteLocation);
 
     RefPtr<EventTarget> m_target;
     int m_identifier;
@@ -86,6 +87,8 @@ private:
     // Radius in CSS px.
     DoubleSize m_radius;
     float m_rotationAngle;
+    // Twist is stored so that it can be exposed for pointer events.
+    double m_twist;
     float m_force;
     DoublePoint m_absoluteLocation;
 };

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -32,6 +32,8 @@
 #import "EventTargetInlines.h"
 #import "MouseEventTypes.h"
 
+#import <wtf/MathExtras.h>
+
 namespace WebCore {
 
 static const AtomString& pointerEventType(PlatformTouchPoint::TouchPhaseType phase)
@@ -84,6 +86,12 @@ PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& eve
     , m_coalescedEvents(coalescedEvents)
     , m_predictedEvents(predictedEvents)
 {
+    // The rotation angle is currently in the range
+    // [-π, π). Convert it to range [0°, 359°]
+    // and flip the direction to clockwise.
+    const auto twistInDegrees = rad2deg(event.twistAtIndex(index));
+    m_twist = std::floor(180 - twistInDegrees);
+
     m_azimuthAngle = event.azimuthAngleAtIndex(index);
     m_altitudeAngle = m_pointerType == penPointerEventType() ? event.altitudeAngleAtIndex(index) : piOverTwoDouble;
     auto tilt = tiltFromAngle(m_altitudeAngle, m_azimuthAngle);

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -290,6 +290,7 @@ public:
         static constexpr double radiusXDefaultValue = 1;
         static constexpr double radiusYDefaultValue = 1;
         static constexpr float rotationAngleDefaultValue = 0.0f;
+        static constexpr double twistDefaultValue = 0;
         static constexpr float forceDefaultValue = 1.0f;
 
         m_id = idDefaultValue; // There is only one active TouchPoint.
@@ -297,6 +298,7 @@ public:
         m_pos = event.position();
         m_radius = { radiusXDefaultValue, radiusYDefaultValue };
         m_rotationAngle = rotationAngleDefaultValue;
+        m_twist = twistDefaultValue;
         m_force = forceDefaultValue;
 
         PlatformEvent::Type type = event.type();

--- a/Source/WebCore/platform/PlatformTouchPoint.h
+++ b/Source/WebCore/platform/PlatformTouchPoint.h
@@ -65,6 +65,7 @@ public:
     DoublePoint pos() const { return m_pos; }
     DoubleSize radius() const { return m_radius; }
     float rotationAngle() const { return m_rotationAngle; }
+    float twist() const { return m_twist; }
     float force() const { return m_force; }
 
 protected:
@@ -74,6 +75,7 @@ protected:
     DoublePoint m_pos;
     DoubleSize m_radius;
     float m_rotationAngle;
+    float m_twist;
     float m_force;
 };
 

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -131,6 +131,7 @@ class WebKit::WebTouchEvent : WebKit::WebEvent {
     double radiusX()
     double radiusY()
     double rotationAngle()
+    double twist()
     double force()
     double altitudeAngle()
     double azimuthAngle()

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -408,7 +408,7 @@ public:
 WebKit2PlatformTouchPoint(const WebPlatformTouchPoint& webTouchPoint)
     : PlatformTouchPoint(webTouchPoint.identifier(), DoublePoint(webTouchPoint.locationInRootView()), DoublePoint(webTouchPoint.locationInViewport()), touchEventType(webTouchPoint)
 #if ENABLE(IOS_TOUCH_EVENTS)
-        , webTouchPoint.radiusX(), webTouchPoint.radiusY(), webTouchPoint.rotationAngle(), webTouchPoint.force(), webTouchPoint.altitudeAngle(), webTouchPoint.azimuthAngle(), webPlatformTouchTypeToPlatform(webTouchPoint.touchType())
+        , webTouchPoint.radiusX(), webTouchPoint.radiusY(), webTouchPoint.rotationAngle(), webTouchPoint.twist(), webTouchPoint.force(), webTouchPoint.altitudeAngle(), webTouchPoint.azimuthAngle(), webPlatformTouchTypeToPlatform(webTouchPoint.touchType())
 #endif
     )
 {

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -64,7 +64,7 @@ public:
     {
     }
 #if ENABLE(IOS_TOUCH_EVENTS)
-    WebPlatformTouchPoint(unsigned identifier, WebCore::DoublePoint locationInRootView, WebCore::DoublePoint locationInViewport, State phase, double radiusX, double radiusY, double rotationAngle, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::DoublePoint locationInRootView, WebCore::DoublePoint locationInViewport, State phase, double radiusX, double radiusY, double rotationAngle, double twist, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
         : m_identifier(identifier)
         , m_locationInRootView(locationInRootView)
         , m_locationInViewport(locationInViewport)
@@ -72,6 +72,7 @@ public:
         , m_radiusX(radiusX)
         , m_radiusY(radiusY)
         , m_rotationAngle(rotationAngle)
+        , m_twist(twist)
         , m_force(force)
         , m_altitudeAngle(altitudeAngle)
         , m_azimuthAngle(azimuthAngle)
@@ -95,6 +96,8 @@ public:
     double radiusY() const { return m_radiusY; }
     void setRotationAngle(double rotationAngle) { m_rotationAngle = rotationAngle; }
     double rotationAngle() const { return m_rotationAngle; }
+    void setTwist(double twist) { m_twist = twist; }
+    double twist() const { return m_twist; }
     void setForce(double force) { m_force = force; }
     double force() const { return m_force; }
     void setAltitudeAngle(double altitudeAngle) { m_altitudeAngle = altitudeAngle; }
@@ -115,6 +118,7 @@ private:
     double m_radiusX { 0 };
     double m_radiusY { 0 };
     double m_rotationAngle { 0 };
+    double m_twist { std::numbers::pi };
     double m_force { 0 };
     double m_altitudeAngle { 0 };
     double m_azimuthAngle { 0 };

--- a/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
+++ b/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
@@ -110,6 +110,7 @@ Vector<WebPlatformTouchPoint> NativeWebTouchEvent::extractWebTouchPoints(const W
         platformTouchPoint.setRadiusY(radius);
         // FIXME (259068): Add support for Touch.rotationAngle.
         platformTouchPoint.setRotationAngle(0);
+        platformTouchPoint.setTwist(touchPoint.twist);
         platformTouchPoint.setForce(touchPoint.force);
         platformTouchPoint.setAltitudeAngle(touchPoint.altitudeAngle);
         platformTouchPoint.setAzimuthAngle(touchPoint.azimuthAngle);

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -140,4 +140,5 @@ enum class ViewStabilityFlag : uint8_t;
 #if ENABLE(MODEL_PROCESS)
 - (void)_setTransform3DForModelViews:(CGFloat)newScale;
 #endif
+- (BOOL)_shouldExposeRollAngleAsTwist;
 @end

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -1124,6 +1124,11 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
 }
 
+- (BOOL)_shouldExposeRollAngleAsTwist
+{
+    return _page->preferences().exposeRollAngleAsTwistEnabled();
+}
+
 @end
 
 #pragma mark Printing

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
@@ -41,6 +41,7 @@ struct WKTouchPoint {
     unsigned identifier { 0 };
     UITouchPhase phase { UITouchPhaseBegan };
     CGFloat majorRadiusInWindowCoordinates { 0 };
+    CGFloat twist { 0 };
     CGFloat force { 0 };
     CGFloat altitudeAngle { 0 };
     CGFloat azimuthAngle { 0 };

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -72,7 +72,7 @@ static Class touchEventsGestureRecognizerClass()
 
 namespace TestWebKitAPI {
 
-static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, WebKit::WKTouchPointType::Direct };
+static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, 0, WebKit::WKTouchPointType::Direct };
 static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, 1, 0, false, { globalTouchPoint }, { }, { }, true };
 static void updateSimulatedTouchEvent(CGPoint location, UITouchPhase phase)
 {


### PR DESCRIPTION
#### ef6f17c72eedaaaab06c75497fa417c6c0b6cc45
<pre>
[Experimental] Expose roll angle of Apple Pencil for `twist` Pointer Event attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=298276">https://bugs.webkit.org/show_bug.cgi?id=298276</a>
<a href="https://rdar.apple.com/159705821">rdar://159705821</a>

Reviewed by Abrar Rahman Protyasha.

Expose `rollAngle` of `UITouch` as the value for pointer event property
`twist`. This feature is disabled by default.

Added layout tests to ensure the default value of `twist` remains 0
for pointer events originating from mouse presses, stylus taps, and
taps.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/pointerevents/ios/pointer-event-twist-on-stylus-down-expected.txt: Added.
* LayoutTests/pointerevents/ios/pointer-event-twist-on-stylus-down.html: Added.
* LayoutTests/pointerevents/pointer-event-constructors-twist-expected.txt: Added.
* LayoutTests/pointerevents/pointer-event-constructors-twist.html: Added.
* LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click-expected.txt: Added.
* LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Touch.cpp:
(WebCore::Touch::Touch):
(WebCore::Touch::cloneWithNewTarget const):
* Source/WebCore/dom/Touch.h:
(WebCore::Touch::create):
(WebCore::Touch::twist const):
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::m_predictedEvents):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::SyntheticTouchPoint::SyntheticTouchPoint):
* Source/WebCore/platform/PlatformTouchPoint.h:
(WebCore::PlatformTouchPoint::twist const):
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchPoint::WebKit2PlatformTouchPoint):
* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebPlatformTouchPoint::WebPlatformTouchPoint):
(WebKit::WebPlatformTouchPoint::setTwist):
(WebKit::WebPlatformTouchPoint::twist const):
* Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm:
(WebKit::NativeWebTouchEvent::extractWebTouchPoints):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _shouldExposeRollAngleAsTwist]):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer _touchEventForChildTouch:withParent:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:ofType:forEvent:]):
* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:

Canonical link: <a href="https://commits.webkit.org/299701@main">https://commits.webkit.org/299701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04eb77044231926f91791e4730fe4bd42a1939cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71958 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52728264-2eb2-4646-98a9-c2cd49d8b3ec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91038 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60345 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e3c436f-753e-4be0-b84c-777359e7ec6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71594 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6de7bad1-3762-4a51-87a6-9cfbdd848a5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69846 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112010 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129131 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118401 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99659 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99504 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22962 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43411 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52373 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147099 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46133 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37800 "Found 1 new JSC binary failure: testapi, Found 18685 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push1.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/EH/try2.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->