### PR TITLE
[JSC] WASM IPInt SIMD: implement extract opcodes

### DIFF
--- a/JSTests/wasm/stress/simd-instructions-extract-lanes.js
+++ b/JSTests/wasm/stress/simd-instructions-extract-lanes.js
@@ -1,0 +1,183 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const test_i8x16_const = "(v128.const i8x16 0x00 0x01 0x7F 0x80 0xFF 0x81 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x0A 0x0B)";
+const test_i16x8_const = "(v128.const i16x8 0x0000 0x0001 0x7FFF 0x8000 0xFFFF 0x8001 0x0002 0x0003)";
+const test_i32x4_const = "(v128.const i32x4 0x12345678 0x9ABCDEF0 0x11111111 0x22222222)";
+const test_i64x2_const = "(v128.const i64x2 0x123456789ABCDEF0 0xFEDCBA0987654321)";
+const test_f32x4_const = "(v128.const f32x4 1.5 -2.25 3.75 -4.125)";
+const test_f64x2_const = "(v128.const f64x2 1.25 -3.5)";
+
+let wat = `
+(module
+    ;; Test i8x16.extract_lane_s (signed byte extraction) - individual functions for each lane
+    (func (export "test_i8x16_extract_lane_s_0") (result i32)
+        (i8x16.extract_lane_s 0 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_s_1") (result i32)
+        (i8x16.extract_lane_s 1 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_s_2") (result i32)
+        (i8x16.extract_lane_s 2 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_s_3") (result i32)
+        (i8x16.extract_lane_s 3 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_s_4") (result i32)
+        (i8x16.extract_lane_s 4 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_s_5") (result i32)
+        (i8x16.extract_lane_s 5 ${test_i8x16_const})
+    )
+
+    ;; Test i8x16.extract_lane_u (unsigned byte extraction) - key test cases
+    (func (export "test_i8x16_extract_lane_u_0") (result i32)
+        (i8x16.extract_lane_u 0 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_u_3") (result i32)
+        (i8x16.extract_lane_u 3 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_u_4") (result i32)
+        (i8x16.extract_lane_u 4 ${test_i8x16_const})
+    )
+    (func (export "test_i8x16_extract_lane_u_5") (result i32)
+        (i8x16.extract_lane_u 5 ${test_i8x16_const})
+    )
+
+    ;; Test i16x8.extract_lane_s (signed 16-bit extraction)
+    (func (export "test_i16x8_extract_lane_s_0") (result i32)
+        (i16x8.extract_lane_s 0 ${test_i16x8_const})
+    )
+    (func (export "test_i16x8_extract_lane_s_2") (result i32)
+        (i16x8.extract_lane_s 2 ${test_i16x8_const})
+    )
+    (func (export "test_i16x8_extract_lane_s_3") (result i32)
+        (i16x8.extract_lane_s 3 ${test_i16x8_const})
+    )
+    (func (export "test_i16x8_extract_lane_s_4") (result i32)
+        (i16x8.extract_lane_s 4 ${test_i16x8_const})
+    )
+    (func (export "test_i16x8_extract_lane_s_5") (result i32)
+        (i16x8.extract_lane_s 5 ${test_i16x8_const})
+    )
+
+    ;; Test i16x8.extract_lane_u (unsigned 16-bit extraction)
+    (func (export "test_i16x8_extract_lane_u_0") (result i32)
+        (i16x8.extract_lane_u 0 ${test_i16x8_const})
+    )
+    (func (export "test_i16x8_extract_lane_u_3") (result i32)
+        (i16x8.extract_lane_u 3 ${test_i16x8_const})
+    )
+    (func (export "test_i16x8_extract_lane_u_4") (result i32)
+        (i16x8.extract_lane_u 4 ${test_i16x8_const})
+    )
+    (func (export "test_i16x8_extract_lane_u_5") (result i32)
+        (i16x8.extract_lane_u 5 ${test_i16x8_const})
+    )
+
+    ;; Test i32x4.extract_lane
+    (func (export "test_i32x4_extract_lane_0") (result i32)
+        (i32x4.extract_lane 0 ${test_i32x4_const})
+    )
+    (func (export "test_i32x4_extract_lane_1") (result i32)
+        (i32x4.extract_lane 1 ${test_i32x4_const})
+    )
+
+    ;; Test i64x2.extract_lane
+    (func (export "test_i64x2_extract_lane_0") (result i64)
+        (i64x2.extract_lane 0 ${test_i64x2_const})
+    )
+    (func (export "test_i64x2_extract_lane_1") (result i64)
+        (i64x2.extract_lane 1 ${test_i64x2_const})
+    )
+
+    ;; Test f32x4.extract_lane
+    (func (export "test_f32x4_extract_lane_0") (result f32)
+        (f32x4.extract_lane 0 ${test_f32x4_const})
+    )
+    (func (export "test_f32x4_extract_lane_1") (result f32)
+        (f32x4.extract_lane 1 ${test_f32x4_const})
+    )
+    (func (export "test_f32x4_extract_lane_2") (result f32)
+        (f32x4.extract_lane 2 ${test_f32x4_const})
+    )
+    (func (export "test_f32x4_extract_lane_3") (result f32)
+        (f32x4.extract_lane 3 ${test_f32x4_const})
+    )
+
+    ;; Test f64x2.extract_lane
+    (func (export "test_f64x2_extract_lane_0") (result f64)
+        (f64x2.extract_lane 0 ${test_f64x2_const})
+    )
+    (func (export "test_f64x2_extract_lane_1") (result f64)
+        (f64x2.extract_lane 1 ${test_f64x2_const})
+    )
+
+    ;; Test v128.const basic functionality
+    (func (export "test_v128_const") (result i32)
+        (i8x16.extract_lane_u 0 (v128.const i8x16 0x42 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00))
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const {
+        test_i8x16_extract_lane_s_0, test_i8x16_extract_lane_s_1, test_i8x16_extract_lane_s_2,
+        test_i8x16_extract_lane_s_3, test_i8x16_extract_lane_s_4, test_i8x16_extract_lane_s_5,
+        test_i8x16_extract_lane_u_0, test_i8x16_extract_lane_u_3, test_i8x16_extract_lane_u_4, test_i8x16_extract_lane_u_5,
+        test_i16x8_extract_lane_s_0, test_i16x8_extract_lane_s_2, test_i16x8_extract_lane_s_3,
+        test_i16x8_extract_lane_s_4, test_i16x8_extract_lane_s_5,
+        test_i16x8_extract_lane_u_0, test_i16x8_extract_lane_u_3, test_i16x8_extract_lane_u_4, test_i16x8_extract_lane_u_5,
+        test_i32x4_extract_lane_0, test_i32x4_extract_lane_1,
+        test_i64x2_extract_lane_0, test_i64x2_extract_lane_1,
+        test_f32x4_extract_lane_0, test_f32x4_extract_lane_1, test_f32x4_extract_lane_2, test_f32x4_extract_lane_3,
+        test_f64x2_extract_lane_0, test_f64x2_extract_lane_1,
+        test_v128_const
+    } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(test_i8x16_extract_lane_s_0(), 0);      // 0x00 -> 0
+        assert.eq(test_i8x16_extract_lane_s_1(), 1);      // 0x01 -> 1
+        assert.eq(test_i8x16_extract_lane_s_2(), 127);    // 0x7F -> 127
+        assert.eq(test_i8x16_extract_lane_s_3(), -128);   // 0x80 -> -128 (sign extended)
+        assert.eq(test_i8x16_extract_lane_s_4(), -1);     // 0xFF -> -1 (sign extended)
+        assert.eq(test_i8x16_extract_lane_s_5(), -127);   // 0x81 -> -127 (sign extended)
+
+        assert.eq(test_i8x16_extract_lane_u_0(), 0);      // 0x00 -> 0
+        assert.eq(test_i8x16_extract_lane_u_3(), 128);    // 0x80 -> 128 (unsigned)
+        assert.eq(test_i8x16_extract_lane_u_4(), 255);    // 0xFF -> 255 (unsigned)
+        assert.eq(test_i8x16_extract_lane_u_5(), 129);    // 0x81 -> 129 (unsigned)
+
+        assert.eq(test_i16x8_extract_lane_s_0(), 0);        // 0x0000 -> 0
+        assert.eq(test_i16x8_extract_lane_s_2(), 32767);    // 0x7FFF -> 32767
+        assert.eq(test_i16x8_extract_lane_s_3(), -32768);   // 0x8000 -> -32768 (sign extended)
+        assert.eq(test_i16x8_extract_lane_s_4(), -1);       // 0xFFFF -> -1 (sign extended)
+        assert.eq(test_i16x8_extract_lane_s_5(), -32767);   // 0x8001 -> -32767 (sign extended)
+
+        assert.eq(test_i16x8_extract_lane_u_0(), 0);        // 0x0000 -> 0
+        assert.eq(test_i16x8_extract_lane_u_3(), 32768);    // 0x8000 -> 32768 (unsigned)
+        assert.eq(test_i16x8_extract_lane_u_4(), 65535);    // 0xFFFF -> 65535 (unsigned)
+        assert.eq(test_i16x8_extract_lane_u_5(), 32769);    // 0x8001 -> 32769 (unsigned)
+
+        assert.eq(test_i32x4_extract_lane_0(), 0x12345678);
+        assert.eq(test_i32x4_extract_lane_1(), 0x9ABCDEF0 | 0); // Force to signed 32-bit
+
+        assert.eq(test_i64x2_extract_lane_0(), 0x123456789ABCDEF0n);
+        assert.eq(test_i64x2_extract_lane_1(), -81986143110479071n); // 0xFEDCBA0987654321 as signed i64
+
+        assert.eq(test_f32x4_extract_lane_0(), 1.5);
+        assert.eq(test_f32x4_extract_lane_1(), -2.25);
+        assert.eq(test_f32x4_extract_lane_2(), 3.75);
+        assert.eq(test_f32x4_extract_lane_3(), -4.125);
+
+        assert.eq(test_f64x2_extract_lane_0(), 1.25);
+        assert.eq(test_f64x2_extract_lane_1(), -3.5);
+
+        assert.eq(test_v128_const(), 0x42);
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -4059,6 +4059,12 @@ end)
     ## SIMD Instructions ##
     #######################
 
+const ImmLaneIdxOffset = 2 # Offset in bytecode
+const ImmLaneIdx16Mask = 0xf
+const ImmLaneIdx8Mask = 0x7
+const ImmLaneIdx4Mask = 0x3
+const ImmLaneIdx2Mask = 0x1
+
 # 0xFD 0x00 - 0xFD 0x0B: memory
 
 unimplementedInstruction(_simd_v128_load_mem)
@@ -4094,46 +4100,104 @@ unimplementedInstruction(_simd_f32x4_splat)
 unimplementedInstruction(_simd_f64x2_splat)
 
 # 0xFD 0x15 - 0xFD 0x22: extract and replace lanes
-unimplementedInstruction(_simd_i8x16_extract_lane_s)
-unimplementedInstruction(_simd_i8x16_extract_lane_u)
+ipintOp(_simd_i8x16_extract_lane_s, macro()
+    # i8x16.extract_lane_s (lane)
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx16Mask, t0
+    loadbsi [sp, t0], t0
+    addp V128ISize, sp
+    pushInt32(t0)
+    advancePC(3)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_i8x16_extract_lane_u, macro()
+    # i8x16.extract_lane_u (lane)
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx16Mask, t0
+    loadb [sp, t0], t0
+    addp V128ISize, sp
+    pushInt32(t0)
+    advancePC(3)
+    nextIPIntInstruction()
+end)
+
 unimplementedInstruction(_simd_i8x16_replace_lane)
-unimplementedInstruction(_simd_i16x8_extract_lane_s)
-unimplementedInstruction(_simd_i16x8_extract_lane_u)
+
+ipintOp(_simd_i16x8_extract_lane_s, macro()
+    # i16x8.extract_lane_s (lane)
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx8Mask, t0
+    loadhsi [sp, t0, 2], t0
+    addp V128ISize, sp
+    pushInt32(t0)
+    advancePC(3)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_i16x8_extract_lane_u, macro()
+    # i16x8.extract_lane_u (lane)
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx8Mask, t0
+    loadh [sp, t0, 2], t0
+    addp V128ISize, sp
+    pushInt32(t0)
+    advancePC(3)
+    nextIPIntInstruction()
+end)
+
 unimplementedInstruction(_simd_i16x8_replace_lane)
 
 ipintOp(_simd_i32x4_extract_lane, macro()
     # i32x4.extract_lane (lane)
-    loadb 2[PC], t0  # lane index
-    andi 0x3, t0
-    popv v0
-    if ARM64 or ARM64E
-        pcrtoaddr _simd_i32x4_extract_lane_0, t1
-        leap [t1, t0, 8], t0
-        emit "br x0"
-        _simd_i32x4_extract_lane_0:
-        umovi t0, v0_i, 0
-        jmp _simd_i32x4_extract_lane_end
-        umovi t0, v0_i, 1
-        jmp _simd_i32x4_extract_lane_end
-        umovi t0, v0_i, 2
-        jmp _simd_i32x4_extract_lane_end
-        umovi t0, v0_i, 3
-        jmp _simd_i32x4_extract_lane_end
-    elsif X86_64
-        # FIXME: implement SIMD instructions for x86 and finish this implementation!
-    end
-_simd_i32x4_extract_lane_end:
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx4Mask, t0
+    loadi [sp, t0, 4], t0
+    addp V128ISize, sp
     pushInt32(t0)
     advancePC(3)
     nextIPIntInstruction()
 end)
 
 unimplementedInstruction(_simd_i32x4_replace_lane)
-unimplementedInstruction(_simd_i64x2_extract_lane)
+
+ipintOp(_simd_i64x2_extract_lane, macro()
+    # i64x2.extract_lane (lane)
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx2Mask, t0
+    loadq [sp, t0, 8], t0
+    addp V128ISize, sp
+    pushInt64(t0)
+    advancePC(3)
+    nextIPIntInstruction()
+end)
+
 unimplementedInstruction(_simd_i64x2_replace_lane)
-unimplementedInstruction(_simd_f32x4_extract_lane)
+
+ipintOp(_simd_f32x4_extract_lane, macro()
+    # f32x4.extract_lane (lane)
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx4Mask, t0
+    loadf [sp, t0, 4], ft0
+    addp V128ISize, sp
+    pushFloat32(ft0)
+    advancePC(3)
+    nextIPIntInstruction()
+end)
+
 unimplementedInstruction(_simd_f32x4_replace_lane)
-unimplementedInstruction(_simd_f64x2_extract_lane)
+
+ipintOp(_simd_f64x2_extract_lane, macro()
+    # f64x2.extract_lane (lane)
+    loadb ImmLaneIdxOffset[PC], t0
+    andi ImmLaneIdx2Mask, t0
+    loadd [sp, t0, 8], ft0
+    addp V128ISize, sp
+    pushFloat64(ft0)
+    advancePC(3)
+    nextIPIntInstruction()
+end)
+
 unimplementedInstruction(_simd_f64x2_replace_lane)
 
 # 0xFD 0x23 - 0xFD 0x2C: i8x16 operations


### PR DESCRIPTION
#### 0ce8441cd8bf9476478643007d540981a72bb079
<pre>
[JSC] WASM IPInt SIMD: implement extract opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=298365">https://bugs.webkit.org/show_bug.cgi?id=298365</a>
<a href="https://rdar.apple.com/159810092">rdar://159810092</a>

Reviewed by Yusuke Suzuki.

Implement extract opcode variants using emulation by loading
the appropriate lane from the stack.

I didn&apos;t find a test that systematically tests each instruction
in isolation, so adding test:
JSTests/wasm/stress/simd-instructions-extract-lanes.js.

Canonical link: <a href="https://commits.webkit.org/299593@main">https://commits.webkit.org/299593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbf2b050b36280a4f839a4827ec24901557f0b04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/119521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29865 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/125791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/71593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121395 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/39909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47791 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/125791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/71593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122470 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/39909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/107168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/125791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/39909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/25273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/69440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/111646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/39909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/25466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/128767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/118037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/46441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/128767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/46806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/103362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/128767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/46303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/52009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/146735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/45767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/146735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/49118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/47455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->