### PR TITLE
Add dynamic_wk_cast to safely cast between different types of WKTypeRef

### DIFF
--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -117,6 +117,7 @@ set(WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/C/WKWindowFeaturesRef.h
     UIProcess/API/C/WebKit2_C.h
 
+    UIProcess/API/cpp/WKCast.h
     UIProcess/API/cpp/WKRetainPtr.h
 
     WebProcess/InjectedBundle/API/c/WKBundle.h

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -349,6 +349,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKCast {
+    header "WKCast.h"
+    export *
+  }
+
   explicit module WKCertificateInfo {
     header "WKCertificateInfo.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1041,6 +1041,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKCast {
+    header "WKCast.h"
+    export *
+  }
+  
   explicit module WKCertificateInfo {
     header "WKCertificateInfo.h"
     export *

--- a/Source/WebKit/UIProcess/API/cpp/WKCast.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKCast.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <WebKit/WKType.h>
+
+namespace detail {
+template<typename> struct TypeCheckHelper;
+}
+#define TYPE_CHECKER(type, checker) \
+extern "C" WK_EXPORT WKTypeID checker(void); \
+namespace detail { \
+template<> struct TypeCheckHelper<type> { \
+    static WKTypeID typeID() { return checker(); } \
+};\
+} // namespace detail
+
+TYPE_CHECKER(WKArrayRef, WKArrayGetTypeID);
+TYPE_CHECKER(WKBooleanRef, WKBooleanGetTypeID);
+TYPE_CHECKER(WKContextMenuItemRef, WKContextMenuItemGetTypeID);
+TYPE_CHECKER(WKDataRef, WKDataGetTypeID);
+TYPE_CHECKER(WKDictionaryRef, WKDictionaryGetTypeID);
+TYPE_CHECKER(WKDoubleRef, WKDoubleGetTypeID);
+TYPE_CHECKER(WKJSHandleRef, WKJSHandleGetTypeID);
+TYPE_CHECKER(WKStringRef, WKStringGetTypeID);
+TYPE_CHECKER(WKUInt64Ref, WKUInt64GetTypeID);
+TYPE_CHECKER(WKURLRef, WKURLGetTypeID);
+
+namespace WebKit {
+
+template<typename T, typename U> inline T dynamic_wk_cast(U* object)
+{
+    if (!object || WKGetTypeID(object) != detail::TypeCheckHelper<T>::typeID())
+        return nullptr;
+    return reinterpret_cast<T>(object);
+}
+
+template<typename> class WKRetainPtr;
+template<typename T, typename U> inline WKRetainPtr<T> dynamic_wk_cast(RetainPtr<U> object)
+{
+    return dynamic_wk_cast<T>(object.get());
+}
+
+} // namespace WebKit
+
+using WebKit::dynamic_wk_cast;
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2620,6 +2620,7 @@
 		FA1ED3F42B76B93700C90F3B /* CoreIPCCFType.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA1ED3F32B76B90700C90F3B /* CoreIPCCFType.mm */; };
 		FA2F854F2E60CBDD00D0ECA8 /* _WKNSURLExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = FA2F854D2E60CA7D00D0ECA8 /* _WKNSURLExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA2F85502E60CBE700D0ECA8 /* _WKNSStringExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = FA2F854B2E60CA7D00D0ECA8 /* _WKNSStringExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA3825FA2E67BF740057AE68 /* WKCast.h in Headers */ = {isa = PBXBuildFile; fileRef = FA3825F92E67BF740057AE68 /* WKCast.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA39AE682B23972B008F93CD /* CoreIPCAuditToken.h in Headers */ = {isa = PBXBuildFile; fileRef = FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */; };
 		FA4066E02D44733200A2E622 /* WKPageFullScreenClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FA4066DF2D4472CE00A2E622 /* WKPageFullScreenClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA4FE2662B75EB290016E671 /* CoreIPCNull.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA4FE2642B75EAFF0016E671 /* CoreIPCNull.mm */; };
@@ -8656,6 +8657,7 @@
 		FA2F854C2E60CA7D00D0ECA8 /* _WKNSStringExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKNSStringExtras.mm; sourceTree = "<group>"; };
 		FA2F854D2E60CA7D00D0ECA8 /* _WKNSURLExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKNSURLExtras.h; sourceTree = "<group>"; };
 		FA2F854E2E60CA7D00D0ECA8 /* _WKNSURLExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKNSURLExtras.mm; sourceTree = "<group>"; };
+		FA3825F92E67BF740057AE68 /* WKCast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKCast.h; sourceTree = "<group>"; };
 		FA39AE4B2B2269C4008F93CD /* APIDictionary.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIDictionary.serialization.in; sourceTree = "<group>"; };
 		FA39AE4C2B229187008F93CD /* WebImage.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebImage.serialization.in; sourceTree = "<group>"; };
 		FA39AE4D2B22D766008F93CD /* APIObject.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIObject.serialization.in; sourceTree = "<group>"; };
@@ -15730,6 +15732,7 @@
 		BC8A501311765F4500757573 /* cpp */ = {
 			isa = PBXGroup;
 			children = (
+				FA3825F92E67BF740057AE68 /* WKCast.h */,
 				BC8A501411765F5600757573 /* WKRetainPtr.h */,
 			);
 			path = cpp;
@@ -18322,6 +18325,7 @@
 				BC60C5791240A546008C5E29 /* WKBundleRangeHandle.h in Headers */,
 				BC5D24C716CD73C5007D5461 /* WKBundleRangeHandlePrivate.h in Headers */,
 				BC14DF9F120B635F00826C0C /* WKBundleScriptWorld.h in Headers */,
+				FA3825FA2E67BF740057AE68 /* WKCast.h in Headers */,
 				BC4075F6124FF0270068F20A /* WKCertificateInfo.h in Headers */,
 				BC407627124FF0400068F20A /* WKCertificateInfoMac.h in Headers */,
 				F43019682DC97B10006522E0 /* WKColorExtensionView.h in Headers */,

--- a/Tools/WebKitTestRunner/DataFunctions.h
+++ b/Tools/WebKitTestRunner/DataFunctions.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebKit/WKCast.h>
 #include <WebKit/WKData.h>
 #include <WebKit/WKRetainPtr.h>
 #include <wtf/UUID.h>
@@ -37,7 +38,7 @@ WKRetainPtr<WKDataRef> uuidToData(const WTF::UUID&);
 
 inline WKDataRef dataValue(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKDataGetTypeID() ? static_cast<WKDataRef>(value) : nullptr;
+    return dynamic_wk_cast<WKDataRef>(value);
 }
 
 inline WTF::UUID dataToUUID(WKDataRef data)

--- a/Tools/WebKitTestRunner/DictionaryFunctions.h
+++ b/Tools/WebKitTestRunner/DictionaryFunctions.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "StringFunctions.h"
+#include <WebKit/WKCast.h>
 
 namespace WTR {
 
@@ -44,7 +45,8 @@ void setValue(const WKRetainPtr<WKMutableDictionaryRef>&, const char* key, const
 
 inline bool booleanValue(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKBooleanGetTypeID() && WKBooleanGetValue(static_cast<WKBooleanRef>(value));
+    WKBooleanRef boolean = dynamic_wk_cast<WKBooleanRef>(value);
+    return boolean && WKBooleanGetValue(boolean);
 }
 
 inline bool booleanValue(const WKRetainPtr<WKTypeRef>& value)
@@ -54,27 +56,29 @@ inline bool booleanValue(const WKRetainPtr<WKTypeRef>& value)
 
 inline WKDictionaryRef dictionaryValue(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKDictionaryGetTypeID() ? static_cast<WKDictionaryRef>(value) : nullptr;
+    return dynamic_wk_cast<WKDictionaryRef>(value);
 }
 
 inline WKArrayRef arrayValue(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKArrayGetTypeID() ? static_cast<WKArrayRef>(value) : nullptr;
+    return dynamic_wk_cast<WKArrayRef>(value);
 }
 
 inline double doubleValue(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKDoubleGetTypeID() ? WKDoubleGetValue(static_cast<WKDoubleRef>(value)) : 0;
+    WKDoubleRef d = dynamic_wk_cast<WKDoubleRef>(value);
+    return d ? WKDoubleGetValue(d) : 0;
 }
 
 inline std::optional<double> optionalDoubleValue(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKDoubleGetTypeID() ? std::make_optional(WKDoubleGetValue(static_cast<WKDoubleRef>(value))) : std::nullopt;
+    WKDoubleRef d = dynamic_wk_cast<WKDoubleRef>(value);
+    return d ? std::make_optional(WKDoubleGetValue(d)) : std::nullopt;
 }
 
 inline WKStringRef stringValue(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKStringGetTypeID() ? static_cast<WKStringRef>(value) : nullptr;
+    return dynamic_wk_cast<WKStringRef>(value);
 }
 
 inline WTF::String toWTFString(WKTypeRef value)
@@ -84,7 +88,8 @@ inline WTF::String toWTFString(WKTypeRef value)
 
 inline uint64_t uint64Value(WKTypeRef value)
 {
-    return value && WKGetTypeID(value) == WKUInt64GetTypeID() ? WKUInt64GetValue(static_cast<WKUInt64Ref>(value)) : 0;
+    WKUInt64Ref i = dynamic_wk_cast<WKUInt64Ref>(value);
+    return i ? WKUInt64GetValue(i) : 0;
 }
 
 inline uint64_t uint64Value(const WKRetainPtr<WKTypeRef>& value)

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -34,6 +34,7 @@
 #include <WebKit/WKBundleFrame.h>
 #include <WebKit/WKBundlePagePrivate.h>
 #include <WebKit/WKBundlePrivate.h>
+#include <WebKit/WKCast.h>
 #include <WebKit/WKContextMenuItem.h>
 #include <WebKit/WKMutableDictionary.h>
 #include <WebKit/WKNumber.h>
@@ -458,9 +459,7 @@ JSValueRef EventSendingController::contextClick(JSContextRef context)
 
     size_t entriesSize = WKArrayGetSize(menuEntries.get());
     for (size_t i = 0; i < entriesSize; ++i) {
-        ASSERT(WKGetTypeID(WKArrayGetItemAtIndex(menuEntries.get(), i)) == WKContextMenuItemGetTypeID());
-
-        WKContextMenuItemRef item = static_cast<WKContextMenuItemRef>(WKArrayGetItemAtIndex(menuEntries.get(), i));
+        WKContextMenuItemRef item = dynamic_wk_cast<WKContextMenuItemRef>(WKArrayGetItemAtIndex(menuEntries.get(), i));
         MenuItemPrivateData* privateData = new MenuItemPrivateData(page, item);
         JSObjectSetPropertyAtIndex(context, array, i, JSObjectMake(context, getMenuItemClass(), privateData), 0);
     }

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -805,7 +805,7 @@ private:
 
     class Callbacks {
     public:
-        void append(WKTypeRef);
+        void append(WKJSHandleRef);
         void clear() { m_callbacks.clear(); }
         void notifyListeners(WKStringRef);
         void notifyListeners();

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1332,14 +1332,12 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetPrivateClickMeasurementTokenPublicKeyURLForTesting")) {
-        ASSERT(WKGetTypeID(messageBody) == WKURLGetTypeID());
-        TestController::singleton().setPrivateClickMeasurementTokenPublicKeyURLForTesting(static_cast<WKURLRef>(messageBody));
+        TestController::singleton().setPrivateClickMeasurementTokenPublicKeyURLForTesting(dynamic_wk_cast<WKURLRef>(messageBody));
         return nullptr;
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetPrivateClickMeasurementTokenSignatureURLForTesting")) {
-        ASSERT(WKGetTypeID(messageBody) == WKURLGetTypeID());
-        TestController::singleton().setPrivateClickMeasurementTokenSignatureURLForTesting(static_cast<WKURLRef>(messageBody));
+        TestController::singleton().setPrivateClickMeasurementTokenSignatureURLForTesting(dynamic_wk_cast<WKURLRef>(messageBody));
         return nullptr;
     }
 


### PR DESCRIPTION
#### e15a031d20be12b21baf6663ae4e669cfc29bce0
<pre>
Add dynamic_wk_cast to safely cast between different types of WKTypeRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=298285">https://bugs.webkit.org/show_bug.cgi?id=298285</a>

Reviewed by Simon Fraser.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/UIProcess/API/cpp/WKCast.h: Added.
(WebKit::wk_cast):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::findOptionsFromArray):
(WTR::CompletionHandler&lt;void):

Canonical link: <a href="https://commits.webkit.org/299503@main">https://commits.webkit.org/299503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e4835f66cde211c7ca5281e9dc53774eecf1355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71311 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4032a00b-ee3a-4d14-ab27-6769518ce397) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47510 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b67ede7-09c8-48c6-ad63-59437ba44269) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71011 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/100a558d-cd94-444b-9825-ad4a1be538f3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25015 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69127 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128490 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34895 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98939 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22412 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18976 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51708 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->