### PR TITLE
[Build Speed] Don't include EventTargetInlines.h in generated JS headers

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -3140,7 +3140,7 @@ sub GenerateHeader
     }
 
     $headerIncludes{"JSWindowProxy.h"} = 1 if $interfaceName eq "DOMWindow";
-    $headerIncludes{"EventTargetInlines.h"} = 1 if $parentClassName eq "JSEventTarget";
+    $headerIncludes{"EventTarget.h"} = 1 if $parentClassName eq "JSEventTarget";
 
     my $exportMacro = GetExportMacroForJSClass($interface);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <WebCore/EventTargetInlines.h>
+#include <WebCore/EventTarget.h>
 #include <WebCore/JSDOMWrapper.h>
 #include <WebCore/JSEventTarget.h>
 #include <WebCore/JSWindowProxy.h>

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "EventTargetInlines.h"
+#include "EventTarget.h"
 #include "ExposedStar.h"
 #include "JSEventTarget.h"
 #include <WebCore/JSDOMWrapper.h>

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "EventTargetInlines.h"
+#include "EventTarget.h"
 #include "JSEventTarget.h"
 #include "TestEventTarget.h"
 #include <WebCore/JSDOMWrapper.h>

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "EventTargetInlines.h"
+#include "EventTarget.h"
 #include "JSEventTarget.h"
 #include <WebCore/JSDOMWrapper.h>
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "EventTargetInlines.h"
+#include "EventTarget.h"
 #include "JSEventTarget.h"
 #include <WebCore/JSDOMWrapper.h>
 


### PR DESCRIPTION
#### a0b88c112e888f31b8957c1659df0544f430af37
<pre>
[Build Speed] Don&apos;t include EventTargetInlines.h in generated JS headers
<a href="https://rdar.apple.com/159765932">rdar://159765932</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298327">https://bugs.webkit.org/show_bug.cgi?id=298327</a>

Reviewed by Eric Carlson.

As it turns out, EventTargetInlines aren&apos;t actually needed in the generated headers.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateHeader):

Canonical link: <a href="https://commits.webkit.org/299524@main">https://commits.webkit.org/299524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d84916a3d1b2058e9513541c889872d8962c19d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71328 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b6d061f-b97a-49ee-affd-71a6d065c51c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90604 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d1d1c5a-3fe5-43bb-91ca-1351916e7757) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71022 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d0d5d59-f3a6-4403-b3a2-2c81d1a69567) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25024 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69143 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128501 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99190 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42742 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51750 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45502 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->