### PR TITLE
[JSC] Hide internal async function frames from stack traces

### DIFF
--- a/JSTests/stress/stack-trace-async-functions.js
+++ b/JSTests/stress/stack-trace-async-functions.js
@@ -1,0 +1,129 @@
+const source = "stack-trace-async-functions.js";
+
+function nop() {}
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+{
+    async function foo() {
+
+        nop();
+
+        throw new Error("error from foo");
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test() {
+                await foo();
+            }, Error, "error from foo",
+            [
+                ["foo", "66:24"],
+                ["test", "72:26"],
+                ["shouldThrowAsync", "8:8"],
+                ["global code", "70:25"]
+            ],
+        );
+    }
+}
+
+{
+    const foo = async () => {
+
+        nop();
+        throw new Error("error from foo");
+    };
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test() {
+                await foo();
+            }, Error, "error from foo",
+            [
+                ["", "88:24"],
+                ["test", "94:26"],
+                ["shouldThrowAsync", "8:8"],
+                ["global code", "92:25"]
+            ],
+        );
+    }
+}
+
+{
+    class Foo {
+        async foo() {
+            nop();
+
+            throw new Error("error from foo");
+        }
+    }
+    const foo = new Foo();
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test() {
+                await foo.foo();
+            }, Error, "error from foo",
+            [
+                ["foo", "111:28"],
+                ["test", "119:30"],
+                ["shouldThrowAsync", "8:8"],
+                ["global code", "117:25"]
+            ],
+        );
+    }
+}

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -615,9 +615,12 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
                 break;
             }
             }
-        } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction())
-            results.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
-        else
+        } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction()) {
+            // FIXME: Remove this check if we set implementationVisibility of the async function wrapper to private
+            // https://bugs.webkit.org/show_bug.cgi?id=298509
+            if (!isAsyncFunctionWrapperParseMode(visitor->codeBlock()->unlinkedCodeBlock()->parseMode()))
+                results.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
+        } else
             results.append(StackFrame(vm, owner, visitor->callee().asCell()));
         return IterationStatus::Continue;
     });


### PR DESCRIPTION
#### b0b84ea785891918f5d7b7e3c33b07991ee6d996
<pre>
[JSC] Hide internal async function frames from stack traces
<a href="https://bugs.webkit.org/show_bug.cgi?id=298373">https://bugs.webkit.org/show_bug.cgi?id=298373</a>

Reviewed by NOBODY (OOPS!).

Async functions sometimes appear duplicated in stack traces.

For example, with this code:

  async function foo() { throw new Error(&quot;error from foo&quot;); }
  foo().catch(e =&gt; print(e.stack));

The output shows foo appearing twice:

  foo@./WebKitBuild/Debug/test.js:1:39
  foo@./WebKitBuild/Debug/test.js:1:60
  global code@./WebKitBuild/Debug/test.js:2:4

This patch fixes it so the internal frame no longer appears in stack traces.

* JSTests/stress/stack-trace-async-functions.js: Added.
(nop):
(shouldThrowAsync):
(throw.new.Error.async foo):
(throw.new.Error):
(async const.foo.async nop):
(async const):
(Foo.prototype.async foo):
(Foo):
(i.shouldThrowAsync.async test):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getStackTrace):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b84ea785891918f5d7b7e3c33b07991ee6d996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71889 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60289 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71555 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25541 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69768 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111941 "Found 57 new JSC stress test failures: stress/async-stack-trace-basic.js.bytecode-cache, stress/async-stack-trace-basic.js.default, stress/async-stack-trace-basic.js.dfg-eager, stress/async-stack-trace-basic.js.dfg-eager-no-cjit-validate, stress/async-stack-trace-basic.js.eager-jettison-no-cjit, stress/async-stack-trace-basic.js.ftl-eager, stress/async-stack-trace-basic.js.ftl-eager-no-cjit, stress/async-stack-trace-basic.js.ftl-eager-no-cjit-b3o1, stress/async-stack-trace-basic.js.ftl-no-cjit-b3o0, stress/async-stack-trace-basic.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129062 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118332 "Found 57 new JSC stress test failures: stress/async-stack-trace-basic.js.bytecode-cache, stress/async-stack-trace-basic.js.default, stress/async-stack-trace-basic.js.dfg-eager, stress/async-stack-trace-basic.js.dfg-eager-no-cjit-validate, stress/async-stack-trace-basic.js.eager-jettison-no-cjit, stress/async-stack-trace-basic.js.ftl-eager, stress/async-stack-trace-basic.js.ftl-eager-no-cjit, stress/async-stack-trace-basic.js.ftl-eager-no-cjit-b3o1, stress/async-stack-trace-basic.js.ftl-no-cjit-b3o0, stress/async-stack-trace-basic.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46736 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35417 "Found 2 new test failures: http/tests/webgpu/webgpu/api/operation/uncapturederror.html http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99603 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99447 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43324 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46598 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52304 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147030 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46064 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37780 "Found 1 new JSC binary failure: testapi, Found 18645 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Closures/closure-funcexpr-eval.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->