### PR TITLE
[css-anchor-position-1] Account for left scrollbar when calculating anchor position

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar-expected.txt
@@ -1,0 +1,6 @@
+
+PASS anchor-positioned element using anchor() in horizontal, right-to-left scroller
+PASS anchor-positioned element using position-area in horizontal, right-to-left scroller
+PASS anchor-positioned element using anchor() in vertical-rl scroller
+PASS anchor-positioned element using position-area in vertical-rl scroller
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+
+<title>Tests anchor positioning in a scroller with left-hand-side scrollbar</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/">
+<link rel="author" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+    .containing-block {
+        position: relative;
+        height: 100px;
+        width: 100px;
+
+        overflow: scroll;
+    }
+
+    #containing-block-vertical-rl {
+        writing-mode: vertical-rl;
+    }
+
+    .anchor {
+        width: 20px;
+        height: 20px;
+        background: red;
+
+        position: absolute;
+        left: 50px;
+        top: 50px;
+    }
+
+    #anchor-1 {
+        anchor-name: --anchor1;
+    }
+
+    #anchor-2 {
+        anchor-name: --anchor2;
+    }
+
+    .target-anchor-function {
+        position: absolute;
+        top: anchor(top);
+        left: anchor(left);
+        right: anchor(right);
+        bottom: anchor(bottom);
+
+        background: green;
+    }
+
+    #target-anchor-function-1 {
+        position-anchor: --anchor1;
+    }
+
+    #target-anchor-function-2 {
+        position-anchor: --anchor2;
+    }
+
+    .target-position-area {
+        position: absolute;
+        position-area: center center;
+        width: 100%;
+        height: 100%;
+
+        background: blue;
+    }
+
+    #target-position-area-1 {
+        position-anchor: --anchor1;
+    }
+
+    #target-position-area-2 {
+        position-anchor: --anchor2;
+    }
+</style>
+
+<div class="containing-block" dir="rtl">
+    <!-- Long content to force scrollbar. -->
+    <div style="height: 200px"></div>
+
+    <div class="anchor" id="anchor-1"></div>
+    <div class="target-anchor-function" id="target-anchor-function-1"></div>
+    <div class="target-position-area" id="target-position-area-1"></div>
+</div>
+
+<div class="containing-block" id="containing-block-vertical-rl">
+    <!-- Long content to force scrollbar. -->
+    <div style="height: 200px; width: 20px"></div>
+
+    <div class="anchor" id="anchor-2"></div>
+    <div class="target-anchor-function" id="target-anchor-function-2"></div>
+    <div class="target-position-area" id="target-position-area-2"></div>
+</div>
+
+<script>
+    function getBoundingClientRectAsArray(element) {
+        const rect = element.getBoundingClientRect();
+        return [rect.left, rect.top, rect.right, rect.bottom];
+    }
+
+    test(() => {
+        const anchor = document.getElementById("anchor-1");
+        const targetAnchorFunction = document.getElementById("target-anchor-function-1");
+
+        assert_array_equals(getBoundingClientRectAsArray(anchor), getBoundingClientRectAsArray(targetAnchorFunction));
+    }, "anchor-positioned element using anchor() in horizontal, right-to-left scroller");
+
+    test(() => {
+        const anchor = document.getElementById("anchor-1");
+        const targetPositionArea = document.getElementById("target-position-area-1");
+
+        assert_array_equals(getBoundingClientRectAsArray(anchor), getBoundingClientRectAsArray(targetPositionArea));
+    }, "anchor-positioned element using position-area in horizontal, right-to-left scroller");
+
+    test(() => {
+        const anchor = document.getElementById("anchor-2");
+        const targetAnchorFunction = document.getElementById("target-anchor-function-2");
+
+        assert_array_equals(getBoundingClientRectAsArray(anchor), getBoundingClientRectAsArray(targetAnchorFunction));
+    }, "anchor-positioned element using anchor() in vertical-rl scroller");
+
+    test(() => {
+        const anchor = document.getElementById("anchor-2");
+        const targetPositionArea = document.getElementById("target-position-area-2");
+
+        assert_array_equals(getBoundingClientRectAsArray(anchor), getBoundingClientRectAsArray(targetPositionArea));
+    }, "anchor-positioned element using position-area in vertical-rl scroller");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL anchor-position-borders-002 assert_array_equals: expected property 0 to be 726 but got 711 (expected array [726, 26, 757, 57] got [711, 26, 742, 57])
-FAIL anchor-position-borders-002 1 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 88, 751, 119] got [705, 88, 736, 119])
+PASS anchor-position-borders-002
+PASS anchor-position-borders-002 1
 PASS anchor-position-borders-002 2
-FAIL anchor-position-borders-002 3 assert_array_equals: expected property 0 to be 720 but got 705 (expected array [720, 224, 751, 255] got [705, 224, 736, 255])
-FAIL anchor-position-borders-002 4 assert_array_equals: expected property 0 to be 714 but got 699 (expected array [714, 296, 745, 327] got [699, 296, 730, 327])
+PASS anchor-position-borders-002 3
+PASS anchor-position-borders-002 4
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar-expected.txt
@@ -1,0 +1,6 @@
+
+PASS anchor-positioned element using anchor() in horizontal, right-to-left scroller
+PASS anchor-positioned element using position-area in horizontal, right-to-left scroller
+FAIL anchor-positioned element using anchor() in vertical-rl scroller assert_array_equals: expected property 0 to be 73 but got 58 (expected array [73, 158, 93, 178] got [58, 158, 78, 178])
+FAIL anchor-positioned element using position-area in vertical-rl scroller assert_array_equals: expected property 0 to be 73 but got 58 (expected array [73, 158, 93, 178] got [58, 158, 78, 178])
+

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -498,6 +498,11 @@ LayoutRect AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(C
             anchorLocation.moveBy(-anchorBox->view().frameView().scrollPositionRespectingCustomFixedPosition());
     }
 
+    if (CheckedPtr containingBox = dynamicDowncast<RenderBox>(containingBlock)) {
+        if (containingBox->shouldPlaceVerticalScrollbarOnLeft())
+            anchorLocation.move(-containingBox->verticalScrollbarWidth(), 0);
+    }
+
     return LayoutRect(anchorLocation, LayoutSize(anchorWidth, anchorHeight));
 }
 
@@ -659,7 +664,7 @@ static LayoutUnit computeInsetValue(CSSPropertyID insetPropertyID, CheckedRef<co
     if (constraints.startIsBefore() == isFlipped)
         anchorPercentage = 1 - anchorPercentage;
 
-    auto containingBlock = anchorPositionedRenderer->container();
+    CheckedPtr containingBlock = anchorPositionedRenderer->container();
     ASSERT(containingBlock);
     auto anchorRect = AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(anchorBox, *containingBlock, anchorPositionedRenderer.get());
     auto anchorRange = constraints.extractRange(anchorRect);


### PR DESCRIPTION
#### 2b1d3c03ed716d5f0c81989398b8deaaada4db40
<pre>
[css-anchor-position-1] Account for left scrollbar when calculating anchor position
<a href="https://rdar.apple.com/155852237">rdar://155852237</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295964">https://bugs.webkit.org/show_bug.cgi?id=295964</a>

Reviewed by Elika Etemad.

If an anchor is in a RTL containing block (horizontal right-to-left,
or vertical-rl), the scrollbar of the containing block is on the left.
In that case, adjust the calculated position of the anchor to account
for the left scrollbar

Test: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar.html: Added.
    - Add test to test anchor in scroller with left-hand-side scrollbar
      (e.g in horizontal RTL or vertical-rl writing mode)

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-borders-002-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar-expected.txt: Added.
    - Add expectation for iOS only. Test is failing in vertical-rl writing mode.
      Tracked at <a href="https://bugs.webkit.org/show_bug.cgi?id=298893.">https://bugs.webkit.org/show_bug.cgi?id=298893.</a>

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock):
(WebCore::Style::computeInsetValue):

Canonical link: <a href="https://commits.webkit.org/300018@main">https://commits.webkit.org/300018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e276a744c171130669e69a7fd366e8d33d31ed6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73066 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9464144-d545-43e3-add8-2c9c38dc8caf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61132 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/efc6317f-0089-4d06-ab5c-047bbe207ab0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72583 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ecef6c9-3ed5-49da-815f-45937946279e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70992 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130258 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100505 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25468 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47771 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53484 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47242 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->