### PR TITLE
Remove redundant sandbox rules in the Networking process on iOS

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -104,6 +104,7 @@
     (iokit-registry-entry-class "AppleKeyStore"))
 
 (allow darwin-notification-post (darwin-notification-post-allowed))
+(allow darwin-notification-post (darwin-notification-post-prefix-allowed))
 
 (allow file-clone
     (subpath
@@ -153,24 +154,18 @@
            (literal "/private/var/Managed Preferences/mobile/.GlobalPreferences.plist"))
     (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
 
-    (deny file-read-metadata 
+    (deny file-read-metadata
         (home-literal "/Library/Caches/powerlog.launchd"))
 
     (allow-read-and-issue-generic-extensions (executable-bundle))
     (allow file-map-executable  (executable-bundle))
-
-    (deny file-read-data file-issue-extension file-map-executable
-        (require-all
-            (executable-bundle)
-            (regex #"/[^/]+/SC_Info/")))
 
     (with-filter (global-name-prefix "")
         (deny mach-lookup 
                (extension "com.apple.security.exception.mach-lookup.global-name")))
     (with-filter (local-name-prefix "")
         (deny mach-lookup 
-               (extension "com.apple.security.exception.mach-lookup.local-name"))
-    )
+               (extension "com.apple.security.exception.mach-lookup.local-name")))
     (allow managed-preference-read
            (extension "com.apple.security.exception.managed-preference.read-only"))
     (allow user-preference-read
@@ -210,8 +205,6 @@
 (allow mach-lookup 
     (global-name "com.apple.runningboard")) ;; Needed by process assertion code (ProcessTaskStateObserver).
 
-(allow-multi-instance-xpc-services)
-
 (allow system-sched
     (require-entitlement "com.apple.private.kernel.override-cpumon"))
 
@@ -222,7 +215,7 @@
            (sysctl-name "vm.footprint_suspend")))
 
 ;; Needed by WebKit LOG macros and ASL logging.
-(deny file-read-metadata 
+(deny file-read-metadata
        (literal "/private/var/run/syslog"))
 
 ;; ObjC map_images needs to send logging data to syslog. <rdar://problem/39778918>
@@ -235,13 +228,7 @@
 (allow ipc-posix-shm-read*
     (ipc-posix-name "apple.shm.notification_center")) ;; Needed by os_log_create
 
-(deny mach-lookup 
-    (global-name "com.apple.distributed_notifications@1v3"))
-
 (managed-configuration-read-public)
-
-(deny mach-lookup 
-    (global-name "com.apple.ctkd.token-client"))
 
 (deny system-info NO_REPORT
     (info-type "net.link.addr"))
@@ -281,18 +268,6 @@
 (allow file-read* file-write* (extension "com.apple.app-sandbox.read-write"))
 (allow file-read* (extension "com.apple.app-sandbox.read"))
 
-;; FIXME: <rdar://problem/17909681> SSO expects to be able to walk the parent
-;; bundle to find Info plists, so we jump through a few hoops here to provide
-;; enough access to make it possible.
-
-;; IOKit user clients
-(deny iokit-open-user-client
-    (iokit-user-client-class "RootDomainUserClient")) ;; Needed by PowerObserver
-
-;; Various services required by CFNetwork and other frameworks
-(deny mach-lookup 
-       (global-name "com.apple.PowerManagement.control"))
-
 (network-client (remote tcp) (remote udp))
 
 ;; allow 3rd party applications to access nsurlstoraged's top level domain data cache
@@ -302,26 +277,17 @@
 (allow file-read-data
     (literal "/usr/local/lib/log")) ; <rdar://problem/36629495>
 
-;; Security framework
-(deny mach-lookup
-    (global-name "com.apple.ocspd")
-    (global-name "com.apple.securityd"))
-
 ;; PassKit framework
 (allow mach-lookup
     (global-name "com.apple.passd.in-app-payment")
     (global-name "com.apple.passd.library"))
 
-(deny mach-lookup 
-    (global-name "com.apple.FileCoordination")
-    (global-name "com.apple.dmd.policy"))
-
-(allow mach-lookup 
+(allow mach-lookup
     (global-name "com.apple.siri.context.service")
     (global-name "com.apple.ctcategories.service"))
 
 (deny file-write-create
-      (vnode-type SYMLINK))
+    (vnode-type SYMLINK))
 
 (deny file-read* NO_REPORT
     (literal "/private/etc/group"))
@@ -392,9 +358,6 @@
 (allow mach-lookup (with telemetry) (global-name "com.apple.webkit.adattributiond.service"))
 (allow mach-lookup (with telemetry) (global-name "com.apple.webkit.webpushd.service"))
 
-;; Access to MobileGestalt
-(deny mach-lookup 
-    (global-name "com.apple.mobilegestalt.xpc"))
 (allow file-read*
     (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))
 (allow iokit-get-properties

--- a/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
@@ -58,16 +58,9 @@
     (allow file-read*
            (literal "/private/var/Managed Preferences/mobile/com.apple.SystemConfiguration.plist"))
 
-    ;; <rdar://problem/13679154>
-    (deny file-read*
-           (literal "/private/var/preferences/com.apple.NetworkStatistics.plist"))
-
     ;; <rdar://problem/15711661>
     (allow mach-lookup
            (global-name "com.apple.nesessionmanager"))
-
-    ;; <rdar://problem/7693463>
-    (deny system-socket (socket-domain AF_ROUTE))
 
 #if PLATFORM(WATCHOS)
     (with-filter
@@ -81,30 +74,14 @@
     (allow mach-lookup (global-name "com.apple.dnssd.service")) ;; <rdar://problem/55562091>
 #endif
 
-    (deny mach-lookup
-           (global-name "com.apple.SystemConfiguration.helper")
-           (global-name "com.apple.SystemConfiguration.SCNetworkReachability")
-           (global-name "com.apple.SystemConfiguration.DNSConfiguration")
-           (global-name "com.apple.SystemConfiguration.PPPController"))
     ;; <rdar://problem/10962803>
     ;; <rdar://problem/13238730>
     (allow mach-lookup
            (global-name "com.apple.SystemConfiguration.configd")
            (global-name "com.apple.SystemConfiguration.NetworkInformation"))
 
-    ;; <rdar://problem/11792470>
-    ;; <rdar://problem/13305819>
-    (deny mach-lookup
-           (global-name "com.apple.commcenter.xpc")
-           (global-name "com.apple.commcenter.cupolicy.xpc"))
-
-    (deny mach-lookup
-           (global-name "com.apple.securityd")
-           (global-name "com.apple.symptomsd"))
     (allow mach-lookup
            (global-name "com.apple.trustd"))
-    (deny file-read*
-           (literal "/private/var/preferences/com.apple.security.plist"))
 
     ;; <rdar://problem/13301795>
     (allow mach-lookup
@@ -123,8 +100,6 @@
 
     (allow mach-lookup
            (global-name "com.apple.AppSSO.service-xpc"))
-    (deny ipc-posix-shm-read-data
-           (ipc-posix-name "/com.apple.AppSSO.version"))
 
     ;; <rdar://problem/30452093>
     (multipath-tcp))
@@ -132,29 +107,6 @@
 (define-once (network-client . filters)
     (allow-network-common)
 
-    ;; <rdar://problem/9193431>
-    (deny mach-lookup
-           (global-name "com.apple.networkd"))
-
-    ;; <rdar://problem/20094008>
-    ;; <rdar://problem/24689958>
-    (with-filter (require-any
-                   (require-entitlement "com.apple.networkd.advisory_socket")
-                   (require-entitlement "com.apple.networkd.disable_opportunistic")
-                   (require-entitlement "com.apple.networkd.modify_settings")
-                   (require-entitlement "com.apple.networkd.persistent_interface")
-                   (require-entitlement "com.apple.networkd_privileged"))
-        (deny mach-lookup
-               (global-name "com.apple.networkd_privileged")))
-
-    ;; <rdar://problem/20201593>
-    (deny mach-lookup
-        (global-name "com.apple.ak.anisette.xpc")
-        (global-name "com.apple.ak.auth.xpc"))
-
-    ;; <rdar://problem/15897781>
-    (deny mach-lookup
-           (global-name "com.apple.nsurlsessiond"))
     (allow file-issue-extension
         (require-all
             (executable-bundle)
@@ -167,10 +119,6 @@
         (global-name "com.apple.sharingd.NSURLSessionProxyService"))
 #endif
 
-    ;; <rdar://problem/15608009>
-    (deny mach-lookup
-           (global-name "com.apple.nsurlstorage-cache"))
-
     ;; <rdar://86781432>
     (allow mach-lookup
            (global-name "com.apple.cfnetwork.AuthBrokerAgent"))
@@ -181,9 +129,6 @@
     ;; <rdar://problem/12620714>
     (deny file-write-create NO_REPORT
           (home-prefix "/Library/Logs/CrashReporter/CFNetwork_"))
-
-    (deny mach-lookup
-           (global-name "com.apple.cookied"))
 
     ;; <rdar://problem/17910466>
     (allow mach-lookup
@@ -225,9 +170,7 @@
     (allow file-read*
            (well-known-system-group-container-subpath "/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/PublicInfo")
            (front-user-home-subpath "/Library/ConfigurationProfiles/PublicInfo")
-           (front-user-home-subpath "/Library/UserConfigurationProfiles/PublicInfo"))
-    (deny mach-lookup
-           (global-name "com.apple.managedconfiguration.profiled.public")))
+           (front-user-home-subpath "/Library/UserConfigurationProfiles/PublicInfo")))
 
 (define-once (mobile-keybag-access)
     (allow iokit-open-user-client
@@ -237,13 +180,6 @@
   (literal "/private/etc/hosts"
            "/private/etc/passwd"
            "/private/etc/services"))
-
-(define-once (allow-multi-instance-xpc-services)
-    ;; <rdar://problem/46716068>
-    (deny mach-lookup
-           (with message "Create a radar and set it as a blocker to rdar://problem/48527566")
-           (xpc-service-name "com.apple.WebKit.Networking"
-                             "com.apple.WebKit.WebContent")))
 
 (define (syscall-unix-allowed)
     (syscall-number
@@ -496,9 +432,11 @@
 #endif
     (allow syscall-mig (kernel-mig-routine-allowed)))
 
-(define (darwin-notification-post-allowed)
+(define (darwin-notification-post-prefix-allowed)
     (notification-name-prefix
-        "com.apple.CFNetwork")
+        "com.apple.CFNetwork"))
+
+(define (darwin-notification-post-allowed)
     (notification-name
         "AppleDatePreferencesChangedNotification"
         "AppleLanguagePreferencesChangedNotification"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8268,7 +8268,6 @@
 		E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuxiliaryProcessProxyCocoa.mm; sourceTree = "<group>"; };
 		E326F4D92CA6C44F00182187 /* LogStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogStream.h; sourceTree = "<group>"; };
 		E326F4DA2CA6C44F00182187 /* LogStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogStream.cpp; sourceTree = "<group>"; };
-		E33072F42E5A1B6300D5E45D /* webcontent-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "webcontent-defines.sb"; sourceTree = "<group>"; };
 		E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UseDownloadPlaceholder.h; sourceTree = "<group>"; };
 		E3439B632345463A0011DE0B /* NetworkProcessConnectionInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkProcessConnectionInfo.h; path = Network/NetworkProcessConnectionInfo.h; sourceTree = "<group>"; };
 		E34B110C27C46BC6006D2F2E /* libWebCoreTestShim.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestShim.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -8285,7 +8284,6 @@
 		E36D701D27B718EF006531B7 /* WebAttachmentElementClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebAttachmentElementClient.cpp; sourceTree = "<group>"; };
 		E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SandboxStateVariables.h; sourceTree = "<group>"; };
 		E36FF00227F36FBD004BE21A /* preferences.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = preferences.sb; sourceTree = "<group>"; };
-		E374E1C62E6251EE00614D31 /* gpu-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "gpu-defines.sb"; sourceTree = "<group>"; };
 		E37726002D0DF248000BCBA6 /* AdditionalFonts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AdditionalFonts.h; sourceTree = "<group>"; };
 		E37726012D0DF248000BCBA6 /* AdditionalFonts.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = AdditionalFonts.serialization.in; sourceTree = "<group>"; };
 		E37A2F1A2B8523300087F394 /* NetworkingProcessExtension.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = NetworkingProcessExtension.entitlements; sourceTree = "<group>"; };
@@ -8296,6 +8294,9 @@
 		E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebMockContentFilterManager.cpp; path = Network/WebMockContentFilterManager.cpp; sourceTree = "<group>"; };
 		E3816B3C27E24639005EAFC0 /* WebMockContentFilterManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebMockContentFilterManager.h; path = Network/WebMockContentFilterManager.h; sourceTree = "<group>"; };
 		E382D57E2C21D500005F7653 /* DownloadProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DownloadProxyCocoa.mm; sourceTree = "<group>"; };
+		E385982C2E68CAA80012AD39 /* gpu-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "gpu-defines.sb"; sourceTree = "<group>"; };
+		E385982D2E68CAA80012AD39 /* networking-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "networking-defines.sb"; sourceTree = "<group>"; };
+		E385982E2E68CAA80012AD39 /* webcontent-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "webcontent-defines.sb"; sourceTree = "<group>"; };
 		E3866AE42397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebDeviceOrientationUpdateProviderProxy.mm; path = ios/WebDeviceOrientationUpdateProviderProxy.mm; sourceTree = "<group>"; };
 		E3866AE62397405300F88FE9 /* WebDeviceOrientationUpdateProviderProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebDeviceOrientationUpdateProviderProxy.h; path = ios/WebDeviceOrientationUpdateProviderProxy.h; sourceTree = "<group>"; };
 		E3866AED2398471A00F88FE9 /* WebDeviceOrientationUpdateProviderProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = WebDeviceOrientationUpdateProviderProxy.messages.in; path = ios/WebDeviceOrientationUpdateProviderProxy.messages.in; sourceTree = "<group>"; };
@@ -8327,7 +8328,6 @@
 		E3D80CA22E43AA3000D285E0 /* com.apple.WebKit.WebContent.Development.sb.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = com.apple.WebKit.WebContent.Development.sb.in; sourceTree = "<group>"; };
 		E3DC5B1A2C9AE09700D73BB3 /* LogStreamIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogStreamIdentifier.h; sourceTree = "<group>"; };
 		E3DCC9AA2DA07FA0008712FE /* WebKitServiceNames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitServiceNames.h; sourceTree = "<group>"; };
-		E3E0A3E02E5B5BB6002B81D6 /* networking-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "networking-defines.sb"; sourceTree = "<group>"; };
 		E3E6297C2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDebuggableProxy.h; sourceTree = "<group>"; };
 		E3E6297D2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDebuggableProxy.cpp; sourceTree = "<group>"; };
 		E3E84BED2AE1AA5A0091B3C2 /* ExtensionKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtensionKitSPI.h; sourceTree = "<group>"; };
@@ -16681,9 +16681,9 @@
 			isa = PBXGroup;
 			children = (
 				E350A7C82934F75F00A06C29 /* common.sb */,
-				E374E1C62E6251EE00614D31 /* gpu-defines.sb */,
-				E3E0A3E02E5B5BB6002B81D6 /* networking-defines.sb */,
-				E33072F42E5A1B6300D5E45D /* webcontent-defines.sb */,
+				E385982C2E68CAA80012AD39 /* gpu-defines.sb */,
+				E385982D2E68CAA80012AD39 /* networking-defines.sb */,
+				E385982E2E68CAA80012AD39 /* webcontent-defines.sb */,
 			);
 			path = iOS;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### fc55b4b5008ca22247637021794fbe055313e85d
<pre>
Remove redundant sandbox rules in the Networking process on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=298337">https://bugs.webkit.org/show_bug.cgi?id=298337</a>
<a href="https://rdar.apple.com/159780207">rdar://159780207</a>

Reviewed by Chris Dumez.

Since the default is to deny access, there is no need to have explicit deny rules, unless they have modifiers that are not default.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/299605@main">https://commits.webkit.org/299605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a438152fd1a2b9128e97cedcda29ede60674e73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125813 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71614 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90801 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71294 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30905 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69462 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128788 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35182 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99229 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22676 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19019 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46324 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52030 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49139 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->