### PR TITLE
Support SVG `<a hreflang>`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1554,7 +1554,7 @@ FAIL SVGAElement interface: attribute download assert_true: The prototype object
 FAIL SVGAElement interface: attribute ping assert_true: The prototype object must have a property "ping" expected true got false
 PASS SVGAElement interface: attribute rel
 PASS SVGAElement interface: attribute relList
-FAIL SVGAElement interface: attribute hreflang assert_true: The prototype object must have a property "hreflang" expected true got false
+PASS SVGAElement interface: attribute hreflang
 FAIL SVGAElement interface: attribute type assert_true: The prototype object must have a property "type" expected true got false
 FAIL SVGAElement interface: attribute text assert_true: The prototype object must have a property "text" expected true got false
 FAIL SVGAElement interface: attribute referrerPolicy assert_true: The prototype object must have a property "referrerPolicy" expected true got false
@@ -1576,7 +1576,7 @@ FAIL SVGAElement interface: objects.a must inherit property "download" with the 
 FAIL SVGAElement interface: objects.a must inherit property "ping" with the proper type assert_inherits: property "ping" not found in prototype chain
 PASS SVGAElement interface: objects.a must inherit property "rel" with the proper type
 PASS SVGAElement interface: objects.a must inherit property "relList" with the proper type
-FAIL SVGAElement interface: objects.a must inherit property "hreflang" with the proper type assert_inherits: property "hreflang" not found in prototype chain
+PASS SVGAElement interface: objects.a must inherit property "hreflang" with the proper type
 FAIL SVGAElement interface: objects.a must inherit property "type" with the proper type assert_inherits: property "type" not found in prototype chain
 FAIL SVGAElement interface: objects.a must inherit property "text" with the proper type assert_inherits: property "text" not found in prototype chain
 FAIL SVGAElement interface: objects.a must inherit property "referrerPolicy" with the proper type assert_inherits: property "referrerPolicy" not found in prototype chain

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-getter-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-getter-01-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SVGAElement.hreflang getter
+PASS Test anchor's hreflang getter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-getter-01.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-getter-01.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>SVGAElement.hreflang getter</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+  </metadata>
+  <a id="test" href="a" hreflang="en"></a>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      var a = document.getElementById("test");
+
+      test(function() {
+        assert_equals(a.hreflang, "en");
+       }, "Test anchor's hreflang getter");
+    });
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-setter-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-setter-01-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SVGAElement.hreflang setter
+PASS Test anchor's hreflang setter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-setter-01.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-setter-01.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>SVGAElement.hreflang setter</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+  </metadata>
+  <a id="test" href="a"></a>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+        var a = document.getElementById("test");
+
+        test(function() {
+            a.hreflang = "fr"
+            assert_equals(a.hreflang, "fr");
+        }, "Test anchor's hreflang setter");
+    });
+  ]]></script>
+</svg>

--- a/Source/WebCore/svg/SVGAElement.idl
+++ b/Source/WebCore/svg/SVGAElement.idl
@@ -28,6 +28,7 @@
 ] interface SVGAElement : SVGGraphicsElement {
     readonly attribute SVGAnimatedString target;
 
+    [Reflect] attribute DOMString hreflang;
     [Reflect] attribute DOMString rel;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
 };

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -79,6 +79,7 @@ horiz-adv-x
 horiz-origin-x
 horiz-origin-y
 href
+hreflang
 image-rendering
 in
 in2


### PR DESCRIPTION
#### bcc938dec3529291faca978f7a68b0de21978b0c
<pre>
Support SVG `&lt;a hreflang&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298316">https://bugs.webkit.org/show_bug.cgi?id=298316</a>

Reviewed by Sam Weinig.

This adds the hreflang IDL attribute to the SVGAElement.

* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-getter-01-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-getter-01.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-setter-01-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.hreflang-setter-01.svg: Added.
* Source/WebCore/svg/SVGAElement.idl:
* Source/WebCore/svg/svgattrs.in:

Canonical link: <a href="https://commits.webkit.org/299704@main">https://commits.webkit.org/299704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/581fe51c89ba40584166ecd239ee8a5588f12894

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24999 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98922 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42717 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51691 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45475 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->