### PR TITLE
[JSC] Implement `Set.prototype.isSupersetOf` in C++

### DIFF
--- a/JSTests/stress/set-prototype-isSupersetOf-empty-sets.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-empty-sets.js
@@ -1,0 +1,47 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+let emptySet1 = new Set();
+let emptySet2 = new Set();
+let result = emptySet1.isSupersetOf(emptySet2);
+shouldBe(result, true);
+
+let set1 = new Set([1, 2, 3]);
+let empty = new Set();
+result = empty.isSupersetOf(set1);
+shouldBe(result, false);
+
+result = set1.isSupersetOf(empty);
+shouldBe(result, true);
+
+let subset = new Set([1, 2]);
+let superset = new Set([1, 2, 3, 4]);
+result = subset.isSupersetOf(superset);
+shouldBe(result, false);
+
+result = superset.isSupersetOf(subset);
+shouldBe(result, true);
+
+let set2 = new Set([2, 3, 4]);
+result = set1.isSupersetOf(set2);
+shouldBe(result, false);
+
+result = set2.isSupersetOf(set1);
+shouldBe(result, false);
+
+let set3 = new Set([1, 2, 3]);
+result = set1.isSupersetOf(set3);
+shouldBe(result, true);
+
+result = set3.isSupersetOf(set1);
+shouldBe(result, true);
+
+let disjoint1 = new Set([1, 2, 3]);
+let disjoint2 = new Set([4, 5, 6]);
+result = disjoint1.isSupersetOf(disjoint2);
+shouldBe(result, false);
+
+result = disjoint2.isSupersetOf(disjoint1);
+shouldBe(result, false);

--- a/JSTests/stress/set-prototype-isSupersetOf-generic-object.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-generic-object.js
@@ -1,0 +1,110 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+        shouldBe(e instanceof errorType, true);
+    }
+    shouldBe(threw, true);
+}
+
+let set1 = new Set([1, 2, 3, 4, 5]);
+let setLikeObject = {
+    size: 3,
+    has: function(key) {
+        return [1, 2, 3].includes(key);
+    },
+    keys: function() {
+        let values = [1, 2, 3];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+let result = set1.isSupersetOf(setLikeObject);
+shouldBe(result, true);
+
+let partialMatch = {
+    size: 3,
+    has: function(key) {
+        return [1, 2, 6].includes(key);
+    },
+    keys: function() {
+        let values = [1, 2, 6];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = set1.isSupersetOf(partialMatch);
+shouldBe(result, false);
+
+let tooBig = {
+    size: 10,
+    has: function(key) {
+        return true;
+    },
+    keys: function() {
+        return {
+            next: function() {
+                throw new Error("Should not be called due to size check");
+            }
+        };
+    }
+};
+
+let smallSet = new Set([1, 2, 3]);
+result = smallSet.isSupersetOf(tooBig);
+shouldBe(result, false);
+
+shouldThrow(() => {
+    set1.isSupersetOf({
+        size: 3,
+        has: "not a function",
+        keys: function() { return {}; }
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.isSupersetOf({
+        size: 3,
+        has: function() { return true; },
+        keys: "not a function"
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.isSupersetOf({
+        size: NaN,
+        has: function() { return true; },
+        keys: function() { return {}; }
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.isSupersetOf({
+        size: -1,
+        has: function() { return true; },
+        keys: function() { return {}; }
+    });
+}, RangeError);

--- a/JSTests/stress/set-prototype-isSupersetOf-iterator-effects.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-iterator-effects.js
@@ -1,0 +1,73 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function main() {
+    let set1 = new Set([1, 2, 3, 4, 5]);
+    let iteratorCallCount = 0;
+    
+    let otherObject = {
+        size: 3,
+        has: function(key) {
+            return [1, 2, 6].includes(key);
+        },
+        keys: function() {
+            let values = [1, 2, 6];
+            let index = 0;
+            return {
+                next: function() {
+                    iteratorCallCount++;
+                    if (iteratorCallCount === 1) {
+                        set1.delete(3);
+                        set1.delete(4);
+                        set1.add(6);
+                    }
+                    if (index < values.length) {
+                        return { value: values[index++], done: false };
+                    }
+                    return { done: true };
+                }
+            };
+        }
+    };
+    
+    let result = set1.isSupersetOf(otherObject);
+    shouldBe(iteratorCallCount >= 1, true);
+}
+
+main();
+
+function testIteratorModification() {
+    let set1 = new Set([1, 2, 3, 4, 5]);
+    let callCount = 0;
+    
+    let otherObject = {
+        size: 2,
+        values: [1, 2],
+        has: function(key) {
+            return this.values.includes(key);
+        },
+        keys: function() {
+            let self = this;
+            let index = 0;
+            return {
+                next: function() {
+                    callCount++;
+                    if (callCount === 1) {
+                        self.values = [1, 2];
+                    }
+                    if (index < self.values.length) {
+                        return { value: self.values[index++], done: false };
+                    }
+                    return { done: true };
+                }
+            };
+        }
+    };
+    
+    let result = set1.isSupersetOf(otherObject);
+    shouldBe(result, true);
+}
+
+testIteratorModification();

--- a/JSTests/stress/set-prototype-isSupersetOf-large-sets.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-large-sets.js
@@ -1,0 +1,61 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function createLargeSet(size, start = 0) {
+    let set = new Set();
+    for (let i = start; i < start + size; i++) {
+        set.add(i);
+    }
+    return set;
+}
+
+let largeSet = createLargeSet(10000, 0);
+let smallSet = createLargeSet(100, 0);
+
+let result = largeSet.isSupersetOf(smallSet);
+shouldBe(result, true);
+
+result = smallSet.isSupersetOf(largeSet);
+shouldBe(result, false);
+
+let set1 = createLargeSet(5000, 0);
+let set2 = createLargeSet(5000, 2500);
+
+result = set1.isSupersetOf(set2);
+shouldBe(result, false);
+
+result = set2.isSupersetOf(set1);
+shouldBe(result, false);
+
+let largeSet1 = createLargeSet(1000, 0);
+let largeSet2 = createLargeSet(1000, 0);
+
+result = largeSet1.isSupersetOf(largeSet2);
+shouldBe(result, true);
+
+result = largeSet2.isSupersetOf(largeSet1);
+shouldBe(result, true);
+
+let perfTestSet = createLargeSet(2000, 0);
+let perfSetLike = {
+    size: 1000,
+    has: function(key) {
+        return key >= 0 && key < 1000;
+    },
+    keys: function() {
+        let index = 0;
+        return {
+            next: function() {
+                if (index < 1000) {
+                    return { value: index++, done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = perfTestSet.isSupersetOf(perfSetLike);
+shouldBe(result, true);

--- a/JSTests/stress/set-prototype-isSupersetOf-property-access-order.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-property-access-order.js
@@ -1,0 +1,80 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let accessOrder = [];
+    let set = new Set([1, 2, 3, 4, 5]);
+    
+    let obj = {
+        get size() {
+            accessOrder.push('size');
+            return 3;
+        },
+        get has() {
+            accessOrder.push('has');
+            return function(key) {
+                return true;
+            };
+        },
+        get keys() {
+            accessOrder.push('keys');
+            return function() {
+                let values = [1, 2, 3];
+                let index = 0;
+                return {
+                    next: function() {
+                        if (index < values.length) {
+                            return { value: values[index++], done: false };
+                        }
+                        return { done: true };
+                    }
+                };
+            };
+        }
+    };
+    
+    set.isSupersetOf(obj);
+    
+    shouldBe(accessOrder.length, 3);
+    shouldBe(accessOrder[0], 'size');
+    shouldBe(accessOrder[1], 'has');
+    shouldBe(accessOrder[2], 'keys');
+}
+
+main();
+
+function testEarlyReturn() {
+    let accessOrder = [];
+    let smallSet = new Set([1, 2, 3]);
+    
+    let obj = {
+        get size() {
+            accessOrder.push('size');
+            return 5;
+        },
+        get has() {
+            accessOrder.push('has');
+            return function(key) {
+                throw new Error("has() should not be called due to size check");
+            };
+        },
+        get keys() {
+            accessOrder.push('keys');
+            return function() {
+                throw new Error("keys() should not be called due to size check");
+            };
+        }
+    };
+    
+    let result = smallSet.isSupersetOf(obj);
+    
+    shouldBe(result, false);
+    shouldBe(accessOrder.length, 3);
+    shouldBe(accessOrder[0], 'size');
+    shouldBe(accessOrder[1], 'has');
+    shouldBe(accessOrder[2], 'keys');
+}
+
+testEarlyReturn();

--- a/JSTests/stress/set-prototype-isSupersetOf-reference.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-reference.js
@@ -1,0 +1,55 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let modificationDetected = false;
+    const set = new Set([1, 2, 3, 4, 5]);
+
+    try {
+        let iteratorCallCount = 0;
+
+        set.isSupersetOf({
+            size: 3,
+            has: function(key) {
+                return [1, 2, 6].includes(key);
+            },
+            keys: function() {
+                let values = [1, 2, 6];
+                let index = 0;
+                return {
+                    next: function() {
+                        iteratorCallCount++;
+                        
+                        if (iteratorCallCount === 1) {
+                            set.delete(1);
+                            set.delete(2);
+                            set.delete(3);
+                            set.delete(4);
+                            set.add(6);
+                            modificationDetected = true;
+                            if (index < values.length) {
+                                return { value: values[index++], done: false };
+                            }
+                        } else if (iteratorCallCount === 2) {
+                            throw new Error("Test exception");
+                        }
+                        
+                        if (index < values.length) {
+                            return { value: values[index++], done: false };
+                        }
+                        return { done: true };
+                    }
+                };
+            }
+        });
+    } catch (e) {
+        shouldBe(e.message, "Test exception");
+    }
+
+    shouldBe(modificationDetected, true);
+    shouldBe(set.size, 2);
+}
+
+main();

--- a/JSTests/stress/set-prototype-isSupersetOf-special-values.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-special-values.js
@@ -1,0 +1,114 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+let set = new Set([0, -0, NaN, undefined, null, "", false, true, 42, "extra"]);
+
+let setLike = {
+    size: 8,
+    has: function(key) {
+        if (key === 0 || key === -0) return true;
+        if (Number.isNaN(key)) return true;
+        if (key === undefined) return true;
+        if (key === null) return true;
+        if (key === "") return true;
+        if (key === false) return true;
+        if (key === true) return true;
+        if (key === 42) return true;
+        return false;
+    },
+    keys: function() {
+        let values = [0, NaN, undefined, null, "", false, true, 42];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+let result = set.isSupersetOf(setLike);
+shouldBe(result, true);
+
+let sym1 = Symbol('test1');
+let sym2 = Symbol('test2');
+let sym3 = Symbol('test3');
+let symbolSet = new Set([sym1, sym2, sym3]);
+
+let symbolSetLike = {
+    size: 2,
+    has: function(key) {
+        return key === sym1 || key === sym2;
+    },
+    keys: function() {
+        let values = [sym1, sym2];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = symbolSet.isSupersetOf(symbolSetLike);
+shouldBe(result, true);
+
+let obj1 = { a: 1 };
+let obj2 = { b: 2 };
+let obj3 = { c: 3 };
+let objectSet = new Set([obj1, obj2, obj3]);
+
+let objectSetLike = {
+    size: 2,
+    has: function(key) {
+        return key === obj1 || key === obj2;
+    },
+    keys: function() {
+        let values = [obj1, obj2];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = objectSet.isSupersetOf(objectSetLike);
+shouldBe(result, true);
+
+let differentObj1 = { a: 1 };
+let differentObj2 = { b: 2 };
+let objectSetLikeDifferent = {
+    size: 2,
+    has: function(key) {
+        return key === differentObj1 || key === differentObj2;
+    },
+    keys: function() {
+        let values = [differentObj1, differentObj2];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = objectSet.isSupersetOf(objectSetLikeDifferent);
+shouldBe(result, false);

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -152,38 +152,6 @@ function symmetricDifference(other)
     return result;
 }
 
-function isSupersetOf(other)
-{
-    "use strict";
-
-    if (!@isSet(this))
-        @throwTypeError("Set operation called on non-Set object");
-
-    // Get Set Record
-    var size = @getSetSizeAsInt(other);
-
-    var has = other.has;
-    if (!@isCallable(has))
-        @throwTypeError("Set.prototype.isSupersetOf expects other.has to be callable");
-
-    var keys = other.keys;
-    if (!@isCallable(keys))
-        @throwTypeError("Set.prototype.isSupersetOf expects other.keys to be callable");
-
-    if (this.@size < size)
-        return false;
-
-    var iterator = keys.@call(other);
-    var wrapper = {
-        @@iterator: function () { return iterator; }
-    };
-
-    for (var key of wrapper) {
-        if (!this.@has(key))
-            return false;
-    }
-    return true;
-}
 
 function isDisjointFrom(other)
 {

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -50,6 +50,7 @@ static JSC_DECLARE_HOST_FUNCTION(setProtoFuncEntries);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIntersection);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncUnion);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIsSubsetOf);
+static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIsSupersetOf);
 
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncSize);
 
@@ -102,7 +103,7 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().differencePublicName(), setPrototypeDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().symmetricDifferencePublicName(), setPrototypeSymmetricDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isSubsetOf"_s, setProtoFuncIsSubsetOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSupersetOfPublicName(), setPrototypeIsSupersetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isSupersetOf"_s, setProtoFuncIsSupersetOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isDisjointFromPublicName(), setPrototypeIsDisjointFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     globalObject->installSetPrototypeWatchpoint(this);
@@ -553,6 +554,130 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
             return JSValue::encode(jsBoolean(false));
 
         thisStorage = currentStorage;
+    }
+
+    return JSValue::encode(jsBoolean(true));
+}
+
+static EncodedJSValue fastSetIsSupersetOf(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (thisSet->size() < otherSet->size())
+        return JSValue::encode(jsBoolean(false));
+
+    JSCell* otherStorageCell = otherSet->storageOrSentinel(vm);
+    if (otherStorageCell == vm.orderedHashTableSentinel())
+        return JSValue::encode(jsBoolean(true));
+
+    auto* otherStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+    JSSet::Helper::Entry entry = 0;
+
+    while (true) {
+        otherStorageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *otherStorage, entry);
+        if (otherStorageCell == vm.orderedHashTableSentinel())
+            break;
+
+        auto* currentStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+        entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+        JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
+
+        bool thisHasEntry = thisSet->has(globalObject, entryKey);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!thisHasEntry)
+            return JSValue::encode(jsBoolean(false));
+
+        otherStorage = currentStorage;
+    }
+
+    return JSValue::encode(jsBoolean(true));
+}
+
+JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSet* thisSet = getSet(globalObject, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue otherValue = callFrame->argument(0);
+
+    if (otherValue.isCell()) [[likely]] {
+        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
+                scope.release();
+                return fastSetIsSupersetOf(globalObject, thisSet, otherSet);
+            }
+        }
+    }
+
+    uint32_t otherSize = getSetSizeAsInt(globalObject, otherValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ASSERT(otherValue.isObject());
+    JSObject* otherObject = asObject(otherValue);
+
+    JSValue has = otherObject->get(globalObject, vm.propertyNames->has);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!has.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.isSupersetOf expects other.has to be callable"_s);
+
+    JSValue keys = otherObject->get(globalObject, vm.propertyNames->keys);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!keys.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.isSupersetOf expects other.keys to be callable"_s);
+
+    if (thisSet->size() < otherSize)
+        return JSValue::encode(jsBoolean(false));
+
+    CallData keysCallData = JSC::getCallData(keys);
+    MarkedArgumentBuffer keysArgs;
+    ASSERT(!keysArgs.hasOverflowed());
+    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue nextMethod = keysResult.get(globalObject, vm.propertyNames->next);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!nextMethod.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.isSupersetOf expects other.keys().next to be callable"_s);
+
+    CallData nextCallData = JSC::getCallData(nextMethod);
+
+    std::optional<CachedCall> cachedNextCall;
+    if (nextCallData.type == CallData::Type::JS) [[likely]] {
+        cachedNextCall.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    while (true) {
+        JSValue nextResult;
+        if (cachedNextCall) [[likely]] {
+            nextResult = cachedNextCall->callWithArguments(globalObject, keysResult);
+            RETURN_IF_EXCEPTION(scope, { });
+        } else {
+            MarkedArgumentBuffer nextArgs;
+            ASSERT(!nextArgs.hasOverflowed());
+            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, nextArgs);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+
+        JSValue doneValue = nextResult.get(globalObject, vm.propertyNames->done);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        bool done = doneValue.toBoolean(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (done)
+            break;
+
+        JSValue value = nextResult.get(globalObject, vm.propertyNames->value);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        bool thisHasValue = thisSet->has(globalObject, value);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!thisHasValue)
+            return JSValue::encode(jsBoolean(false));
     }
 
     return JSValue::encode(jsBoolean(true));


### PR DESCRIPTION
#### 54ed7bdc67272428e6c057e65aac9f7c8ac1fa3a
<pre>
[JSC] Implement `Set.prototype.isSupersetOf` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=298319">https://bugs.webkit.org/show_bug.cgi?id=298319</a>

Reviewed by Yusuke Suzuki.

This patch changes to implement `Set.prototype.isSupersetOf` in C++.

                          TipOfTree                  Patched

set-isSupersetOf        5.0179+-0.1692     ^      1.8690+-0.1636        ^ definitely 2.6848x faster

* JSTests/stress/set-prototype-isSupersetOf-empty-sets.js: Added.
(shouldBe):
* JSTests/stress/set-prototype-isSupersetOf-generic-object.js: Added.
(shouldBe):
(let.setLikeObject.has):
(let.setLikeObject.return.next):
(let.setLikeObject.keys):
(let.partialMatch.has):
(let.partialMatch.return.next):
(let.partialMatch.keys):
(let.tooBig.has):
(let.tooBig.return.next):
(let.tooBig.keys):
(shouldThrow.set1.isSupersetOf):
(shouldThrow):
* JSTests/stress/set-prototype-isSupersetOf-iterator-effects.js: Added.
(shouldBe):
(main.let.otherObject.has):
(main.let.otherObject.return.next):
(main.let.otherObject.keys):
(testIteratorModification.let.otherObject.has):
(testIteratorModification.let.otherObject.return.next):
(testIteratorModification.let.otherObject.keys):
(testIteratorModification):
* JSTests/stress/set-prototype-isSupersetOf-large-sets.js: Added.
(shouldBe):
(let.perfSetLike.has):
(let.perfSetLike.return.next):
(let.perfSetLike.keys):
(set let):
* JSTests/stress/set-prototype-isSupersetOf-property-access-order.js: Added.
(shouldBe):
(main.let.obj.get size):
(main.let.obj.get has):
(main.let.obj.get keys.return.next):
(main.let.obj.get keys):
(main.let.set new):
(testEarlyReturn.let.obj.get size):
(testEarlyReturn.let.obj.get has):
(testEarlyReturn.let.obj.get keys):
(testEarlyReturn):
* JSTests/stress/set-prototype-isSupersetOf-reference.js: Added.
(shouldBe):
(main.try.set isSupersetOf):
(main.try.set isSupersetOf.):
(main.const.set new):
(main.set catch):
(main):
* JSTests/stress/set-prototype-isSupersetOf-special-values.js: Added.
(shouldBe):
(let.setLike.has):
(let.setLike.return.next):
(let.setLike.keys):
(let.set new):
(let.symbolSetLike.has):
(let.symbolSetLike.return.next):
(let.symbolSetLike.keys):
(let.result.set isSupersetOf):
(let.objectSetLike.has):
(let.objectSetLike.return.next):
(let.objectSetLike.keys):
(let.objectSetLikeDifferent.has):
(let.objectSetLikeDifferent.return.next):
(let.objectSetLikeDifferent.keys):
* Source/JavaScriptCore/builtins/SetPrototype.js:
(isSupersetOf.wrapper.iterator): Deleted.
(isSupersetOf): Deleted.
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):
(JSC::fastSetIsSupersetOf):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/299667@main">https://commits.webkit.org/299667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe94e6147dbf1be11106cb82706ba663bf8da203

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71512 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90769 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60066 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25200 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69357 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111564 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128686 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117957 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99333 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99145 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25242 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51922 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146657 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45687 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37703 "Found 1 new JSC binary failure: testapi, Found 18620 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->