### PR TITLE
neon.h: Avoid -Wundef for SIMDE_ARCH_RISCV_ZVFH

### DIFF
--- a/Source/WTF/wtf/simde/arm/neon.h
+++ b/Source/WTF/wtf/simde/arm/neon.h
@@ -47928,7 +47928,7 @@ SIMDE_FUNCTION_ATTRIBUTES
 simde_float16x8_t simde_vcmlaq_rot90_laneq_f16(simde_float16x8_t r, simde_float16x8_t a, simde_float16x8_t b, const int lane)
     SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3)
 {
-  #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE > 128)
+  #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE > 128)
       simde_float16x8_private r_ = simde_float16x8_to_private(r),
                               a_ = simde_float16x8_to_private(a),
                               b_ = simde_vdupq_n_f16(simde_float16x8_to_private(b).values[lane]);
@@ -68511,7 +68511,7 @@ simde_float16x4x2_t
 simde_vld2_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld2_f16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float16x4_private r_[2];
     vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)&ptr[0], 4);
     r_[0].sv64 = __riscv_vget_v_f16m1x2_f16m1(dest, 0);
@@ -69008,7 +69008,7 @@ simde_float16x8x2_t
 simde_vld2q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld2q_f16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float16x8_private r_[2];
     vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_f16m1x2_f16m1(dest, 0);
@@ -70728,7 +70728,7 @@ simde_vld3_f16(simde_float16_t const *ptr) {
     return vld3_f16(ptr);
   #else
     simde_float16x4_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_f16m1x3_f16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_f16m1x3_f16m1(dest, 1);
@@ -71091,7 +71091,7 @@ simde_vld3q_f16(simde_float16_t const *ptr) {
     return vld3q_f16(ptr);
   #else
     simde_float16x8_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)&ptr[0], 8);
       r_[0].sv128 = __riscv_vget_v_f16m1x3_f16m1(dest, 0);
       r_[1].sv128 = __riscv_vget_v_f16m1x3_f16m1(dest, 1);
@@ -73104,7 +73104,7 @@ simde_vld4_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_f16(ptr);
   #else
     simde_float16x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 4);
       a_[0].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 1);
@@ -73412,7 +73412,7 @@ simde_vld4q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_f16(ptr);
   #else
     simde_float16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 8);
       a_[0].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 1);
@@ -143215,7 +143215,7 @@ simde_vst2_f16(simde_float16_t *ptr, simde_float16x4x2_t val) {
   #else
     simde_float16x4_private a_[2] = {simde_float16x4_to_private(val.val[0]),
                                      simde_float16x4_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)ptr, 4);
       dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 1, a_[1].sv64);
@@ -143525,7 +143525,7 @@ void
 simde_vst2q_f16(simde_float16_t *ptr, simde_float16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst2q_f16(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float16x8_private a_[2] = {simde_float16x8_to_private(val.val[0]),
                                      simde_float16x8_to_private(val.val[1])};
     vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)ptr, 8);
@@ -144672,7 +144672,7 @@ simde_vst3_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_float16x4x3_t 
     simde_float16x4_private a[3] = { simde_float16x4_to_private(val.val[0]),
                                       simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)ptr, 4);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a[1].sv64);
@@ -145078,7 +145078,7 @@ simde_vst3q_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_float16x8x3_t
     simde_float16x8_private a_[3] = { simde_float16x8_to_private(val.val[0]),
                                       simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)ptr, 8);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a_[1].sv128);
@@ -146476,7 +146476,7 @@ simde_vst4_f16(simde_float16_t *ptr, simde_float16x4x4_t val) {
   #else
     simde_float16x4_private a_[4] = { simde_float16x4_to_private(val.val[0]), simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]), simde_float16x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)ptr, 4);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 1, a_[1].sv64);
@@ -146816,7 +146816,7 @@ simde_vst4q_f16(simde_float16_t *ptr, simde_float16x8x4_t val) {
   #else
     simde_float16x8_private a_[4] = { simde_float16x8_to_private(val.val[0]), simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]), simde_float16x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)ptr, 8);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 1, a_[1].sv128);


### PR DESCRIPTION
When building WebKit on a RISC-V VM providing the RVA23S64 ISA profile a warning is issued:

    Source/WTF/wtf/simde/arm/neon.h:140518:42: warning:
    ‘SIMDE_ARCH_RISCV_ZVFH’ is not defined, evaluates to ‘0’ [-Wundef]
    140518 |     #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
           |

Use `defined(SIMDE_ARCH_RISCV_ZVFH)` instead of `SIMDE_ARCH_RISCV_ZVFH.`

Links: https://bugs.webkit.org/show_bug.cgi?id=298303
Canonical link: https://commits.webkit.org/299488@main

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7a10c065ec3404a329d8f64b59e1273c1c8d3f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119192 "18 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47455 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90546 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/crashtests/inline-float-parallel-flow.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24962 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69067 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111310 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128433 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117707 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99105 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98885 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22359 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42678 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45969 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51649 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146410 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45436 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37651 "Found 1 new JSC binary failure: testapi, Found 18690 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->