### PR TITLE
[Liquid Glass] [iOS] reddit.com: no blur at bottom of "Unreviewed content" overlay

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-full-viewport-backdrop-filter-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-full-viewport-backdrop-filter-expected.txt
@@ -1,0 +1,10 @@
+Content underneath backdrop filter
+
+PASS colors.top is "multiple"
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "multiple"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-full-viewport-backdrop-filter.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-full-viewport-backdrop-filter.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=75 ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+        }
+
+        .full-viewport-backdrop {
+            position: fixed;
+            inset: 0;
+            backdrop-filter: blur(40px);
+            pointer-events: none;
+        }
+
+        h1 {
+            margin-top: 100px;
+            text-align: center;
+            font-size: 40px;
+        }
+
+        .tall {
+            height: 200vh;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(75, 0, 75, 0);
+        await UIHelper.ensurePresentationUpdate();
+
+        colors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colors.top", "multiple");
+        shouldBeNull("colors.left");
+        shouldBeNull("colors.right");
+        shouldBeEqualToString("colors.bottom", "multiple");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<div class="full-viewport-backdrop"></div>
+<h1>Content underneath backdrop filter</h1>
+<div class="tall"></div>
+<pre id="console"></pre>
+<pre id="description"></pre>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2153,7 +2153,7 @@ static bool isHiddenOrNearlyTransparent(const RenderBox& box)
     if (box.opacity() < PageColorSampler::nearlyTransparentAlphaThreshold)
         return true;
 
-    if (!box.hasBackground() && !box.firstChild() && !is<RenderReplaced>(box))
+    if (!box.hasBackground() && !box.hasBackdropFilter() && !box.firstChild() && !is<RenderReplaced>(box))
         return true;
 
     return false;


### PR DESCRIPTION
#### fa5e369db4a5feea900b82cd5d61245f0209a2ab
<pre>
[Liquid Glass] [iOS] reddit.com: no blur at bottom of &quot;Unreviewed content&quot; overlay
<a href="https://bugs.webkit.org/show_bug.cgi?id=298324">https://bugs.webkit.org/show_bug.cgi?id=298324</a>
<a href="https://rdar.apple.com/158543289">rdar://158543289</a>

Reviewed by Simon Fraser.

For the purposes of color sampling, the heuristic currently &quot;punches through&quot; transparent (or
nearly-transparent) containers with `pointer-events: none;`, that don&apos;t have any children or
background. However, this fails to account for the case where such a container has a backdrop filter
(and contains no other rendered content or background). On Reddit, this causes the &quot;Unreviewed
content&quot; modal overlay to be ignored for the purposes of extending fixed colors.

Handle this scenario by considering a container with CSS `backdrop-filter` to be visible, therefore
avoiding the `isHiddenOrNearlyTransparent` check. This results in extending the page background
color into the obscured edges beyond the viewport.

* LayoutTests/fast/page-color-sampling/color-sampling-full-viewport-backdrop-filter-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-full-viewport-backdrop-filter.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::isHiddenOrNearlyTransparent):

Canonical link: <a href="https://commits.webkit.org/299509@main">https://commits.webkit.org/299509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9351316a24be73348adcf8ad3098dc103ce203e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71316 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/431e0ea0-9cf7-4ef6-b5f7-fab81d7f14b8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47515 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc49ab84-840c-476a-92e8-bc88fcaf691b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71023 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38a3c0d5-a5ae-4b36-a1c1-381fdeecc76d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25019 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69135 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128495 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46163 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25147 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44411 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22416 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51713 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->