### PR TITLE
REGRESSION(298480@main): [ macOS wk2 ] http/tests/navigation/ping-attribute/anchor-cookie.html is a flaky text failure.

### DIFF
--- a/LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe.html
+++ b/LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe.html
@@ -21,14 +21,12 @@ iframe.onload = async () => {
     let fr = iframe.getBoundingClientRect(), br = button.getBoundingClientRect();
     let x = Math.round(fr.left + br.left + br.width / 2), y = Math.round(fr.top + br.top + br.height / 2);
 
-    for (let i = 0; i < 10; ++i) {
-        if (testRunner.isIOSFamily && window.eventSender)
-            await UIHelper.activateAt(x, y);
-        else {
-            await eventSender?.asyncMouseMoveTo(x, y);
-            await eventSender?.asyncMouseDown();
-            await eventSender?.asyncMouseUp();
-        }
+    if (testRunner.isIOSFamily && window.eventSender)
+        await UIHelper.activateAt(x, y);
+    else {
+        await eventSender?.asyncMouseMoveTo(x, y);
+        await eventSender?.asyncMouseDown();
+        await eventSender?.asyncMouseUp();
     }
 };
 </script>

--- a/LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js
+++ b/LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js
@@ -27,7 +27,7 @@ function clearLastPingResultAndRunTest(callback)
     }
 
     var xhr = new XMLHttpRequest;
-    xhr.open("GET", "../../resources/delete-ping.py", true /* async */);
+    xhr.open("GET", "../resources/delete-ping.py", true /* async */);
     xhr.send(null);
     xhr.onload = callback;
     xhr.onerror = done;

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2409,8 +2409,6 @@ webkit.org/b/297006 [ Debug ] http/tests/media/media-element-frame-destroyed-cra
 [ Release ] http/wpt/service-workers/service-worker-spinning-install.https.html [ Failure ]
 http/wpt/service-workers/service-worker-spinning-activate.https.html [ Failure ]
 
-webkit.org/b/297428 http/tests/navigation/ping-attribute/anchor-cookie.html [ Pass Failure ]
-
 webkit.org/b/267778 [ Release ] fast/forms/listbox-padding-clip-selected.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/298044 [ arm64 ] fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html [ Pass Failure ]

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -60,6 +60,7 @@ public:
 
     InjectedBundlePage* page() const;
     WKBundlePageRef pageRef() const;
+    uint64_t testIdentifier() const { return m_testIdentifier; }
     size_t pageCount() const { return m_pages.size(); }
 
     void dumpBackForwardListsForAllPages(StringBuilder&);
@@ -187,6 +188,7 @@ private:
     bool m_dumpPixels { false };
     bool m_pixelResultIsPending { false };
     bool m_accessibilityIsolatedTreeMode { false };
+    uint64_t m_testIdentifier { 0 };
 
     WTF::Seconds m_timeout;
 

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -47,6 +47,7 @@ public:
     static Ref<TestInvocation> create(WKURLRef, const TestOptions&);
     ~TestInvocation();
 
+    uint64_t identifier() const { return m_identifier; }
     WKURLRef url() const { return m_url.get(); }
     bool urlContains(StringView) const;
     
@@ -123,6 +124,7 @@ private:
 
     const TestOptions m_options;
     
+    uint64_t m_identifier;
     WKRetainPtr<WKURLRef> m_url;
     String m_urlString;
     RunLoop::Timer m_waitToDumpWatchdogTimer;


### PR DESCRIPTION
#### 9cc9590aec1f307806227eae156cee4a15b5bcc7
<pre>
REGRESSION(298480@main): [ macOS wk2 ] http/tests/navigation/ping-attribute/anchor-cookie.html is a flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297428">https://bugs.webkit.org/show_bug.cgi?id=297428</a>
<a href="https://rdar.apple.com/158358934">rdar://158358934</a>

Reviewed by Darin Adler.

* LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe.html:
This test was scheduling a LOT more clicks than expected with EventSender. The reason
for this is that `iframe.onload` would get called again every time a click was made,
since it would cause the form to get submitted and thus the iframe to reload. We would
thus schedule 10 clicks per each frame load and each click would schedule its own frame
load. The crazy thing is that the test would &quot;finish&quot; after 10 clicks and the remaining
clicks would trigger on following tests, causing the flakiness. In the case of
anchor-cookie.html, it would click the link in the test too early, before the cookie
was set or before any existing ping was deleted.

* LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js:
(clearLastPingResultAndRunTest):
Revert change the delete-ping.py URL made in 299131@main as an attempt to fix
the flakiness. The URL was in fact correct and the XHR was merely failing because
it got aborted when the link was clicked unexpectedly, causing a navigation.

* LayoutTests/platform/mac-wk2/TestExpectations:
Unmark the test as flaky.

* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::create):
(WTR::EventSendingController::createEventSenderDictionary):
(WTR::EventSendingController::createMouseMessageBody):
(WTR::EventSendingController::mouseDown):
(WTR::EventSendingController::mouseUp):
(WTR::EventSendingController::mouseMoveTo):
(WTR::EventSendingController::asyncMouseDown):
(WTR::EventSendingController::asyncMouseUp):
(WTR::EventSendingController::asyncMouseMoveTo):
(WTR::EventSendingController::mouseForceClick):
(WTR::EventSendingController::startAndCancelMouseForceClick):
(WTR::EventSendingController::mouseForceDown):
(WTR::EventSendingController::mouseForceUp):
(WTR::EventSendingController::mouseForceChanged):
(WTR::EventSendingController::leapForward):
(WTR::EventSendingController::scheduleAsynchronousClick):
(WTR::EventSendingController::createKeyDownMessageBody):
(WTR::EventSendingController::createRawKeyDownMessageBody):
(WTR::EventSendingController::createRawKeyUpMessageBody):
(WTR::EventSendingController::keyDown):
(WTR::EventSendingController::rawKeyDown):
(WTR::EventSendingController::rawKeyUp):
(WTR::EventSendingController::scheduleAsynchronousKeyDown):
(WTR::EventSendingController::mouseScrollBy):
(WTR::EventSendingController::mouseScrollByWithWheelAndMomentumPhases):
(WTR::EventSendingController::setWheelHasPreciseDeltas):
(WTR::EventSendingController::continuousMouseScrollBy):
(WTR::EventSendingController::contextClick):
(WTR::EventSendingController::textZoomIn):
(WTR::EventSendingController::textZoomOut):
(WTR::EventSendingController::zoomPageIn):
(WTR::EventSendingController::zoomPageOut):
(WTR::EventSendingController::addTouchPoint):
(WTR::EventSendingController::updateTouchPoint):
(WTR::EventSendingController::setTouchModifier):
(WTR::EventSendingController::setTouchPointRadius):
(WTR::EventSendingController::touchStart):
(WTR::EventSendingController::touchMove):
(WTR::EventSendingController::touchEnd):
(WTR::EventSendingController::touchCancel):
(WTR::EventSendingController::clearTouchPoints):
(WTR::EventSendingController::releaseTouchPoint):
(WTR::EventSendingController::cancelTouchPoint):
(WTR::EventSendingController::smartMagnify):
(WTR::EventSendingController::scaleGestureStart):
(WTR::EventSendingController::scaleGestureChange):
(WTR::EventSendingController::scaleGestureEnd):
(): Deleted.
(WTR::createMouseMessageBody): Deleted.
(WTR::createKeyDownMessageBody): Deleted.
(WTR::createRawKeyDownMessageBody): Deleted.
(WTR::createRawKeyUpMessageBody): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didCreatePage):
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::InjectedBundle::beginTesting):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
(WTR::InjectedBundle::testIdentifier const):
* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::TestInvocation):
(WTR::TestInvocation::createTestSettingsDictionary):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.h:
Do hardening in WebKitTestRunner to prevent this sort of flakiness bug
in the future. In particular, each test invocation is now assigned an
identifier, which is passed to the injected bundle at the beginning
of each test. Whenever the injected bundle sends a EventSender IPC
message to the UIProces, it attaches this identifier. This allows the
UI process to filter out EventSender messages from previous tests
that may have been left over in the IPC pipe.
As an optimization, also disable the previous EventSendingController
instance when we start a new test and make sure it no longer attempts
to send any new IPC from then on. This IPC would be ignored by the
UIProcess now with my changes above but we may as well not send it.

Canonical link: <a href="https://commits.webkit.org/299534@main">https://commits.webkit.org/299534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5030f79f1a52fb47d2e48f29a63a0e20d788f7fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71388 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/510ba196-cabe-47b5-a9d6-817e68f49966) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4c7a63e-4a84-4f71-ae0c-c0e07a12cced) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71095 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7864c9e4-0175-41c2-9c9b-e1321eabb841) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69212 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128562 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34978 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99008 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25166 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22479 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46098 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45563 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->