### PR TITLE
REGRESSION (287736@main?): [ iOS ] fast/mediastream/microphone-interruption-and-audio-session.html is constantly failing.

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
+++ b/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
@@ -24,9 +24,13 @@
         });
     }
 
+    const streams = [];
     var context = new AudioContext();
     promise_test(async (test) => {
+        test.add_cleanup(() => streams.forEach(stream => stream.getTracks().forEach(track => track.stop())));
+
         const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+        streams.push(stream);
         if (!window.internals)
             return;
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test1");
@@ -38,6 +42,7 @@
         await onMutePromise1;
         // We clone the capture stream to trigger an audio session category recomputation.
         let clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "AmbientSound", "test2");
 
         const onUnmutePromise1 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise1");
@@ -45,6 +50,7 @@
             internals.setPageMuted("");
         await onUnmutePromise1;
         clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test3");
 
         // PlayAndRecord should stick even with capture interruption.
@@ -53,6 +59,7 @@
             internals.beginAudioSessionInterruption();
         await onMutePromise2;
         clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test4");
 
         const onUnmutePromise2 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise2");
@@ -60,6 +67,7 @@
             internals.endAudioSessionInterruption();
         await onUnmutePromise2;
         clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test5");
     }, "AudioSession category should staty to PlayAndRecord when interrupted, not when muted by user");
     </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7755,8 +7755,6 @@ webkit.org/b/288694 [ Debug arm64 ] fast/multicol/body-stuck-with-dirty-bit-with
 
 webkit.org/b/287569 http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe.html [ Timeout ]
 
-webkit.org/b/287033 fast/mediastream/microphone-interruption-and-audio-session.html [ Failure ]
-
 webkit.org/b/288987 fast/viewport/ios/device-width-viewport-after-changing-view-scale.html [ Pass Failure ]
 
 webkit.org/b/289002 [ Release ] imported/blink/fast/text/international-iteration-simple-text.html [ Pass Failure ]

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -113,6 +113,11 @@ AudioSession& AudioSession::singleton()
 
 void AudioSession::setSharedSession(Ref<AudioSession>&& session)
 {
+    Ref previousSession = sharedAudioSession() ? *sharedAudioSession() : dummyAudioSession().get();
+    previousSession->m_interruptionObservers.forEach([&](auto& observer) {
+        session->addInterruptionObserver(observer);
+    });
+
     sharedAudioSession() = session.copyRef();
 
     audioSessionChangedObservers().forEach([session] (auto& observer) {


### PR DESCRIPTION
#### 20364996cad7609cd039757bf4952be858cfbc27
<pre>
REGRESSION (287736@main?): [ iOS ] fast/mediastream/microphone-interruption-and-audio-session.html is constantly failing.
<a href="https://rdar.apple.com/144177133">rdar://144177133</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287033">https://bugs.webkit.org/show_bug.cgi?id=287033</a>

Reviewed by Eric Carlson.

Make sure that interruption observers registered are preserved when changing of AudioSession singleton.
This is in particular useful in GPUProcess where we might sometime register the observers on the dunmmy audio session.
We also update the test to make sure capture tracks are stopped explicitly.

* LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::setSharedSession):

Canonical link: <a href="https://commits.webkit.org/299686@main">https://commits.webkit.org/299686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a2c1ae1e5b708bc446a3bce0b52ce55ab7c7694

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71679 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0869215-e3bc-4ca0-83c1-6cd65747da3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90848 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60145 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc04a9ab-1de9-4f39-8d09-4b8c0dca4e62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71363 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1cdb3ab-c3d6-4883-a5be-85eabd509c2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69534 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128853 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99443 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99285 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25253 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22731 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43091 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52095 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45855 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49204 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->