### PR TITLE
[WebGPU + Swift] CommandEncoder.beginRenderPass doesn't support MTLRasterizationRateMaps

### DIFF
--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -223,6 +223,7 @@ public:
     ExternalTextureData createExternalTextureFromPixelBuffer(CVPixelBufferRef, WGPUColorSpace) const;
     RefPtr<XRSubImage> getXRViewSubImage(XRProjectionLayer&);
     RefPtr<XRSubImage> getXRViewSubImage() const;
+    id<MTLTexture> getXRViewSubImageDepthTexture() const;
     const std::optional<const MachSendRight> webProcessID() const;
 #if CPU(X86_64)
     bool isIntel() const { return [m_device.name localizedCaseInsensitiveContainsString:@"intel"]; }

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -419,6 +419,16 @@ RefPtr<XRSubImage> Device::getXRViewSubImage() const
     return m_xrSubImage;
 }
 
+id<MTLTexture> Device::getXRViewSubImageDepthTexture() const
+{
+    if (auto subImage = getXRViewSubImage()) {
+        if (RefPtr depthTexture = subImage->depthTexture())
+            return depthTexture->texture();
+    }
+
+    return nil;
+}
+
 void Device::makeInvalid()
 {
     m_device = nil;

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -93,6 +93,7 @@ public:
     uint32_t parentRelativeSlice() const;
     uint32_t parentRelativeMipLevel() const;
     bool is2DTexture() const { return dimension() == WGPUTextureViewDimension_2D; }
+    id<MTLRasterizationRateMap> rasterizationMapForSlice(uint32_t slice);
 
 private:
     TextureView(id<MTLTexture>, const WGPUTextureViewDescriptor&, const std::optional<WGPUExtent3D>&, Texture&, Device&);

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -189,6 +189,11 @@ void TextureView::setCommandEncoder(CommandEncoder& commandEncoder) const
         commandEncoder.makeSubmitInvalid();
 }
 
+id<MTLRasterizationRateMap> TextureView::rasterizationMapForSlice(uint32_t slice)
+{
+    return apiParentTexture().rasterizationMapForSlice(slice);
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs


### PR DESCRIPTION
#### 8143775764dbeb21cba114daa6b0a8fdefa64630
<pre>
[WebGPU + Swift] CommandEncoder.beginRenderPass doesn&apos;t support MTLRasterizationRateMaps
<a href="https://bugs.webkit.org/show_bug.cgi?id=297666">https://bugs.webkit.org/show_bug.cgi?id=297666</a>
<a href="https://rdar.apple.com/158779822">rdar://158779822</a>

Reviewed by Tadeu Zagallo.

Add MTLRasterizationRateMap changes to the swift version

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::getXRViewSubImageDepthTexture const):
* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::rasterizationMapForSlice):

Canonical link: <a href="https://commits.webkit.org/299500@main">https://commits.webkit.org/299500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3989db12797d41cbc0c436f75bd452710c2410d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71307 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fff1066b-0635-4fed-a0d7-9b54e4bd40d0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47506 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/973abb0d-63b5-4d6a-8eef-0bf4e37beafb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71005 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6ce0a47-b2bb-4be5-acee-31e32493df3f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30638 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69123 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128486 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99156 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98933 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44403 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22403 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51704 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45486 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->