### PR TITLE
ViewTransitions access layout state on RenderFragmentedFlow without flushing layout.

### DIFF
--- a/LayoutTests/fast/css/view-transitions-layout-fragments-expected.txt
+++ b/LayoutTests/fast/css/view-transitions-layout-fragments-expected.txt
@@ -1,0 +1,3 @@
+This test should not crash.
+
+

--- a/LayoutTests/fast/css/view-transitions-layout-fragments.html
+++ b/LayoutTests/fast/css/view-transitions-layout-fragments.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+ol { initial; column-width: 0; content-visibility: hidden; }
+* { overflow: scroll; }
+</style>
+<script>
+function runTest() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    document.startViewTransition();
+}
+</script>
+</head>
+<body onload=runTest()>
+<p>This test should not crash.</p>
+<ol>
+    <li></li>
+</old>
+</body>
+</html>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -491,6 +491,9 @@ static ExceptionOr<void> forEachRendererInPaintOrder(NOESCAPE const std::functio
     if (result.hasException())
         return result.releaseException();
 
+    if (auto* renderBox = dynamicDowncast<RenderBox>(layer.renderer()); renderBox && isSkippedContentRoot(*renderBox))
+        return { };
+
     layer.updateLayerListsIfNeeded();
 
 #if ASSERT_ENABLED
@@ -541,8 +544,8 @@ ExceptionOr<void> ViewTransition::captureOldState()
     ListHashSet<AtomString> usedTransitionNames;
     Vector<CheckedRef<RenderLayerModelObject>> captureRenderers;
 
-    // Ensure style & render tree are up-to-date.
-    protectedDocument()->updateStyleIfNeededIgnoringPendingStylesheets();
+    // Ensure style & layout are up-to-date.
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
     if (CheckedPtr view = document()->renderView()) {
         Ref frame = CheckedRef { view->frameView() }->frame();
@@ -756,8 +759,8 @@ void ViewTransition::activateViewTransition()
 
     protectedDocument()->clearRenderingIsSuppressedForViewTransition();
 
-    // Ensure style & render tree are up-to-date.
-    protectedDocument()->updateStyleIfNeededIgnoringPendingStylesheets();
+    // Ensure style & layout are up-to-date.
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
     auto checkSize = checkForViewportSizeChange();
     if (checkSize.hasException()) {
@@ -981,7 +984,7 @@ ExceptionOr<void> ViewTransition::updatePseudoElementStylesRead()
     if (!document)
         return { };
 
-    document->updateStyleIfNeededIgnoringPendingStylesheets();
+    document->updateLayoutIgnorePendingStylesheets();
 
     for (auto& [name, capturedElement] : m_namedElements.map()) {
         if (auto newStyleable = capturedElement->newElement.styleable()) {


### PR DESCRIPTION
#### 3e5a85384588394904e4290b495e3c49acde2c71
<pre>
ViewTransitions access layout state on RenderFragmentedFlow without flushing layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298362">https://bugs.webkit.org/show_bug.cgi?id=298362</a>
&lt;<a href="https://rdar.apple.com/157024885">rdar://157024885</a>&gt;

Reviewed by Alan Baradlay.

rendererIsFragmented (in ViewTransition.cpp) relies on post-layout data, so we
need to flush layout and not just style before iterating renderers.

* LayoutTests/fast/css/view-transitions-layout-fragments-expected.txt: Added.
* LayoutTests/fast/css/view-transitions-layout-fragments.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::updatePseudoElementStylesRead):

Canonical link: <a href="https://commits.webkit.org/299580@main">https://commits.webkit.org/299580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76654f6683883b1c10b3c03b38371167928c2480

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71416 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e48fc98-646b-48a3-b850-b7ae2302ef14) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90685 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60010 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/897a8d75-53c8-45a8-870f-3b1b93f9baac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71126 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bc075d1-c797-4a70-b907-236dd095e2b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128590 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25196 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42830 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46126 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51826 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45591 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48941 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->