### PR TITLE
[GTK][WPE] Gamepad press buttons or axis events not triggered

### DIFF
--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
@@ -44,7 +44,6 @@ public:
         LeftStickY,
         RightStickX,
         RightStickY,
-        Count,
     };
     enum class StandardGamepadButton : int8_t {
         Unknown = -1,
@@ -65,7 +64,6 @@ public:
         DPadLeft,
         DPadRight,
         Mode,
-        Count,
     };
 
     ManetteGamepad(ManetteDevice*, unsigned index);


### PR DESCRIPTION
#### 5dbec340da22d814d66692dacb641c2a3eefb936
<pre>
[GTK][WPE] Gamepad press buttons or axis events not triggered
<a href="https://bugs.webkit.org/show_bug.cgi?id=298310">https://bugs.webkit.org/show_bug.cgi?id=298310</a>

Reviewed by Carlos Garcia Campos.

When WebKitGTK or WPEWebKit try to map a button or axis number to the
canonical layout defined in the W3C Gamepad spec, they return &apos;Unknown&apos; in
case the button or axis number doesn&apos;t correspond to a standard value.
As a result of that, press button or axis events are not handled if
value was &apos;Unknown&apos;, what gives the impression the event didn&apos;t even happen.

The W3C Gamepad spec recommends to remap buttons and axis to a canonical
ordering if possible. In case not, the devices should still be exposed in
their raw form.

So, instead of returning &apos;Unknown&apos; for a value outside of range,
we return the modulo of the raw value by the total number of standard
values.  That ensures the value will always be within the range and the
events will always be handled if they were triggered.

* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
(WebCore::toStandardGamepadAxis):
(WebCore::toStandardGamepadButton):
(WebCore::ManetteGamepad::ManetteGamepad):
(WebCore::ManetteGamepad::buttonPressedOrReleased):
(WebCore::ManetteGamepad::absoluteAxisChanged):
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:
* Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp:
(wpeGamepadButton):
(wpeGamepadAxis):
(wpeGamepadManetteStartInputMonitor):
(wpeGamepadButtonFromEvent): Deleted.

Canonical link: <a href="https://commits.webkit.org/299618@main">https://commits.webkit.org/299618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/083d1fc5f90af6299d02ac2388cbb88a51952205

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122555 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/31923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/107245 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/71361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69533 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35240 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99284 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44709 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22729 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19025 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46388 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/52094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->