### PR TITLE
[JSC] Enhance error message for for-of loops without Symbol.iterator

### DIFF
--- a/JSTests/stress/iterator-error-messages-consistent.js
+++ b/JSTests/stress/iterator-error-messages-consistent.js
@@ -1,0 +1,81 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function testIteratorError(value, expectedError) {
+    function iterate() {
+        for (let x of value) { }
+    }
+    
+    shouldThrow(iterate, expectedError);
+}
+
+function runTest(value, expectedError) {
+    for (let i = 0; i < testLoopCount; i++) {
+        testIteratorError(value, expectedError);
+    }
+}
+
+runTest(null, "TypeError: null is not an object (evaluating 'value')");
+runTest(undefined, "TypeError: undefined is not an object (evaluating 'value')");
+runTest(0, "TypeError: number is not iterable");
+runTest(42, "TypeError: number is not iterable");
+runTest(true, "TypeError: true is not iterable");
+runTest(false, "TypeError: false is not iterable");
+runTest(Symbol("test"), "TypeError: value is not iterable");
+runTest({}, "TypeError: {} is not iterable");
+runTest({ a: 1 }, "TypeError: {} is not iterable");
+
+function testFromEntries(value, expectedError) {
+    function test() {
+        return Object.fromEntries(value);
+    }
+    shouldThrow(test, expectedError);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testFromEntries(0, "TypeError: number is not iterable");
+    testFromEntries(true, "TypeError: true is not iterable");
+    testFromEntries(null, "TypeError: null is not an object");
+}
+
+function testDestructuring(value, expectedError) {
+    function test() {
+        let [x] = value;
+    }
+    shouldThrow(test, expectedError);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testDestructuring(42, "TypeError: number is not iterable");
+    testDestructuring(null, "TypeError: null is not an object (evaluating 'value')");
+}
+
+function testSpread(value, expectedError) {
+    function test() {
+        return [...value];
+    }
+    shouldThrow(test, expectedError);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testSpread(0, "TypeError: Spread syntax requires ...iterable[Symbol.iterator] to be a function");
+    testSpread(null, "TypeError: Spread syntax requires ...iterable not be null or undefined");
+    testSpread(false, "TypeError: Spread syntax requires ...iterable[Symbol.iterator] to be a function");
+}

--- a/JSTests/stress/object-from-entries.js
+++ b/JSTests/stress/object-from-entries.js
@@ -23,9 +23,9 @@ shouldBe(Object.fromEntries.length, 1);
 
 shouldThrow(() => Object.fromEntries(null), `TypeError: null is not an object`);
 shouldThrow(() => Object.fromEntries(undefined), `TypeError: undefined is not an object`);
-shouldThrow(() => Object.fromEntries(0), `TypeError: undefined is not a function`);
-shouldThrow(() => Object.fromEntries(true), `TypeError: undefined is not a function`);
-shouldThrow(() => Object.fromEntries(Symbol("Cocoa")), `TypeError: undefined is not a function`);
+shouldThrow(() => Object.fromEntries(0), `TypeError: number is not iterable`);
+shouldThrow(() => Object.fromEntries(true), `TypeError: true is not iterable`);
+shouldThrow(() => Object.fromEntries(Symbol("Cocoa")), `TypeError: value is not iterable`);
 shouldThrow(() => Object.fromEntries("Cocoa"), `TypeError: Object.fromEntries requires the first iterable parameter yields objects`);
 shouldThrow(() => Object.fromEntries([0]), `TypeError: Object.fromEntries requires the first iterable parameter yields objects`);
 shouldThrow(() => Object.fromEntries([["Cocoa", "Cappuccino"], 0]), `TypeError: Object.fromEntries requires the first iterable parameter yields objects`);

--- a/LayoutTests/inspector/unit-tests/array-utilities-expected.txt
+++ b/LayoutTests/inspector/unit-tests/array-utilities-expected.txt
@@ -186,5 +186,5 @@ Node:
 
 Object (doesn't have [Symbol.iterator]):
 PASS: Should produce an exception.
-TypeError: undefined is not a function (near '...item of iterable...')
+TypeError: {} is not iterable
 

--- a/LayoutTests/inspector/unit-tests/set-utilities-expected.txt
+++ b/LayoutTests/inspector/unit-tests/set-utilities-expected.txt
@@ -49,7 +49,7 @@ Node:
 
 Object (doesn't have [Symbol.iterator]):
 PASS: Should produce an exception.
-TypeError: undefined is not a function (near '...item of iterable...')
+TypeError: {} is not iterable
 
 -- Running test case: Set.prototype.take
 PASS: Set can take `key`.

--- a/LayoutTests/js/let-syntax-expected.txt
+++ b/LayoutTests/js/let-syntax-expected.txt
@@ -404,7 +404,7 @@ PASS Does not have syntax error: 'var {let} = 40;'
 SyntaxError: Cannot use abbreviated destructuring syntax for keyword 'let'.
 SyntaxError: Cannot use abbreviated destructuring syntax for keyword 'let'.
 PASS Has syntax error: ''use strict'; var {let} = 40;'
-TypeError: undefined is not a function (near '...[let]...')
+TypeError: number is not iterable
 PASS Does not have syntax error: 'var [let] = 40;'
 SyntaxError: Cannot use 'let' as a variable name in strict mode.
 SyntaxError: Cannot use 'let' as a variable name in strict mode.

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -3117,12 +3117,12 @@ llintOpWithMetadata(op_iterator_open, OpIteratorOpen, macro (size, get, dispatch
         callSlowPath(_iterator_open_try_fast_wide32)
     end
     size(fastNarrow, fastWide16, fastWide32, macro (callOp) callOp() end)
-
-    # FIXME: We should do this with inline assembly since it's the "fast" case.
+    
     bbeq r1, constexpr IterationMode::Generic, .iteratorOpenGeneric
     dispatch()
 
 .iteratorOpenGeneric:
+    btpz r0, .iteratorOpenException
     macro gotoGetByIdCheckpoint()
         jmp .getByIdStart
     end
@@ -3162,6 +3162,10 @@ llintOpWithMetadata(op_iterator_open, OpIteratorOpen, macro (size, get, dispatch
 .iteratorOpenGenericGetNextSlow:
     callSlowPath(_llint_slow_path_iterator_open_get_next)
     dispatch()
+
+.iteratorOpenException:
+    jmp _llint_throw_from_slow_path_trampoline
+
 end)
 
 llintOpWithMetadata(op_iterator_next, OpIteratorNext, macro (size, get, dispatch, metadata, return)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -3304,12 +3304,12 @@ llintOpWithMetadata(op_iterator_open, OpIteratorOpen, macro (size, get, dispatch
         callSlowPath(_iterator_open_try_fast_wide32)
     end
     size(fastNarrow, fastWide16, fastWide32, macro (callOp) callOp() end)
-
-    # FIXME: We should do this with inline assembly since it's the "fast" case.
+    
     bbeq r1, constexpr IterationMode::Generic, .iteratorOpenGeneric
     dispatch()
 
 .iteratorOpenGeneric:
+    btpz r0, .iteratorOpenException
     macro gotoGetByIdCheckpoint()
         jmp .getByIdStart
     end
@@ -3350,6 +3350,9 @@ llintOpWithMetadata(op_iterator_open, OpIteratorOpen, macro (size, get, dispatch
 .iteratorOpenGenericGetNextSlow:
     callSlowPath(_llint_slow_path_iterator_open_get_next)
     dispatch()
+
+.iteratorOpenException:
+    jmp _llint_throw_from_slow_path_trampoline
 
 end)
 

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -798,7 +798,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_is_constructor)
 }
 
 template<OpcodeSize width>
-ALWAYS_INLINE UGPRPair iteratorOpenTryFastImpl(VM& vm, JSGlobalObject* globalObject, CodeBlock* codeBlock, CallFrame* callFrame, const JSInstruction* pc)
+ALWAYS_INLINE UGPRPair iteratorOpenTryFastImpl(VM& vm, JSGlobalObject* globalObject, CodeBlock* codeBlock, CallFrame* callFrame, ThrowScope& throwScope, const JSInstruction* pc)
 {
     auto bytecode = pc->asKnownWidth<OpIteratorOpen, width>();
     auto& metadata = bytecode.metadata(codeBlock);
@@ -807,7 +807,8 @@ ALWAYS_INLINE UGPRPair iteratorOpenTryFastImpl(VM& vm, JSGlobalObject* globalObj
     JSValue symbolIterator = GET_C(bytecode.m_symbolIterator).jsValue();
     auto& iterator = GET(bytecode.m_iterator);
 
-    if (getIterationMode(vm, globalObject, iterable, symbolIterator) == IterationMode::FastArray) {
+    auto iterationMode = getIterationMode(vm, globalObject, iterable, symbolIterator);
+    if (iterationMode == IterationMode::FastArray) {
         // We should be good to go.
         metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastArray;
         GET(bytecode.m_next) = JSValue();
@@ -817,6 +818,12 @@ ALWAYS_INLINE UGPRPair iteratorOpenTryFastImpl(VM& vm, JSGlobalObject* globalObj
         return encodeResult(pc, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::FastArray)));
     }
 
+    auto validationResult = validateIterable(vm, iterable, symbolIterator);
+    if (validationResult != IterableValidationResult::Valid) [[unlikely]] {
+        throwTypeError(globalObject, throwScope, getIteratorErrorMessage(validationResult, iterable));
+        return encodeResult(nullptr, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::Generic)));
+    }
+
     // Return to the bytecode to try in generic mode.
     metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::Generic;
     return encodeResult(pc, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::Generic)));
@@ -824,23 +831,20 @@ ALWAYS_INLINE UGPRPair iteratorOpenTryFastImpl(VM& vm, JSGlobalObject* globalObj
 
 JSC_DEFINE_COMMON_SLOW_PATH(iterator_open_try_fast_narrow)
 {
-    // Don't set PC; we can't throw and it's relatively slow.
-    BEGIN_NO_SET_PC();
-    return iteratorOpenTryFastImpl<Narrow>(vm, globalObject, codeBlock, callFrame, pc);
+    BEGIN();
+    return iteratorOpenTryFastImpl<Narrow>(vm, globalObject, codeBlock, callFrame, throwScope, pc);
 }
 
 JSC_DEFINE_COMMON_SLOW_PATH(iterator_open_try_fast_wide16)
 {
-    // Don't set PC; we can't throw and it's relatively slow.
-    BEGIN_NO_SET_PC();
-    return iteratorOpenTryFastImpl<Wide16>(vm, globalObject, codeBlock, callFrame, pc);
+    BEGIN();
+    return iteratorOpenTryFastImpl<Wide16>(vm, globalObject, codeBlock, callFrame, throwScope, pc);
 }
 
 JSC_DEFINE_COMMON_SLOW_PATH(iterator_open_try_fast_wide32)
 {
-    // Don't set PC; we can't throw and it's relatively slow.
-    BEGIN_NO_SET_PC();
-    return iteratorOpenTryFastImpl<Wide32>(vm, globalObject, codeBlock, callFrame, pc);
+    BEGIN();
+    return iteratorOpenTryFastImpl<Wide32>(vm, globalObject, codeBlock, callFrame, throwScope, pc);
 }
 
 template<OpcodeSize width>


### PR DESCRIPTION
#### 0051bbf2491fd2b54a5f2465a7e932e47ec184a0
<pre>
[JSC] Enhance error message for for-of loops without Symbol.iterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=157041">https://bugs.webkit.org/show_bug.cgi?id=157041</a>
<a href="https://rdar.apple.com/problem/159814766">rdar://problem/159814766</a>

Reviewed by Keith Miller.

This adds a check to verify that Symbol.iterator property is callable
before attempting to use it. If it&apos;s not callable (undefined, null, or not a function),
we now throw a clearer TypeError message. This avoids adding error checks at the
bytecode generation stage and instead handles errors at runtime.

* JSTests/stress/iterator-error-messages-consistent.js:
(runTest):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::iteratorOpenTryFastImpl):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::validateIterable):
(JSC::throwIteratorError):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIterable):
* JSTests/stress/iterator-error-messages-consistent.js: Added.
(shouldBe):
(shouldThrow):
(iterate):
(runTest):
(test):
(testFromEntries):
(testDestructuring):
(testSpread):
* JSTests/stress/object-from-entries.js:
(): Deleted.
* LayoutTests/inspector/unit-tests/array-utilities-expected.txt:
* LayoutTests/inspector/unit-tests/set-utilities-expected.txt:
* LayoutTests/js/let-syntax-expected.txt:
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::iteratorOpenTryFastImpl):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::validateIterable):
(JSC::throwIteratorError):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIterable):

Canonical link: <a href="https://commits.webkit.org/300154@main">https://commits.webkit.org/300154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f90beea779b89b34ed104cf6afe74edcfb4fa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73540 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92251 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61374 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71478 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113587 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130732 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119977 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25556 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45081 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53956 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150139 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47715 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->