### PR TITLE
REGRESSION(298691@main): [ macOS wk2, iOS ] imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7083,8 +7083,6 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-e
 
 # -- Navigation API -- #
 
-webkit.org/b/297477 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html [ Timeout Pass Failure ]
-
 # These cross-window needs --allowed-host=www1.localhost, so tested manually.
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-crossdocument-crossorigin-sameorigindomain.sub.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/common/dispatcher/dispatcher.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/common/dispatcher/dispatcher.js
@@ -78,6 +78,7 @@ const sendItem = async function (uuid, resolver, message) {
       try {
         let response = await fetch(dispatcher_url + `?uuid=${uuid}`, {
           method: 'POST',
+          keepalive: true,
           body: message
         })
         if (await response.text() == "done") {

--- a/LayoutTests/imported/w3c/web-platform-tests/common/dispatcher/remote-executor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/common/dispatcher/remote-executor.html
@@ -5,7 +5,7 @@
 </body>
 <script src="./dispatcher.js"
         crossorigin
-        integrity="sha256-daCATx8B9i1s6ixqZvCGcGQOv3a+VMoor6aS9UNUoiY=">
+        integrity="sha256-XZ2RxxHB3PF14zUZkzgB3mgWSn3R8JCPuDfZURvajRI=">
 </script>
 <script>
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
#### 048951b7d112d7887a1113b38959d6b7b5f53155
<pre>
REGRESSION(298691@main): [ macOS wk2, iOS ] imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=297477">https://bugs.webkit.org/show_bug.cgi?id=297477</a>
<a href="https://rdar.apple.com/158434206">rdar://158434206</a>

Reviewed by Chris Dumez.

This fix the flakiness of this test.

WPT test utility has a bug that can fixed in this patch. The fetch is used for the communication
between the pages, fetch doesn&apos;t have &apos;keepalive&apos; flag on, so they sometimes get cancelled because
of the navigation.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/common/dispatcher/dispatcher.js:
(async await):
(const.sendItem):
* LayoutTests/imported/w3c/web-platform-tests/common/dispatcher/remote-executor.html:

Canonical link: <a href="https://commits.webkit.org/299594@main">https://commits.webkit.org/299594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea6baadf2377460c13b37703dafe6511aada64bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71526 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22df6d4b-ffc4-461b-9ae8-b977adffad69) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60069 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3dbc10b8-9e18-4d47-954d-dc4bdb2e86a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71240 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7ce1df2-8ba8-4ccd-8547-15437f06a0b8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25213 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69372 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128700 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99345 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42942 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46236 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49051 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47388 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->