### PR TITLE
Support SVG `<a download>`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SVG <a> fires navigate and populates downloadRequest with ''
+PASS SVG <a> fires navigate and populates downloadRequest with 'filename'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download-userInitiated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download-userInitiated-expected.txt
@@ -1,0 +1,4 @@
+Click me
+
+PASS SVG <a download> click fires navigate event
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download-userInitiated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download-userInitiated.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<body>
+<svg><a id="a" href="?1"><text x="0" y="5">Click me</text></a></svg>
+<script>
+async_test(t => {
+  a.download = "";
+  navigation.onnavigate = t.step_func(e => {
+    assert_equals(e.navigationType, "push");
+    assert_true(e.cancelable);
+    assert_true(e.canIntercept);
+    assert_true(e.userInitiated);
+    assert_false(e.hashChange);
+    assert_equals(e.downloadRequest, "");
+    assert_equals(e.formData, null);
+    assert_equals(new URL(e.destination.url).search, "?1");
+    assert_false(e.destination.sameDocument);
+    assert_equals(e.destination.key, "");
+    assert_equals(e.destination.id, "");
+    assert_equals(e.destination.index, -1);
+    assert_equals(e.sourceElement, document.getElementById("a"));
+    e.preventDefault();
+    t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
+  });
+  test_driver.click(a);
+}, `SVG <a download> click fires navigate event`);
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-download.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<svg><a id="a" href="foo.html"></a></svg>
+<script>
+for (const download_attr of ["", "filename"]) {
+  async_test(t => {
+    a.download = download_attr;
+    navigation.onnavigate = t.step_func_done(e => {
+      assert_equals(e.navigationType, "push");
+      assert_true(e.cancelable);
+      assert_true(e.canIntercept);
+      assert_false(e.userInitiated);
+      assert_false(e.hashChange);
+      assert_equals(e.downloadRequest, download_attr);
+      assert_equals(e.formData, null);
+      assert_equals(new URL(e.destination.url).pathname,
+                    "/navigation-api/navigate-event/foo.html");
+      assert_false(e.destination.sameDocument);
+      assert_equals(e.destination.key, "");
+      assert_equals(e.destination.id, "");
+      assert_equals(e.destination.index, -1);
+      assert_equals(e.sourceElement, a);
+      e.preventDefault();
+    });
+    a.dispatchEvent(new MouseEvent('click')); // SVG <a> doesn't support .click()
+  }, `SVG <a> fires navigate and populates downloadRequest with '${download_attr}'`);
+}
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1550,7 +1550,7 @@ PASS SVGAElement interface: existence and properties of interface prototype obje
 PASS SVGAElement interface: existence and properties of interface prototype object's "constructor" property
 PASS SVGAElement interface: existence and properties of interface prototype object's @@unscopables property
 PASS SVGAElement interface: attribute target
-FAIL SVGAElement interface: attribute download assert_true: The prototype object must have a property "download" expected true got false
+PASS SVGAElement interface: attribute download
 FAIL SVGAElement interface: attribute ping assert_true: The prototype object must have a property "ping" expected true got false
 PASS SVGAElement interface: attribute rel
 PASS SVGAElement interface: attribute relList
@@ -1572,7 +1572,7 @@ PASS SVGAElement interface: attribute href
 PASS SVGAElement must be primary interface of objects.a
 PASS Stringification of objects.a
 PASS SVGAElement interface: objects.a must inherit property "target" with the proper type
-FAIL SVGAElement interface: objects.a must inherit property "download" with the proper type assert_inherits: property "download" not found in prototype chain
+PASS SVGAElement interface: objects.a must inherit property "download" with the proper type
 FAIL SVGAElement interface: objects.a must inherit property "ping" with the proper type assert_inherits: property "ping" not found in prototype chain
 PASS SVGAElement interface: objects.a must inherit property "rel" with the proper type
 PASS SVGAElement interface: objects.a must inherit property "relList" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a-download-click-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a-download-click-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Clicking on an <a> element with a download attribute must not throw an exception null is not an object (evaluating 'link.href')
+PASS Clicking on an <a> element with a download attribute must not throw an exception
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1029,6 +1029,7 @@ http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.
 loader/navigation-policy [ Skip ]
 
 # <a download> is not supported in WK1 yet.
+webkit.org/b/156069 imported/w3c/web-platform-tests/svg/linking/scripted/a-download-click.svg [ Failure ]
 webkit.org/b/156069 fast/dom/HTMLAnchorElement/anchor-nodownload-set.html [ Failure ]
 webkit.org/b/156069 fast/dom/HTMLAnchorElement/anchor-download.html [ Failure ]
 webkit.org/b/156069 fast/dom/HTMLAnchorElement/anchor-download-synthetic-click.html [ Skip ]

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -34,6 +34,7 @@
 #include "LegacyRenderSVGTransformableContainer.h"
 #include "LocalFrame.h"
 #include "MouseEvent.h"
+#include "OriginAccessPatterns.h"
 #include "PlatformMouseEvent.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGInline.h"
@@ -45,6 +46,7 @@
 #include "SVGNames.h"
 #include "SVGSMILElement.h"
 #include "XLinkNames.h"
+#include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -143,8 +145,24 @@ void SVGAElement::defaultEventHandler(Event& event)
                 target = blankTargetFrameName();
             event.setDefaultHandled();
 
-            if (RefPtr frame = document().frame())
-                frame->loader().changeLocation(protectedDocument()->completeURL(url), target, &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
+            Ref document = this->document();
+            RefPtr frame { document->frame() };
+            if (!frame)
+                return;
+
+            URL completedURL = document->completeURL(url);
+
+            AtomString downloadAttribute;
+            if (document->settings().downloadAttributeEnabled()) {
+                // Ignore the download attribute completely if the href URL is cross origin.
+                bool isSameOrigin = completedURL.protocolIsData() || document->protectedSecurityOrigin()->canRequest(completedURL, OriginAccessPatternsForWebProcess::singleton());
+                if (isSameOrigin)
+                    downloadAttribute = AtomString { ResourceResponse::sanitizeSuggestedFilename(attributeWithoutSynchronization(SVGNames::downloadAttr)) };
+                else if (hasAttributeWithoutSynchronization(SVGNames::downloadAttr))
+                    document->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "The download attribute on anchor was ignored because its href URL has a different security origin."_s);
+            }
+
+            frame->loader().changeLocation(completedURL, target, &event, ReferrerPolicy::EmptyString, document->shouldOpenExternalURLsPolicyToPropagate(), std::nullopt, downloadAttribute, std::nullopt, NavigationHistoryBehavior::Push, this);
             return;
         }
     }

--- a/Source/WebCore/svg/SVGAElement.idl
+++ b/Source/WebCore/svg/SVGAElement.idl
@@ -28,6 +28,7 @@
 ] interface SVGAElement : SVGGraphicsElement {
     readonly attribute SVGAnimatedString target;
 
+    [EnabledBySetting=DownloadAttributeEnabled, Reflect] attribute DOMString download;
     [Reflect] attribute DOMString hreflang;
     [Reflect] attribute DOMString rel;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -40,6 +40,7 @@ direction
 display
 divisor
 dominant-baseline
+download
 dur
 dx
 dy


### PR DESCRIPTION
#### ac204acf80a5066bfb36843d69cf818631d2a0b0
<pre>
Support SVG `&lt;a download&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298271">https://bugs.webkit.org/show_bug.cgi?id=298271</a>

Reviewed by NOBODY (OOPS!).

Updates the SVGAElement to handle the download attribute.
This now behaves the same as with HTMLAnchorElement.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac204acf80a5066bfb36843d69cf818631d2a0b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126484 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91238 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60537 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71789 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25814 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35689 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99849 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99692 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45148 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23170 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43676 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52613 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46375 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->