### PR TITLE
http/tests/security/service-worker-network-load.html is randomly timing out since the beginning

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7046,8 +7046,6 @@ webkit.org/b/245032 imported/w3c/web-platform-tests/css/compositing/root-element
 
 webkit.org/b/261916 media/video-pause-while-seeking.html [ Pass Failure ]
 
-webkit.org/b/262734 http/tests/security/service-worker-network-load.html [ Pass Timeout ]
-
 webkit.org/b/263233 http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html [ Failure Pass ]
 
 webkit.org/b/263434 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic.html [ Skip ]

--- a/LayoutTests/http/tests/security/service-worker-network-load.html
+++ b/LayoutTests/http/tests/security/service-worker-network-load.html
@@ -46,10 +46,11 @@ function service_unregister(scope) {
       })
 }
 
-function wating_stat(test, worker, state) {
+function waiting_state(test, worker, state) {
   return new Promise(test.step_func(function(resolve) {
       worker.addEventListener('statechange', test.step_func(function() {
-            resolve(state);
+            if (worker.state === state)
+                resolve();
         }));
     }));
 }
@@ -60,7 +61,7 @@ trigger(t => {
 
     return service_register(script, scope)
       .then(reg => {
-          return wating_stat(t, reg.installing, 'activated');
+          return waiting_state(t, reg.installing, 'activated');
         })
       .then(frame => {
           setTimeout(() => with_iframe(scope + 'asdf.py') , 1);


### PR DESCRIPTION
#### 463323f43f3ac3a85d8d37102f240a7953fce3ee
<pre>
http/tests/security/service-worker-network-load.html is randomly timing out since the beginning
<a href="https://rdar.apple.com/116882425">rdar://116882425</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=262734">https://bugs.webkit.org/show_bug.cgi?id=262734</a>

Reviewed by Brady Eidson and Sihui Liu.

The results on the bots show that the preloadResponse promise gets resolved with undefined.
This should only happen when navigation preload is not enabled.
The script is not waiting for the worker to be activated, while the worker is enabling navigation preload within the activate event handler.
This triggers a race as the routine wait_state will sometimes resolve with &apos;activating&apos; instead of &apos;activated&apos;.
To remove this race, we fix the routine wait_state to actually wait for the &apos;activated&apos; state.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/security/service-worker-network-load.html:

Canonical link: <a href="https://commits.webkit.org/299599@main">https://commits.webkit.org/299599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1666890c63f85bf3ccad973671cfcc5c8c319948

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71477 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57ed1da8-a509-4cd7-b9a9-61be254f642a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90730 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60043 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/821bc45f-a234-495c-b197-85141428389c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71207 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21fac1fd-5296-45c1-9214-447018925853) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25169 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128651 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99309 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44549 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22554 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42891 "Hash 1666890c for PR 50299 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46187 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49002 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->