### PR TITLE
[JSC] Use more StringView in String prototype functions

### DIFF
--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -72,6 +72,13 @@ bool StringView::startsWith(StringView prefix) const
     return ::WTF::startsWith(*this, prefix);
 }
 
+bool StringView::hasInfixStartingAt(StringView prefix, unsigned start) const
+{
+    if (start > length())
+        return false;
+    return ::WTF::startsWith(substring(start), prefix);
+}
+
 bool StringView::startsWithIgnoringASCIICase(StringView prefix) const
 {
     return ::WTF::startsWithIgnoringASCIICase(*this, prefix);
@@ -85,6 +92,14 @@ bool StringView::endsWith(char16_t character) const
 bool StringView::endsWith(StringView suffix) const
 {
     return ::WTF::endsWith(*this, suffix);
+}
+
+bool StringView::hasInfixEndingAt(StringView suffix, unsigned end) const
+{
+    if (end < suffix.length())
+        return false;
+    size_t start = end - suffix.length();
+    return hasInfixStartingAt(suffix, start);
 }
 
 bool StringView::endsWithIgnoringASCIICase(StringView suffix) const

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -186,10 +186,12 @@ public:
     WTF_EXPORT_PRIVATE bool startsWith(char16_t) const;
     WTF_EXPORT_PRIVATE bool startsWith(StringView) const;
     WTF_EXPORT_PRIVATE bool startsWithIgnoringASCIICase(StringView) const;
+    WTF_EXPORT_PRIVATE bool hasInfixStartingAt(StringView prefix, unsigned start) const;
 
     WTF_EXPORT_PRIVATE bool endsWith(char16_t) const;
     WTF_EXPORT_PRIVATE bool endsWith(StringView) const;
     WTF_EXPORT_PRIVATE bool endsWithIgnoringASCIICase(StringView) const;
+    WTF_EXPORT_PRIVATE bool hasInfixEndingAt(StringView suffix, unsigned end) const;
 
     float toFloat(bool& isValid) const;
     double toDouble(bool& isValid) const;


### PR DESCRIPTION
#### 37df6bac1d0104df2055d26ac89220449c320b98
<pre>
[JSC] Use more StringView in String prototype functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=298280">https://bugs.webkit.org/show_bug.cgi?id=298280</a>
<a href="https://rdar.apple.com/159710956">rdar://159710956</a>

Reviewed by Yijia Huang.

Let&apos;s avoid resolving strings in many of String prototype functions.
Unless there is an explicit reason, we should just use StringView to
avoid resolving substring ropes.

* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::trimString):
(JSC::stringIncludesImpl):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::hasInfixStartingAt const):
(WTF::StringView::hasInfixEndingAt const):
* Source/WTF/wtf/text/StringView.h:

Canonical link: <a href="https://commits.webkit.org/299478@main">https://commits.webkit.org/299478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/936c47a6519ae0483b445a7a0dc2906cde4dace9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71200 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c5a482e-8a94-43c1-bcb5-a9b290b2fe1b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90486 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f407fc65-bbc2-4158-80d2-b09f9c3c4f25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70915 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca71b579-689e-40a8-858a-e947ce59afe7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24914 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69007 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111255 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128378 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117652 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34792 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98853 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22312 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18963 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51594 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146350 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45381 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37637 "Found 1 new JSC binary failure: testapi, Found 18594 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->