### PR TITLE
Implement _WKSerializedNode of DocumentFragment, template elements, and shadow roots

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -42,6 +42,7 @@
 #include "HTMLOptionsCollection.h"
 #include "HTMLSlotElement.h"
 #include "HTMLTableRowsCollection.h"
+#include "HTMLTemplateElement.h"
 #include "InspectorInstrumentation.h"
 #include "JSNodeCustom.h"
 #include "LabelsNodeList.h"

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -132,10 +132,19 @@ Element* DocumentFragment::getElementById(const AtomString& id) const
     return nullptr;
 }
 
-SerializedNode DocumentFragment::serializeNode(CloningOperation) const
+SerializedNode DocumentFragment::serializeNode(CloningOperation type) const
 {
-    // FIXME: Implement.
-    return { SerializedNode::DocumentFragment { } };
+    Vector<SerializedNode> children;
+    switch (type) {
+    case CloningOperation::SelfOnly:
+    case CloningOperation::SelfWithTemplateContent:
+        break;
+    case CloningOperation::Everything:
+        children = serializeChildNodes();
+        break;
+    }
+
+    return { SerializedNode::DocumentFragment { WTFMove(children) } };
 }
 
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -896,6 +896,8 @@ public:
     double lookupCSSRandomBaseValue(const std::optional<Style::PseudoElementIdentifier>&, const CSSCalc::RandomCachingKey&) const;
     bool hasRandomCachingKeyMap() const;
 
+    void addShadowRoot(Ref<ShadowRoot>&&);
+
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 
@@ -909,8 +911,6 @@ protected:
     void classAttributeChanged(const AtomString& newClassString, AttributeModificationReason);
     void partAttributeChanged(const AtomString& newValue);
 
-    void addShadowRoot(Ref<ShadowRoot>&&);
-
     ExceptionOr<void> replaceChildrenWithMarkup(const String&, OptionSet<ParserContentPolicy>);
 
     static ExceptionOr<void> mergeWithNextTextNode(Text&);
@@ -923,6 +923,9 @@ protected:
 
     void disconnectFromIntersectionObservers();
     static AtomString makeTargetBlankIfHasDanglingMarkup(const AtomString& target);
+
+    template<typename ShadowRoot> std::optional<ShadowRoot> serializeShadowRoot() const;
+    template<typename Attribute> Vector<Attribute> serializeAttributes() const;
 
 private:
     LocalFrame* documentFrameWithNonNullView() const;

--- a/Source/WebCore/dom/SerializedNode.h
+++ b/Source/WebCore/dom/SerializedNode.h
@@ -41,6 +41,11 @@ class QualifiedName;
 class JSDOMGlobalObject;
 
 enum class ClonedDocumentType : uint8_t;
+enum class ShadowRootAvailableToElementInternals : bool;
+enum class ShadowRootDelegatesFocus : bool;
+enum class ShadowRootSerializable : bool;
+enum class ShadowRootScopedCustomElementRegistry : bool;
+enum class SlotAssignmentMode : bool;
 
 struct SerializedNode {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(SerializedNode, WEBCORE_EXPORT);
@@ -72,13 +77,19 @@ struct SerializedNode {
         Variant<String, URL> documentURI;
         String contentType;
     };
-    struct DocumentFragment : public ContainerNode {
-        // FIXME: Implement.
-    };
+    struct DocumentFragment : public ContainerNode { };
     struct DocumentType {
         String name;
         String publicId;
         String systemId;
+    };
+    struct ShadowRoot : public DocumentFragment {
+        bool openMode;
+        SlotAssignmentMode slotAssignmentMode;
+        ShadowRootDelegatesFocus delegatesFocus;
+        ShadowRootSerializable serializable;
+        ShadowRootAvailableToElementInternals availableToElementInternals;
+        ShadowRootScopedCustomElementRegistry hasScopedCustomElementRegistry;
     };
     struct Element : public ContainerNode {
         struct Attribute {
@@ -87,12 +98,10 @@ struct SerializedNode {
         };
         QualifiedName name;
         Vector<Attribute> attributes;
-    };
-    struct ShadowRoot : public DocumentFragment {
-        // FIXME: Implement.
+        std::optional<ShadowRoot> shadowRoot;
     };
     struct HTMLTemplateElement : public Element {
-        // FIXME: Implement serialization of its content.
+        std::optional<DocumentFragment> content;
     };
     struct CharacterData {
         String data;
@@ -107,7 +116,7 @@ struct SerializedNode {
     Variant<Attr, CDATASection, Comment, Document, DocumentFragment, DocumentType, Element, ProcessingInstruction, ShadowRoot, Text, HTMLTemplateElement> data;
 
     WEBCORE_EXPORT static JSC::JSValue deserialize(SerializedNode&&, JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, WebCore::Document&);
-    static RefPtr<WebCore::Node> deserialize(SerializedNode&&, WebCore::Document&);
+    static Ref<WebCore::Node> deserialize(SerializedNode&&, WebCore::Document&);
 };
 
 }

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -44,6 +44,8 @@ class TrustedHTML;
 class WebAnimation;
 
 enum class ParserContentPolicy : uint8_t;
+enum class ShadowRootAvailableToElementInternals : bool { No, Yes };
+enum class ShadowRootScopedCustomElementRegistry : bool { No, Yes };
 
 struct GetHTMLOptions;
 
@@ -56,15 +58,11 @@ class ShadowRoot final : public DocumentFragment, public TreeScope {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ShadowRoot);
 public:
 
-    enum class DelegatesFocus : bool { No, Yes };
     enum class Clonable : bool { No, Yes };
-    enum class Serializable : bool { No, Yes };
-    enum class AvailableToElementInternals : bool { No, Yes };
-    enum class ScopedCustomElementRegistry : bool { No, Yes };
 
     static Ref<ShadowRoot> create(Document& document, ShadowRootMode type, SlotAssignmentMode assignmentMode = SlotAssignmentMode::Named,
-        DelegatesFocus delegatesFocus = DelegatesFocus::No, Clonable clonable = Clonable::No, Serializable serializable = Serializable::No, AvailableToElementInternals availableToElementInternals = AvailableToElementInternals::No,
-        RefPtr<CustomElementRegistry>&& registry = nullptr, ScopedCustomElementRegistry scopedRegistry = ScopedCustomElementRegistry::No, const AtomString& referenceTarget = nullAtom())
+        ShadowRootDelegatesFocus delegatesFocus = ShadowRootDelegatesFocus::No, Clonable clonable = Clonable::No, ShadowRootSerializable serializable = ShadowRootSerializable::No, ShadowRootAvailableToElementInternals availableToElementInternals = ShadowRootAvailableToElementInternals::No,
+        RefPtr<CustomElementRegistry>&& registry = nullptr, ShadowRootScopedCustomElementRegistry scopedRegistry = ShadowRootScopedCustomElementRegistry::No, const AtomString& referenceTarget = nullAtom())
     {
         return adoptRef(*new ShadowRoot(document, type, assignmentMode, delegatesFocus, clonable, serializable, availableToElementInternals, WTFMove(registry), scopedRegistry, referenceTarget));
     }
@@ -163,7 +161,7 @@ public:
     }
 
 private:
-    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, DelegatesFocus, Clonable, Serializable, AvailableToElementInternals, RefPtr<CustomElementRegistry>&&, ScopedCustomElementRegistry, const AtomString& referenceTarget);
+    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, ShadowRootDelegatesFocus, Clonable, ShadowRootSerializable, ShadowRootAvailableToElementInternals, RefPtr<CustomElementRegistry>&&, ShadowRootScopedCustomElementRegistry, const AtomString& referenceTarget);
     ShadowRoot(Document&, std::unique_ptr<SlotAssignment>&&);
 
     bool childTypeAllowed(NodeType) const override;

--- a/Source/WebCore/dom/SlotAssignmentMode.h
+++ b/Source/WebCore/dom/SlotAssignmentMode.h
@@ -27,7 +27,7 @@
 
 namespace WebCore {
 
-enum class SlotAssignmentMode : uint8_t {
+enum class SlotAssignmentMode : bool {
     Manual,
     Named,
 };

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.cpp
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.cpp
@@ -26,11 +26,28 @@
 #include "config.h"
 #include "TemplateContentDocumentFragment.h"
 
+#include "HTMLTemplateElement.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(TemplateContentDocumentFragment);
+
+TemplateContentDocumentFragment::TemplateContentDocumentFragment(Document& document, const HTMLTemplateElement& host)
+    : DocumentFragment(document)
+    , m_host(host)
+{
+}
+
+const HTMLTemplateElement* TemplateContentDocumentFragment::host() const
+{
+    return m_host.get();
+}
+
+void TemplateContentDocumentFragment::clearHost()
+{
+    m_host = nullptr;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -28,32 +28,29 @@
 #pragma once
 
 #include "DocumentFragment.h"
-#include "Element.h"
 
 namespace WebCore {
+
+class HTMLTemplateElement;
 
 class TemplateContentDocumentFragment final : public DocumentFragment {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TemplateContentDocumentFragment);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TemplateContentDocumentFragment);
 public:
-    static Ref<TemplateContentDocumentFragment> create(Document& document, const Element& host)
+    static Ref<TemplateContentDocumentFragment> create(Document& document, const HTMLTemplateElement& host)
     {
         return adoptRef(*new TemplateContentDocumentFragment(document, host));
     }
 
-    const Element* host() const { return m_host.get(); }
-    void clearHost() { m_host = nullptr; }
+    const HTMLTemplateElement* host() const;
+    void clearHost();
 
 private:
-    TemplateContentDocumentFragment(Document& document, const Element& host)
-        : DocumentFragment(document)
-        , m_host(host)
-    {
-    }
+    TemplateContentDocumentFragment(Document&, const HTMLTemplateElement&);
 
     bool isTemplateContent() const override { return true; }
 
-    WeakPtr<const Element, WeakPtrImplWithEventTargetData> m_host;
+    WeakPtr<const HTMLTemplateElement, WeakPtrImplWithEventTargetData> m_host;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -52,6 +52,8 @@ public:
 
     void setDeclarativeShadowRoot(ShadowRoot&);
 
+    void adoptDeserializedContent(Ref<TemplateContentDocumentFragment>&&);
+
 private:
     HTMLTemplateElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -27,6 +27,7 @@
 #include "WebKitNamespace.h"
 
 #include "Element.h"
+#include "ExceptionOr.h"
 #include "FrameLoader.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
@@ -73,8 +74,10 @@ Ref<WebKitJSHandle> WebKitNamespace::createJSHandle(Document& document, JSC::Str
     return WebKitJSHandle::create(document, object.get());
 }
 
-Ref<WebKitSerializedNode> WebKitNamespace::serializeNode(Node& node, SerializedNodeInit&& init)
+ExceptionOr<Ref<WebKitSerializedNode>> WebKitNamespace::serializeNode(Node& node, SerializedNodeInit&& init)
 {
+    if (node.isShadowRoot()) [[unlikely]]
+        return Exception { ExceptionCode::NotSupportedError };
     return WebKitSerializedNode::create(node, init.deep);
 }
 

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -55,7 +55,7 @@ public:
     struct SerializedNodeInit {
         bool deep { false };
     };
-    Ref<WebKitSerializedNode> serializeNode(Node&, SerializedNodeInit&&);
+    ExceptionOr<Ref<WebKitSerializedNode>> serializeNode(Node&, SerializedNodeInit&&);
 
 private:
     explicit WebKitNamespace(LocalDOMWindow&, UserContentProvider&);

--- a/Source/WebKit/Shared/SerializedNode.serialization.in
+++ b/Source/WebKit/Shared/SerializedNode.serialization.in
@@ -64,6 +64,7 @@
 [Nested] struct WebCore::SerializedNode::Element : WebCore::SerializedNode::ContainerNode {
     WebCore::SerializedNode::QualifiedName name;
     Vector<WebCore::SerializedNode::Element::Attribute> attributes;
+    std::optional<WebCore::SerializedNode::ShadowRoot> shadowRoot;
 };
 [Nested] struct WebCore::SerializedNode::Comment : WebCore::SerializedNode::CharacterData {
 };
@@ -75,9 +76,21 @@
     String target;
 };
 [Nested] struct WebCore::SerializedNode::ShadowRoot : WebCore::SerializedNode::DocumentFragment {
+    bool openMode;
+    WebCore::SlotAssignmentMode slotAssignmentMode;
+    WebCore::ShadowRootDelegatesFocus delegatesFocus;
+    WebCore::ShadowRootSerializable serializable;
+    WebCore::ShadowRootAvailableToElementInternals availableToElementInternals;
+    WebCore::ShadowRootScopedCustomElementRegistry hasScopedCustomElementRegistry;
 };
 [Nested] struct WebCore::SerializedNode::HTMLTemplateElement : WebCore::SerializedNode::Element {
+    std::optional<WebCore::SerializedNode::DocumentFragment> content;
 };
+[Nested] enum class WebCore::SlotAssignmentMode : bool
+[Nested] enum class WebCore::ShadowRootDelegatesFocus : bool
+[Nested] enum class WebCore::ShadowRootSerializable : bool
+[Nested] enum class WebCore::ShadowRootAvailableToElementInternals : bool
+[Nested] enum class WebCore::ShadowRootScopedCustomElementRegistry : bool
 
 struct WebCore::SerializedNode {
     Variant<WebCore::SerializedNode::Attr, WebCore::SerializedNode::CDATASection, WebCore::SerializedNode::Comment, WebCore::SerializedNode::Document, WebCore::SerializedNode::DocumentFragment, WebCore::SerializedNode::DocumentType, WebCore::SerializedNode::Element, WebCore::SerializedNode::ProcessingInstruction, WebCore::SerializedNode::ShadowRoot, WebCore::SerializedNode::Text, WebCore::SerializedNode::HTMLTemplateElement> data;


### PR DESCRIPTION
#### 68b4ea83bc8107bb5e0907815d9982c42a09cde1
<pre>
Implement _WKSerializedNode of DocumentFragment, template elements, and shadow roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=298367">https://bugs.webkit.org/show_bug.cgi?id=298367</a>
<a href="https://rdar.apple.com/159811421">rdar://159811421</a>

Reviewed by Ryosuke Niwa.

This makes _WKSerializedNode able to handle anything that Node.cloneNode can
except the interactions with CustomElementRegistry, which is a little unclear because
Node.cloneNode only works within the scope of one document but _WKSerializedNode doesn&apos;t.

I use a little bit of explicit template instantiation so I can return nested types without
including SerializedNode.h from other headers to keep the build time low.

* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::serializeNode const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::serializeShadowRoot const):
(WebCore::Element::serializeAttributes const):
(WebCore::Element::serializeNode const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/SerializedNode.cpp:
(WebCore::addShadowRootIfNecessary):
(WebCore::SerializedNode::deserialize):
* Source/WebCore/dom/SerializedNode.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::serializeNode const):
* Source/WebCore/dom/SlotAssignmentMode.h:
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::adoptDeserializedContent):
(WebCore::HTMLTemplateElement::serializeNode const):
* Source/WebCore/html/HTMLTemplateElement.h:
* Source/WebKit/Shared/SerializedNode.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SerializedNode.mm:
(TestWebKitAPI::TEST(SerializedNode, Basic)):

Canonical link: <a href="https://commits.webkit.org/299731@main">https://commits.webkit.org/299731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/936ff65590963cb130ddecd53eafa711d36b7060

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72048 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de406489-8e62-4094-b51c-1858ca61f2c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91110 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60421 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d879bce-b809-4287-88db-8289ab4d1b97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71666 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/121565da-0387-460b-98de-30934d4f5912) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25684 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69940 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101716 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129225 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99731 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99576 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43516 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19081 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52463 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47909 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->