### PR TITLE
Implement support for :open CSS pseudo class on details and dialog

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1940,11 +1940,6 @@ imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-017.html [ ImageO
 imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-018.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020.html [ ImageOnlyFailure ]
 
-# :open pseudo-class
-imported/w3c/web-platform-tests/css/selectors/selectors-4/details-open-pseudo-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/selectors/selectors-4/details-open-pseudo-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-pseudo-invalidation.html [ ImageOnlyFailure ]
-
 # This test is bit heavy for debug
 [ Debug ] imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open.optional-expected.txt
@@ -2,11 +2,11 @@ reset
 
 
 
-FAIL CSS :open for <input type=date> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL CSS :open for <input type=datetime-local> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL CSS :open for <input type=week> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL CSS :open for <input type=month> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL CSS :open for <input type=time> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL CSS :open for <input type=color> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL CSS :open for <input type=text list=datalist> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL CSS :open for <input type=date> assert_true: Should match :open after opening the picker. expected true got false
+FAIL CSS :open for <input type=datetime-local> assert_true: Should match :open after opening the picker. expected true got false
+FAIL CSS :open for <input type=week> assert_true: Should match :open after opening the picker. expected true got false
+FAIL CSS :open for <input type=month> assert_true: Should match :open after opening the picker. expected true got false
+FAIL CSS :open for <input type=time> assert_true: Should match :open after opening the picker. expected true got false
+FAIL CSS :open for <input type=color> assert_true: Should match :open after opening the picker. expected true got false
+PASS CSS :open for <input type=text list=datalist>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt
@@ -1,0 +1,13 @@
+This is some text.
+
+
+PASS :open pseudo-class invalidation with dialog.show() + dialog.close()
+PASS :open pseudo-class invalidation with dialog.show() + dialog.requestClose()
+PASS :open pseudo-class invalidation with dialog.show() + dialog.open = false
+PASS :open pseudo-class invalidation with dialog.showModal() + dialog.close()
+PASS :open pseudo-class invalidation with dialog.showModal() + dialog.requestClose()
+PASS :open pseudo-class invalidation with dialog.showModal() + dialog.open = false
+PASS :open pseudo-class invalidation with dialog.open = true/false
+PASS :open pseudo-class invalidation with details.open = true/false
+FAIL :open pseudo-class invalidation with select.showPicker() assert_equals: ancestor should be green since select is open expected "rgb(255, 0, 0)" but got "rgb(0, 0, 0)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>CSS Selectors Invalidation: :modal pseudo class in :has()</title>
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#open-state">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  #subject:has(#dialog:open) { color: green; }
+  #subject:has(#details:open) { color: blue; }
+  #subject:has(#select:open) { color: red; }
+</style>
+<div id="subject">
+  This is some text.
+  <dialog id="dialog">This is a dialog</dialog>
+  <details id="details">This is a details</details>
+  <select id="select"><option>1</option></select>
+</div>
+<script>
+    // Dialog tests
+  test(function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    dialog.show();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since dialog is open");
+    dialog.close();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since dialog is closed");
+  }, ":open pseudo-class invalidation with dialog.show() + dialog.close()");
+  test(function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black ");
+    dialog.show();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since dialog is open");
+    dialog.requestClose();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since dialog is closed");
+  }, ":open pseudo-class invalidation with dialog.show() + dialog.requestClose()");
+  test(function(t) {
+    t.add_cleanup(() => {
+      dialog.open = true;
+      dialog.close();
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    dialog.show();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since dialog is open");
+    dialog.open = false;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since dialog is closed");
+  }, ":open pseudo-class invalidation with dialog.show() + dialog.open = false");
+  test(function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    dialog.showModal();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since dialog is open");
+    dialog.close();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since dialog is closed");
+  }, ":open pseudo-class invalidation with dialog.showModal() + dialog.close()");
+  test(function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    dialog.showModal();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since dialog is shown modally");
+    dialog.requestClose();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since dialog is closed");
+  }, ":open pseudo-class invalidation with dialog.showModal() + dialog.requestClose()");
+  test(function(t) {
+    t.add_cleanup(() => {
+      dialog.open = true;
+      dialog.close();
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    dialog.showModal();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since dialog is open");
+    dialog.open = false;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since dialog is closed");
+  }, ":open pseudo-class invalidation with dialog.showModal() + dialog.open = false");
+  test(function(t) {
+    t.add_cleanup(() => {
+      dialog.open = true;
+      dialog.close();
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    dialog.open = true;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since dialog is open");
+    dialog.open = false;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since dialog is closed");
+  }, ":open pseudo-class invalidation with dialog.open = true/false");
+  // Details tests
+  test(function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    details.open = true;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 255)",
+                  "ancestor should be green since details is open");
+      details.open = false;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since details is closed");
+  }, ":open pseudo-class invalidation with details.open = true/false");
+  // Select tests
+  promise_test(async t => {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    await test_driver.bless('show picker');
+    select.showPicker();
+    assert_equals(getComputedStyle(subject).color, "rgb(255, 0, 0)",
+                  "ancestor should be green since select is open");
+  }, ":open pseudo-class invalidation with select.showPicker()");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
@@ -1,6 +1,7 @@
+details
 
 
-FAIL The dialog element should support :open. ':open' is not a valid selector.
-FAIL The details element should support :open. ':open' is not a valid selector.
-FAIL The select element should support :open. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+PASS The dialog element should support :open.
+PASS The details element should support :open.
+FAIL The select element should support :open. assert_true: :open should match when the select is open. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
@@ -1,5 +1,11 @@
 
 
-FAIL In dialog mode the first focusable element should get focus. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL In dialog mode tab should not close the picker. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL In dialog mode the first focusable element should get focus. assert_equals: The anchor should be focused. expected Element node <a id="interactive1" href="https://www.example.com/">Elep... but got Element node <select id="target">
+  <div></div>
+  <span></span>
+  <a i...
+FAIL In dialog mode tab should not close the picker. assert_equals: The anchor should be focused. expected Element node <a id="interactive1" href="https://www.example.com/">Elep... but got Element node <select id="target">
+  <div></div>
+  <span></span>
+  <a i...
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt
@@ -1,10 +1,10 @@
 
 
-FAIL Button controller code should not run if the mousedown event is preventDefaulted. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Listbox controller code should not run if the mousedown event is preventDefaulted. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL <select> should fire input and change events when new option is selected. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL <select> should not fire input and change events when new selected option has the same value as the old. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL <select> should fire input and change events when option in listbox is clicked promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Check that <Space> opens <select>. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Check that <Space> opens <select> when <select> specifies tabindex promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+PASS Button controller code should not run if the mousedown event is preventDefaulted.
+FAIL Listbox controller code should not run if the mousedown event is preventDefaulted. assert_true: expected true got false
+FAIL <select> should fire input and change events when new option is selected. assert_true: expected true got false
+FAIL <select> should not fire input and change events when new selected option has the same value as the old. assert_true: expected true got false
+FAIL <select> should fire input and change events when option in listbox is clicked assert_true: expected true got false
+FAIL Check that <Space> opens <select>. assert_true: <Space> should open select expected true got false
+FAIL Check that <Space> opens <select> when <select> specifies tabindex assert_true: <Space> should open select expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events.optional-expected.txt
@@ -1,6 +1,6 @@
 
 
 
-FAIL Events, implicit button promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Events, explicit button promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Events, implicit button assert_true: expected true got false
+FAIL Events, explicit button assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Select should not match :focus-visible when using mouse. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Select should not match :focus-visible when using mouse. assert_true: select should open after clicking it. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
@@ -1,7 +1,7 @@
 
 
-FAIL Behavior of Home and End for customizable-<select> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Behavior of Home and End for customizable-<select>, starting at the top promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Behavior of Home and End for customizable-<select>, starting at the bottom promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Behavior of PageUp and PageDown for customizable-<select> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Behavior of Home and End for customizable-<select> assert_true: expected true got false
+FAIL Behavior of Home and End for customizable-<select>, starting at the top assert_true: expected true got false
+FAIL Behavior of Home and End for customizable-<select>, starting at the bottom assert_true: expected true got false
+FAIL Behavior of PageUp and PageDown for customizable-<select> assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional-expected.txt
@@ -1,7 +1,7 @@
 
 
-FAIL Behavior of Home for customizable-<select> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Behavior of End for customizable-<select> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Behavior of PageUp for customizable-<select> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL Behavior of PageDown for customizable-<select> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Behavior of Home for customizable-<select> assert_true: expected true got false
+FAIL Behavior of End for customizable-<select> assert_true: expected true got false
+FAIL Behavior of PageUp for customizable-<select> assert_true: expected true got false
+FAIL Behavior of PageDown for customizable-<select> assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL select can be nested inside a popover promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL a popover can be nested inside select promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL select can be nested inside a modal dialog promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL a modal dialog can be nested inside select promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL select can be nested inside a popover assert_true: the select should be showing expected true got false
+FAIL a popover can be nested inside select assert_true: the select should be showing expected true got false
+FAIL select can be nested inside a modal dialog assert_true: the select should be showing expected true got false
+FAIL a modal dialog can be nested inside select assert_true: the select should be showing expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Hidden options should be skipped when changing focus using the up and down keys. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Hidden options should be skipped when changing focus using the up and down keys. assert_true: The select should be open after pressing space. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
@@ -1,12 +1,12 @@
 light dismiss
 custom button  fallback button
 
-FAIL fallbackbutton: Select with appearance:base-select should open and close when clicking the button. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL fallbackbutton: Clicking the label should focus the select button without opening the picker. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL fallbackbutton: Touch input should work the same as mouse input. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL custombutton: Select with appearance:base-select should open and close when clicking the button. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL custombutton: Clicking the label should focus the select button without opening the picker. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL custombutton: Touch input should work the same as mouse input. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL fallbackbutton: Select with appearance:base-select should open and close when clicking the button. assert_true: Select should be open after clicking the button. expected true got false
+FAIL fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_true: Select should be open after clicking the button. expected true got false
+PASS fallbackbutton: Clicking the label should focus the select button without opening the picker.
+FAIL fallbackbutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
+FAIL custombutton: Select with appearance:base-select should open and close when clicking the button. assert_true: Select should be open after clicking the button. expected true got false
+FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_true: Select should be open after clicking the button. expected true got false
+PASS custombutton: Clicking the label should focus the select button without opening the picker.
+FAIL custombutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Clicking interactive elements inside the select picker should focus them. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Clicking interactive elements inside the select picker should focus them. assert_true: select should open after being clicked. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation-expected.txt
@@ -1,4 +1,4 @@
   option
 
-FAIL select should not match :open when light dismissed. assert_equals: The select should match :not(:open) at the start of the test. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 255)"
+FAIL select should not match :open when light dismissed. assert_equals: The select should match :open when opened. expected "rgb(255, 0, 0)" but got "rgb(0, 255, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Type to search should focus but not select an option until selection is confirmed. promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Type to search should focus but not select an option until selection is confirmed. assert_true: The select should be open after pressing space. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
@@ -5,8 +5,8 @@ FAIL Basic functionality of select picker with appearance:auto assert_equals: ex
 FAIL Basic functionality of select picker with appearance:none assert_equals: expected "none" but got ""
 FAIL Switching appearance in popover-open should close the picker assert_equals: expected "none" but got ""
 FAIL Switching appearance in JS after picker is open should close the picker assert_equals: expected "none" but got ""
-FAIL Test of the test harness promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL The select picker is closed if the <select> appearance value is changed via CSS while the picker is open promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL The select picker is closed if the ::picker() appearance value is changed via CSS while the picker is open promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
-FAIL The select picker is closed if the <select> inline appearance value is changed while the picker is open promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Test of the test harness assert_equals: expected "base-select" but got "auto"
+FAIL The select picker is closed if the <select> appearance value is changed via CSS while the picker is open assert_equals: expected "base-select" but got "auto"
+FAIL The select picker is closed if the ::picker() appearance value is changed via CSS while the picker is open assert_equals: expected "base-select" but got "auto"
+FAIL The select picker is closed if the <select> inline appearance value is changed while the picker is open assert_equals: expected "base-select" but got "auto"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Validate <option> is focusable when is a descendant of <select> promise_test: Unhandled rejection with value: object "SyntaxError: ':open' is not a valid selector."
+FAIL Validate <option> is focusable when is a descendant of <select> assert_true: expected true got false
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3573,6 +3573,9 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped
 
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/customizable-select-in-page-keyboard-behavior.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/customizable-select-in-page-mouse-behavior.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5748,6 +5748,7 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-arrow-scroll.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-tabindex-order.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-tab-navigation.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/click/auxclick_event.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/click/click_event_target_child_parent.html [ Skip ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
@@ -2,12 +2,12 @@
 
 FAIL defaultbutton: When the listbox is closed, spacebar should open the listbox. assert_true: The select should be open after pressing space. expected true got false
 FAIL defaultbutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
-PASS defaultbutton: When the listbox is closed, the enter key should not trigger form submission.
+FAIL defaultbutton: When the listbox is closed, the enter key should not trigger form submission. assert_true: Enter should open the listbox on non-Mac platforms. expected true got false
 FAIL defaultbutton: When the listbox is open, the enter key should commit the selected option. assert_true: The select should open when clicked. expected true got false
 FAIL defaultbutton: When the listbox is open, the tab key should close the listbox. assert_true: Space should open the listbox. expected true got false
 FAIL custombutton: When the listbox is closed, spacebar should open the listbox. assert_true: The select should be open after pressing space. expected true got false
 FAIL custombutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
-FAIL custombutton: When the listbox is closed, the enter key should not trigger form submission. assert_false: Enter should not submit the form when the listbox is closed. expected false got true
+FAIL custombutton: When the listbox is closed, the enter key should not trigger form submission. assert_true: Enter should open the listbox on non-Mac platforms. expected true got false
 FAIL custombutton: When the listbox is open, the enter key should commit the selected option. assert_true: The select should open when clicked. expected true got false
 FAIL custombutton: When the listbox is open, the tab key should close the listbox. assert_true: Space should open the listbox. expected true got false
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5796,6 +5796,20 @@ OffscreenCanvasInWorkersEnabled:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
+OpenPseudoClassEnabled:
+  type: bool
+  status: testable
+  humanReadableName: ":open pseudo-class"
+  humanReadableDescription: "Enable the :open CSS pseudo-class"
+  category: css
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 OpenXRDMABufRelaxedForTesting:
   type: bool
   status: internal
@@ -8375,7 +8389,7 @@ UnifyDamagedRegions:
        default: false
      WebCore:
        default: false
-       
+
 UpdateSceneGeometryEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -189,6 +189,9 @@
         },
         "only-child": {},
         "only-of-type": {},
+        "open": {
+            "settings-flag": "openPseudoClassEnabled"
+        },
         "optional": {},
         "out-of-range": {},
         "past": {

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1230,6 +1230,9 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         case CSSSelector::PseudoClass::InternalMediaDocument:
             return isMediaDocument(element);
 
+        case CSSSelector::PseudoClass::Open:
+            return matchesOpenPseudoClass(element);
+
         case CSSSelector::PseudoClass::PopoverOpen:
             return matchesPopoverOpenPseudoClass(element);
 

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -30,6 +30,7 @@
 #include "FocusController.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameSelection.h"
+#include "HTMLDetailsElement.h"
 #include "HTMLDialogElement.h"
 #include "HTMLFrameElement.h"
 #include "HTMLIFrameElement.h"
@@ -587,6 +588,16 @@ ALWAYS_INLINE bool matchesModalPseudoClass(const Element& element)
 ALWAYS_INLINE bool matchesPopoverOpenPseudoClass(const Element& element)
 {
     return element.isPopoverShowing();
+}
+
+ALWAYS_INLINE bool matchesOpenPseudoClass(const Element& element)
+{
+    if (auto* dialog = dynamicDowncast<HTMLDialogElement>(element))
+        return dialog->isOpen();
+    if (auto* details = dynamicDowncast<HTMLDetailsElement>(element))
+        return details->isOpen();
+
+    return false;
 }
 
 ALWAYS_INLINE bool matchesUserInvalidPseudoClass(const Element& element)

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -122,6 +122,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , cssTextTransformMathAutoEnabled { settings.cssTextTransformMathAutoEnabled() }
     , cssInternalAutoBaseParsingEnabled { settings.cssInternalAutoBaseParsingEnabled() }
     , cssMathDepthEnabled { settings.cssMathDepthEnabled() }
+    , openPseudoClassEnabled { settings.openPseudoClassEnabled() }
     , propertySettings { CSSPropertySettings { settings } }
 {
 }
@@ -161,7 +162,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.cssTextTransformMathAutoEnabled,
         context.cssInternalAutoBaseParsingEnabled,
         context.cssMathDepthEnabled,
-        context.htmlEnhancedSelectPseudoElementsEnabled
+        context.htmlEnhancedSelectPseudoElementsEnabled,
+        context.openPseudoClassEnabled
     );
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -87,6 +87,7 @@ struct CSSParserContext {
     bool cssInternalAutoBaseParsingEnabled : 1 { false };
     bool webkitMediaTextTrackDisplayQuirkEnabled : 1 { false };
     bool cssMathDepthEnabled : 1 { false };
+    bool openPseudoClassEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -44,6 +44,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , thumbAndTrackPseudoElementsEnabled(context.thumbAndTrackPseudoElementsEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
     , webkitMediaTextTrackDisplayQuirkEnabled(context.webkitMediaTextTrackDisplayQuirkEnabled)
+    , openPseudoClassEnabled(context.openPseudoClassEnabled)
 {
 }
 
@@ -58,6 +59,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , thumbAndTrackPseudoElementsEnabled(document.settings().thumbAndTrackPseudoElementsEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
     , webkitMediaTextTrackDisplayQuirkEnabled(document.quirks().needsWebKitMediaTextTrackDisplayQuirk())
+    , openPseudoClassEnabled(document.settings().openPseudoClassEnabled())
 {
 }
 
@@ -72,7 +74,8 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.targetTextPseudoElementEnabled,
         context.thumbAndTrackPseudoElementsEnabled,
         context.viewTransitionsEnabled,
-        context.webkitMediaTextTrackDisplayQuirkEnabled
+        context.webkitMediaTextTrackDisplayQuirkEnabled,
+        context.openPseudoClassEnabled
     );
     add(hasher, context.mode, bits);
 }

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -45,6 +45,7 @@ struct CSSSelectorParserContext {
     bool thumbAndTrackPseudoElementsEnabled : 1 { false };
     bool viewTransitionsEnabled : 1 { false };
     bool webkitMediaTextTrackDisplayQuirkEnabled : 1 { false };
+    bool openPseudoClassEnabled : 1 { false };
 
     bool isHashTableDeletedValue : 1 { false };
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -127,6 +127,7 @@ using PseudoClassesSet = UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<C
     v(operationHasAttachment) \
     v(operationMatchesDir) \
     v(operationMatchesLangPseudoClass) \
+    v(operationMatchesOpenPseudoClass) \
     v(operationMatchesPopoverOpenPseudoClass) \
     v(operationMatchesModalPseudoClass) \
     v(operationMatchesHtmlDocumentPseudoClass) \
@@ -283,6 +284,7 @@ static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesV
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationHasAttachment, bool, (const Element&));
 #endif
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesHtmlDocumentPseudoClass, bool, (const Element&));
+static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesOpenPseudoClass, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesPopoverOpenPseudoClass, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesModalPseudoClass, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesActiveViewTransitionPseudoClass, bool, (const Element&));
@@ -1029,6 +1031,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesPopoverOpenPseudoClass, bool, 
     return matchesPopoverOpenPseudoClass(element);
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesOpenPseudoClass, bool, (const Element& element))
+{
+    COUNT_SELECTOR_OPERATION(operationMatchesOpenPseudoClass);
+    return matchesOpenPseudoClass(element);
+}
+
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesModalPseudoClass, bool, (const Element& element))
 {
     COUNT_SELECTOR_OPERATION(operationMatchesModalPseudoClass);
@@ -1198,6 +1206,10 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 
     case CSSSelector::PseudoClass::PopoverOpen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPopoverOpenPseudoClass));
+        return FunctionType::SimpleSelectorChecker;
+
+    case CSSSelector::PseudoClass::Open:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesOpenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
     case CSSSelector::PseudoClass::Modal:

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -34,6 +34,7 @@
 #include "HTMLSummaryElement.h"
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
+#include "PseudoClassChangeInvalidation.h"
 #include "ShadowRoot.h"
 #include "ShouldNotFireMutationEventsScope.h"
 #include "SlotAssignment.h"
@@ -164,6 +165,9 @@ void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomS
             RefPtr root = shadowRoot();
             RefPtr defaultSlot = m_defaultSlot;
             ASSERT(root);
+            auto isOpen = !newValue.isNull();
+            Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Open, isOpen);
+            m_isOpen = isOpen;
             if (!newValue.isNull()) {
                 defaultSlot->removeInlineStyleProperty(CSSPropertyContentVisibility);
                 queueDetailsToggleEventTask(ToggleState::Closed, ToggleState::Open);
@@ -221,6 +225,11 @@ void HTMLDetailsElement::ensureDetailsExclusivityAfterMutation()
 void HTMLDetailsElement::toggleOpen()
 {
     setBooleanAttribute(HTMLNames::openAttr, !hasAttributeWithoutSynchronization(HTMLNames::openAttr));
+}
+
+bool HTMLDetailsElement::isOpen() const
+{
+    return m_isOpen;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -41,6 +41,8 @@ public:
 
     void queueDetailsToggleEventTask(ToggleState oldState, ToggleState newState);
 
+    bool isOpen() const;
+
 private:
     HTMLDetailsElement(const QualifiedName&, Document&);
 
@@ -57,6 +59,7 @@ private:
     WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_summarySlot;
     WeakPtr<HTMLSummaryElement, WeakPtrImplWithEventTargetData> m_defaultSummary;
     RefPtr<HTMLSlotElement> m_defaultSlot;
+    bool m_isOpen { false };
 
     RefPtr<ToggleEventTask> m_toggleEventTask;
 };

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -287,6 +287,16 @@ void HTMLDialogElement::removedFromAncestor(RemovalType removalType, ContainerNo
     setIsModal(false);
 }
 
+void HTMLDialogElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
+{
+    HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+    if (name == openAttr) {
+        auto isOpen = !newValue.isNull();
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Open, isOpen);
+        m_isOpen = isOpen;
+    }
+}
+
 void HTMLDialogElement::setIsModal(bool newValue)
 {
     if (m_isModal == newValue)
@@ -305,7 +315,7 @@ void HTMLDialogElement::queueDialogToggleEventTask(ToggleState oldState, ToggleS
 
 bool HTMLDialogElement::isOpen() const
 {
-    return hasAttributeWithoutSynchronization(HTMLNames::openAttr);
+    return m_isOpen;
 }
 
 }

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -64,8 +64,11 @@ private:
     void setIsModal(bool newValue);
     bool supportsFocus() const final;
 
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+
     String m_returnValue;
     bool m_isModal { false };
+    bool m_isOpen { false };
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
 
     RefPtr<ToggleEventTask> m_toggleEventTask;


### PR DESCRIPTION
#### 842e79a7f43306fdefb9b66942d168b429675174
<pre>
Implement support for :open CSS pseudo class on details and dialog
<a href="https://bugs.webkit.org/show_bug.cgi?id=284398">https://bugs.webkit.org/show_bug.cgi?id=284398</a>

Reviewed by Tim Nguyen.

This implements support for the `:open` pseudo class on the
details and dialog elements. This is behind a testable runtime
flag.

Follow-up patches will be needed to support select and input elements too.

See CSS spec at <a href="https://drafts.csswg.org/selectors-4/#open-state">https://drafts.csswg.org/selectors-4/#open-state</a>

See HTML spec at <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-open">https://html.spec.whatwg.org/multipage/semantics-other.html#selector-open</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesOpenPseudoClass):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::attributeChanged):
(WebCore::HTMLDetailsElement::isOpen const):
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::attributeChanged):
(WebCore::HTMLDialogElement::isOpen const):
* Source/WebCore/html/HTMLDialogElement.h:

Canonical link: <a href="https://commits.webkit.org/305917@main">https://commits.webkit.org/305917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27d63231d415d4ac13c1fcbdf1b10c2422a03f53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147911 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12300 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9892 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125176 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87900 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9560 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7061 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8199 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131746 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150692 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/568 "Failed to checkout and rebase branch from PR 50315") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11833 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1236 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115437 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; 38 flakes 11 failures; Uploaded test results; Running layout-tests-repeat-failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115755 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29412 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/10541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121661 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11877 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171044 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75555 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->