### PR TITLE
Keyboard closes after typing one character in gif search field on x.com

### DIFF
--- a/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
+++ b/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
@@ -76,16 +76,18 @@ addEventListener("load", async () => {
     await shouldBecomeEqual("targetContainsCaretSelection()", "true");
 
     console.log("8. Dismissing keyboard");
-    document.body.blur();
+    document.getElementById("editor").blur();
     await UIHelper.waitForKeyboardToHide();
 
     finishJSTest();
 });
 </script>
 </head>
-<body contenteditable>
-    <div id="start"><br></div>
-    <p id="description"></p>
-    <div id="target"><br></div>
+<body>
+    <div id="editor" contenteditable>
+        <div id="start"><br></div>
+        <p id="description"></p>
+        <div id="target"><br></div>
+    </div>
 </body>
 </html>

--- a/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement-expected.txt
+++ b/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement-expected.txt
@@ -1,0 +1,19 @@
+Test keyboard restoration when input elements are replaced during the same presentation update.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is false
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is false
+PASS isShowingKeyboard is true
+PASS isShowingKeyboard is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+
+

--- a/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement.html
+++ b/LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <style>
+        input {
+            display: block;
+            width: 200px;
+            height: 30px;
+            font-size: 16px;
+        }
+
+        .container {
+            margin: 20px;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+
+        addEventListener("load", async () => {
+            if (!window.testRunner)
+                return;
+
+            description("Test keyboard restoration when input elements are replaced during the same presentation update.");
+
+            await UIHelper.setHardwareKeyboardAttached(false);
+
+            // Test 1: Keyboard should remain visible after element replacement during same presentation update.
+            const container1 = document.getElementById('container1');
+            const input1 = document.getElementById('input1');
+
+            await UIHelper.activateElement(input1);
+            await UIHelper.waitForKeyboardToShow();
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            container1.innerHTML = '<input type="text" id="input1_replaced">';
+            const input1_replaced = document.getElementById('input1_replaced');
+            input1_replaced.focus();
+            await UIHelper.ensurePresentationUpdate();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            input1_replaced.blur();
+            await UIHelper.waitForKeyboardToHide();
+
+            // Test 2: Programmatic focus without user interaction should not show keyboard
+            const input2 = document.getElementById('input2');
+
+            input2.focus();
+            await UIHelper.ensurePresentationUpdate();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeFalse("isShowingKeyboard");
+
+            input2.blur();
+
+            // Test 3: Focus after presentation update should not show keyboard
+            const container3 = document.getElementById('container3');
+            const input3 = document.getElementById('input3');
+
+            await UIHelper.activateElement(input3);
+            await UIHelper.waitForKeyboardToShow();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            container3.innerHTML = '';
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensurePresentationUpdate();
+
+            container3.innerHTML = '<input type="text" id="input3_delayed">';
+            const input3_delayed = document.getElementById('input3_delayed');
+            input3_delayed.focus();
+
+            await UIHelper.ensurePresentationUpdate();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeFalse("isShowingKeyboard");
+
+            // Test 4: Programmatic focus immediately after keyboard explicitly dismissed should not show keyboard.
+            const container4 = document.getElementById('container4');
+            const input4 = document.getElementById('input4');
+
+            await UIHelper.activateElement(input4);
+            await UIHelper.waitForKeyboardToShow();
+
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeTrue("isShowingKeyboard");
+
+            setInterval(function(){
+                input4.focus();
+            }, 2);
+
+            await UIHelper.dismissFormAccessoryView();
+            await UIHelper.waitForKeyboardToHide();
+            await UIHelper.ensurePresentationUpdate();
+
+            await UIHelper.ensurePresentationUpdate();
+            isShowingKeyboard = await UIHelper.isShowingKeyboard();
+            shouldBeFalse("isShowingKeyboard");
+
+            finishJSTest();
+        });
+    </script>
+</head>
+
+<body>
+    <div class="container" id="container1">
+        <input type="text" id="input1">
+    </div>
+    <div class="container" id="container2">
+        <input type="text" id="input2">
+    </div>
+    <div class="container" id="container3">
+        <input type="text" id="input3">
+    </div>
+    <div class="container" id="container4">
+        <input type="text" id="input4">
+    </div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -566,6 +566,8 @@ struct ImageAnalysisContextMenuActionData {
 
     BOOL _keyboardDidRequestDismissal;
     BOOL _isKeyboardScrollingAnimationRunning;
+    BOOL _keyboardDismissedInCurrentPresentationUpdate;
+    BOOL _editingEndedByUser;
 
     BOOL _candidateViewNeedsUpdate;
     BOOL _seenHardwareKeyDownInNonEditableElement;


### PR DESCRIPTION
#### 4d0798bc6ead79eef655fe887a0e052c4b2e4c49
<pre>
Keyboard closes after typing one character in gif search field on x.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=298304">https://bugs.webkit.org/show_bug.cgi?id=298304</a>
<a href="https://rdar.apple.com/146920597">rdar://146920597</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

If the keyboard is hidden and an element is programatically focused during
the same presentation update, allow the keyboard to show again.

Track explicit user dismissals of the keyboard using `_editingEndedWithReason`,
and only restore the keyboard if `_editingEndedWithReason` is false.

With these changes, layout test
tap-to-change-selection-after-accepting-inline-prediction.html began to fail
due to it using `&lt;body contenteditable&gt;` as the focused element. When
the body was blurred, focus was restored to the body again, and the keyboard
remained open as a result. The test has been updated to use `&lt;div contenteditable&gt;`
instead so that the keyboard is correctly dismissed.

* LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html:
* LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement-expected.txt: Added.
* LayoutTests/fast/forms/ios/keyboard-restoration-after-element-replacement.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
(-[WKContentView endEditingAndUpdateFocusAppearanceWithReason:]):
(-[WKContentView _didCommitLoadForMainFrame]):
(-[WKContentView _hideKeyboard]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):

Canonical link: <a href="https://commits.webkit.org/299615@main">https://commits.webkit.org/299615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03a3d6ca3245199b5a3406dbd2290bc9fd168d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71651 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2298495e-b390-4aaf-bc74-6aff61857546) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90826 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0f163b7-277f-477a-9833-e95f650906d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71332 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8fadab8-80bd-4693-b5ea-929176445945) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25323 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128825 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99417 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25220 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22703 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46361 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52067 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->