### PR TITLE
[Site Isolation] Hovering in and out of an iframe which has mouse events zoom set only works occasionally

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/mouseenter-mouseleave-remote-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/mouseenter-mouseleave-remote-frame-expected.txt
@@ -1,0 +1,10 @@
+Verifies that mouseenter and mouseleave events work correctly on remote frames.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Mouse events captured: mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe, mouseenter on remoteframe, mouseleave on remoteframe
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/mouseenter-mouseleave-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/mouseenter-mouseleave-remote-frame.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that mouseenter and mouseleave events work correctly on remote frames.");
+jsTestIsAsync = true;
+
+var mouseEvents = [];
+
+async function doTest() {
+    document.body.offsetLeft;
+    // Repeat multiple times as this test is meant to verify flaky behavior is fixed
+    for (let i = 0; i < 5; i++) {
+        await eventSender.asyncMouseMoveTo(1, 1);
+        await eventSender.asyncMouseMoveTo(110,140);
+        await eventSender.asyncMouseMoveTo(10, 10);
+        await eventSender.asyncMouseMoveTo(150, 150);
+    }
+    await eventSender.asyncMouseMoveTo(1, 1);
+
+    debug("Mouse events captured: " + mouseEvents.join(", "));
+    finishJSTest();
+}
+
+document.addEventListener("DOMContentLoaded", function(event) {
+    var iframe = document.getElementById('remoteframe');
+    iframe.addEventListener('mouseenter', function(ev) {
+        mouseEvents.push(ev.type + " on " + ev.target.id);
+    });
+    iframe.addEventListener('mouseleave', function(ev) {
+        mouseEvents.push(ev.type + " on " + ev.target.id);
+    });
+    doTest();
+});
+</script>
+<iframe id="remoteframe" src="http://localhost:8000/site-isolation/resources/green-background.html" style="width:100px; height:100px; background-color:blue; top:100px; left:100px; position:absolute"></iframe>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2366,8 +2366,10 @@ HandleUserInputEventResult EventHandler::handleMouseMoveEvent(const PlatformMous
 
     bool swallowEvent = false;
     auto subframe = isCapturingMouseEventsElement() ? subframeForTargetNode(m_capturingMouseEventsElement.get()) : subframeForHitTestResult(mouseEvent);
-    if (auto remoteMouseEventData = userInputEventDataForRemoteFrame(dynamicDowncast<RemoteFrame>(subframe).get(), mouseEvent.hitTestResult().roundedPointInInnerNodeFrame()))
+    if (auto remoteMouseEventData = userInputEventDataForRemoteFrame(dynamicDowncast<RemoteFrame>(subframe).get(), mouseEvent.hitTestResult().roundedPointInInnerNodeFrame())) {
+        updateMouseEventTargetNode(eventNames().mousemoveEvent, mouseEvent.protectedTargetNode().get(), platformMouseEvent, FireMouseOverOut::Yes);
         return *remoteMouseEventData;
+    }
 
     RefPtr localSubframe = dynamicDowncast<LocalFrame>(subframe.get());
  


### PR DESCRIPTION
#### a5f321e72ebf9e50c1a9b40708cd1c8c5ca3d4d0
<pre>
[Site Isolation] Hovering in and out of an iframe which has mouse events zoom set only works occasionally
<a href="https://bugs.webkit.org/show_bug.cgi?id=298348">https://bugs.webkit.org/show_bug.cgi?id=298348</a>
<a href="https://rdar.apple.com/124108238">rdar://124108238</a>

Reviewed by Sihui Liu and Ryan Reno.

With site isolation enabled, mouse events transitioning to remote frames
would skip calling updateMouseEventTargetNode, preventing mouseout events
from being dispatched for the previously hovered element. This caused hover
animations to work inconsistently. This change ensures updateMouseEventTargetNode
is called before returning for remote frames, allowing proper coordination
across process boundaries and adds a test for verification.

Test: http/tests/site-isolation/mouse-events/mouseenter-mouseleave-remote-frame.html
* LayoutTests/http/tests/site-isolation/mouse-events/mouseenter-mouseleave-remote-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/mouseenter-mouseleave-remote-frame.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMouseMoveEvent):

Canonical link: <a href="https://commits.webkit.org/300856@main">https://commits.webkit.org/300856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28156c4e7067334df4bc4fd7b9bc6dd27d90599f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133569 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102843 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102657 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26118 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26263 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47890 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56637 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->