### PR TITLE
REGRESSION(299123@main): Frequent web process terminations (message check RemoteGraphicsContext_ClipToImageBuffer)

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -342,6 +342,14 @@ void BifurcatedGraphicsContext::clipToImageBuffer(ImageBuffer& imageBuffer, cons
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
+void BifurcatedGraphicsContext::clipToNativeImage(const NativeImage& image, const FloatRect& destRect)
+{
+    m_primaryContext.clipToNativeImage(image, destRect);
+    m_secondaryContext.clipToNativeImage(image, destRect);
+
+    VERIFY_STATE_SYNCHRONIZATION();
+}
+
 IntRect BifurcatedGraphicsContext::clipBounds() const
 {
     return m_primaryContext.clipBounds();

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -98,6 +98,7 @@ public:
     void clipOut(const Path&) final;
 
     void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToNativeImage(const NativeImage&, const FloatRect&) final;
 
     IntRect clipBounds() const final;
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -471,6 +471,12 @@ void GraphicsContext::clipOutRoundedRect(const FloatRoundedRect& rect)
     clipOut(path);
 }
 
+void GraphicsContext::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& rect)
+{
+    if (RefPtr image = nativeImageForDrawing(buffer))
+        clipToNativeImage(*image, rect);
+}
+
 IntRect GraphicsContext::clipBounds() const
 {
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -299,7 +299,8 @@ public:
     virtual void clipOut(const Path&) = 0;
     WEBCORE_EXPORT virtual void clipOutRoundedRect(const FloatRoundedRect&);
     virtual void clipPath(const Path&, WindRule = WindRule::EvenOdd) = 0;
-    WEBCORE_EXPORT virtual void clipToImageBuffer(ImageBuffer&, const FloatRect&) = 0;
+    WEBCORE_EXPORT virtual void clipToImageBuffer(ImageBuffer&, const FloatRect&);
+    WEBCORE_EXPORT virtual void clipToNativeImage(const NativeImage&, const FloatRect&) = 0;
     WEBCORE_EXPORT virtual IntRect clipBounds() const;
 
     // Text

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -132,6 +132,7 @@ private:
     void clipRoundedRect(const FloatRoundedRect&) final { }
     void clipOutRoundedRect(const FloatRoundedRect&) final { }
     void clipToImageBuffer(ImageBuffer&, const FloatRect&) final { }
+    void clipToNativeImage(const NativeImage&, const FloatRect&) final { }
 
     void fillRect(const FloatRect&, Gradient&) final { }
     void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode = BlendMode::Normal) final { }

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -1158,24 +1158,23 @@ IntRect OperationRecorder::clipBounds() const
     return enclosingIntRect(state.ctmInverse.mapRect(state.clipBounds));
 }
 
-void OperationRecorder::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
+void OperationRecorder::clipToNativeImage(const NativeImage& nativeImage, const FloatRect& destRect)
 {
-    struct ClipToImageBuffer final: PaintingOperation, OperationData<RefPtr<cairo_surface_t>, FloatRect> {
-        virtual ~ClipToImageBuffer() = default;
+    struct ClipToNativeImage final: PaintingOperation, OperationData<RefPtr<cairo_surface_t>, FloatRect> {
+        virtual ~ClipToNativeImage() = default;
 
         void execute(WebCore::GraphicsContextCairo& context) override
         {
-            Cairo::clipToImageBuffer(context, arg<0>().get(), arg<1>());
+            Cairo::clipToNativeImage(context, arg<0>().get(), arg<1>());
         }
 
         void dump(TextStream& ts) override
         {
-            ts << indent << "ClipToImageBuffer<>\n"_s;
+            ts << indent << "ClipToNativeImage<>\n"_s;
         }
     };
 
-    if (auto nativeImage = buffer.createNativeImageReference())
-        append(createCommand<ClipToImageBuffer>(nativeImage->platformImage(), destRect));
+    append(createCommand<ClipToNativeImage>(nativeImage.platformImage(), destRect));
 }
 
 void OperationRecorder::applyDeviceScaleFactor(float)

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -103,7 +103,7 @@ private:
     void clipOut(const WebCore::Path&) override;
     void clipPath(const WebCore::Path&, WebCore::WindRule) override;
     WebCore::IntRect clipBounds() const override;
-    void clipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect&) override;
+    void clipToNativeImage(const WebCore::NativeImage&, const WebCore::FloatRect&) override;
 #if ENABLE(VIDEO)
     void drawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) override;
 #endif

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -191,7 +191,7 @@ static void fillShadowBuffer(GraphicsContextCairo& platformContext, ImageBuffer&
     platformContext.save();
 
     if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
-        clipToImageBuffer(platformContext, nativeImage->platformImage().get(), FloatRect(layerOrigin, expandedIntSize(layerSize)));
+        clipToNativeImage(platformContext, nativeImage->platformImage().get(), FloatRect(layerOrigin, expandedIntSize(layerSize)));
 
     FillSource fillSource;
     fillSource.globalAlpha = shadowState.globalAlpha;
@@ -1327,7 +1327,7 @@ void clipPath(GraphicsContextCairo& platformContext, const Path& path, WindRule 
     cairo_set_fill_rule(cr, savedFillRule);
 }
 
-void clipToImageBuffer(GraphicsContextCairo& platformContext, cairo_surface_t* image, const FloatRect& destRect)
+void clipToNativeImage(GraphicsContextCairo& platformContext, cairo_surface_t* image, const FloatRect& destRect)
 {
     platformContext.pushImageMask(image, destRect);
 }

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.h
@@ -168,7 +168,7 @@ void clipOut(GraphicsContextCairo&, const FloatRect&);
 void clipOut(GraphicsContextCairo&, const Path&);
 void clipPath(GraphicsContextCairo&, const Path&, WindRule);
 
-void clipToImageBuffer(GraphicsContextCairo&, cairo_surface_t*, const FloatRect&);
+void clipToNativeImage(GraphicsContextCairo&, cairo_surface_t*, const FloatRect&);
 
 } // namespace Cairo
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -219,10 +219,9 @@ IntRect GraphicsContextCairo::clipBounds() const
     return Cairo::State::getClipBounds(*platformContext());
 }
 
-void GraphicsContextCairo::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
+void GraphicsContextCairo::clipToNativeImage(const NativeImage& image, const FloatRect& destRect)
 {
-    if (auto nativeImage = nativeImageForDrawing(buffer))
-        Cairo::clipToImageBuffer(*this, nativeImage->platformImage().get(), destRect);
+    Cairo::clipToNativeImage(*this, image.platformImage().get(), destRect);
 }
 
 void GraphicsContextCairo::drawFocusRing(const Path& path, float outlineWidth, const Color& color)

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -101,7 +101,7 @@ public:
     void clipOut(const Path&) final;
     void clipPath(const Path&, WindRule) final;
     IntRect clipBounds() const final;
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToNativeImage(const NativeImage&, const FloatRect&) final;
     
     RenderingMode renderingMode() const final;
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1027,18 +1027,14 @@ void GraphicsContextCG::clipPath(const Path& path, WindRule clipRule)
     }
 }
 
-void GraphicsContextCG::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
+void GraphicsContextCG::clipToNativeImage(const NativeImage& nativeImage, const FloatRect& destRect)
 {
-    auto nativeImage = imageBuffer.createNativeImageReference();
-    if (!nativeImage)
-        return;
-
     // FIXME: This image needs to be grayscale to be used as an alpha mask here.
     CGContextRef context = platformContext();
     CGContextTranslateCTM(context, destRect.x(), destRect.maxY());
     CGContextScaleCTM(context, 1, -1);
     CGContextClipToRect(context, { { }, destRect.size() });
-    CGContextClipToMask(context, { { }, destRect.size() }, nativeImage->platformImage().get());
+    CGContextClipToMask(context, { { }, destRect.size() }, nativeImage.platformImage().get());
     CGContextScaleCTM(context, 1, -1);
     CGContextTranslateCTM(context, -destRect.x(), -destRect.maxY());
 }

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -94,7 +94,7 @@ public:
 
     void clipPath(const Path&, WindRule = WindRule::EvenOdd) final;
 
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToNativeImage(const NativeImage&, const FloatRect&) final;
 
     IntRect clipBounds() const final;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -50,6 +50,7 @@ class ClipOutRoundedRect;
 class ClipOutToPath;
 class ClipPath;
 class ClipToImageBuffer;
+class ClipToNativeImage;
 class ConcatenateCTM;
 class DrawControlPart;
 class DrawDotsForDocumentMarker;
@@ -116,6 +117,7 @@ using Item = Variant
     , ClipOutToPath
     , ClipPath
     , ClipToImageBuffer
+    , ClipToNativeImage
     , ConcatenateCTM
     , DrawControlPart
     , DrawDotsForDocumentMarker

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -234,6 +234,18 @@ void ClipToImageBuffer::dump(TextStream& ts, OptionSet<AsTextFlag> flags) const
     ts.dumpProperty("dest-rect"_s, destinationRect());
 }
 
+void ClipToNativeImage::apply(GraphicsContext& context) const
+{
+    context.clipToNativeImage(m_image, m_destinationRect);
+}
+
+void ClipToNativeImage::dump(TextStream& ts, OptionSet<AsTextFlag> flags) const
+{
+    if (flags.contains(AsTextFlag::IncludeResourceIdentifiers))
+        ts.dumpProperty("image-identifier"_s, m_image->renderingResourceIdentifier());
+    ts.dumpProperty("dest-rect"_s, destinationRect());
+}
+
 void ClipOutToPath::apply(GraphicsContext& context) const
 {
     context.clipOut(m_path);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -405,6 +405,27 @@ private:
     FloatRect m_destinationRect;
 };
 
+class ClipToNativeImage {
+public:
+    static constexpr char name[] = "clip-to-native-image";
+
+    ClipToNativeImage(Ref<const NativeImage> image, const FloatRect& destinationRect)
+        : m_image(WTFMove(image))
+        , m_destinationRect(destinationRect)
+    {
+    }
+
+    const NativeImage& image() const { return m_image; }
+    FloatRect destinationRect() const { return m_destinationRect; }
+
+    void apply(GraphicsContext&) const;
+    void dump(TextStream&, OptionSet<AsTextFlag>) const;
+
+private:
+    const Ref<const NativeImage> m_image;
+    FloatRect m_destinationRect;
+};
+
 class ClipOutToPath {
 public:
     static constexpr char name[] = "clip-out-to-path";

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -252,6 +252,12 @@ void Recorder::updateStateForClipToImageBuffer(const FloatRect& rect)
     currentState().clipBounds.intersect(currentState().ctm.mapRect(rect));
 }
 
+void Recorder::updateStateForClipToNativeImage(const FloatRect& rect)
+{
+    appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
+    currentState().clipBounds.intersect(currentState().ctm.mapRect(rect));
+}
+
 IntRect Recorder::clipBounds() const
 {
     if (auto inverse = currentState().ctm.inverse())

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -121,6 +121,7 @@ protected:
     WEBCORE_EXPORT void updateStateForClipOut(const Path&);
     WEBCORE_EXPORT void updateStateForClipOutRoundedRect(const FloatRoundedRect&);
     WEBCORE_EXPORT void updateStateForClipToImageBuffer(const FloatRect&);
+    WEBCORE_EXPORT void updateStateForClipToNativeImage(const FloatRect&);
     WEBCORE_EXPORT void updateStateForApplyDeviceScaleFactor(float);
     WEBCORE_EXPORT bool decomposeDrawGlyphsIfNeeded(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode);
     FloatRect initialClip() const { return m_initialClip; }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -177,6 +177,12 @@ void RecorderImpl::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& 
     m_items.append(ClipToImageBuffer(imageBuffer, destinationRect));
 }
 
+void RecorderImpl::clipToNativeImage(const NativeImage& image, const FloatRect& destinationRect)
+{
+    updateStateForClipToNativeImage(destinationRect);
+    m_items.append(ClipToNativeImage(image, destinationRect));
+}
+
 void RecorderImpl::clipOut(const Path& path)
 {
     updateStateForClipOut(path);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -67,6 +67,7 @@ public:
     void clipOutRoundedRect(const FloatRoundedRect&) final;
     void clipPath(const Path&, WindRule) final;
     void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToNativeImage(const NativeImage&, const FloatRect&) final;
     void beginTransparencyLayer(float) final;
     void beginTransparencyLayer(CompositeOperator, BlendMode) final;
     void endTransparencyLayer() final;

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -620,13 +620,11 @@ IntRect GraphicsContextSkia::clipBounds() const
     return enclosingIntRect(m_canvas.getLocalClipBounds());
 }
 
-void GraphicsContextSkia::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
+void GraphicsContextSkia::clipToNativeImage(const NativeImage& nativeImage, const FloatRect& destRect)
 {
-    if (auto nativeImage = nativeImageForDrawing(buffer)) {
-        auto image = nativeImage->platformImage();
-        trackAcceleratedRenderingFenceIfNeeded(image);
-        m_canvas.clipShader(image->makeShader(SkTileMode::kDecal, SkTileMode::kDecal, { }, SkMatrix::Translate(SkFloatToScalar(destRect.x()), SkFloatToScalar(destRect.y()))));
-    }
+    auto image = nativeImage.platformImage();
+    trackAcceleratedRenderingFenceIfNeeded(image);
+    m_canvas.clipShader(image->makeShader(SkTileMode::kDecal, SkTileMode::kDecal, { }, SkMatrix::Translate(SkFloatToScalar(destRect.x()), SkFloatToScalar(destRect.y()))));
 }
 
 void GraphicsContextSkia::drawFocusRing(const Path& path, float, const Color& color)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -107,7 +107,7 @@ public:
     void clipOut(const Path&) final;
     void clipPath(const Path&, WindRule) final;
     IntRect clipBounds() const final;
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToNativeImage(const NativeImage&, const FloatRect&) final;
 
     RenderingMode renderingMode() const final;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -322,6 +322,13 @@ void RemoteGraphicsContext::clipToImageBuffer(RenderingResourceIdentifier imageB
     context().clipToImageBuffer(*clipImage, destinationRect);
 }
 
+void RemoteGraphicsContext::clipToNativeImage(RenderingResourceIdentifier identifier, const FloatRect& destinationRect)
+{
+    RefPtr image = resourceCache().cachedNativeImage(identifier);
+    MESSAGE_CHECK(image);
+    context().clipToNativeImage(*image, destinationRect);
+}
+
 void RemoteGraphicsContext::clipOutToPath(const Path& path)
 {
     context().clipOut(path);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -101,6 +101,7 @@ public:
     void clipOut(const WebCore::FloatRect&);
     void clipOutRoundedRect(const WebCore::FloatRoundedRect&);
     void clipToImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::FloatRect& destinationRect);
+    void clipToNativeImage(WebCore::RenderingResourceIdentifier, const WebCore::FloatRect& destinationRect);
     void clipOutToPath(const WebCore::Path&);
     void clipPath(const WebCore::Path&, WebCore::WindRule);
     void resetClip();

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -69,6 +69,7 @@ messages -> RemoteGraphicsContext Stream {
     ClipOut(WebCore::FloatRect rect)
     ClipOutRoundedRect(WebCore::FloatRoundedRect rect)
     ClipToImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, WebCore::FloatRect destinationRect)
+    ClipToNativeImage(WebCore::RenderingResourceIdentifier identifier, WebCore::FloatRect destinationRect)
     ClipOutToPath(WebCore::Path path)
     ClipPath(WebCore::Path path, enum:bool WebCore::WindRule windRule)
     ResetClip()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -207,9 +207,20 @@ void RemoteGraphicsContextProxy::clipOutRoundedRect(const FloatRoundedRect& rect
 
 void RemoteGraphicsContextProxy::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destinationRect)
 {
+    if (!recordResourceUse(imageBuffer)) {
+        GraphicsContext::clipToImageBuffer(imageBuffer, destinationRect);
+        return;
+    }
     updateStateForClipToImageBuffer(destinationRect);
-    recordResourceUse(imageBuffer);
     send(Messages::RemoteGraphicsContext::ClipToImageBuffer(imageBuffer.renderingResourceIdentifier(), destinationRect));
+}
+
+void RemoteGraphicsContextProxy::clipToNativeImage(const NativeImage& image, const FloatRect& destinationRect)
+{
+    if (!recordResourceUse(image))
+        return;
+    updateStateForClipToNativeImage(destinationRect);
+    send(Messages::RemoteGraphicsContext::ClipToNativeImage(image.renderingResourceIdentifier(), destinationRect));
 }
 
 void RemoteGraphicsContextProxy::clipOut(const Path& path)
@@ -623,7 +634,7 @@ void RemoteGraphicsContextProxy::setURLForRect(const URL& link, const FloatRect&
     send(Messages::RemoteGraphicsContext::SetURLForRect(link, destRect));
 }
 
-bool RemoteGraphicsContextProxy::recordResourceUse(NativeImage& image)
+bool RemoteGraphicsContextProxy::recordResourceUse(const NativeImage& image)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
     if (!renderingBackend) [[unlikely]] {
@@ -650,7 +661,7 @@ bool RemoteGraphicsContextProxy::recordResourceUse(NativeImage& image)
 #endif
     }
 
-    renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image, colorSpace);
+    renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(const_cast<NativeImage&>(image), colorSpace);
     return true;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -90,6 +90,7 @@ private:
     void clipOutRoundedRect(const WebCore::FloatRoundedRect&) final;
     void clipPath(const WebCore::Path&, WebCore::WindRule) final;
     void clipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destinationRect) final;
+    void clipToNativeImage(const WebCore::NativeImage&, const WebCore::FloatRect& destinationRect) final;
     void resetClip() final;
     void beginTransparencyLayer(float) final;
     void beginTransparencyLayer(WebCore::CompositeOperator, WebCore::BlendMode) final;
@@ -139,7 +140,7 @@ private:
     void endPage() final;
     void setURLForRect(const URL&, const WebCore::FloatRect&) final;
 
-    bool recordResourceUse(WebCore::NativeImage&);
+    bool recordResourceUse(const WebCore::NativeImage&);
     bool recordResourceUse(WebCore::ImageBuffer&);
     bool recordResourceUse(const WebCore::SourceImage&);
     bool recordResourceUse(WebCore::Font&);


### PR DESCRIPTION
#### e0bd44d68219e1080f93d07395f44633dfe07100
<pre>
REGRESSION(299123@main): Frequent web process terminations (message check RemoteGraphicsContext_ClipToImageBuffer)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298384">https://bugs.webkit.org/show_bug.cgi?id=298384</a>
<a href="https://rdar.apple.com/159388928">rdar://159388928</a>

Reviewed by NOBODY (OOPS!).

Clipping to WCP-local ImageBuffers would fail the &quot;recordResourceUse&quot;
phase but still continue sending the ClipToImageBuffer message.
Fix by using the pattern of delegating to the
GraphicsContext::clipToImageBuffer, which takes the (local) NativeImage
and applies the added clipToNativeImage.

Later on when remote NativeImages are added, clipToImageBuffer will
be removed.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::clipToNativeImage):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::clipToImageBuffer):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::OperationRecorder::clipToNativeImage):
(WebCore::Cairo::OperationRecorder::clipToImageBuffer): Deleted.
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::fillShadowBuffer):
(WebCore::Cairo::clipToNativeImage):
(WebCore::Cairo::clipToImageBuffer): Deleted.
* Source/WebCore/platform/graphics/cairo/CairoOperations.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::clipToNativeImage):
(WebCore::GraphicsContextCairo::clipToImageBuffer): Deleted.
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::clipToNativeImage):
(WebCore::GraphicsContextCG::clipToImageBuffer): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::ClipToImageBuffer::dump const):
(WebCore::DisplayList::ClipToNativeImage::apply const):
(WebCore::DisplayList::ClipToNativeImage::dump const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::ClipToNativeImage::ClipToNativeImage):
(WebCore::DisplayList::ClipToNativeImage::image const):
(WebCore::DisplayList::ClipToNativeImage::destinationRect const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::updateStateForClipToNativeImage):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::clipToNativeImage):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::clipToNativeImage):
(WebCore::GraphicsContextSkia::clipToImageBuffer): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::clipToNativeImage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::clipToImageBuffer):
(WebKit::RemoteGraphicsContextProxy::clipToNativeImage):
(WebKit::RemoteGraphicsContextProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0bd44d68219e1080f93d07395f44633dfe07100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71661 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07a7b9d4-48f6-4aff-b907-c1692e2cc633) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90832 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60137 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9aec485d-9006-47a6-9947-675e94e44f0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71339 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6817e466-28ce-4ff9-b4ae-c534e5772604) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25336 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69514 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128835 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99429 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99271 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44695 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43073 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52077 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45837 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->