### PR TITLE
[JSC] Fix debug_ipint.py instruction list

### DIFF
--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -71,13 +71,7 @@ IPINT_INSTRUCTIONS = [
     # 0xD0
     'ref_null_t', 'ref_is_null', 'ref_func', 'ref_eq', 'ref_as_non_null', 'br_on_null', 'br_on_non_null',
     # 0xFB
-    # The four instructions starting with 0xFB are in transition. The names appearing below are their current
-    # names in InPlaceInterpreter64.asm.
-    'fb_block', 'fc_block', 'simd', 'atomic',
-    # There was an attempted PR that would change their names: https://bugs.webkit.org/show_bug.cgi?id=292725
-    # The PR has been reverted, but if it's reintroduced after fixes, the names above should be changed
-    # to the commented out names below:
-    # 'gc_prefix', 'conversion_prefix', 'simd_prefix', 'atomic_prefix',
+    'gc_prefix', 'conversion_prefix', 'simd_prefix', 'atomic_prefix',
 
     # extended
     'struct_new', 'struct_new_default', 'struct_get',
@@ -331,7 +325,7 @@ def ipint_continue_on_all_breakpoints(debugger, command, exec_ctx, output, inter
         brk.SetAutoContinue(True)
 
 
-def set_breakpoints(debugger, command, exe_ctx, output, internal_dict):
+def ipint_set_all_breakpoints(debugger, command, exe_ctx, output, internal_dict):
     if not breakpoints:
         print("Initializing internal breakpoints...", file=output)
         set_breakpoints_internal(debugger, True)
@@ -350,5 +344,5 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand('command script add -f debug_ipint.ipint_disable_all_breakpoints ipint_disable_all_breakpoints')
     debugger.HandleCommand('command script add -f debug_ipint.ipint_reenable_all_breakpoints ipint_reenable_all_breakpoints')
     debugger.HandleCommand('command script add -f debug_ipint.ipint_continue_on_all_breakpoints ipint_autocontinue')
-    debugger.HandleCommand('command script add -f debug_ipint.set_breakpoints set_breakpoints')
+    debugger.HandleCommand('command script add -f debug_ipint.ipint_set_all_breakpoints ipint_set_all_breakpoints')
     print("IPInt debugger ready")


### PR DESCRIPTION
#### 1b4949dcd7bdd692c3ea5dc5d8da078dff6428ee
<pre>
[JSC] Fix debug_ipint.py instruction list
<a href="https://bugs.webkit.org/show_bug.cgi?id=298340">https://bugs.webkit.org/show_bug.cgi?id=298340</a>
<a href="https://rdar.apple.com/159785565">rdar://159785565</a>

Reviewed by Mark Lam.

296121@main renamed some IPInt instructions. Update debug_ipint.py
instruction list to reflect the current names to get the IPInt
debugger working again.

Also, rename set_breakpoints to make it apparent that this is
an IPInt related command when typing help in lldb.

Canonical link: <a href="https://commits.webkit.org/299521@main">https://commits.webkit.org/299521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc1def15e7a9b9e86f985d9e017222b2df1f1e34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/899664e0-95f4-4bbd-a46c-f55a71243c31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47562 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/294c40fa-22bb-4046-9cd4-07ad755321b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122246 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/31651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/106957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71064 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c66b07e-6063-4b21-aacd-9d495eecbbfd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/25067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69181 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/101103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/25257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128539 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46212 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/34955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46577 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/103156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/98984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44444 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/22461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18985 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46075 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47227 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->