### PR TITLE
[WebGPU Swift] https://webgpu.github.io/webgpu-samples/?sample=helloTriangle crashes on launch

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -105,15 +105,8 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
         .endOfPassWriteIndex = descriptor.timestampWrites ? descriptor.timestampWrites->endOfPassWriteIndex : 0
     };
 
-    WGPURenderPassDescriptorMaxDrawCount maxDrawCount {
-        .chain = {
-            nullptr,
-            WGPUSType_RenderPassDescriptorMaxDrawCount,
-        },
-        .maxDrawCount = descriptor.maxDrawCount.value_or(0)
-    };
     WGPURenderPassDescriptor backingDescriptor {
-        .nextInChain = descriptor.maxDrawCount ? &maxDrawCount.chain : nullptr,
+        .maxDrawCount = descriptor.maxDrawCount.value_or(UINT64_MAX),
         .label = label.data(),
         .colorAttachmentCount = colorAttachments.size(),
         .colorAttachments = colorAttachments.size() ? colorAttachments.span().data() : nullptr,

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -518,13 +518,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
         return CommandEncoder_beginRenderPass_thunk(this, descriptor);
 #endif
 
-    auto maxDrawCount = UINT64_MAX;
-    if (descriptor.nextInChain) {
-        if (descriptor.nextInChain->sType != WGPUSType_RenderPassDescriptorMaxDrawCount)
-            return RenderPassEncoder::createInvalid(*this, m_device, @"descriptor is corrupted");
-        auto* maxDrawCountStruct = reinterpret_cast<const WGPURenderPassDescriptorMaxDrawCount*>(descriptor.nextInChain);
-        maxDrawCount = maxDrawCountStruct->maxDrawCount;
-    }
+    auto maxDrawCount = descriptor.maxDrawCount;
 
     if (!prepareTheEncoderState()) {
         GENERATE_INVALID_ENCODER_STATE_ERROR();

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -309,17 +309,15 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
 {
 #if ENABLE(WEBGPU_SWIFT)
     NSError *error = nil;
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [&] {
-        MTLCompileOptions* options = [MTLCompileOptions new];
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        options.fastMathEnabled = YES;
-        ALLOW_DEPRECATED_DECLARATIONS_END
-        id<MTLLibrary> library = [device newLibraryWithSource:@"[[vertex]] float4 vsNop() { return (float4)0; }" options:options error:&error];
-        if (error)
-            WTFLogAlways("newLibraryWithSource failed: %@", error.localizedDescription); // NOLINT
-        m_nopVertexFunction = [library newFunctionWithName:@"vsNop"];
-    });
+    MTLCompileOptions* options = [MTLCompileOptions new];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    options.fastMathEnabled = YES;
+    ALLOW_DEPRECATED_DECLARATIONS_END
+    id<MTLLibrary> library = [device newLibraryWithSource:@"[[vertex]] float4 vsNop() { return (float4)0; }" options:options error:&error];
+    if (error)
+        WTFLogAlways("newLibraryWithSource failed: %@", error.localizedDescription); // NOLINT
+    m_nopVertexFunction = [library newFunctionWithName:@"vsNop"];
+
     RELEASE_ASSERT(m_nopVertexFunction);
     RELEASE_ASSERT(!error);
 #endif

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -83,7 +83,6 @@ public:
     WGPUQueryType type() const { return m_type; }
     id<MTLBuffer> visibilityBuffer() const { return m_visibilityBuffer; }
     CounterSampleBuffer counterSampleBufferWithOffset() const;
-    [[noreturn]] id<MTLCounterSampleBuffer> counterSampleBuffer() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     void setCommandEncoder(CommandEncoder&) const;
     bool isDestroyed() const;

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -153,7 +153,6 @@ struct WGPUQueueDescriptor;
 struct WGPURenderBundleDescriptor;
 struct WGPURenderBundleEncoderDescriptor;
 struct WGPURenderPassDepthStencilAttachment;
-struct WGPURenderPassDescriptorMaxDrawCount;
 struct WGPURenderPassTimestampWrites;
 struct WGPURequestAdapterOptions;
 struct WGPUSamplerBindingLayout;
@@ -491,7 +490,6 @@ typedef enum WGPUSType {
     WGPUSType_SurfaceDescriptorFromWaylandSurface = 0x00000008,
     WGPUSType_SurfaceDescriptorFromAndroidNativeWindow = 0x00000009,
     WGPUSType_SurfaceDescriptorFromXcbWindow = 0x0000000A,
-    WGPUSType_RenderPassDescriptorMaxDrawCount = 0x0000000F,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType WGPU_ENUM_ATTRIBUTE;
 
@@ -1018,12 +1016,6 @@ typedef struct WGPURenderPassDepthStencilAttachment {
     WGPUBool stencilReadOnly;
 } SWIFT_ESCAPABLE WGPURenderPassDepthStencilAttachment WGPU_STRUCTURE_ATTRIBUTE;
 
-// Can be chained in WGPURenderPassDescriptor
-typedef struct WGPURenderPassDescriptorMaxDrawCount {
-    WGPUChainedStruct chain;
-    uint64_t maxDrawCount;
-} SWIFT_ESCAPABLE WGPURenderPassDescriptorMaxDrawCount WGPU_STRUCTURE_ATTRIBUTE;
-
 typedef struct WGPURenderPassTimestampWrites {
     WGPUQuerySet querySet;
     uint32_t beginningOfPassWriteIndex;
@@ -1383,7 +1375,7 @@ typedef struct WGPUDeviceDescriptor {
 } WGPUDeviceDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassDescriptor {
-    WGPUChainedStruct const * nextInChain;
+    uint64_t maxDrawCount;
     WGPU_NULLABLE char const * label;
     size_t colorAttachmentCount;
     WGPURenderPassColorAttachment const * colorAttachments;
@@ -1393,10 +1385,6 @@ typedef struct WGPURenderPassDescriptor {
 
     auto colorAttachmentsSpan() const { return unsafeMakeSpan(colorAttachments, colorAttachmentCount); }
 } __attribute__((swift_attr("@safe"))) SWIFT_ESCAPABLE WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
-
-inline struct WGPUChainedStruct const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorNextChainedStruct(const WGPURenderPassDescriptor * __counted_by(1) __attribute__((lifetimebound)) __attribute__((noescape)) descriptor) {
-    return descriptor->nextInChain;
-}
 
 inline WGPURenderPassTimestampWrites const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorTimestampWrites(const WGPURenderPassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor) {
     return descriptor->timestampWrites;


### PR DESCRIPTION
#### 5f940dafb1bdab24d0c3104794b9df352d7070b3
<pre>
[WebGPU Swift] <a href="https://webgpu.github.io/webgpu-samples/?sample=helloTriangle">https://webgpu.github.io/webgpu-samples/?sample=helloTriangle</a> crashes on launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=298318">https://bugs.webkit.org/show_bug.cgi?id=298318</a>
<a href="https://rdar.apple.com/159757436">rdar://159757436</a>

Reviewed by Tadeu Zagallo.

WebGPU Swift was missing some changes resulting in assertions or
other crashes.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.timestampWriteIndex(_:defaultValue:offset:)):
(WebGPU.beginRenderPass(_:)):
(WebGPU.beginComputePass(_:)):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::getXRViewSubImageDepthTexture const):
* Source/WebGPU/WebGPU/QuerySet.h:
(WebGPU::QuerySet::counterSampleBuffer const): Deleted.
* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::rasterizationMapForSlice):
* Source/WebGPU/WebGPU/WebGPU.h:
(wgpuGetRenderPassDescriptorNextChainedStruct): Deleted.

Canonical link: <a href="https://commits.webkit.org/299527@main">https://commits.webkit.org/299527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c120677661d3d42d3d9317218ffe26abdb715d63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71359 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afbe142f-5ddc-4826-987b-e3be908aeefe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90637 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/764736dc-c70c-4456-8e09-510bdf73f2a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71056 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67dc28d1-3731-4796-9a30-409b73a8af89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69176 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128534 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34953 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99204 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98980 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22455 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51770 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45535 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->