### PR TITLE
Switch controls may be sized incorrectly due to incorrect margins

### DIFF
--- a/LayoutTests/platform/mac-sequoia/fast/forms/switch-repaint-size-vertical-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/fast/forms/switch-repaint-size-vertical-expected.txt
@@ -1,0 +1,6 @@
+
+(repaint rects
+  (rect 8 8 18 41)
+  (rect 30 40 5 9)
+)
+

--- a/LayoutTests/platform/mac-sonoma/fast/forms/switch-repaint-size-vertical-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/fast/forms/switch-repaint-size-vertical-expected.txt
@@ -1,0 +1,6 @@
+
+(repaint rects
+  (rect 8 8 18 41)
+  (rect 30 40 5 9)
+)
+

--- a/LayoutTests/platform/mac/fast/forms/switch-repaint-size-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/switch-repaint-size-vertical-expected.txt
@@ -1,0 +1,6 @@
+
+(repaint rects
+  (rect 7 6 21 36)
+  (rect 30 30 16 28)
+)
+

--- a/LayoutTests/platform/mac/fast/forms/switch-repaint-size-vertical.html
+++ b/LayoutTests/platform/mac/fast/forms/switch-repaint-size-vertical.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<style>
+	input {
+		writing-mode: vertical-lr;
+	}
+
+	#mini-switch {
+		width: 5px;
+		height: 9px;
+	}
+</style>
+<body>
+	<input type="checkbox" switch id="default-switch">
+	<input type="checkbox" switch id="mini-switch">
+	<pre id=repaintRects></pre>
+</body>
+<script>
+	if (window.internals && window.testRunner) {
+		testRunner.dumpAsText();
+		testRunner.waitUntilDone();
+		window.internals.startTrackingRepaints();
+	}
+
+	document.getElementById("default-switch").checked = true;
+	document.getElementById("mini-switch").checked = true;
+
+	repaintRects.innerText = internals.repaintRectsAsText();
+	
+	if (window.internals && window.testRunner) {
+		internals.stopTrackingRepaints();
+		testRunner.notifyDone();
+	}
+</script>
+</html>

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1030,26 +1030,17 @@ static const std::span<const IntSize, 4> switchSizes()
     return sizes;
 }
 
-static std::span<const int, 4> switchMargins(NSControlSize controlSize)
-{
-    static constexpr std::array margins {
-        // top right bottom left
-        std::array { 2, 2, 1, 2 },
-        std::array { 2, 2, 1, 2 },
-        std::array { 1, 1, 0, 1 },
-        std::array { 2, 2, 1, 2 },
-    };
-    return margins[controlSize];
-}
-
 static std::span<const int, 4> visualSwitchMargins(NSControlSize controlSize, bool isVertical)
 {
-    auto margins = switchMargins(controlSize);
-    if (isVertical) {
-        static const std::array verticalMargins { margins[3], margins[0], margins[1], margins[2] };
-        return verticalMargins;
-    }
-    return margins;
+    static constexpr std::array switchMarginsNonMini { 2, 2, 1, 2 };
+    static constexpr std::array switchMarginsMini { 1, 1, 0, 1 };
+    static constexpr std::array switchMarginsNonMiniVertical { switchMarginsNonMini[3], switchMarginsNonMini[0], switchMarginsNonMini[1], switchMarginsNonMini[2] };
+    static constexpr std::array switchMarginsMiniVertical { switchMarginsMini[3], switchMarginsMini[0], switchMarginsMini[1], switchMarginsMini[2] };
+
+    if (controlSize == NSControlSizeMini)
+        return isVertical ? switchMarginsMiniVertical : switchMarginsMini;
+
+    return isVertical ? switchMarginsNonMiniVertical : switchMarginsNonMini;
 }
 
 static Style::PreferredSizePair switchSize(const Style::PreferredSizePair& zoomedSize, float zoomFactor)


### PR DESCRIPTION
#### 5670c407c90c83f96deecd9545028124725b08a7
<pre>
Switch controls may be sized incorrectly due to incorrect margins
<a href="https://bugs.webkit.org/show_bug.cgi?id=298334">https://bugs.webkit.org/show_bug.cgi?id=298334</a>
<a href="https://rdar.apple.com/159729284">rdar://159729284</a>

Reviewed by Aditya Keerthi, Abrar Rahman Protyasha, and Wenson Hsieh.

In `RenderThemeMac::visualSwitchMargins`, `verticalMargins` was `static const`
despite the result depending on the passed control size. As a result,
it never updated for other control sizes on subsequent calls. Replace this logic
to ensure that subsequent calls return the correct values.

* LayoutTests/platform/mac-sequoia/fast/forms/switch-repaint-size-vertical-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/fast/forms/switch-repaint-size-vertical-expected.txt: Added.
* LayoutTests/platform/mac/fast/forms/switch-repaint-size-vertical-expected.txt: Added.
* LayoutTests/platform/mac/fast/forms/switch-repaint-size-vertical.html: Added.
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::visualSwitchMargins):
(WebCore::switchMargins): Deleted.

Canonical link: <a href="https://commits.webkit.org/299543@main">https://commits.webkit.org/299543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ae088ffdce48c6b939c910e06c80aef1352579e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71435 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a6f07c2-7bd2-4f45-9b09-7ccd234fae25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47f81a70-6fb5-4761-94b4-64a3d02639d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71141 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e2554a1-035d-4bae-b716-8aaa9e031679) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25126 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69263 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128609 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99266 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99054 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25176 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22512 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46145 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51845 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45610 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48960 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->