### PR TITLE
AX: WebKit can sometimes fail to expose content within dynamically expanded details elements in the accessibility tree

### DIFF
--- a/LayoutTests/accessibility/missing-content-inside-expanded-details-expected.txt
+++ b/LayoutTests/accessibility/missing-content-inside-expanded-details-expected.txt
@@ -1,0 +1,24 @@
+This test ensures content inside dynamically expanded details elements is accessible.
+
+
+{#details AXRole: AXGroup}
+
+{AXRole: AXDisclosureTriangle}
+
+{AXRole: AXStaticText AXValue: Foo}
+
+{#details AXRole: AXGroup}
+
+{AXRole: AXDisclosureTriangle}
+
+{AXRole: AXStaticText AXValue: Foo}
+
+{AXRole: AXGroup}
+
+{AXRole: AXStaticText AXValue: Bar}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo
+Bar

--- a/LayoutTests/accessibility/missing-content-inside-expanded-details.html
+++ b/LayoutTests/accessibility/missing-content-inside-expanded-details.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<details id="details">
+    <summary>Foo</summary>
+    <p>Bar</p>
+</details>
+
+<script>
+var output = "This test ensures content inside dynamically expanded details elements is accessible.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+    output += dumpAXSearchTraversal(webarea);
+
+    document.getElementById("details").setAttribute("open", "");
+    var traversalOutput;
+    setTimeout(async function() {
+        await waitFor(() => {
+            traversalOutput = dumpAXSearchTraversal(webarea);
+            return traversalOutput.includes("Bar");
+        });
+        output += traversalOutput;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -870,6 +870,7 @@ accessibility/dynamically-changing-iframe-remains-accessible.html [ Skip ]
 accessibility/ignore-modals-without-any-content.html [ Skip ]
 accessibility/iframe-tree-update-with-dirty-layout.html [ Skip ]
 accessibility/iframe-with-role.html [ Skip ]
+accessibility/missing-content-inside-expanded-details.html [ Skip ]
 
 accessibility/editable-webpage-focused-ui-element.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2970,6 +2970,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
             if (RefPtr object = get(*element)) {
                 postNotification(*object, AXNotification::ExpandedChanged);
                 childrenChanged(object.get());
+                object->recomputeIsIgnoredForDescendants();
             }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -3097,11 +3098,8 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         postNotification(element, AXNotification::HasPopupChanged);
     else if (attrName == aria_hiddenAttr) {
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-        if (RefPtr axObject = getOrCreate(*element)) {
-            Accessibility::enumerateDescendantsIncludingIgnored<AXCoreObject>(*axObject, /* includeSelf */ true, [] (auto& descendant) {
-                downcast<AccessibilityObject>(descendant).recomputeIsIgnored();
-            });
-        }
+        if (RefPtr axObject = getOrCreate(*element))
+            axObject->recomputeIsIgnoredForDescendants(/* includeSelf */ true);
 #else
         if (RefPtr parent = get(element->parentNode()))
             childrenChanged(parent.get());

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3924,6 +3924,13 @@ bool AccessibilityObject::isIgnoredWithoutCache(AXObjectCache* cache) const
     return ignored;
 }
 
+void AccessibilityObject::recomputeIsIgnoredForDescendants(bool includeSelf)
+{
+    Accessibility::enumerateDescendantsIncludingIgnored<AXCoreObject>(*this, includeSelf, [] (auto& descendant) {
+        downcast<AccessibilityObject>(descendant).recomputeIsIgnored();
+    });
+}
+
 Vector<Ref<Element>> AccessibilityObject::elementsFromAttribute(const QualifiedName& attribute) const
 {
     RefPtr element = dynamicDowncast<Element>(node());

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -277,6 +277,7 @@ public:
     virtual bool computeIsIgnored() const { return true; }
     bool isIgnored() const final;
     void recomputeIsIgnored();
+    void recomputeIsIgnoredForDescendants(bool includeSelf = false);
     AccessibilityObjectInclusion defaultObjectInclusion() const;
     bool isIgnoredByDefault() const;
     bool includeIgnoredInCoreTree() const;


### PR DESCRIPTION
#### b4ca025c66ee4d2e7d7b0295eac08a6d41b34aca
<pre>
AX: WebKit can sometimes fail to expose content within dynamically expanded details elements in the accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=298403">https://bugs.webkit.org/show_bug.cgi?id=298403</a>
<a href="https://rdar.apple.com/159291226">rdar://159291226</a>

Reviewed by Joshua Hoffman.

We need to re-compute is-ignored for descendants of details that become expanded or collapsed.

* LayoutTests/accessibility/missing-content-inside-expanded-details-expected.txt: Added.
* LayoutTests/accessibility/missing-content-inside-expanded-details.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::recomputeIsIgnoredForDescendants):
* Source/WebCore/accessibility/AccessibilityObject.h:

Canonical link: <a href="https://commits.webkit.org/299601@main">https://commits.webkit.org/299601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f058a1c8f0091378f3043a19fc5d7150fe9a6a2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71591 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4ca3f6e-0d4c-484b-a808-213467473f98) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76d56885-10cc-49e6-b54e-74d643b07b5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71282 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21653992-ace5-4c0a-9ea5-5c53676158d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69442 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128765 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99383 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22660 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52007 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49116 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->