### PR TITLE
Migrate postPageMessage functions with boolean param from testRunner.idl to testRunnerJS

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -43,10 +43,6 @@ interface TestRunner {
 
     // Downloads.
     undefined waitUntilDownloadFinished();
-    undefined setShouldLogDownloadCallbacks(boolean value);
-    undefined setShouldLogDownloadSize(boolean value);
-    undefined setShouldLogDownloadExpectedSize(boolean value);
-    undefined setShouldDownloadContentDispositionAttachments(boolean value);
 
     const unsigned short RENDER_TREE_SHOW_ALL_LAYERS            = 1;
     const unsigned short RENDER_TREE_SHOW_LAYER_NESTING         = 2;
@@ -100,12 +96,6 @@ interface TestRunner {
     undefined setCacheModel(long model);
     undefined setAsynchronousSpellCheckingEnabled(boolean value);
     undefined setPrinting();
-    undefined setShouldDecideNavigationPolicyAfterDelay(boolean value);
-    undefined setShouldDecideResponsePolicyAfterDelay(boolean value);
-    undefined setNavigationGesturesEnabled(boolean value);
-    undefined setIgnoresViewportScaleLimits(boolean value);
-    undefined setUseDarkAppearanceForTesting(boolean useDarkAppearance);
-    undefined setShouldDownloadUndisplayableMIMETypes(boolean value);
     undefined stopLoading();
 
     // Special DOM functions.
@@ -113,9 +103,6 @@ interface TestRunner {
     undefined execCommand(DOMString name, DOMString showUI, DOMString value);
     boolean isCommandEnabled(DOMString name);
     unsigned long windowCount();
-
-    // Device Orientation Motion.
-    undefined setShouldAllowDeviceOrientationAndMotionAccess(boolean value);
 
     // Special DOM variables.
     attribute boolean globalFlag;
@@ -256,9 +243,6 @@ interface TestRunner {
     undefined queueNonLoadingScript(DOMString script);
 
     // Authentication
-    undefined setRejectsProtectionSpaceAndContinueForAuthenticationChallenges(boolean value);
-    undefined setHandlesAuthenticationChallenges(boolean value);
-    undefined setShouldLogCanAuthenticateAgainstProtectionSpace(boolean value);
     undefined setAuthenticationUsername(DOMString username);
     undefined setAuthenticationPassword(DOMString password);
 
@@ -271,7 +255,6 @@ interface TestRunner {
     readonly attribute boolean secureEventInputIsEnabled;
     
     // Override plugin load policy.
-    undefined setBlockAllPlugins(boolean shouldBlock);
     undefined setPluginSupportedMode(DOMString mode);
 
     // Hooks to the JSC compiler.

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -937,41 +937,6 @@ void TestRunner::queueNonLoadingScript(JSStringRef script)
     InjectedBundle::singleton().queueNonLoadingScript(toWK(script).get());
 }
 
-void TestRunner::setRejectsProtectionSpaceAndContinueForAuthenticationChallenges(bool value)
-{
-    postPageMessage("SetRejectsProtectionSpaceAndContinueForAuthenticationChallenges", value);
-}
-    
-void TestRunner::setHandlesAuthenticationChallenges(bool handlesAuthenticationChallenges)
-{
-    postPageMessage("SetHandlesAuthenticationChallenges", handlesAuthenticationChallenges);
-}
-
-void TestRunner::setShouldLogCanAuthenticateAgainstProtectionSpace(bool value)
-{
-    postPageMessage("SetShouldLogCanAuthenticateAgainstProtectionSpace", value);
-}
-
-void TestRunner::setShouldLogDownloadCallbacks(bool value)
-{
-    postPageMessage("SetShouldLogDownloadCallbacks", value);
-}
-
-void TestRunner::setShouldDownloadContentDispositionAttachments(bool value)
-{
-    postPageMessage("SetShouldDownloadContentDispositionAttachments", value);
-}
-
-void TestRunner::setShouldLogDownloadSize(bool value)
-{
-    postPageMessage("SetShouldLogDownloadSize", value);
-}
-
-void TestRunner::setShouldLogDownloadExpectedSize(bool value)
-{
-    postPageMessage("SetShouldLogDownloadExpectedSize", value);
-}
-
 void TestRunner::setAuthenticationUsername(JSStringRef username)
 {
     postPageMessage("SetAuthenticationUsername", toWK(username));
@@ -985,11 +950,6 @@ void TestRunner::setAuthenticationPassword(JSStringRef password)
 bool TestRunner::secureEventInputIsEnabled() const
 {
     return postSynchronousPageMessageReturningBoolean("SecureEventInputIsEnabled");
-}
-
-void TestRunner::setBlockAllPlugins(bool shouldBlock)
-{
-    postPageMessage("SetBlockAllPlugins", shouldBlock);
 }
 
 void TestRunner::setPluginSupportedMode(JSStringRef mode)
@@ -1010,43 +970,6 @@ JSValueRef TestRunner::numberOfDFGCompiles(JSContextRef context, JSValueRef func
 JSValueRef TestRunner::neverInlineFunction(JSContextRef context, JSValueRef function)
 {
     return JSC::setNeverInline(context, function);
-}
-
-void TestRunner::setShouldDecideNavigationPolicyAfterDelay(bool value)
-{
-    m_shouldDecideNavigationPolicyAfterDelay = value;
-    postPageMessage("SetShouldDecideNavigationPolicyAfterDelay", value);
-}
-
-void TestRunner::setShouldDecideResponsePolicyAfterDelay(bool value)
-{
-    m_shouldDecideResponsePolicyAfterDelay = value;
-    postPageMessage("SetShouldDecideResponsePolicyAfterDelay", value);
-}
-
-void TestRunner::setNavigationGesturesEnabled(bool value)
-{
-    postPageMessage("SetNavigationGesturesEnabled", value);
-}
-
-void TestRunner::setIgnoresViewportScaleLimits(bool value)
-{
-    postPageMessage("SetIgnoresViewportScaleLimits", value);
-}
-
-void TestRunner::setUseDarkAppearanceForTesting(bool useDarkAppearance)
-{
-    postPageMessage("SetUseDarkAppearanceForTesting", useDarkAppearance);
-}
-
-void TestRunner::setShouldDownloadUndisplayableMIMETypes(bool value)
-{
-    postPageMessage("SetShouldDownloadUndisplayableMIMETypes", value);
-}
-
-void TestRunner::setShouldAllowDeviceOrientationAndMotionAccess(bool value)
-{
-    postPageMessage("SetShouldAllowDeviceOrientationAndMotionAccess", value);
 }
 
 void TestRunner::terminateGPUProcess()

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -210,9 +210,6 @@ public:
     void setPrinting() { m_isPrinting = true; }
 
     // Authentication
-    void setRejectsProtectionSpaceAndContinueForAuthenticationChallenges(bool);
-    void setHandlesAuthenticationChallenges(bool);
-    void setShouldLogCanAuthenticateAgainstProtectionSpace(bool);
     void setAuthenticationUsername(JSStringRef);
     void setAuthenticationPassword(JSStringRef);
 
@@ -221,7 +218,6 @@ public:
     // Audio testing.
     void setAudioResult(JSContextRef, JSValueRef data);
 
-    void setBlockAllPlugins(bool);
     void setPluginSupportedMode(JSStringRef);
 
     WhatToDump whatToDump() const;
@@ -248,10 +244,6 @@ public:
 
     // Downloads
     bool shouldFinishAfterDownload() const { return m_shouldFinishAfterDownload; }
-    void setShouldLogDownloadCallbacks(bool);
-    void setShouldLogDownloadSize(bool);
-    void setShouldLogDownloadExpectedSize(bool);
-    void setShouldDownloadContentDispositionAttachments(bool);
 
     bool shouldAllowEditing() const { return m_shouldAllowEditing; }
 
@@ -370,15 +362,6 @@ public:
     JSValueRef numberOfDFGCompiles(JSContextRef, JSValueRef function);
     JSValueRef neverInlineFunction(JSContextRef, JSValueRef function);
 
-    bool shouldDecideNavigationPolicyAfterDelay() const { return m_shouldDecideNavigationPolicyAfterDelay; }
-    void setShouldDecideNavigationPolicyAfterDelay(bool);
-    bool shouldDecideResponsePolicyAfterDelay() const { return m_shouldDecideResponsePolicyAfterDelay; }
-    void setShouldDecideResponsePolicyAfterDelay(bool);
-    void setNavigationGesturesEnabled(bool);
-    void setIgnoresViewportScaleLimits(bool);
-    void setUseDarkAppearanceForTesting(bool);
-    void setShouldDownloadUndisplayableMIMETypes(bool);
-    void setShouldAllowDeviceOrientationAndMotionAccess(bool);
     void stopLoading();
 
     bool didCancelClientRedirect() const { return m_didCancelClientRedirect; }
@@ -616,8 +599,6 @@ private:
 
     bool m_globalFlag { false };
 
-    bool m_shouldDecideNavigationPolicyAfterDelay { false };
-    bool m_shouldDecideResponsePolicyAfterDelay { false };
     bool m_shouldFinishAfterDownload { false };
     bool m_didCancelClientRedirect { false };
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1925,6 +1925,21 @@ if (window.testRunner) {
     testRunner.requestExitFullscreenFromUIProcess = () => post(['RequestExitFullscreenFromUIProcess']);
     testRunner.keyExistsInKeychain = (attrLabel, applicationLabelBase64) => post(['KeyExistsInKeychain', attrLabel, applicationLabelBase64]);
     testRunner.indicateFindMatch = index => post(['IndicateFindMatch', index]);
+    testRunner.setShouldLogDownloadCallbacks = value => post(['SetShouldLogDownloadCallbacks', value]);
+    testRunner.setShouldLogDownloadSize = value => post(['SetShouldLogDownloadSize', value]);
+    testRunner.setShouldLogDownloadExpectedSize = value => post(['SetShouldLogDownloadExpectedSize', value]);
+    testRunner.setShouldDownloadContentDispositionAttachments = value => post(['SetShouldDownloadContentDispositionAttachments', value]);
+    testRunner.setShouldDecideNavigationPolicyAfterDelay = value => post(['SetShouldDecideNavigationPolicyAfterDelay', value]);
+    testRunner.setShouldDecideResponsePolicyAfterDelay = value => post(['SetShouldDecideResponsePolicyAfterDelay', value]);
+    testRunner.setNavigationGesturesEnabled = value => post(['SetNavigationGesturesEnabled', value]);
+    testRunner.setIgnoresViewportScaleLimits = value => post(['SetIgnoresViewportScaleLimits', value]);
+    testRunner.setUseDarkAppearanceForTesting = value => post(['SetUseDarkAppearanceForTesting', value]);
+    testRunner.setShouldDownloadUndisplayableMIMETypes = value => post(['SetShouldDownloadUndisplayableMIMETypes', value]);
+    testRunner.setShouldAllowDeviceOrientationAndMotionAccess = value => post(['SetShouldAllowDeviceOrientationAndMotionAccess', value]);
+    testRunner.setRejectsProtectionSpaceAndContinueForAuthenticationChallenges = value => post(['SetRejectsProtectionSpaceAndContinueForAuthenticationChallenges', value]);
+    testRunner.setHandlesAuthenticationChallenges = value => post(['SetHandlesAuthenticationChallenges', value]);
+    testRunner.setShouldLogCanAuthenticateAgainstProtectionSpace = value => post(['SetShouldLogCanAuthenticateAgainstProtectionSpace', value]);
+    testRunner.setBlockAllPlugins = value => post(['SetBlockAllPlugins', value]);
 }
 )testRunnerJS";
 
@@ -2030,6 +2045,81 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
 
     if (WKStringIsEqualToUTF8CString(command, "KeyExistsInKeychain"))
         return completionHandler(adoptWK(WKBooleanCreate(keyExistsInKeychain(toWTFString(argument), toWTFString(argument2)))).get());
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldLogDownloadCallbacks")) {
+        m_shouldLogDownloadCallbacks = WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldLogDownloadSize")) {
+        setShouldLogDownloadSize(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldLogDownloadExpectedSize")) {
+        setShouldLogDownloadExpectedSize(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldDownloadContentDispositionAttachments")) {
+        setShouldDownloadContentDispositionAttachments(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldDecideNavigationPolicyAfterDelay")) {
+        setShouldDecideNavigationPolicyAfterDelay(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldDecideResponsePolicyAfterDelay")) {
+        setShouldDecideResponsePolicyAfterDelay(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetNavigationGesturesEnabled")) {
+        setNavigationGesturesEnabled(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetIgnoresViewportScaleLimits")) {
+        setIgnoresViewportScaleLimits(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetUseDarkAppearanceForTesting")) {
+        setUseDarkAppearanceForTesting(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldDownloadUndisplayableMIMETypes")) {
+        setShouldDownloadUndisplayableMIMETypes(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldAllowDeviceOrientationAndMotionAccess")) {
+        setShouldAllowDeviceOrientationAndMotionAccess(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetRejectsProtectionSpaceAndContinueForAuthenticationChallenges")) {
+        setRejectsProtectionSpaceAndContinueForAuthenticationChallenges(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetHandlesAuthenticationChallenges")) {
+        setHandlesAuthenticationChallenges(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetShouldLogCanAuthenticateAgainstProtectionSpace")) {
+        m_shouldLogCanAuthenticateAgainstProtectionSpace = WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument));
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "SetBlockAllPlugins")) {
+        setBlockAllPlugins(WKBooleanGetValue(dynamic_wk_cast<WKBooleanRef>(argument)));
+        return completionHandler(nullptr);
+    }
 
     ASSERT_NOT_REACHED();
 }

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -530,41 +530,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "SetRejectsProtectionSpaceAndContinueForAuthenticationChallenges")) {
-        TestController::singleton().setRejectsProtectionSpaceAndContinueForAuthenticationChallenges(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetHandlesAuthenticationChallenges")) {
-        TestController::singleton().setHandlesAuthenticationChallenges(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldLogCanAuthenticateAgainstProtectionSpace")) {
-        TestController::singleton().setShouldLogCanAuthenticateAgainstProtectionSpace(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldLogDownloadCallbacks")) {
-        TestController::singleton().setShouldLogDownloadCallbacks(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldDownloadContentDispositionAttachments")) {
-        TestController::singleton().setShouldDownloadContentDispositionAttachments(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldLogDownloadSize")) {
-        TestController::singleton().setShouldLogDownloadSize(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldLogDownloadExpectedSize")) {
-        TestController::singleton().setShouldLogDownloadExpectedSize(booleanValue(messageBody));
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "SetAuthenticationUsername")) {
         WKStringRef username = stringValue(messageBody);
         TestController::singleton().setAuthenticationUsername(toWTFString(username));
@@ -577,49 +542,9 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "SetBlockAllPlugins")) {
-        TestController::singleton().setBlockAllPlugins(booleanValue(messageBody));
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "SetPluginSupportedMode")) {
         WKStringRef mode = stringValue(messageBody);
         TestController::singleton().setPluginSupportedMode(toWTFString(mode));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldDecideNavigationPolicyAfterDelay")) {
-        TestController::singleton().setShouldDecideNavigationPolicyAfterDelay(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldDecideResponsePolicyAfterDelay")) {
-        TestController::singleton().setShouldDecideResponsePolicyAfterDelay(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetNavigationGesturesEnabled")) {
-        TestController::singleton().setNavigationGesturesEnabled(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetIgnoresViewportScaleLimits")) {
-        TestController::singleton().setIgnoresViewportScaleLimits(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetUseDarkAppearanceForTesting")) {
-        TestController::singleton().setUseDarkAppearanceForTesting(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldDownloadUndisplayableMIMETypes")) {
-        TestController::singleton().setShouldDownloadUndisplayableMIMETypes(booleanValue(messageBody));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldAllowDeviceOrientationAndMotionAccess")) {
-        TestController::singleton().setShouldAllowDeviceOrientationAndMotionAccess(booleanValue(messageBody));
         return;
     }
 


### PR DESCRIPTION
#### b5b21b534443eca166f7fecaa7e62619a05efcb2
<pre>
Migrate postPageMessage functions with boolean param from testRunner.idl to testRunnerJS
<a href="https://bugs.webkit.org/show_bug.cgi?id=298279">https://bugs.webkit.org/show_bug.cgi?id=298279</a>
<a href="https://rdar.apple.com/159710985">rdar://159710985</a>

Reviewed by Alex Christensen.

This migrates a large batch of functions that use postPageMessage with a boolean parameter from testRunner.idl to testRunnerJS in the TestController.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setRejectsProtectionSpaceAndContinueForAuthenticationChallenges): Deleted.
(WTR::TestRunner::setHandlesAuthenticationChallenges): Deleted.
(WTR::TestRunner::setShouldLogCanAuthenticateAgainstProtectionSpace): Deleted.
(WTR::TestRunner::setShouldLogDownloadCallbacks): Deleted.
(WTR::TestRunner::setShouldDownloadContentDispositionAttachments): Deleted.
(WTR::TestRunner::setShouldLogDownloadSize): Deleted.
(WTR::TestRunner::setShouldLogDownloadExpectedSize): Deleted.
(WTR::TestRunner::setBlockAllPlugins): Deleted.
(WTR::TestRunner::setShouldDecideNavigationPolicyAfterDelay): Deleted.
(WTR::TestRunner::setShouldDecideResponsePolicyAfterDelay): Deleted.
(WTR::TestRunner::setNavigationGesturesEnabled): Deleted.
(WTR::TestRunner::setIgnoresViewportScaleLimits): Deleted.
(WTR::TestRunner::setUseDarkAppearanceForTesting): Deleted.
(WTR::TestRunner::setShouldDownloadUndisplayableMIMETypes): Deleted.
(WTR::TestRunner::setShouldAllowDeviceOrientationAndMotionAccess): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::shouldFinishAfterDownload const):
(WTR::TestRunner::shouldDecideNavigationPolicyAfterDelay const):
(WTR::TestRunner::shouldDecideResponsePolicyAfterDelay const):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::if):
(WTR::CompletionHandler&lt;void):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/299520@main">https://commits.webkit.org/299520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deed870e91be2eea4182c883c5958e4ec47e38a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71340 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71035 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25229 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128516 "Hash deed870e for PR 50212 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46185 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/128516 "Hash deed870e for PR 50212 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103135 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/128516 "Hash deed870e for PR 50212 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44434 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22439 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46052 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45515 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->