### PR TITLE
[WPE] WPE Platform: Always set a default size in the toplevel

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -149,6 +149,17 @@ static void wpeToplevelGetProperty(GObject* object, guint propId, GValue* value,
     }
 }
 
+static void wpeToplevelConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_toplevel_parent_class)->constructed(object);
+    auto* toplevel = WPE_TOPLEVEL(object);
+    auto* priv = toplevel->priv;
+    auto settings = wpe_display_get_settings(priv->display.get());
+
+    GVariant* toplevelSize = wpe_settings_get_value(settings, WPE_SETTING_TOPLEVEL_DEFAULT_SIZE, nullptr);
+    g_variant_get(toplevelSize, "(uu)", &priv->width, &priv->height);
+}
+
 static void wpe_toplevel_class_init(WPEToplevelClass* toplevelClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(toplevelClass);
@@ -156,6 +167,7 @@ static void wpe_toplevel_class_init(WPEToplevelClass* toplevelClass)
     objectClass->dispose = wpeToplevelDispose;
     objectClass->set_property = wpeToplevelSetProperty;
     objectClass->get_property = wpeToplevelGetProperty;
+    objectClass->constructed = wpeToplevelConstructed;
 
     /**
      * WPEToplevel:display:

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -561,7 +561,11 @@ void wpe_view_set_toplevel(WPEView* view, WPEToplevel* toplevel)
     priv->toplevel = toplevel;
 
     if (priv->toplevel) {
+        int toplevelHeight, toplevelWidth;
+        wpe_toplevel_get_size(priv->toplevel.get(), &toplevelWidth, &toplevelHeight);
+
         wpeToplevelAddView(priv->toplevel.get(), view);
+        wpe_view_resized(view, toplevelWidth, toplevelHeight);
         wpeViewScaleChanged(view, wpe_toplevel_get_scale(priv->toplevel.get()));
         wpeViewToplevelStateChanged(view, wpe_toplevel_get_state(priv->toplevel.get()));
         wpeViewScreenChanged(view);


### PR DESCRIPTION
#### 1bb1c3bc0ab56831f16120f8af0830d3465ece07
<pre>
[WPE] WPE Platform: Always set a default size in the toplevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=298413">https://bugs.webkit.org/show_bug.cgi?id=298413</a>

Reviewed by NOBODY (OOPS!).

On Wayland there is no guarantee that we get sizing information
and the compositor may defer toplevel sizing to us. This happens
on Weston when exiting fullscreen.

Instead always use the default size in the toplevel and let views
derive their size from that.

* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
(wpeToplevelConstructed):
(wpe_toplevel_class_init):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):
(wpe_view_set_toplevel):
(wpeViewConstructed): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bb1c3bc0ab56831f16120f8af0830d3465ece07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29827 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/125751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/71555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47752 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/125751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/71555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/31825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/107132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/125751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/69398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/101288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/25429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128729 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46403 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/35134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46768 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/103326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/99178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/44616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/22624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46264 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/51971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45729 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->