### PR TITLE
[css-animations] resolve `animation-name` as tree-scoped references

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow-expected.html
@@ -1,0 +1,41 @@
+<style>
+
+  div {
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+
+  #red {
+    width: 300px;
+    height: 300px;
+    background-color: red;
+  }
+
+  #lightgreen {
+    width: 300px;
+    height: 100px;
+    background-color: lightgreen;
+  }
+
+  #green {
+    left: 100px;
+    top: 100px;
+    width: 200px;
+    height: 100px;
+    background-color: green;
+  }
+
+  #darkgreen {
+    left: 200px;
+    top: 200px;
+    width: 100px;
+    height: 100px;
+    background-color: darkgreen;
+  }
+
+</style>
+<div id="red"></div>
+<div id="lightgreen"></div>
+<div id="green"></div>
+<div id="darkgreen"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow-ref.html
@@ -1,0 +1,41 @@
+<style>
+
+  div {
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+
+  #red {
+    width: 300px;
+    height: 300px;
+    background-color: red;
+  }
+
+  #lightgreen {
+    width: 300px;
+    height: 100px;
+    background-color: lightgreen;
+  }
+
+  #green {
+    left: 100px;
+    top: 100px;
+    width: 200px;
+    height: 100px;
+    background-color: green;
+  }
+
+  #darkgreen {
+    left: 200px;
+    top: 200px;
+    width: 100px;
+    height: 100px;
+    background-color: darkgreen;
+  }
+
+</style>
+<div id="red"></div>
+<div id="lightgreen"></div>
+<div id="green"></div>
+<div id="darkgreen"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Matching animation-name with nested shadow roots</title>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
+<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="match" href="animation-name-in-nested-shadow-ref.html">
+</head>
+<body>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  @keyframes doc {
+    from, to { background-color: lightgreen }
+  }
+
+  .anim {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+    animation-duration: 1s;
+    animation-fill-mode: both;
+  }
+
+  #doc_anim_doc { animation-name: doc; }
+  #doc_anim_outer { animation-name: outer; }
+  #doc_anim_inner { animation-name: inner; }
+
+  #outer_host {
+    position: absolute;
+    left: 100px;
+    top: 0;
+  }
+</style>
+
+<div id="doc_anim_doc" class="anim"></div>
+<div id="doc_anim_outer" class="anim"></div>
+<div id="doc_anim_inner" class="anim"></div>
+<div id="outer_host">
+  <template shadowrootmode="open">
+    <style>
+      @keyframes outer {
+        from, to { background-color: green }
+      }
+
+      .anim {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+        animation-duration: 1s;
+        animation-fill-mode: both;
+      }
+
+      #outer_anim_doc { animation-name: doc; }
+      #outer_anim_outer { animation-name: outer; }
+      #outer_anim_inner { animation-name: inner; }
+
+      #inner_host {
+        position: absolute;
+        left: 100px;
+        top: 0;
+      }
+
+    </style>
+    <div id="outer_anim_doc" class="anim"></div>
+    <div id="outer_anim_outer" class="anim"></div>
+    <div id="outer_anim_inner" class="anim"></div>
+    <div id="inner_host">
+      <template shadowrootmode="open">
+        <style>
+          @keyframes inner {
+            from, to { background-color: darkgreen }
+          }
+
+          .anim {
+            width: 100px;
+            height: 100px;
+            background-color: red;
+            animation-duration: 1s;
+            animation-fill-mode: both;
+          }
+
+          #inner_anim_doc { animation-name: doc; }
+          #inner_anim_outer { animation-name: outer; }
+          #inner_anim_inner { animation-name: inner; }
+        </style>
+        <div id="inner_anim_doc" class="anim"></div>
+        <div id="inner_anim_outer" class="anim"></div>
+        <div id="inner_anim_inner" class="anim"></div>
+      </template>
+    </div>
+  </template>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-expected.html
@@ -1,0 +1,1 @@
+<div style="width: 100px; height: 100px; background-color: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match-expected.html
@@ -1,0 +1,1 @@
+<div style="width: 100px; height: 100px; background-color: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Matching animation-name from within a shadow root with multiple @keyframes rules</title>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
+<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="match" href="animation-name-in-shadow-part-ref.html">
+</head>
+<body>
+
+<style>
+
+#shadow {
+  width: 100px;
+  height: 100px;
+}
+
+@keyframes animation {
+  from, to { background-color: blue }
+}
+
+#shadow::part(target) {
+  height: 100px;
+  width: 100px;
+  background-color: red;
+}
+
+</style>
+
+<div id="shadow">
+  <template shadowrootmode="open">
+    <style>
+      @keyframes animation {
+        from, to { background-color: green }
+      }
+
+      div {
+        animation: animation 1s both;
+      }
+    </style>
+    <div part="target"></div>
+  </template>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match-expected.html
@@ -1,0 +1,1 @@
+<div style="width: 100px; height: 100px; background-color: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Matching animation-name from within a shadow root with multiple @keyframes rules</title>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
+<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="match" href="animation-name-in-shadow-part-ref.html">
+</head>
+<body>
+
+<style>
+
+#shadow {
+  width: 100px;
+  height: 100px;
+}
+
+@keyframes animation {
+  from, to { background-color: green }
+}
+
+#shadow::part(target) {
+  height: 100px;
+  width: 100px;
+  animation: animation 1s both;
+  background-color: red;
+}
+
+</style>
+
+<div id="shadow">
+  <template shadowrootmode="open">
+    <style>
+      @keyframes animation {
+        from, to { background-color: blue }
+      }
+    </style>
+    <div part="target"></div>
+  </template>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-ref.html
@@ -1,0 +1,1 @@
+<div style="width: 100px; height: 100px; background-color: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Matching animation-name from within a shadow root with a single @keyframes rule in the outer scope</title>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
+<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="match" href="animation-name-in-shadow-part-ref.html">
+</head>
+<body>
+
+<style>
+
+#shadow {
+  width: 100px;
+  height: 100px;
+}
+
+@keyframes animation {
+  from, to { background-color: green }
+}
+
+#shadow::part(target) {
+  height: 100px;
+  width: 100px;
+  animation: animation 1s both;
+  background-color: red;
+}
+
+</style>
+
+<div id="shadow">
+  <template shadowrootmode="open">
+    <div part="target"></div>
+  </template>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/keyframes-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/keyframes-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL @keyframes from the document should apply in the shadow tree assert_equals: expected 1 but got 0
+PASS @keyframes from the document should apply in the shadow tree
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1407,8 +1407,10 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const RenderStyle& una
 
     BlendingKeyframes blendingKeyframes(AtomString { backingStyleAnimationName->name });
     if (m_target) {
-        if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingStyleAnimationName->scopeOrdinal))
-            styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, blendingKeyframes, backingStyleAnimation.timingFunction().value.ptr());
+        Style::Scope::resolveTreeScopedReference(*m_target, *backingStyleAnimationName, [&](const Style::Scope& scope, const AtomString&) {
+            ASSERT(scope.resolverIfExists());
+            return scope.resolverIfExists()->keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, blendingKeyframes, backingStyleAnimation.timingFunction().value.ptr());
+        });
 
         // Ensure resource loads for all the frames.
         for (auto& keyframe : blendingKeyframes) {

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -302,7 +302,7 @@ auto Resolver::initializeStateAndStyle(const Element& element, const ResolutionC
     return state;
 }
 
-BuilderContext Resolver::builderContext(State& state)
+BuilderContext Resolver::builderContext(State& state) const
 {
     return {
         document(),
@@ -385,7 +385,7 @@ UnadjustedStyle Resolver::unadjustedStyleForCachedMatchResult(Element& element, 
     };
 }
 
-std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, BlendingKeyframe& blendingKeyframe)
+std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, BlendingKeyframe& blendingKeyframe) const
 {
     // Add all the animating properties to the keyframe.
     bool hasRevert = false;
@@ -437,7 +437,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
     return state.takeStyle();
 }
 
-bool Resolver::isAnimationNameValid(const String& name)
+bool Resolver::isAnimationNameValid(const String& name) const
 {
     return m_keyframesRuleMap.find(AtomString(name)) != m_keyframesRuleMap.end()
         || userAgentKeyframes().find(AtomString(name)) != userAgentKeyframes().end();
@@ -537,13 +537,13 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-void Resolver::keyframeStylesForAnimation(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, BlendingKeyframes& list, const TimingFunction* defaultTimingFunction)
+bool Resolver::keyframeStylesForAnimation(Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, BlendingKeyframes& list, const TimingFunction* defaultTimingFunction) const
 {
     list.clear();
 
     auto keyframeRules = keyframeRulesForName(list.keyframesName(), defaultTimingFunction);
     if (keyframeRules.isEmpty())
-        return;
+        return false;
 
     // Construct and populate the style for each keyframe.
     for (auto& keyframeRule : keyframeRules) {
@@ -561,6 +561,8 @@ void Resolver::keyframeStylesForAnimation(Element& element, const RenderStyle& e
             list.updatePropertiesMetadata(keyframeRule->properties());
         }
     }
+
+    return true;
 }
 
 std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, const PseudoElementRequest& pseudoElementRequest, const ResolutionContext& context)

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -104,7 +104,7 @@ public:
 
     ResolvedStyle styleForElement(Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&, const TimingFunction*);
+    bool keyframeStylesForAnimation(Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&, const TimingFunction*) const;
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(Element&, const PseudoElementRequest&, const ResolutionContext&);
 
@@ -126,8 +126,8 @@ public:
 
     void addCurrentSVGFontFaceRules();
 
-    std::unique_ptr<RenderStyle> styleForKeyframe(Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&);
-    bool isAnimationNameValid(const String&);
+    std::unique_ptr<RenderStyle> styleForKeyframe(Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&) const;
+    bool isAnimationNameValid(const String&) const;
 
     void setViewTransitionStyles(CSSSelector::PseudoElement, const AtomString&, Ref<MutableStyleProperties>);
 
@@ -176,7 +176,7 @@ private:
     class State;
 
     State initializeStateAndStyle(const Element&, const ResolutionContext&, std::unique_ptr<RenderStyle>&& initialStyle = { });
-    BuilderContext builderContext(State&);
+    BuilderContext builderContext(State&) const;
 
     void applyMatchedProperties(State&, const MatchResult&, PropertyCascade::IncludedProperties&&);
     void setGlobalStateAfterApplyingProperties(const BuilderState&);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -349,8 +349,11 @@ void Styleable::cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimati
 
 static bool keyframesRuleExistsForAnimation(Element& element, const Style::ScopedName& animationName)
 {
-    auto* styleScope = Style::Scope::forOrdinal(element, animationName.scopeOrdinal);
-    return styleScope && styleScope->resolver().isAnimationNameValid(animationName.name);
+    return Style::Scope::resolveTreeScopedReference(element, animationName, [](const Style::Scope& scope, const AtomString& name) -> bool {
+        if (auto* resolver = scope.resolverIfExists())
+            return resolver->isAnimationNameValid(name);
+        return false;
+    });
 }
 
 bool Styleable::animationListContainsNewlyValidAnimation(const Style::Animations& animations) const


### PR DESCRIPTION
#### 5e9cf5c17d3448f24c84ba5af5529c69c0fc9935
<pre>
[css-animations] resolve `animation-name` as tree-scoped references
<a href="https://bugs.webkit.org/show_bug.cgi?id=296048">https://bugs.webkit.org/show_bug.cgi?id=296048</a>
<a href="https://rdar.apple.com/156484228">rdar://156484228</a>

Reviewed by Antti Koivisto.

Adopt `Style::Scope::resolveTreeScopedReference()` introduced in 300333@main to resolve `animation-name`
and find the correct scope to find the matching `@keyframes` rule.

Because `resolveTreeScopedReference()` provides a const `Style::Scope` and `Style::Resolver` to work with,
a few methods on `Style::Resolver` needed to be updated to be marked const, which they should have been
all along.

Additionally, because the `resolveTreeScopedReference()` lambda needs to return a truthy value to determine
whether a matching `@keyframes` rule was found for the provided scope, we needed to change
`Style::Resolver::keyframeStylesForAnimation()` to return a `bool` to indicate whether it processed an
`@keyframes` rule.

Tests: imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow.html
       imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match.html
       imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match.html
       imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/keyframes-002-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::builderContext const):
(WebCore::Style::Resolver::styleForKeyframe const):
(WebCore::Style::Resolver::isAnimationNameValid const):
(WebCore::Style::Resolver::keyframeStylesForAnimation const):
(WebCore::Style::Resolver::builderContext): Deleted.
(WebCore::Style::Resolver::styleForKeyframe): Deleted.
(WebCore::Style::Resolver::isAnimationNameValid): Deleted.
(WebCore::Style::Resolver::keyframeStylesForAnimation): Deleted.
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::keyframesRuleExistsForAnimation):

Canonical link: <a href="https://commits.webkit.org/300706@main">https://commits.webkit.org/300706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e11fc927a7f452b5ca8233d5836425a3b9788e6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75708 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62361 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110545 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74555 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28703 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73808 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133019 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102431 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102273 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25860 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->