### PR TITLE
[css-anchor-position-1] wrong clip testing with 'position-visibility: anchors-visible'

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7683,7 +7683,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-to-fixed-anchor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-chained-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-colspan-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-001.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.clip {
+    overflow: hidden;
+    border: 2px solid red;
+}
+.c {
+    position: absolute;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    border: 2px solid green;
+}
+.anchor {
+    background: blue;
+}
+.anchored {
+    position: absolute;
+    background: green;
+}
+</style>
+<div class=clip><div class=c><div class=anchor>anchor</div><div class=anchored>anchored</div>
+</div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.clip {
+    overflow: hidden;
+    border: 2px solid red;
+}
+.c {
+    position: absolute;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    border: 2px solid green;
+}
+.anchor {
+    background: blue;
+}
+.anchored {
+    position: absolute;
+    background: green;
+}
+</style>
+<div class=clip><div class=c><div class=anchor>anchor</div><div class=anchored>anchored</div>
+</div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Anchor Positioning Test: position-visibility: anchors-visible</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-visibility">
+<link rel="match" href="position-visibility-anchors-visible-clip-ref.html">
+<style>
+.clip {
+    overflow: hidden;
+    border: 2px solid red;
+}
+.c {
+    position: absolute;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    border: 2px solid green;
+}
+.anchor {
+    anchor-name: --foo;
+    background: blue;
+}
+.anchored {
+    left: anchor(left);
+    top: anchor(bottom);
+    position: absolute;
+    position-anchor: --foo;
+    background: green;
+}
+</style>
+<div class=clip><div class=c><div class=anchor>anchor</div></div></div>
+<div class=anchored>anchored</div>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1432,7 +1432,7 @@ bool AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxe
 
     auto anchorRect = defaultAnchor->localToAbsoluteQuad(FloatQuad { localAnchorRect }).boundingBox();
 
-    for (auto* anchorAncestor = defaultAnchor->parent(); anchorAncestor && anchorAncestor != anchoredContainingBlock; anchorAncestor = anchorAncestor->parent()) {
+    for (auto* anchorAncestor = defaultAnchor->container(); anchorAncestor && anchorAncestor != anchoredContainingBlock; anchorAncestor = anchorAncestor->container()) {
         if (!anchorAncestor->hasNonVisibleOverflow())
             continue;
         auto* clipAncestor = dynamicDowncast<RenderBox>(*anchorAncestor);


### PR DESCRIPTION
#### 52647688635a838d355fdc63ae061545d0f41680
<pre>
[css-anchor-position-1] wrong clip testing with &apos;position-visibility: anchors-visible&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=298379">https://bugs.webkit.org/show_bug.cgi?id=298379</a>
<a href="https://rdar.apple.com/159790886">rdar://159790886</a>

Reviewed by Alan Baradlay.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-clip.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes):

Traverse the container chain instead of the parent chain to find the boxes that actually clip the anchor.

Canonical link: <a href="https://commits.webkit.org/299554@main">https://commits.webkit.org/299554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46b13b2dfd90b58580b131802215ad60f530d5b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71462 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe074c7f-5713-4e87-bf30-b3741dbdf2e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90721 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62e93d27-0b3e-4a9e-97f1-dfcc4e3d8477) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107046 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71187 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32103b34-246a-4011-8ff0-4a40f5bbb3bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101195 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25346 "Found 1 new test failure: scrollingcoordinator/mac/programmatic-frame-scroll.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128636 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46309 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35046 "Found 1 new test failure: http/tests/websocket/web-socket-loads-captured-in-per-page-domains.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99296 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25183 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42876 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51872 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45637 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47324 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->