### PR TITLE
[JSC] Clean up Wasm GC code in IPInt and runtime

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -167,7 +167,6 @@ wasm/WasmBBQJIT64.cpp
 wasm/WasmBBQPlan.cpp
 wasm/WasmCallee.cpp
 wasm/WasmCalleeGroup.cpp
-wasm/WasmConstExprGenerator.cpp
 wasm/WasmEntryPlan.cpp
 wasm/WasmFormat.h
 wasm/WasmFunctionParser.h

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3259,7 +3259,7 @@ reservedOpcode(0xff)
     #####################
 
 ipintOp(_struct_new, macro()
-    loadp IPInt::StructNewMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::StructNewMetadata::type[MC], a1  # type
     move sp, a2
     operationCallMayThrow(macro() cCall3(_ipint_extern_struct_new) end)
     loadh IPInt::StructNewMetadata::params[MC], t1  # number of parameters popped
@@ -3273,7 +3273,7 @@ ipintOp(_struct_new, macro()
 end)
 
 ipintOp(_struct_new_default, macro()
-    loadp IPInt::StructNewDefaultMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::StructNewDefaultMetadata::type[MC], a1  # type
     operationCallMayThrow(macro() cCall2(_ipint_extern_struct_new_default) end)
     pushQuad(r0)
     loadb IPInt::StructNewDefaultMetadata::length[MC], t0
@@ -3332,7 +3332,7 @@ ipintOp(_struct_set, macro()
 end)
 
 ipintOp(_array_new, macro()
-    loadi IPInt::ArrayNewMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::ArrayNewMetadata::type[MC], a1  # type
     popInt32(a3, t0)  # length
     popQuad(a2)  # default value
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_new) end)
@@ -3346,7 +3346,7 @@ ipintOp(_array_new, macro()
 end)
 
 ipintOp(_array_new_default, macro()
-    loadi IPInt::ArrayNewMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::ArrayNewMetadata::type[MC], a1  # type
     popInt32(a2, t0)  # length
     operationCallMayThrow(macro() cCall3(_ipint_extern_array_new_default) end)
 
@@ -3359,7 +3359,7 @@ ipintOp(_array_new_default, macro()
 end)
 
 ipintOp(_array_new_fixed, macro()
-    loadi IPInt::ArrayNewFixedMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::ArrayNewFixedMetadata::type[MC], a1  # type
     loadi IPInt::ArrayNewFixedMetadata::arraySize[MC], a2  # array length
     move sp, a3  # arguments
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_new_fixed) end)
@@ -3406,7 +3406,7 @@ ipintOp(_array_new_elem, macro()
 end)
 
 ipintOp(_array_get, macro()
-    loadi IPInt::ArrayGetSetMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::ArrayGetSetMetadata::type[MC], a1  # type
     popInt32(a3, a0)  # index
     popQuad(a2)  # array
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_get) end)
@@ -3420,7 +3420,7 @@ ipintOp(_array_get, macro()
 end)
 
 ipintOp(_array_get_s, macro()
-    loadi IPInt::ArrayGetSetMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::ArrayGetSetMetadata::type[MC], a1  # type
     popInt32(a3, a0)  # index
     popQuad(a2)  # array
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_get_s) end)
@@ -3434,7 +3434,7 @@ ipintOp(_array_get_s, macro()
 end)
 
 ipintOp(_array_get_u, macro()
-    loadi IPInt::ArrayGetSetMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::ArrayGetSetMetadata::type[MC], a1  # type
     popInt32(a3, a0)  # index
     popQuad(a2)  # array
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_get) end)
@@ -3448,7 +3448,7 @@ ipintOp(_array_get_u, macro()
 end)
 
 ipintOp(_array_set, macro()
-    loadi IPInt::ArrayGetSetMetadata::typeIndex[MC], a1  # type index
+    loadi IPInt::ArrayGetSetMetadata::type[MC], a1  # type
     move sp, a2  # stack pointer with all the arguments
     operationCallMayThrow(macro() cCall3(_ipint_extern_array_set) end)
 
@@ -3523,7 +3523,7 @@ ipintOp(_array_init_elem, macro()
 end)
 
 ipintOp(_ref_test, macro()
-    loadi IPInt::RefTestCastMetadata::typeIndex[MC], a1
+    loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
     move 0, a2  # allowNull
     popQuad(a3)
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
@@ -3537,7 +3537,7 @@ ipintOp(_ref_test, macro()
 end)
 
 ipintOp(_ref_test_nullable, macro()
-    loadi IPInt::RefTestCastMetadata::typeIndex[MC], a1
+    loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
     move 1, a2  # allowNull
     popQuad(a3)
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
@@ -3551,7 +3551,7 @@ ipintOp(_ref_test_nullable, macro()
 end)
 
 ipintOp(_ref_cast, macro()
-    loadi IPInt::RefTestCastMetadata::typeIndex[MC], a1
+    loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
     move 0, a2  # allowNull
     popQuad(a3)
     operationCallMayThrow(macro() cCall3(_ipint_extern_ref_cast) end)
@@ -3565,7 +3565,7 @@ ipintOp(_ref_cast, macro()
 end)
 
 ipintOp(_ref_cast_nullable, macro()
-    loadi IPInt::RefTestCastMetadata::typeIndex[MC], a1
+    loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
     move 1, a2  # allowNull
     popQuad(a3)
     operationCallMayThrow(macro() cCall3(_ipint_extern_ref_cast) end)
@@ -3580,7 +3580,7 @@ end)
 
 ipintOp(_br_on_cast, macro()
     validateOpcodeConfig(a1)
-    loadi IPInt::RefTestCastMetadata::typeIndex[MC], a1
+    loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
     # fb 18 FLAGS
     loadb 2[PC], a2
     rshifti 1, a2  # bit 1 = null2
@@ -3598,7 +3598,7 @@ end)
 
 ipintOp(_br_on_cast_fail, macro()
     validateOpcodeConfig(a1)
-    loadi IPInt::RefTestCastMetadata::typeIndex[MC], a1
+    loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
     loadb 2[PC], a2
     # fb 19 FLAGS
     rshifti 1, a2  # bit 1 = null2

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -171,6 +171,7 @@ using JSResizableOrGrowableSharedBigUint64Array = JSGenericResizableOrGrowableSh
     macro(StringObject, JSType::StringObjectType, JSType::DerivedStringObjectType) \
     macro(ShadowRealmObject, JSType::ShadowRealmType, JSType::ShadowRealmType) \
     macro(JSDataView, JSType::DataViewType, JSType::DataViewType) \
+    macro(WebAssemblyGCObjectBase, JSType::WebAssemblyGCObjectType, JSType::WebAssemblyGCObjectType) \
 
 #define FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD(macro) \
     FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD_FORWARD_DECLARED(macro) \

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -141,7 +141,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
             return;
         } else {
             JSValue internref = Wasm::internalizeExternref(argument);
-            if (!Wasm::TypeInformation::castReference(internref, m_type.isNullable(), m_type.index)) {
+            if (!Wasm::TypeInformation::isReferenceValueAssignable(internref, m_type.isNullable(), m_type.index)) {
                 // FIXME: provide a better error message here
                 // https://bugs.webkit.org/show_bug.cgi?id=247746
                 throwTypeError(globalObject, throwScope, "Argument value did not match the reference type"_s);

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -1045,7 +1045,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI31GetU(ExpressionType, Expr
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNew(uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
     changeStackSize(-1);
@@ -1055,7 +1055,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNew(uint32_t index, Exp
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewData(uint32_t index, uint32_t dataSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewDataMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         dataSegmentIndex,
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
@@ -1066,7 +1066,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewData(uint32_t index,
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewElem(uint32_t index, uint32_t elemSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewElemMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         elemSegmentIndex,
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
@@ -1077,7 +1077,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewElem(uint32_t index,
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewFixed(uint32_t index, ArgumentList& args, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewFixedMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         static_cast<uint32_t>(args.size()),
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
@@ -1088,7 +1088,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewFixed(uint32_t index
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewDefault(uint32_t index, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
     return { };
@@ -1097,7 +1097,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayNewDefault(uint32_t ind
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayGet(ExtGCOpType, uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayGetSetMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
     changeStackSize(-1);
@@ -1107,7 +1107,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArrayGet(ExtGCOpType, uint32
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArraySet(uint32_t index, ExpressionType, ExpressionType, ExpressionType)
 {
     m_metadata->appendMetadata<IPInt::ArrayGetSetMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
     changeStackSize(-3);
@@ -1162,7 +1162,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructNew(uint32_t index, Ar
 {
     const StructType& type = *m_info.typeSignatures[index]->expand().as<StructType>();
     m_metadata->appendMetadata<IPInt::StructNewMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         static_cast<uint16_t>(type.fieldCount()),
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
@@ -1173,7 +1173,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructNew(uint32_t index, Ar
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addStructNewDefault(uint32_t index, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::StructNewDefaultMetadata>({
-        static_cast<Wasm::TypeIndex>(index),
+        index,
         static_cast<uint8_t>(getCurrentInstructionLength())
     });
     changeStackSize(1);

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -282,13 +282,13 @@ enum class UIntBytecode: uint8_t {
 // GC Metadata
 
 struct StructNewMetadata {
-    Wasm::TypeIndex typeIndex;
+    uint32_t type;
     uint16_t params;
     uint8_t length;
 };
 
 struct StructNewDefaultMetadata {
-    Wasm::TypeIndex typeIndex;
+    uint32_t type;
     uint8_t length;
 };
 
@@ -298,30 +298,30 @@ struct StructGetSetMetadata {
 };
 
 struct ArrayNewMetadata {
-    Wasm::TypeIndex typeIndex;
+    uint32_t type;
     uint8_t length;
 };
 
 struct ArrayNewFixedMetadata {
-    Wasm::TypeIndex typeIndex;
+    uint32_t type;
     uint32_t arraySize;
     uint8_t length;
 };
 
 struct ArrayNewDataMetadata {
-    Wasm::TypeIndex typeIndex;
+    uint32_t type;
     uint32_t dataSegmentIndex;
     uint8_t length;
 };
 
 struct ArrayNewElemMetadata {
-    Wasm::TypeIndex typeIndex;
+    uint32_t type;
     uint32_t elemSegmentIndex;
     uint8_t length;
 };
 
 struct ArrayGetSetMetadata {
-    Wasm::TypeIndex typeIndex;
+    uint32_t type;
     uint8_t length;
 };
 
@@ -344,7 +344,7 @@ struct ArrayInitElemMetadata {
 };
 
 struct RefTestCastMetadata {
-    int32_t typeIndex;
+    int32_t toHeapType;
     uint8_t length;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -95,20 +95,20 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, IPIntStackEntry* sp, TableCopyMeta
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_size, int32_t);
 
 // Wasm-GC
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_new, Wasm::TypeIndex, IPIntStackEntry* sp);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_new_default, Wasm::TypeIndex);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_new, uint32_t, IPIntStackEntry* sp);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_new_default, uint32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_get, EncodedJSValue, uint32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_get_s, EncodedJSValue, uint32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_set, EncodedJSValue, uint32_t, IPIntStackEntry*);
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new, Wasm::TypeIndex, EncodedJSValue, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_default, Wasm::TypeIndex, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_fixed, Wasm::TypeIndex, uint32_t, IPIntStackEntry*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new, uint32_t, EncodedJSValue, uint32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_default, uint32_t, uint32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_fixed, uint32_t, uint32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_data, IPInt::ArrayNewDataMetadata*, uint32_t, uint32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_elem, IPInt::ArrayNewElemMetadata*, uint32_t, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get, Wasm::TypeIndex, EncodedJSValue, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get_s, Wasm::TypeIndex, EncodedJSValue, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_set, Wasm::TypeIndex, IPIntStackEntry*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get, uint32_t, EncodedJSValue, uint32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get_s, uint32_t, EncodedJSValue, uint32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_set, uint32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_fill, IPIntStackEntry* sp);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_copy, IPIntStackEntry* sp);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_init_data, uint32_t, IPIntStackEntry* sp);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -1091,7 +1091,7 @@ Ref<const RTT> TypeInformation::getCanonicalRTT(TypeIndex type)
     return result.releaseNonNull();
 }
 
-bool TypeInformation::castReference(JSValue refValue, bool allowNull, TypeIndex typeIndex)
+bool TypeInformation::isReferenceValueAssignable(JSValue refValue, bool allowNull, TypeIndex typeIndex, const RTT* rtt)
 {
     if (refValue.isNull())
         return allowNull;
@@ -1123,37 +1123,32 @@ bool TypeInformation::castReference(JSValue refValue, bool allowNull, TypeIndex 
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
-    } else {
-        const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
-        auto signatureRTT = TypeInformation::getCanonicalRTT(typeIndex);
-        if (signature.is<FunctionSignature>()) {
-            WebAssemblyFunctionBase* funcRef = jsDynamicCast<WebAssemblyFunctionBase*>(refValue);
-            if (!funcRef)
-                return false;
-            auto funcRTT = funcRef->rtt();
-            if (funcRTT == signatureRTT.ptr())
-                return true;
-            return funcRTT->isStrictSubRTT(signatureRTT.get());
-        }
-        if (signature.is<ArrayType>()) {
-            JSWebAssemblyArray* arrayRef = jsDynamicCast<JSWebAssemblyArray*>(refValue);
-            if (!arrayRef)
-                return false;
-            auto arrayRTT = arrayRef->rtt();
-            if (arrayRTT.ptr() == signatureRTT.ptr())
-                return true;
-            return arrayRTT->isStrictSubRTT(signatureRTT.get());
-        }
-        ASSERT(signature.is<StructType>());
-        JSWebAssemblyStruct* structRef = jsDynamicCast<JSWebAssemblyStruct*>(refValue);
-        if (!structRef)
-            return false;
-        auto structRTT = structRef->rtt();
-        if (structRTT.ptr() == signatureRTT.ptr())
-            return true;
-        return structRTT->isStrictSubRTT(signatureRTT.get());
+        return false;
     }
 
+    RefPtr<const RTT> signatureRTT;
+    if (!rtt) {
+        signatureRTT = TypeInformation::getCanonicalRTT(typeIndex);
+        rtt = signatureRTT.get();
+    }
+
+    switch (rtt->kind()) {
+    case RTTKind::Function: {
+        WebAssemblyFunctionBase* funcRef = jsDynamicCast<WebAssemblyFunctionBase*>(refValue);
+        if (!funcRef)
+            return false;
+        return funcRef->rtt()->isSubRTT(*rtt);
+    }
+    case RTTKind::Array:
+    case RTTKind::Struct: {
+        auto* object = jsDynamicCast<WebAssemblyGCObjectBase*>(refValue);
+        if (!object)
+            return false;
+        return object->rtt()->isSubRTT(*rtt);
+    }
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -950,7 +950,7 @@ public:
     static RefPtr<const RTT> tryGetCanonicalRTT(TypeIndex);
     static Ref<const RTT> getCanonicalRTT(TypeIndex);
 
-    static bool castReference(JSValue, bool, TypeIndex);
+    static bool isReferenceValueAssignable(JSValue, bool, TypeIndex, const RTT* = nullptr);
 
     static const TypeDefinition& get(TypeIndex);
     static TypeIndex get(const TypeDefinition&);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -229,7 +229,7 @@ ALWAYS_INLINE uint64_t toWebAssemblyValue(JSGlobalObject* globalObject, const Wa
             RELEASE_ASSERT_NOT_REACHED();
         else {
             value = Wasm::internalizeExternref(value);
-            if (!Wasm::TypeInformation::castReference(value, type.isNullable(), type.index)) {
+            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, type.isNullable(), type.index)) {
                 // FIXME: provide a better error message here
                 // https://bugs.webkit.org/show_bug.cgi?id=247746
                 return throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -344,7 +344,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             auto global = globalValue->global()->get(globalObject);
                             RETURN_IF_EXCEPTION(scope, void());
                             value = Wasm::internalizeExternref(global);
-                            if (!Wasm::TypeInformation::castReference(value, declaredGlobalType.isNullable(), declaredGlobalType.index))
+                            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, declaredGlobalType.isNullable(), declaredGlobalType.index))
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
                             m_instance->setGlobal(import.kindIndex, value);
                         }
@@ -407,7 +407,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "cannot be exnref"_s)));
                         else {
                             value = Wasm::internalizeExternref(value);
-                            if (!Wasm::TypeInformation::castReference(value, global.type.isNullable(), global.type.index))
+                            if (!Wasm::TypeInformation::isReferenceValueAssignable(value, global.type.isNullable(), global.type.index))
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
                             m_instance->setGlobal(import.kindIndex, value);
                         }


### PR DESCRIPTION
#### 4e473f2358932522198c562882acee840b2e4b8c
<pre>
[JSC] Clean up Wasm GC code in IPInt and runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=298404">https://bugs.webkit.org/show_bug.cgi?id=298404</a>
<a href="https://rdar.apple.com/problem/159866339">rdar://problem/159866339</a>

Reviewed by Dan Hecht.

1. Clean up IPInt Wasm GC code. We should not use typeIndex /
   Wasm::TypeIndex types for non TypeIndex types. They are just uint32_t
   index in the module, so we should just use it.
2. We should not call TypeDefinition::expand() at runtime in general. In
   Wasm GC code, WebAssemblyGCStructure, already-expanded TypeDefinition
   and RTT are already there. Just use it instead of expanding it.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/runtime/JSCast.h:
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::createNewArray):
(JSC::Wasm::ConstExprGenerator::addArrayNew):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::createNewStruct):
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
(JSC::Wasm::Global::set):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addArrayNew):
(JSC::Wasm::IPIntGenerator::addArrayNewData):
(JSC::Wasm::IPIntGenerator::addArrayNewElem):
(JSC::Wasm::IPIntGenerator::addArrayNewFixed):
(JSC::Wasm::IPIntGenerator::addArrayNewDefault):
(JSC::Wasm::IPIntGenerator::addArrayGet):
(JSC::Wasm::IPIntGenerator::addArraySet):
(JSC::Wasm::IPIntGenerator::addStructNew):
(JSC::Wasm::IPIntGenerator::addStructNewDefault):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
(JSC::Wasm::arrayNewFixed):
(JSC::Wasm::structNew):
(JSC::Wasm::refCast):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeInformation::isReferenceValueAssignable):
(JSC::Wasm::TypeInformation::castReference):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::toWebAssemblyValue):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/299590@main">https://commits.webkit.org/299590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d71174cd468781c2368ce86301f6e9c3ede5466

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71560 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6290ac1-9cb8-4759-b43a-413a6ad0e248) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f9680f1-909e-4786-aa84-08ad63e409f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71259 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e59285da-9c40-4664-95a9-ce013fc6fafd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69404 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111613 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128734 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118003 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35137 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99185 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22629 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19014 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51976 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146702 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45734 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37714 "Found 1 new JSC binary failure: testapi, Found 18615 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49085 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->