### PR TITLE
[JSC] Add async stack traces behind the flag

### DIFF
--- a/JSTests/stress/async-stack-trace-basic.js
+++ b/JSTests/stress/async-stack-trace-basic.js
@@ -1,0 +1,221 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-basic.js";
+
+function nop() {}
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    let stackLineIndex = 0;
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+{
+    async function one(x) {
+        nop();
+        nop();
+
+        await two(x);
+    }
+
+    async function two(x) {
+        await x;
+        nop();
+
+
+        nop();
+        throw new Error("error");
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test() {
+                await one(1);
+            }, Error, "error",
+            [
+                ["two", "78:24"],
+                ["one", "69:18"],
+                ["test", "84:26"],
+                ["drainMicrotasks", "[native code]"],
+                ["shouldThrowAsync", "19:20"],
+                ["global code", "82:25"]
+            ],
+        );
+        drainMicrotasks();
+    }
+}
+
+{
+    async function one(x) {
+
+        nop();
+
+
+        return await two(x);
+    }
+
+    async function two(x) {
+
+        await x;
+
+
+        nop();
+        return +x; // This will raise a TypeError.
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test () {
+                await one(Symbol());
+            }, TypeError, "Cannot convert a symbol to a number",
+            [
+                ["two", "114:16"],
+                ["one", "105:25"],
+                ["test", "120:26"],
+                ["drainMicrotasks", "[native code]"],
+                ["shouldThrowAsync", "19:20"],
+                ["global code", "118:25"]
+            ],
+        );
+        drainMicrotasks();
+    }
+}
+
+{
+    function callOne(x) {
+
+
+        nop();
+        return one(x);
+    }
+
+    function callTwo(x) {
+
+
+        nop();
+
+
+        return two(x);
+    }
+
+    async function one(x) {
+
+
+        nop();
+        return await callTwo(x);
+    }
+
+    async function two(x) {
+        await x;
+        throw new Error("error");
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test () {
+                await callOne(1);
+            }, Error, "error",
+            [
+                ["two", "161:24"],
+                ["one", "156:29"],
+                ["test", "167:30"],
+                ["drainMicrotasks", "[native code]"],
+                ["shouldThrowAsync", "19:20"],
+                ["global code", "165:25"]
+            ],
+        );
+        drainMicrotasks();
+    }
+}
+
+{
+    async function one(x) {
+        nop();
+        nop();
+
+        await two(x);
+    }
+
+    async function two(x) {
+        await x;
+        nop();
+
+
+        nop();
+        await throwError();
+    }
+
+    async function throwError() {
+        throw new Error("error");
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test() {
+                await one(1);
+            }, Error, "error",
+            [
+                ["throwError", "200:24"],
+                ["throwError", "199:35"],
+                ["two", "196:25"],
+                ["one", "187:18"],
+                ["test", "206:26"],
+                ["drainMicrotasks", "[native code]"],
+                ["shouldThrowAsync", "19:20"],
+                ["global code", "204:25"]
+            ],
+        );
+        drainMicrotasks();
+    }
+}

--- a/JSTests/stress/async-stack-trace-bound-functions-basic.js
+++ b/JSTests/stress/async-stack-trace-bound-functions-basic.js
@@ -1,0 +1,108 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-bound-functions-basic.js";
+
+function nop() {}
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    let stackLineIndex = 0;
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            else if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+{
+    async function foo(x) {
+
+        nop();
+
+        nop();
+
+        await bar.bind(this)(x);
+    }
+
+    async function bar(x) {
+
+
+        nop();
+
+
+        await baz.bind(this)(x);
+    }
+
+    async function baz(x) {
+        await x;
+
+        nop();
+        throw new Error("error from baz");
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test() {
+                await foo(1);
+            }, Error, "error from baz",
+            [
+                ["baz", "87:24"],
+                ["bar", "80:29"],
+                ["foo", "71:29"],
+                ["test", "93:26"],
+                ["drainMicrotasks", "[native code]"],
+                ["shouldThrowAsync", "19:20"],
+                ["global code", "91:25"]
+            ],
+        );
+        drainMicrotasks();
+    }
+}
+

--- a/JSTests/stress/async-stack-trace-nested-deep.js
+++ b/JSTests/stress/async-stack-trace-nested-deep.js
@@ -1,0 +1,763 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-nested-deep.js";
+
+function nop() {}
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    let stackLineIndex = 0;
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            else if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+async function level1() {
+
+    nop();
+    await level2();
+}
+
+async function level2() {
+    nop();
+
+    await level3();
+
+    nop();
+}
+
+async function level3() {
+    await level4();
+
+    nop();
+}
+
+async function level4() {
+
+    nop();
+
+
+    await level5();
+}
+
+async function level5() {
+    nop();
+
+    await level6();
+}
+
+async function level6() {
+    nop();
+    await level7();
+
+}
+
+async function level7() {
+
+    nop();
+    await level8();
+}
+
+async function level8() {
+    await level9();
+}
+
+async function level9() {
+
+    await level10();
+
+}
+
+async function level10() {
+    await level11();
+}
+
+async function level11() {
+
+    await level12();
+}
+
+async function level12() {
+    nop();
+    await level13();
+
+}
+
+async function level13() {
+
+    await level14();
+    nop();
+}
+
+async function level14() {
+    await level15();
+
+    nop();
+}
+
+async function level15() {
+
+    nop();
+    await level16();
+}
+
+async function level16() {
+    await level17();
+}
+
+async function level17() {
+    nop();
+
+    await level18();
+}
+
+async function level18() {
+
+    await level19();
+    nop();
+}
+
+async function level19() {
+    await level20();
+
+}
+
+async function level20() {
+
+    nop();
+    await level21();
+}
+
+async function level21() {
+    await level22();
+    nop();
+
+}
+
+async function level22() {
+
+    await level23();
+}
+
+async function level23() {
+    nop();
+    await level24();
+
+}
+
+async function level24() {
+
+    await level25();
+    nop();
+}
+
+async function level25() {
+    await level26();
+}
+
+async function level26() {
+    nop();
+
+    await level27();
+}
+
+async function level27() {
+
+    await level28();
+    nop();
+}
+
+async function level28() {
+    await level29();
+
+}
+
+async function level29() {
+
+    nop();
+    await level30();
+}
+
+async function level30() {
+    await level31();
+    nop();
+
+}
+
+async function level31() {
+
+    await level32();
+}
+
+async function level32() {
+    nop();
+    await level33();
+
+}
+
+async function level33() {
+
+    await level34();
+    nop();
+}
+
+async function level34() {
+    await level35();
+}
+
+async function level35() {
+    nop();
+
+    await level36();
+}
+
+async function level36() {
+
+    await level37();
+    nop();
+}
+
+async function level37() {
+    await level38();
+
+}
+
+async function level38() {
+
+    nop();
+    await level39();
+}
+
+async function level39() {
+    await level40();
+    nop();
+
+}
+
+async function level40() {
+
+    await level41();
+}
+
+async function level41() {
+    nop();
+    await level42();
+
+}
+
+async function level42() {
+
+    await level43();
+    nop();
+}
+
+async function level43() {
+    await level44();
+}
+
+async function level44() {
+    nop();
+
+    await level45();
+}
+
+async function level45() {
+
+    await level46();
+    nop();
+}
+
+async function level46() {
+    await level47();
+
+}
+
+async function level47() {
+
+    nop();
+    await level48();
+}
+
+async function level48() {
+    await level49();
+    nop();
+
+}
+
+async function level49() {
+
+    await level50();
+}
+
+async function level50() {
+    nop();
+    await level51();
+
+}
+
+async function level51() {
+
+    await level52();
+    nop();
+}
+
+async function level52() {
+    await level53();
+}
+
+async function level53() {
+    nop();
+
+    await level54();
+}
+
+async function level54() {
+
+    await level55();
+    nop();
+}
+
+async function level55() {
+    await level56();
+
+}
+
+async function level56() {
+
+    nop();
+    await level57();
+}
+
+async function level57() {
+    await level58();
+    nop();
+
+}
+
+async function level58() {
+
+    await level59();
+}
+
+async function level59() {
+    nop();
+    await level60();
+
+}
+
+async function level60() {
+
+    await level61();
+    nop();
+}
+
+async function level61() {
+    await level62();
+}
+
+async function level62() {
+    nop();
+
+    await level63();
+}
+
+async function level63() {
+
+    await level64();
+    nop();
+}
+
+async function level64() {
+    await level65();
+
+}
+
+async function level65() {
+
+    nop();
+    await level66();
+}
+
+async function level66() {
+    await level67();
+    nop();
+
+}
+
+async function level67() {
+
+    await level68();
+}
+
+async function level68() {
+    nop();
+    await level69();
+
+}
+
+async function level69() {
+
+    await level70();
+    nop();
+}
+
+async function level70() {
+    await level71();
+}
+
+async function level71() {
+    nop();
+
+    await level72();
+}
+
+async function level72() {
+
+    await level73();
+    nop();
+}
+
+async function level73() {
+    await level74();
+
+}
+
+async function level74() {
+
+    nop();
+    await level75();
+}
+
+async function level75() {
+    await level76();
+    nop();
+
+}
+
+async function level76() {
+
+    await level77();
+}
+
+async function level77() {
+    nop();
+    await level78();
+
+}
+
+async function level78() {
+
+    await level79();
+    nop();
+}
+
+async function level79() {
+    await level80();
+}
+
+async function level80() {
+    nop();
+
+    await level81();
+}
+
+async function level81() {
+
+    await level82();
+    nop();
+}
+
+async function level82() {
+    await level83();
+
+}
+
+async function level83() {
+
+    nop();
+    await level84();
+}
+
+async function level84() {
+    await level85();
+    nop();
+
+}
+
+async function level85() {
+
+    await level86();
+}
+
+async function level86() {
+    nop();
+    await level87();
+
+}
+
+async function level87() {
+
+    await level88();
+    nop();
+}
+
+async function level88() {
+    await level89();
+}
+
+async function level89() {
+    nop();
+
+    await level90();
+}
+
+async function level90() {
+
+    await level91();
+    nop();
+}
+
+async function level91() {
+    await level92();
+
+}
+
+async function level92() {
+
+    nop();
+    await level93();
+}
+
+async function level93() {
+    await level94();
+    nop();
+
+}
+
+async function level94() {
+
+    await level95();
+}
+
+async function level95() {
+    nop();
+    await level96();
+
+}
+
+async function level96() {
+
+    await level97();
+    nop();
+}
+
+async function level97() {
+    await level98();
+}
+
+async function level98() {
+    nop();
+
+    await level99();
+}
+
+async function level99() {
+
+    await level100();
+    nop();
+}
+
+async function level100() {
+    await level101();
+
+}
+
+async function level101() {
+
+    nop();
+    await delayedOperation(1);
+
+    await delayedOperation(2);
+    nop();
+
+    await problematicFunction();
+}
+
+async function delayedOperation(id) {
+
+    nop();
+    await id;
+}
+
+async function problematicFunction() {
+
+
+    nop();
+    throw new Error("error");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldThrowAsync(
+        async function test () {
+            await level1();
+        }, Error, "error",
+        [
+            ["problematicFunction", "645:20"],
+            ["problematicFunction", "641:36"],
+            ["level101", "632:30"],
+            ["level100", "620:19"],
+            ["level99", "615:19"],
+            ["level98", "610:18"],
+            ["level97", "604:18"],
+            ["level96", "599:18"],
+            ["level95", "593:18"],
+            ["level94", "588:18"],
+            ["level93", "581:18"],
+            ["level92", "577:18"],
+            ["level91", "570:18"],
+            ["level90", "565:18"],
+            ["level89", "560:18"],
+            ["level88", "554:18"],
+            ["level87", "549:18"],
+            ["level86", "543:18"],
+            ["level85", "538:18"],
+            ["level84", "531:18"],
+            ["level83", "527:18"],
+            ["level82", "520:18"],
+            ["level81", "515:18"],
+            ["level80", "510:18"],
+            ["level79", "504:18"],
+            ["level78", "499:18"],
+            ["level77", "493:18"],
+            ["level76", "488:18"],
+            ["level75", "481:18"],
+            ["level74", "477:18"],
+            ["level73", "470:18"],
+            ["level72", "465:18"],
+            ["level71", "460:18"],
+            ["level70", "454:18"],
+            ["level69", "449:18"],
+            ["level68", "443:18"],
+            ["level67", "438:18"],
+            ["level66", "431:18"],
+            ["level65", "427:18"],
+            ["level64", "420:18"],
+            ["level63", "415:18"],
+            ["level62", "410:18"],
+            ["level61", "404:18"],
+            ["level60", "399:18"],
+            ["level59", "393:18"],
+            ["level58", "388:18"],
+            ["level57", "381:18"],
+            ["level56", "377:18"],
+            ["level55", "370:18"],
+            ["level54", "365:18"],
+            ["level53", "360:18"],
+            ["level52", "354:18"],
+            ["level51", "349:18"],
+            ["level50", "343:18"],
+            ["level49", "338:18"],
+            ["level48", "331:18"],
+            ["level47", "327:18"],
+            ["level46", "320:18"],
+            ["level45", "315:18"],
+            ["level44", "310:18"],
+            ["level43", "304:18"],
+            ["level42", "299:18"],
+            ["level41", "293:18"],
+            ["level40", "288:18"],
+            ["level39", "281:18"],
+            ["level38", "277:18"],
+            ["level37", "270:18"],
+            ["level36", "265:18"],
+            ["level35", "260:18"],
+            ["level34", "254:18"],
+            ["level33", "249:18"],
+            ["level32", "243:18"],
+            ["level31", "238:18"],
+            ["level30", "231:18"],
+            ["level29", "227:18"],
+            ["level28", "220:18"],
+            ["level27", "215:18"],
+            ["level26", "210:18"],
+            ["level25", "204:18"],
+            ["level24", "199:18"],
+            ["level23", "193:18"],
+            ["level22", "188:18"],
+            ["level21", "181:18"],
+            ["level20", "177:18"],
+            ["level19", "170:18"],
+            ["level18", "165:18"],
+            ["level17", "160:18"],
+            ["level16", "154:18"],
+            ["level15", "150:18"],
+            ["level14", "142:18"],
+            ["level13", "137:18"],
+            ["level12", "131:18"],
+            ["level11", "126:18"],
+            ["level10", "121:18"],
+            ["level9", "116:18"],
+            ["level8", "111:17"],
+            ["level7", "107:17"],
+            ["level6", "100:17"],
+            ["level5", "95:17"],
+            ["level4", "89:17"],
+            ["level3", "79:17"],
+            ["level2", "73:17"],
+            ["level1", "67:17"],
+            ["drainMicrotasks", "[native code]"],
+            ["shouldThrowAsync", "19:20"],
+            ["global code", "649:21"]
+        ],
+    );
+    drainMicrotasks();
+}

--- a/JSTests/stress/async-stack-trace-nested.js
+++ b/JSTests/stress/async-stack-trace-nested.js
@@ -1,0 +1,183 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-nested.js";
+
+function nop() {}
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    let stackLineIndex = 0;
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            else if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+async function level1() {
+
+    nop();
+
+
+    await level2();
+}
+
+async function level2() {
+
+
+    nop();
+
+    await level3();
+
+
+    nop();
+}
+
+async function level3() {
+
+    await level4();
+
+
+    nop();
+}
+
+async function level4() {
+
+
+    nop();
+
+
+    await level5();
+}
+
+async function level5() {
+    nop();
+
+
+
+    await level6();
+}
+
+async function level6() {
+
+    nop();
+
+    await level7();
+}
+
+async function level7() {
+
+
+    nop();
+    await level8();
+}
+
+async function level8() {
+
+    await level9();
+}
+
+async function level9() {
+
+
+    await level10();
+
+
+}
+
+async function level10() {
+    await delayedOperation(1);
+
+    await delayedOperation(2);
+
+
+    await problematicFunction();
+}
+
+async function delayedOperation(id) {
+
+    nop();
+    await id; // Simple await
+}
+
+async function problematicFunction() {
+
+
+    nop();
+    throw new Error("error");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldThrowAsync(
+        async function test () {
+            await level1();
+        }, Error, "error",
+        [
+            ["problematicFunction", "154:20"],
+            ["problematicFunction", "150:36"],
+            ["level10", "141:30"],
+            ["level9", "130:18"],
+            ["level8", "124:17"],
+            ["level7", "119:17"],
+            ["level6", "112:17"],
+            ["level5", "105:17"],
+            ["level4", "97:17"],
+            ["level3", "85:17"],
+            ["level2", "77:17"],
+            ["level1", "69:17"],
+            ["test", "160:25"],
+            ["drainMicrotasks", "[native code]"],
+            ["shouldThrowAsync", "19:20"],
+            ["global code", "158:21"]
+        ],
+    );
+    drainMicrotasks();
+}
+

--- a/JSTests/stress/async-stack-trace-switch.js
+++ b/JSTests/stress/async-stack-trace-switch.js
@@ -1,0 +1,112 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-switch.js";
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+{
+    async function foo(value) {
+        switch (value) {
+            case 1:
+            case 2:
+            case 3:
+                return "foo";
+        }
+        await bar(value);
+    }
+
+    async function bar(value) {
+        switch (value) {
+            case 1:
+            case 2:
+            case 3:
+                return "bar";
+        }
+
+        switch (value) {
+            case 4:
+            case 5:
+                return "bar";
+        }
+
+        await baz(value);
+    }
+
+    async function baz(value) {
+        await value;
+
+        throw new Error("error from baz");
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        shouldThrowAsync(
+            async function test() {
+                await foo(9);
+            }, Error, "error from baz",
+            [
+                ["baz", "92:24"],
+                ["bar", "86:18"],
+                ["foo", "69:18"],
+                ["test", "98:26"],
+                ["drainMicrotasks", "[native code]"],
+                ["shouldThrowAsync", "17:20"],
+                ["global code", "96:25"]
+            ],
+        );
+        drainMicrotasks();
+    }
+}

--- a/JSTests/stress/never-inlined-functions.js
+++ b/JSTests/stress/never-inlined-functions.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+const regularFunction = function () {};
+const promiseReactionJob = $vm.createBuiltin("(function () { return @promiseReactionJob })")();
+const promiseReactionJobWithoutPromise = $vm.createBuiltin("(function () { return @promiseReactionJobWithoutPromise })")();
+
+shouldBe($vm.isNeverInline(regularFunction), false);
+shouldBe($vm.isNeverInline(promiseReactionJob), true);
+shouldBe($vm.isNeverInline(promiseReactionJobWithoutPromise), true);

--- a/Source/JavaScriptCore/builtins/PromiseOperations.js
+++ b/Source/JavaScriptCore/builtins/PromiseOperations.js
@@ -308,6 +308,7 @@ function createResolvingFunctions(promise)
 }
 
 @linkTimeConstant
+@neverInline
 function promiseReactionJobWithoutPromise(handler, argument, context)
 {
     "use strict";
@@ -423,6 +424,7 @@ function createResolvingFunctionsWithoutPromise(onFulfilled, onRejected, context
 }
 
 @linkTimeConstant
+@neverInline
 function promiseReactionJob(promiseOrCapability, handler, argument, contextOrState)
 {
     // Promise Reaction has four types.
@@ -452,7 +454,15 @@ function promiseReactionJob(promiseOrCapability, handler, argument, contextOrSta
 
     // Case (4).
     if (!promiseOrCapability) {
-        @promiseReactionJobWithoutPromise(handler, argument, contextOrState);
+        // inlined promiseReactionJobWithPromise
+        try {
+            if (contextOrState)
+                handler(argument, contextOrState);
+            else
+                handler(argument);
+        } catch {
+            // This is user-uncatchable promise. We just ignore the error here.
+        }
         return;
     }
 

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -70,6 +70,7 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
     class ProgramExecutable;
     class ModuleProgramExecutable;
     class Register;
+    class JSGenerator;
     class JSObject;
     class JSScope;
     class SourceCode;
@@ -156,6 +157,7 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
         static JSValue checkVMEntryPermission();
 
     private:
+        void getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results, JSGenerator* initialGenerator, size_t maxStackSize);
         enum ExecutionFlag { Normal, InitializeAndReturn };
         
         CodeBlock* prepareForCachedCall(CachedCall&, JSFunction*);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1877,6 +1877,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_performProxyObjectSetByValStrictFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetByValStrict)));
     m_performProxyObjectSetByValSloppyFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetByValSloppy)));
 
+    m_promiseReactionJobFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::promiseReactionJob)));
+    m_promiseReactionJobWithoutPromiseFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::promiseReactionJobWithoutPromise)));
+
     if (Options::exposeProfilersOnGlobalObject()) {
 #if ENABLE(SAMPLING_PROFILER)
         putDirectWithoutTransition(vm, Identifier::fromString(vm, "__enableSamplingProfiler"_s), JSFunction::create(vm, this, 1, "enableSamplingProfiler"_s, enableSamplingProfiler, ImplementationVisibility::Public), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
@@ -2626,6 +2629,8 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_arrayProtoValuesFunction.visit(visitor);
     thisObject->m_promiseResolveFunction.visit(visitor);
     visitor.append(thisObject->m_objectProtoValueOfFunction);
+    visitor.append(thisObject->m_promiseReactionJobFunction);
+    visitor.append(thisObject->m_promiseReactionJobWithoutPromiseFunction);
     thisObject->m_numberProtoToStringFunction.visit(visitor);
     visitor.append(thisObject->m_functionProtoHasInstanceSymbolFunction);
     visitor.append(thisObject->m_performProxyObjectHasFunction);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -299,6 +299,8 @@ public:
     WriteBarrier<JSFunction> m_performProxyObjectSetSloppyFunction;
     WriteBarrier<JSFunction> m_performProxyObjectSetByValStrictFunction;
     WriteBarrier<JSFunction> m_performProxyObjectSetByValSloppyFunction;
+    WriteBarrier<JSFunction> m_promiseReactionJobFunction;
+    WriteBarrier<JSFunction> m_promiseReactionJobWithoutPromiseFunction;
     WriteBarrier<JSObject> m_regExpProtoSymbolReplace;
     LazyProperty<JSGlobalObject, GetterSetter> m_throwTypeErrorArgumentsCalleeGetterSetter;
 
@@ -726,6 +728,8 @@ public:
     JSFunction* parseIntFunction() const { return m_parseIntFunction.get(this); }
     JSFunction* parseFloatFunction() const { return m_parseFloatFunction.get(this); }
 
+    JSFunction* promiseReactionJobFunction() const { return m_promiseReactionJobFunction.get(); }
+    JSFunction* promiseReactionJobWithoutPromiseFunction() const { return m_promiseReactionJobWithoutPromiseFunction.get(); }
     JSFunction* evalFunction() const;
     JSFunction* throwTypeErrorFunction() const;
     JSFunction* objectProtoToStringFunction() const { return m_objectProtoToStringFunction.get(this); }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -635,6 +635,7 @@ bool hasCapacityToUseLargeGigacage();
     /* Feature Flags */\
     \
     /* Restricted so some app doesn't set this environment variable and start using it. */ \
+    v(Bool, useAsyncStackTrace, false, Normal, "Enable async stack traces") \
     v(Bool, disallowMixedWasmExceptions, true, Restricted, "Disallow using both legacy and modern (try_table) wasm exception specs in the same module."_s) \
     v(Bool, useExplicitResourceManagement, false, Normal, "Enable explicit resource management builtins and syntax."_s) \
     v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -44,6 +44,7 @@ struct JSFrameData {
     WriteBarrier<JSCell> callee;
     WriteBarrier<CodeBlock> codeBlock;
     BytecodeIndex bytecodeIndex;
+    bool m_isAsyncFrameWithoutCodeBlock { false };
 };
 
 struct WasmFrameData {
@@ -58,6 +59,7 @@ public:
     StackFrame(VM&, JSCell* owner, JSCell* callee);
     StackFrame(VM&, JSCell* owner, JSCell* callee, CodeBlock*, BytecodeIndex);
     StackFrame(VM&, JSCell* owner, CodeBlock*, BytecodeIndex);
+    StackFrame(VM&, JSCell* owner, JSCell* callee, bool isAsyncFrameWithoutCodeBlock);
     StackFrame(Wasm::IndexOrName);
     StackFrame(Wasm::IndexOrName, size_t functionIndex);
     StackFrame() = default;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2150,6 +2150,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionCpuClflush);
 static JSC_DECLARE_HOST_FUNCTION(functionLLintTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionBaselineJITTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionNoInline);
+static JSC_DECLARE_HOST_FUNCTION(functionIsNeverInline);
 static JSC_DECLARE_HOST_FUNCTION(functionTriggerMemoryPressure);
 static JSC_DECLARE_HOST_FUNCTION(functionGC);
 static JSC_DECLARE_HOST_FUNCTION(functionEdenGC);
@@ -2613,6 +2614,24 @@ JSC_DEFINE_HOST_FUNCTION(functionNoInline, (JSGlobalObject*, CallFrame* callFram
         executable->setNeverInline(true);
     
     return JSValue::encode(jsUndefined());
+}
+
+// Check that the argument function is never inlined (set by $vm.noInline or the @neverInline attribute)
+// Usage:
+// function f() {}
+// $vm.isNeverInline(f);
+JSC_DEFINE_HOST_FUNCTION(functionIsNeverInline, (JSGlobalObject*, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    if (callFrame->argumentCount() < 1)
+        return JSValue::encode(jsBoolean(false));
+
+    JSValue theFunctionValue = callFrame->uncheckedArgument(0);
+
+    if (FunctionExecutable* executable = getExecutableForFunction(theFunctionValue))
+        return JSValue::encode(jsBoolean(executable->neverInline()));
+
+    return JSValue::encode(jsBoolean(false));
 }
 
 // Runs a full GC synchronously.
@@ -4354,6 +4373,7 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "baselineJITTrue"_s, functionBaselineJITTrue, 0);
 
     addFunction(vm, "noInline"_s, functionNoInline, 1);
+    addFunction(vm, "isNeverInline"_s, functionIsNeverInline, 1);
 
     addFunction(vm, "triggerMemoryPressure"_s, functionTriggerMemoryPressure, 0);
     addFunction(vm, "gc"_s, functionGC, 0);


### PR DESCRIPTION
#### 74c38785fa38f8debe3dcec803b13bd44843b242
<pre>
[JSC] Add async stack traces behind the flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=296261">https://bugs.webkit.org/show_bug.cgi?id=296261</a>

Reviewed by Yusuke Suzuki.

This reverts <a href="https://commits.webkit.org/299498@main">https://commits.webkit.org/299498@main</a> to reland <a href="https://commits.webkit.org/299482@main">https://commits.webkit.org/299482@main</a>

------

JSC cannot obtain sufficient async stack traces. For example, this code:

    async function one(x) {
        await two(x);
    }
    async function two(x) {
        await x;
        throw new Error(&quot;error from two&quot;);
    }
    one(1).catch((err) =&gt; { print(err.stack); });

prints this stack trace:

    two@./test.js:6:20

When an error occurs within an async function, the stack trace is cut off
at the most recent await point, so higher-level functions in the async call
chain are not displayed. This happens because when an async function is
suspended at an await statement and later resumed from the microtask queue,
the original call stack is lost.

While this behavior is correct from the semantics of call stacks and microtask
queues, it is inconvenient for users.

This patch builds async stack traces through the following approach (only when
the --useAsyncStackTrace flag is enabled):

- Detect calls to `@promiseReactionJob` and `@promiseReactionJobWithoutPromise`
  during stack trace construction and retrieve the JSGenerator object hidden
  behind async-await from its arguments
- Obtain references to awaited Promises held in each generator&apos;s Context field
- Trace async context (parent generators recorded as @context fields) from the
  Promise&apos;s reaction chain
- Walk up the chain of parent generators and construct stack frames from function
  information stored in each async function&apos;s Next field

After this patch, the previous code outputs this stack trace:

    two@./WebKitBuild/Debug/test.js:6:20
    one@./WebKitBuild/Debug/test.js:2:14

V8 constructs async stack traces using a similar approach [1][2].

[1]: <a href="https://docs.google.com/document/d/13Sy_kBIJGP0XT34V1CV3nkWya4TwYx9L3Yv45LdGB6Q/edit?tab=t.0#heading=h.9ss45aibqpw2">https://docs.google.com/document/d/13Sy_kBIJGP0XT34V1CV3nkWya4TwYx9L3Yv45LdGB6Q/edit?tab=t.0#heading=h.9ss45aibqpw2</a>
[2]: <a href="https://issues.chromium.org/issues/42210758">https://issues.chromium.org/issues/42210758</a>

* JSTests/stress/async-stack-trace-basic.js: Added.
(nop):
(shouldThrowAsync):
(throw.new.Error.async one):
(throw.new.Error.async two):
(async one):
(async two):
(throw.new.Error.async drainMicrotasks):
(callOne):
(callTwo):
(async drainMicrotasks):
(async throwError):
* JSTests/stress/async-stack-trace-bound-functions-basic.js: Added.
(nop):
(shouldThrowAsync):
(throw.new.Error.async foo):
(throw.new.Error.async bar):
(throw.new.Error.async baz):
* JSTests/stress/async-stack-trace-nested-deep.js: Added.
(nop):
(shouldThrowAsync):
(async level1):
(async level2):
(async level3):
(async level4):
(async level5):
(async level6):
(async level7):
(async level8):
(async level9):
(async level10):
(async level11):
(async level12):
(async level13):
(async level14):
(async level15):
(async level16):
(async level17):
(async level18):
(async level19):
(async level20):
(async level21):
(async level22):
(async level23):
(async level24):
(async level25):
(async level26):
(async level27):
(async level28):
(async level29):
(async level30):
(async level31):
(async level32):
(async level33):
(async level34):
(async level35):
(async level36):
(async level37):
(async level38):
(async level39):
(async level40):
(async level41):
(async level42):
(async level43):
(async level44):
(async level45):
(async level46):
(async level47):
(async level48):
(async level49):
(async level50):
(async level51):
(async level52):
(async level53):
(async level54):
(async level55):
(async level56):
(async level57):
(async level58):
(async level59):
(async level60):
(async level61):
(async level62):
(async level63):
(async level64):
(async level65):
(async level66):
(async level67):
(async level68):
(async level69):
(async level70):
(async level71):
(async level72):
(async level73):
(async level74):
(async level75):
(async level76):
(async level77):
(async level78):
(async level79):
(async level80):
(async level81):
(async level82):
(async level83):
(async level84):
(async level85):
(async level86):
(async level87):
(async level88):
(async level89):
(async level90):
(async level91):
(async level92):
(async level93):
(async level94):
(async level95):
(async level96):
(async level97):
(async level98):
(async level99):
(async level100):
(async level101):
(async delayedOperation):
(async problematicFunction):
* JSTests/stress/async-stack-trace-nested.js: Added.
(nop):
(shouldThrowAsync):
(async level1):
(async level2):
(async level3):
(async level4):
(async level5):
(async level6):
(async level7):
(async level8):
(async level9):
(async level10):
(async delayedOperation):
(async problematicFunction):
* JSTests/stress/async-stack-trace-switch.js: Added.
(shouldThrowAsync):
(throw.new.Error.async foo):
(throw.new.Error.async bar):
(throw.new.Error.async baz):
* JSTests/stress/never-inlined-functions.js: Added.
(shouldBe):
(const.regularFunction):
* Source/JavaScriptCore/builtins/PromiseOperations.js:
(linkTimeConstant.neverInline.promiseReactionJob):
(linkTimeConstant.promiseReactionJobWithoutPromise): Deleted.
(linkTimeConstant.promiseReactionJob): Deleted.
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):
(JSC::Interpreter::getStackTrace):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::promiseReactionJobFunction const):
(JSC::JSGlobalObject::promiseReactionJobWithoutPromiseFunction const):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/StackFrame.cpp:
(JSC::StackFrame::StackFrame):
(JSC::StackFrame::sourceURL const):
(JSC::StackFrame::sourceURLStripped const):
* Source/JavaScriptCore/runtime/StackFrame.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):

Canonical link: <a href="https://commits.webkit.org/299595@main">https://commits.webkit.org/299595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c3f94b1c8f145e5a7ceb8eb5dd6a2cad77a5f60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90711 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60029 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25145 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69282 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111504 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128626 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117897 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99288 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99082 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25205 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22530 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51862 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146597 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45627 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37692 "Found 1 new JSC binary failure: testapi, Found 18677 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->