### PR TITLE
Enable WebGPU Swift on asan fuzzing builds

### DIFF
--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -169,6 +169,9 @@ bool isShaderValidationEnabled(id<MTLDevice> device)
 
 bool isWebGPUSwiftEnabled()
 {
+#if defined(ENABLE_LIBFUZZER) && ENABLE_LIBFUZZER && defined(ASAN_ENABLED) && ASAN_ENABLED
+    return true;
+#else
     static std::once_flag onceFlag;
     static bool isWebGPUSwiftEnabled;
     std::call_once(onceFlag, [&] {
@@ -177,6 +180,7 @@ bool isWebGPUSwiftEnabled()
             WTFLogAlways("WebGPU: using SWIFT backend"); // NOLINT
     });
     return isWebGPUSwiftEnabled;
+#endif
 }
 
 static HardwareCapabilities apple4(id<MTLDevice> device)


### PR DESCRIPTION
#### 81d6f5cbf1c54f1aac39725d89cfdfbad3eb4839
<pre>
Enable WebGPU Swift on asan fuzzing builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=298392">https://bugs.webkit.org/show_bug.cgi?id=298392</a>
<a href="https://rdar.apple.com/159850918">rdar://159850918</a>

Reviewed by Cameron McCormack.

Use the Swift backend by default on Asan LibFuzzer builds.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::isWebGPUSwiftEnabled):

Canonical link: <a href="https://commits.webkit.org/300423@main">https://commits.webkit.org/300423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0481d7a05c8fb51f1179bb5d4b214036021a1bd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71491 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31da210e-4537-45e9-b5dc-b0e5a63517f7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90749 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60058 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61eebe28-74df-4565-ab99-ac4c2fa86124) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71217 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3afbf591-d224-4974-82a9-993f162edff1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30803 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69324 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128665 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99127 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42905 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51901 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->