### PR TITLE
[GTK][WPE] Rename DMABufFormat to BufferFormat

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -175,15 +175,15 @@ bool PlatformDisplay::destroyEGLImage(EGLImage image) const
 }
 
 #if USE(GBM)
-const Vector<GLDisplay::DMABufFormat>& PlatformDisplay::dmabufFormats()
+const Vector<GLDisplay::BufferFormat>& PlatformDisplay::bufferFormats()
 {
-    return m_eglDisplay->dmabufFormats();
+    return m_eglDisplay->bufferFormats();
 }
 
 #if USE(GSTREAMER)
-const Vector<GLDisplay::DMABufFormat>& PlatformDisplay::dmabufFormatsForVideo()
+const Vector<GLDisplay::BufferFormat>& PlatformDisplay::bufferFormatsForVideo()
 {
-    return m_eglDisplay->dmabufFormatsForVideo();
+    return m_eglDisplay->bufferFormatsForVideo();
 }
 #endif
 #endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -92,9 +92,9 @@ public:
     EGLImage createEGLImage(EGLContext, EGLenum target, EGLClientBuffer, const Vector<EGLAttrib>&) const;
     bool destroyEGLImage(EGLImage) const;
 #if USE(GBM)
-    const Vector<GLDisplay::DMABufFormat>& dmabufFormats();
+    const Vector<GLDisplay::BufferFormat>& bufferFormats();
 #if USE(GSTREAMER)
-    const Vector<GLDisplay::DMABufFormat>& dmabufFormatsForVideo();
+    const Vector<GLDisplay::BufferFormat>& bufferFormatsForVideo();
 #endif
 #endif
 

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.h
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "FourCC.h"
 #include <optional>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
@@ -63,13 +64,13 @@ public:
     const Extensions& extensions() const { return m_extensions; }
 
 #if USE(GBM)
-    struct DMABufFormat {
-        uint32_t fourcc { 0 };
+    struct BufferFormat {
+        FourCC fourcc { 0 };
         Vector<uint64_t, 1> modifiers;
     };
-    const Vector<DMABufFormat>& dmabufFormats();
+    const Vector<BufferFormat>& bufferFormats();
 #if USE(GSTREAMER)
-    const Vector<DMABufFormat>& dmabufFormatsForVideo();
+    const Vector<BufferFormat>& bufferFormatsForVideo();
 #endif
 #endif
 
@@ -84,13 +85,13 @@ private:
     Extensions m_extensions;
 
 #if USE(GBM)
-    Lock m_dmabufFormatsLock;
-    bool m_dmabufFormatsInitialized WTF_GUARDED_BY_LOCK(m_dmabufFormatsLock) { false };
-    Vector<DMABufFormat> m_dmabufFormats;
+    Lock m_bufferFormatsLock;
+    bool m_bufferFormatsInitialized WTF_GUARDED_BY_LOCK(m_bufferFormatsLock) { false };
+    Vector<BufferFormat> m_bufferFormats;
 #if USE(GSTREAMER)
-    Lock m_dmabufFormatsForVideoLock;
-    bool m_dmabufFormatsForVideoInitialized WTF_GUARDED_BY_LOCK(m_dmabufFormatsForVideoLock) { false };
-    Vector<DMABufFormat> m_dmabufFormatsForVideo;
+    Lock m_bufferFormatsForVideoLock;
+    bool m_bufferFormatsForVideoInitialized WTF_GUARDED_BY_LOCK(m_bufferFormatsForVideoLock) { false };
+    Vector<BufferFormat> m_bufferFormatsForVideo;
 #endif
 #endif
 };

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -63,7 +63,7 @@ GraphicsContextGLTextureMapperGBM::~GraphicsContextGLTextureMapperGBM()
 
 bool GraphicsContextGLTextureMapperGBM::platformInitialize()
 {
-    auto isOpaqueFormat = [](uint32_t fourcc) -> bool {
+    auto isOpaqueFormat = [](FourCC fourcc) -> bool {
         return fourcc != DRM_FORMAT_ARGB8888
             && fourcc != DRM_FORMAT_RGBA8888
             && fourcc != DRM_FORMAT_ABGR8888
@@ -75,13 +75,13 @@ bool GraphicsContextGLTextureMapperGBM::platformInitialize()
     };
 
     bool isOpaque = !contextAttributes().alpha;
-    const auto& supportedFormats = PlatformDisplay::sharedDisplay().dmabufFormats();
+    const auto& supportedFormats = PlatformDisplay::sharedDisplay().bufferFormats();
     for (const auto& format : supportedFormats) {
         bool matchesOpacity = isOpaqueFormat(format.fourcc) == isOpaque;
         if (!matchesOpacity && m_drawingBufferFormat.fourcc)
             continue;
 
-        m_drawingBufferFormat.fourcc = format.fourcc;
+        m_drawingBufferFormat.fourcc = format.fourcc.value;
         m_drawingBufferFormat.modifiers = format.modifiers;
         if (matchesOpacity)
             break;

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -111,7 +111,7 @@ private:
     };
 
     bool performDMABufSyncSystemCall(OptionSet<DMABufSyncFlag> flags);
-    bool allocate(struct gbm_device*, const GLDisplay::DMABufFormat&);
+    bool allocate(struct gbm_device*, const GLDisplay::BufferFormat&);
     bool createDMABufFromGBMBufferObject();
     UnixFileDescriptor exportGBMBufferObjectAsDMABuf(unsigned planeIndex);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1956,26 +1956,26 @@ GRefPtr<GstCaps> buildDMABufCaps()
 
     GValue supportedFormats = G_VALUE_INIT;
     g_value_init(&supportedFormats, GST_TYPE_LIST);
-    const auto& dmabufFormats = PlatformDisplay::sharedDisplay().dmabufFormatsForVideo();
-    for (const auto& format : dmabufFormats) {
+    const auto& bufferFormats = PlatformDisplay::sharedDisplay().bufferFormatsForVideo();
+    for (const auto& format : bufferFormats) {
 #if GST_CHECK_VERSION(1, 24, 0)
         if (format.modifiers.isEmpty() || format.modifiers[0] == DRM_FORMAT_MOD_INVALID) {
             GValue value = G_VALUE_INIT;
             g_value_init(&value, G_TYPE_STRING);
-            g_value_take_string(&value, gst_video_dma_drm_fourcc_to_string(format.fourcc, DRM_FORMAT_MOD_LINEAR));
+            g_value_take_string(&value, gst_video_dma_drm_fourcc_to_string(format.fourcc.value, DRM_FORMAT_MOD_LINEAR));
             gst_value_list_append_and_take_value(&supportedFormats, &value);
         } else {
             for (auto modifier : format.modifiers) {
                 GValue value = G_VALUE_INIT;
                 g_value_init(&value, G_TYPE_STRING);
-                g_value_take_string(&value, gst_video_dma_drm_fourcc_to_string(format.fourcc, modifier));
+                g_value_take_string(&value, gst_video_dma_drm_fourcc_to_string(format.fourcc.value, modifier));
                 gst_value_list_append_and_take_value(&supportedFormats, &value);
             }
         }
 #else
         GValue value = G_VALUE_INIT;
         g_value_init(&value, G_TYPE_STRING);
-        g_value_set_string(&value, gst_video_format_to_string(drmFourccToGstVideoFormat(format.fourcc)));
+        g_value_set_string(&value, gst_video_format_to_string(drmFourccToGstVideoFormat(format.fourcc.value)));
         gst_value_list_append_and_take_value(&supportedFormats, &value);
 #endif
     }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -185,8 +185,8 @@ Vector<RendererBufferFormat> AcceleratedBackingStore::preferredBufferFormats()
     RendererBufferFormat format;
     format.usage = RendererBufferFormat::Usage::Rendering;
     format.drmDevice = drmMainDevice();
-    format.formats = display.glDisplay()->dmabufFormats().map([](const auto& format) -> RendererBufferFormat::Format {
-        return { format.fourcc, format.modifiers };
+    format.formats = display.glDisplay()->bufferFormats().map([](const auto& format) -> RendererBufferFormat::Format {
+        return { format.fourcc.value, format.modifiers };
     });
     return { WTFMove(format) };
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -529,7 +529,7 @@ AcceleratedSurface::SwapChain::SwapChain(uint64_t surfaceID)
 #if USE(GBM) && (PLATFORM(GTK) || ENABLE(WPE_PLATFORM))
 void AcceleratedSurface::SwapChain::setupBufferFormat(const Vector<RendererBufferFormat>& preferredFormats, bool isOpaque)
 {
-    auto isOpaqueFormat = [](uint32_t fourcc) -> bool {
+    auto isOpaqueFormat = [](FourCC fourcc) -> bool {
         return fourcc != DRM_FORMAT_ARGB8888
             && fourcc != DRM_FORMAT_RGBA8888
             && fourcc != DRM_FORMAT_ABGR8888
@@ -543,7 +543,7 @@ void AcceleratedSurface::SwapChain::setupBufferFormat(const Vector<RendererBuffe
     // The preferred formats vector is sorted by usage, but all formats for the same usage has the same priority.
     Locker locker { m_bufferFormatLock };
     BufferFormat newBufferFormat;
-    const auto& supportedFormats = PlatformDisplay::sharedDisplay().dmabufFormats();
+    const auto& supportedFormats = PlatformDisplay::sharedDisplay().bufferFormats();
     for (const auto& bufferFormat : preferredFormats) {
 
         auto matchesOpacity = false;


### PR DESCRIPTION
#### 6ce73258f3b88680c6e820cccd612ab9f9cca047
<pre>
[GTK][WPE] Rename DMABufFormat to BufferFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=298309">https://bugs.webkit.org/show_bug.cgi?id=298309</a>

Reviewed by Carlos Garcia Campos.

Rename DMABufFormat to BufferFormat, and accordingly
::dmabufFormat[ForVideo]() methods as ::bufferFormat[ForVideo].
While at it, take WebCore::FourCC into usage.

Canonical link: <a href="https://commits.webkit.org/299614@main">https://commits.webkit.org/299614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7257a0faafbf377dc83cf9dba3e725145a980b3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47481 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90567 "Found 1 new test failure: http/wpt/service-workers/service-worker-spinning-activate.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70977 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69091 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128458 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99133 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46493 "Failed to checkout and rebase branch from PR 50232") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98908 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25219 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42704 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51677 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45459 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->