### PR TITLE
Service worker downloads are not being saved to Downloads folder

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.h
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.h
@@ -28,10 +28,6 @@
 #import <Foundation/NSProgress.h>
 #import <wtf/RefPtr.h>
 
-#if HAVE(MODERN_DOWNLOADPROGRESS)
-#import <WebKitAdditions/DownloadProgressAdditions.h>
-#endif
-
 namespace WebKit {
 
 class Download;
@@ -42,8 +38,19 @@ class SandboxExtension;
 NS_ASSUME_NONNULL_BEGIN
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-WKDOWNLOADPROGRESS_ADDITIONS
-#endif
+@class UTType;
+
+bool enableModernDownloadProgress();
+Vector<uint8_t> activityAccessToken();
+
+#if defined(__OBJC__)
+@interface WKModernDownloadProgress : NSProgress
+- (instancetype)initWithDownloadTask:(NSURLSessionDownloadTask *)task download:(WebKit::Download&)download URL:(NSURL *)fileURL useDownloadPlaceholder:(BOOL)useDownloadPlaceholder resumePlaceholderURL:(nullable NSURL *)resumePlaceholderURL liveActivityAccessToken:(NSData *)liveActivityAccessToken;
+- (void)startUpdatingDownloadProgress;
+- (void)didFinish:(void (^)())completionHandler;
+@end
+#endif // defined(__OBJC__)
+#endif // HAVE(MODERN_DOWNLOADPROGRESS)
 
 @interface WKDownloadProgress : NSProgress
 

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
@@ -27,10 +27,16 @@
 #import "WKDownloadProgress.h"
 
 #import "Download.h"
+#import "Logging.h"
 #import <pal/spi/cocoa/NSProgressSPI.h>
 #import <sys/xattr.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/WeakObjCPtr.h>
+
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+#import <BrowserEngineKit/BrowserEngineKit.h>
+#import <wtf/cocoa/VectorCocoa.h>
+#endif // HAVE(MODERN_DOWNLOADPROGRESS)
 
 static void* WKDownloadProgressBytesExpectedToReceiveCountContext = &WKDownloadProgressBytesExpectedToReceiveCountContext;
 static void* WKDownloadProgressBytesReceivedContext = &WKDownloadProgressBytesReceivedContext;
@@ -39,8 +45,150 @@ static NSString * const countOfBytesExpectedToReceiveKeyPath = @"countOfBytesExp
 static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-#import <WebKitAdditions/DownloadProgressAdditions.mm>
+bool enableModernDownloadProgress()
+{
+#if PLATFORM(IOS) && !PLATFORM(IOS_SIMULATOR)
+    return true;
+#else
+    return false;
 #endif
+}
+
+Vector<uint8_t> activityAccessToken()
+{
+    return makeVector([BEDownloadMonitor createAccessToken]);
+}
+
+@implementation WKModernDownloadProgress {
+    RetainPtr<NSURLSessionDownloadTask> m_task;
+    WeakPtr<WebKit::Download> m_download;
+    RetainPtr<BEDownloadMonitor> m_downloadMonitor;
+    BlockPtr<void()> m_didFinishCompletionHandler;
+    BOOL m_useDownloadPlaceholder;
+    BOOL m_fileCreatedHandlerCalled;
+}
+
+- (void)performCancel
+{
+    if (m_download)
+        m_download->cancel([](auto) { }, WebKit::Download::IgnoreDidFailCallback::No);
+    m_download = nullptr;
+}
+
+- (void)begin
+{
+    [m_downloadMonitor beginMonitoring:makeBlockPtr([weakDownload = WeakPtr { m_download }](BEDownloadMonitorLocation *location, NSError *error) {
+        RELEASE_LOG(Network, "Download begin for url %{sensitive}s, error %s", location.url.absoluteString.UTF8String, error.localizedDescription.UTF8String);
+        ensureOnMainRunLoop([weakDownload = WTFMove(weakDownload), location = RetainPtr { location }] {
+            if (!weakDownload)
+                return;
+            weakDownload->setPlaceholderURL(location.get().url, location.get().bookmarkData);
+        });
+    }).get()];
+}
+
+- (void)resume:(NSURL *)url
+{
+    [m_downloadMonitor resumeMonitoring:url completionHandler:^(NSError *) { }];
+}
+
+- (instancetype)initWithDownloadTask:(NSURLSessionDownloadTask *)task download:(WebKit::Download&)download URL:(NSURL *)fileURL useDownloadPlaceholder:(BOOL)useDownloadPlaceholder resumePlaceholderURL:(NSURL *)resumePlaceholderURL liveActivityAccessToken:(NSData *)liveActivityAccessToken
+{
+    if (!(self = [self init]))
+        return nil;
+
+    m_task = task;
+    m_download = download;
+    m_useDownloadPlaceholder = useDownloadPlaceholder;
+    m_fileCreatedHandlerCalled = NO;
+
+    self.kind = NSProgressKindFile;
+    self.fileOperationKind = NSProgressFileOperationKindDownloading;
+    if (!m_useDownloadPlaceholder)
+        self.fileURL = fileURL;
+
+    self.cancellable = YES;
+    self.cancellationHandler = makeBlockPtr([weakSelf = WeakObjCPtr<WKModernDownloadProgress> { self }] () mutable {
+        ensureOnMainRunLoop([weakSelf = WTFMove(weakSelf)] {
+            [weakSelf performCancel];
+        });
+    }).get();
+
+    auto fileCreatedHandlerDownloadMonitorLocation = makeBlockPtr([weakDownload = WeakPtr { m_download }, weakSelf = WeakObjCPtr<WKModernDownloadProgress> { self }](BEDownloadMonitorLocation *location) mutable {
+        RELEASE_LOG(Network, "File created handler for url %{sensitive}s", location.url.absoluteString.UTF8String);
+        ensureOnMainRunLoop([weakDownload = WTFMove(weakDownload), location = RetainPtr { location }, weakSelf = WTFMove(weakSelf)] {
+            if (!weakDownload)
+                return;
+            weakDownload->setFinalURL(location.get().url, location.get().bookmarkData);
+            if (!weakSelf)
+                return;
+            weakSelf.get()->m_fileCreatedHandlerCalled = YES;
+            if (!weakSelf.get()->m_didFinishCompletionHandler)
+                return;
+            weakSelf.get()->m_didFinishCompletionHandler();
+        });
+    });
+
+    m_downloadMonitor = adoptNS([BEDownloadMonitor alloc]);
+
+    RetainPtr<NSURL> sourceURL = task.currentRequest.URL;
+    if (!sourceURL)
+        sourceURL = adoptNS([[NSURL alloc] initWithString:@""]);
+    [m_downloadMonitor initWithSourceURL:sourceURL.get() destinationURL:fileURL observedProgress:self liveActivityAccessToken:liveActivityAccessToken];
+
+    if (useDownloadPlaceholder)
+        [m_downloadMonitor useDownloadsFolderWithPlaceholderType:nil finalFileCreatedHandler:fileCreatedHandlerDownloadMonitorLocation.get()];
+
+    if (resumePlaceholderURL)
+        [self resume:resumePlaceholderURL];
+    else
+        [self begin];
+
+    return self;
+}
+
+- (void)startUpdatingDownloadProgress
+{
+    [m_task addObserver:self forKeyPath:countOfBytesExpectedToReceiveKeyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:WKDownloadProgressBytesExpectedToReceiveCountContext];
+    [m_task addObserver:self forKeyPath:countOfBytesReceivedKeyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:WKDownloadProgressBytesReceivedContext];
+}
+
+- (void)didFinish:(void (^)())completionHandler
+{
+    if (self.completedUnitCount != self.totalUnitCount)
+        self.totalUnitCount = self.completedUnitCount;
+
+    if (m_useDownloadPlaceholder && !m_fileCreatedHandlerCalled)
+        m_didFinishCompletionHandler = completionHandler;
+    else
+        completionHandler();
+}
+
+- (void)dealloc
+{
+    [m_task.get() removeObserver:self forKeyPath:countOfBytesExpectedToReceiveKeyPath];
+    [m_task.get() removeObserver:self forKeyPath:countOfBytesReceivedKeyPath];
+
+    [super dealloc];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey, id> *)change context:(void *)context
+{
+    if (context == WKDownloadProgressBytesExpectedToReceiveCountContext) {
+        RetainPtr<NSNumber> value = static_cast<NSNumber *>(change[NSKeyValueChangeNewKey]);
+        ASSERT([value isKindOfClass:[NSNumber class]]);
+        int64_t expectedByteCount = value.get().longLongValue;
+        self.totalUnitCount = (expectedByteCount <= 0) ? -1 : expectedByteCount;
+    } else if (context == WKDownloadProgressBytesReceivedContext) {
+        RetainPtr<NSNumber> value = static_cast<NSNumber *>(change[NSKeyValueChangeNewKey]);
+        ASSERT([value isKindOfClass:[NSNumber class]]);
+        self.completedUnitCount = value.get().longLongValue;
+    } else
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+}
+
+@end
+#endif // HAVE(MODERN_DOWNLOADPROGRESS)
 
 @implementation WKDownloadProgress {
     RetainPtr<NSURLSessionDownloadTask> m_task;


### PR DESCRIPTION
#### 465721e59955c1f54f1262b1276ba268ee4ae96b
<pre>
Service worker downloads are not being saved to Downloads folder
<a href="https://bugs.webkit.org/show_bug.cgi?id=298321">https://bugs.webkit.org/show_bug.cgi?id=298321</a>
<a href="https://rdar.apple.com/154501503">rdar://154501503</a>

Reviewed by Chris Dumez and Youenn Fablet.

Service worker downloads have a download data task (m_downloadTask) in the Download object which is nil.
The current code will prevent these downloads from being saved in the Downloads folder by disabling the
placeholder feature in WKModernDownloadProgress. Local testing shows that there is no need to disable
the placeholder feature for Service worker downloads. This patch enables the placeholder feature for
these downloads. Additionally, the use of WebKit additions is removed for the modern download progress
feature.

* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::publishProgress):
* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.h:
* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm:
(enableModernDownloadProgress):
(activityAccessToken):
(-[WKModernDownloadProgress performCancel]):
(-[WKModernDownloadProgress begin]):
(-[WKModernDownloadProgress resume:]):
(-[WKModernDownloadProgress initWithDownloadTask:download:URL:useDownloadPlaceholder:resumePlaceholderURL:liveActivityAccessToken:]):
(-[WKModernDownloadProgress startUpdatingDownloadProgress]):
(-[WKModernDownloadProgress didFinish:]):
(-[WKModernDownloadProgress dealloc]):
(-[WKModernDownloadProgress observeValueForKeyPath:ofObject:change:context:]):

Canonical link: <a href="https://commits.webkit.org/299564@main">https://commits.webkit.org/299564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d93ee1374ed5c862637a6b7cfd450887d5097d3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71480 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a2debdb-713f-412f-984d-50b484ca9a66) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90733 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a4ca7b8-480b-4dae-b9e3-98fdd8805a84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71211 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c31d38c-7223-4515-84f9-89927f4112bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30792 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69312 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128654 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99312 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99120 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44554 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42894 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18998 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51890 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45655 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->