### PR TITLE
[JSC] WASM IPInt SIMD: implement store, load, load and splat, load and extend

### DIFF
--- a/JSTests/wasm/stress/simd-instructions-load-store.js
+++ b/JSTests/wasm/stress/simd-instructions-load-store.js
@@ -1,0 +1,434 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const verbose = false;
+
+let wat = `
+(module
+    (memory (export "memory") 1)
+
+    (func (export "test_v128_store") (param $addr i32)
+        (v128.store (local.get $addr)
+            (v128.const i32x4 0x12345678 0x9ABCDEF0 0x11111111 0x22222222))
+    )
+
+    (func (export "test_v128_store_offset") (param $addr i32)
+        (v128.store offset=16 (local.get $addr)
+            (v128.const i64x2 0x123456789ABCDEF0 0xFEDCBA9876543210))
+    )
+
+    (func (export "test_v128_load") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load (local.get $src)))
+    )
+
+    (func (export "test_v128_load_offset") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load offset=16 (local.get $src)))
+    )
+
+    (func (export "test_v128_load8x8_s") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load8x8_s (local.get $src)))
+    )
+
+    (func (export "test_v128_load8x8_u") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load8x8_u (local.get $src)))
+    )
+
+    (func (export "test_v128_load16x4_s") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load16x4_s (local.get $src)))
+    )
+
+    (func (export "test_v128_load16x4_u") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load16x4_u (local.get $src)))
+    )
+
+    (func (export "test_v128_load32x2_s") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load32x2_s (local.get $src)))
+    )
+
+    (func (export "test_v128_load32x2_u") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load32x2_u (local.get $src)))
+    )
+
+    (func (export "test_v128_load8_splat") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load8_splat (local.get $src)))
+    )
+
+    (func (export "test_v128_load16_splat") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load16_splat (local.get $src)))
+    )
+
+    (func (export "test_v128_load32_splat") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load32_splat (local.get $src)))
+    )
+
+    (func (export "test_v128_load64_splat") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load64_splat (local.get $src)))
+    )
+)
+`
+
+async function test_store() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const memory = instance.exports.memory
+    const buffer = memory.buffer
+    const u8 = new Uint8Array(buffer)
+    const u16 = new Uint16Array(buffer)
+    const u32 = new Uint32Array(buffer)
+    const u64 = new BigUint64Array(buffer)
+    const i16 = new Int16Array(buffer)
+
+    const {
+        test_v128_store,
+        test_v128_store_offset,
+        test_v128_load,
+        test_v128_load_offset,
+        test_v128_load8x8_s,
+        test_v128_load8x8_u
+    } = instance.exports
+
+    function clearMemory() {
+        u8.fill(0)
+    }
+
+    function setupLoad8x8TestData(offset = 0) {
+        // Set up test data: mix of values including high bytes that would be negative if signed
+        u8[offset + 0] = 0x12    // signed: 18, unsigned: 18
+        u8[offset + 1] = 0xFF    // signed: -1, unsigned: 255
+        u8[offset + 2] = 0x7F    // signed: 127, unsigned: 127
+        u8[offset + 3] = 0x80    // signed: -128, unsigned: 128
+        u8[offset + 4] = 0x00    // signed: 0, unsigned: 0
+        u8[offset + 5] = 0xCE    // signed: -50, unsigned: 206
+        u8[offset + 6] = 0x64    // signed: 100, unsigned: 100
+        u8[offset + 7] = 0x9C    // signed: -100, unsigned: 156
+    }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // Test basic v128.store
+        clearMemory()
+        test_v128_store(0)
+        assert.eq(u32[0], 0x12345678)
+        assert.eq(u32[1], 0x9ABCDEF0)
+        assert.eq(u32[2], 0x11111111)
+        assert.eq(u32[3], 0x22222222)
+
+        // Test v128.store with offset
+        clearMemory()
+        test_v128_store_offset(0)
+        assert.eq(u64[2], 0x123456789ABCDEF0n)  // offset 16 = index 2 in u64 array
+        assert.eq(u64[3], 0xFEDCBA9876543210n)
+
+        // Test store at different address
+        clearMemory()
+        test_v128_store(64)
+        assert.eq(u32[16], 0x12345678)  // 64/4 = 16
+        assert.eq(u32[17], 0x9ABCDEF0)
+        assert.eq(u32[18], 0x11111111)
+        assert.eq(u32[19], 0x22222222)
+
+        // Verify other memory locations are still zero
+        assert.eq(u32[0], 0)
+        assert.eq(u32[15], 0)
+        assert.eq(u32[20], 0)
+
+        // Test v128.load - store data, then load and store to different location
+        clearMemory()
+        test_v128_store(0)  // Store test pattern at address 0
+        test_v128_load(0, 128)  // Load from address 0, store to address 128
+
+        // Verify the loaded data matches the original
+        assert.eq(u32[32], 0x12345678)  // 128/4 = 32
+        assert.eq(u32[33], 0x9ABCDEF0)
+        assert.eq(u32[34], 0x11111111)
+        assert.eq(u32[35], 0x22222222)
+
+        // Test v128.load with offset
+        clearMemory()
+        test_v128_store_offset(0)  // Store test pattern at offset 16 from address 0
+        test_v128_load_offset(0, 192)  // Load from offset 16, store to address 192
+
+        // Verify the loaded data matches the original
+        assert.eq(u64[24], 0x123456789ABCDEF0n)  // 192/8 = 24
+        assert.eq(u64[25], 0xFEDCBA9876543210n)
+
+        // Test v128.load8x8_s - sign extension from i8 to i16
+        clearMemory()
+        setupLoad8x8TestData(0)
+
+        test_v128_load8x8_s(0, 256)  // Load 8 bytes from address 0, store result to address 256
+
+        // Verify sign extension
+        assert.eq(i16[128], 18)
+        assert.eq(i16[129], -1)
+        assert.eq(i16[130], 127)
+        assert.eq(i16[131], -128)
+        assert.eq(i16[132], 0)
+        assert.eq(i16[133], -50)
+        assert.eq(i16[134], 100)
+        assert.eq(i16[135], -100)
+
+        // Test v128.load8x8_u - zero extension from u8 to u16
+        clearMemory()
+        setupLoad8x8TestData(8)
+
+        test_v128_load8x8_u(8, 320)  // Load 8 bytes from address 8, store result to address 320
+
+        // Verify zero extension
+        assert.eq(u16[160], 0x0012)
+        assert.eq(u16[161], 0x00FF)
+        assert.eq(u16[162], 0x007F)
+        assert.eq(u16[163], 0x0080)
+        assert.eq(u16[164], 0x0000)
+        assert.eq(u16[165], 0x00CE)
+        assert.eq(u16[166], 0x0064)
+        assert.eq(u16[167], 0x009C)
+    }
+    if (verbose)
+        print("Store tests passed!")
+}
+
+async function test_load_extend() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const memory = instance.exports.memory
+    const buffer = memory.buffer
+    const u8 = new Uint8Array(buffer)
+    const u16 = new Uint16Array(buffer)
+    const u32 = new Uint32Array(buffer)
+    const u64 = new BigUint64Array(buffer)
+
+    const {
+        test_v128_load16x4_s,
+        test_v128_load16x4_u,
+        test_v128_load32x2_s,
+        test_v128_load32x2_u
+    } = instance.exports
+
+    function clearMemory() {
+        u8.fill(0)
+    }
+
+    function setupLoad16x4TestData(offset = 0) {
+        // Set up test data: mix of 16-bit values including high values that would be negative if signed
+        const baseIndex = offset / 2
+        u16[baseIndex + 0] = 0x1234    // signed: 4660, unsigned: 4660
+        u16[baseIndex + 1] = 0xFFFF    // signed: -1, unsigned: 65535
+        u16[baseIndex + 2] = 0x7FFF    // signed: 32767, unsigned: 32767
+        u16[baseIndex + 3] = 0x8000    // signed: -32768, unsigned: 32768
+    }
+
+    function setupLoad32x2TestData(offset = 0) {
+        // Set up test data: mix of 32-bit values including high values that would be negative if signed
+        const baseIndex = offset / 4
+        u32[baseIndex + 0] = 0x12345678    // signed: 305419896, unsigned: 305419896
+        u32[baseIndex + 1] = 0xFFFFFFFF    // signed: -1, unsigned: 4294967295
+    }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // Test v128.load16x4_s - sign extension from i16 to i32
+        clearMemory()
+        setupLoad16x4TestData(0)
+        test_v128_load16x4_s(0, 384)
+
+        const i32 = new Int32Array(buffer)
+        assert.eq(i32[96], 4660)
+        assert.eq(i32[97], -1)
+        assert.eq(i32[98], 32767)
+        assert.eq(i32[99], -32768)
+
+        // Test v128.load16x4_u - zero extension from u16 to u32
+        clearMemory()
+        setupLoad16x4TestData(8)
+        test_v128_load16x4_u(8, 448)
+
+        assert.eq(u32[112], 0x00001234)
+        assert.eq(u32[113], 0x0000FFFF)
+        assert.eq(u32[114], 0x00007FFF)
+        assert.eq(u32[115], 0x00008000)
+
+        // Test v128.load32x2_s - sign extension from i32 to i64
+        clearMemory()
+        setupLoad32x2TestData(0)
+        test_v128_load32x2_s(0, 512)
+
+        const i64 = new BigInt64Array(buffer)
+        assert.eq(i64[64], 0x12345678n)
+        assert.eq(i64[65], -1n)
+
+        // Test v128.load32x2_u - zero extension from u32 to u64
+        clearMemory()
+        setupLoad32x2TestData(8)
+        test_v128_load32x2_u(8, 576)
+
+        assert.eq(u64[72], 0x12345678n)
+        assert.eq(u64[73], 0xFFFFFFFFn)
+    }
+    if (verbose)
+        print("Load extend tests passed!")
+}
+
+async function test_load_splat() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const memory = instance.exports.memory
+    const buffer = memory.buffer
+    const u8 = new Uint8Array(buffer)
+    const u16 = new Uint16Array(buffer)
+    const u32 = new Uint32Array(buffer)
+    const u64 = new BigUint64Array(buffer)
+
+    const {
+        test_v128_load8_splat,
+        test_v128_load16_splat,
+        test_v128_load32_splat,
+        test_v128_load64_splat
+    } = instance.exports
+
+    function clearMemory() {
+        u8.fill(0)
+    }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // Test v128.load8_splat - load 1 byte and splat to all 16 lanes
+        clearMemory()
+        u8[0] = 0xAB
+        test_v128_load8_splat(0, 640)
+
+        // Verify all 16 bytes are 0xAB
+        for (let j = 0; j < 16; j++)
+            assert.eq(u8[640 + j], 0xAB)
+
+        // Test v128.load16_splat - load 1 i16 and splat to all 8 lanes
+        clearMemory()
+        u16[0] = 0x1234
+        test_v128_load16_splat(0, 704)
+
+        // Verify all 8 i16 values are 0x1234
+        for (let j = 0; j < 8; j++)
+            assert.eq(u16[352 + j], 0x1234)
+
+        // Test v128.load32_splat - load 1 i32 and splat to all 4 lanes
+        clearMemory()
+        u32[0] = 0x12345678
+        test_v128_load32_splat(0, 768)
+
+        // Verify all 4 i32 values are 0x12345678
+        for (let j = 0; j < 4; j++)
+            assert.eq(u32[192 + j], 0x12345678)
+
+        // Test v128.load64_splat - load 1 i64 and splat to all 2 lanes
+        clearMemory()
+        u64[0] = 0x123456789ABCDEF0n
+        test_v128_load64_splat(0, 832)
+
+        // Verify all 2 i64 values are 0x123456789ABCDEF0n
+        for (let j = 0; j < 2; j++)
+            assert.eq(u64[104 + j], 0x123456789ABCDEF0n)
+    }
+    if (verbose)
+        print("Load splat tests passed!")
+}
+
+async function test_bounds_checking() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const memory = instance.exports.memory
+    const buffer = memory.buffer
+    const memorySize = 65536  // 1 page = 64KB
+
+    const {
+        test_v128_load16x4_s,
+        test_v128_load16x4_u,
+        test_v128_load32x2_s,
+        test_v128_load32x2_u,
+        test_v128_load8_splat,
+        test_v128_load16_splat,
+        test_v128_load32_splat,
+        test_v128_load64_splat
+    } = instance.exports
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        try {
+            test_v128_load16x4_s(memorySize - 7, 0)  // Should fail: needs 8 bytes but only 7 available
+            throw new Error("v128.load16x4_s should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load16x4_u(memorySize - 7, 0)  // Should fail: needs 8 bytes but only 7 available
+            throw new Error("v128.load16x4_u should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load32x2_s(memorySize - 7, 0)  // Should fail: needs 8 bytes but only 7 available
+            throw new Error("v128.load32x2_s should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load32x2_u(memorySize - 7, 0)  // Should fail: needs 8 bytes but only 7 available
+            throw new Error("v128.load32x2_u should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load8_splat(memorySize, 0)  // Should fail: trying to read at exactly memorySize
+            throw new Error("v128.load8_splat should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load16_splat(memorySize - 1, 0)  // Should fail: needs 2 bytes but only 1 available
+            throw new Error("v128.load16_splat should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load32_splat(memorySize - 3, 0)  // Should fail: needs 4 bytes but only 3 available
+            throw new Error("v128.load32_splat should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load64_splat(memorySize - 7, 0)  // Should fail: needs 8 bytes but only 7 available
+            throw new Error("v128.load64_splat should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        // Test valid boundary cases (should succeed)
+        test_v128_load16x4_s(memorySize - 8, 0)   // Exactly at boundary: reads 8 bytes
+        test_v128_load16x4_u(memorySize - 8, 16)  // Exactly at boundary: reads 8 bytes
+        test_v128_load32x2_s(memorySize - 8, 32)  // Exactly at boundary: reads 8 bytes
+        test_v128_load32x2_u(memorySize - 8, 48)  // Exactly at boundary: reads 8 bytes
+        test_v128_load8_splat(memorySize - 1, 64)  // Exactly at boundary: reads 1 byte
+        test_v128_load16_splat(memorySize - 2, 80) // Exactly at boundary: reads 2 bytes
+        test_v128_load32_splat(memorySize - 4, 96) // Exactly at boundary: reads 4 bytes
+        test_v128_load64_splat(memorySize - 8, 112) // Exactly at boundary: reads 8 bytes
+    }
+    if (verbose)
+        print("Bounds checking tests passed!")
+}
+
+await assert.asyncTest(test_store())
+await assert.asyncTest(test_load_extend())
+await assert.asyncTest(test_load_splat())
+await assert.asyncTest(test_bounds_checking())

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -678,16 +678,38 @@ Value IPIntGenerator::addConstant(Type type, uint64_t value)
 
 // SIMD
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&) IPINT_UNIMPLEMENTED
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t) IPINT_UNIMPLEMENTED
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&)
+{
+    changeStackSize(0); // Pop address, push v128 value (net change = 0)
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset)
+{
+    changeStackSize(-2); // Pop address and v128 value
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&) IPINT_UNIMPLEMENTED
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&) IPINT_UNIMPLEMENTED
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) IPINT_UNIMPLEMENTED
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) IPINT_UNIMPLEMENTED
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) IPINT_UNIMPLEMENTED
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+{
+    return addSIMDLoad(pointer, offset, result);
+}
+
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&) IPINT_UNIMPLEMENTED
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) IPINT_UNIMPLEMENTED
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) IPINT_UNIMPLEMENTED
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+{
+    return addSIMDLoad(pointer, offset, result);
+}
+
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) IPINT_UNIMPLEMENTED
 
 IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)


### PR DESCRIPTION
#### 12553bef37149a796dfaa74d3db1ccbd5cfefeb5
<pre>
[JSC] WASM IPInt SIMD: implement store, load, load and splat, load and extend
<a href="https://bugs.webkit.org/show_bug.cgi?id=298421">https://bugs.webkit.org/show_bug.cgi?id=298421</a>
<a href="https://rdar.apple.com/159898337">rdar://159898337</a>

Reviewed by Yusuke Suzuki.

For ARM, implement these instructions in WasmIPInt:

v128_load_mem
v128_load_8x8s_mem
v128_load_8x8u_mem
v128_load_16x4s_mem
v128_load_16x4u_mem
v128_load_32x2s_mem
v128_load_32x2u_mem
v128_load8_splat_mem
v128_load16_splat_mem
v128_load32_splat_mem
v128_load64_splat_mem
v128_store_mem

* JSTests/wasm/stress/simd-instructions-load-store.js: Added.
New test case to systematically verify each of these instructions in isolation

Canonical link: <a href="https://commits.webkit.org/299622@main">https://commits.webkit.org/299622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66121b0cc88cb9623a2771901480d21d8851f932

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9486a628-e298-4a07-9ae8-63df1c03cd45) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90796 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60101 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f37b39c-5afa-4d97-8114-8a129ce05415) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71288 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5fd45f5-328b-4719-bf38-11b8c5e3b9ee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69452 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111657 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128778 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118048 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46452 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99390 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44649 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43016 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52020 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146746 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45778 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37727 "Found 1 new JSC binary failure: testapi, Found 18619 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/memop_bounds_check.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->