### PR TITLE
[WebAuthn] Full exclude list sent after batching during makeCredential

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -21,4 +21,5 @@ PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport and appid ex
 PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.
 PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator. 2
+PASS PublicKeyCredential's [[create]] with excludeCredentials - verify preflighted credentials not sent in main request.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -553,4 +553,59 @@
             checkCtapMakeCredentialResult(credential, true, ["usb"]);
         });
     }, "PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator. 2");
+        promise_test(t => {
+        // Test bidirectional HID validation with exclude list preflight
+        // This test validates that WebKit sends the expected sequence of HID messages:
+        // 1. Two silent authenticatorGetAssertion requests (exclude list preflight)
+        // 2. One authenticatorMakeCredential request (actual credential creation)
+        
+        const excludeCredential1 = Base64URL.parse("dGVzdGNyZWRlbnRpYWwx"); // "testcredential1"
+        const excludeCredential2 = Base64URL.parse("dGVzdGNyZWRlbnRpYWwy"); // "testcredential2"
+        
+        let config = {
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                payloadBase64: [
+                    "Lg==", // Response to first exclude list preflight (credential not found)
+                    "Lg==", // Response to second exclude list preflight (credential not found)
+                    testCreationMessageBase64 // Response to actual makeCredential
+                ],
+                validateExpectedCommands: true,
+                expectedCommandsBase64: [
+                    "AqQBaWxvY2FsaG9zdAJYIBraShsL58mV/5Ewkij+Q37ohfCSmOvvqFo/YdrkFzG1A4GiYmlkT3Rlc3RjcmVkZW50aWFsMWR0eXBlanB1YmxpYy1rZXkFoWJ1cPQ=",
+                    "AqQBaWxvY2FsaG9zdAJYIBraShsL58mV/5Ewkij+Q37ohfCSmOvvqFo/YdrkFzG1A4GiYmlkT3Rlc3RjcmVkZW50aWFsMmR0eXBlanB1YmxpYy1rZXkFoWJ1cPQ=",
+                    "AaQBWCAa2kobC+fJlf+RMJIo/kN+6IXwkpjr76haP2Ha5BcxtQKiYmlkaWxvY2FsaG9zdGRuYW1laWxvY2FsaG9zdAOjYmlkSgABAgMEBQYHCAlkbmFtZW5Kb2huIEFwcGxlc2VlZGtkaXNwbGF5TmFtZWlBcHBsZXNlZWQEgaJjYWxnJmR0eXBlanB1YmxpYy1rZXk="
+                ]
+            }
+        };
+        
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 1000,
+                excludeCredentials: [
+                    { type: "public-key", id: excludeCredential1 },
+                    { type: "public-key", id: excludeCredential2 }
+                ]
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with excludeCredentials - verify preflighted credentials not sent in main request.");
+
 </script>

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
@@ -127,10 +127,12 @@ Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, c
     cborMap[CBORValue(3)] = convertUserEntityToCBOR(options.user);
     cborMap[CBORValue(4)] = convertParametersToCBOR(trimmedParameters(options.pubKeyCredParams, authenticatorSupportedParameters));
     if (overrideExcludeCredentials) {
-        CBORValue::ArrayValue excludeListArray;
-        for (const auto& descriptor : *overrideExcludeCredentials)
-            excludeListArray.append(convertDescriptorToCBOR(descriptor));
-        cborMap[CBORValue(5)] = CBORValue(WTFMove(excludeListArray));
+        if (!overrideExcludeCredentials->isEmpty()) {
+            CBORValue::ArrayValue excludeListArray;
+            for (const auto& descriptor : *overrideExcludeCredentials)
+                excludeListArray.append(convertDescriptorToCBOR(descriptor));
+            cborMap[CBORValue(5)] = CBORValue(WTFMove(excludeListArray));
+        }
     } else if (!options.excludeCredentials.isEmpty()) {
         CBORValue::ArrayValue excludeListArray;
         for (const auto& descriptor : options.excludeCredentials)

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
@@ -79,6 +79,8 @@ struct MockWebAuthenticationConfiguration {
 
     struct HidConfiguration {
         Vector<String> payloadBase64;
+        Vector<String> expectedCommandsBase64;
+        bool validateExpectedCommands { false };
         HidStage stage { HidStage::Info };
         HidSubStage subStage { HidSubStage::Init };
         HidError error { HidError::Success };

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -93,6 +93,8 @@
     Conditional=WEB_AUTHN,
 ] dictionary MockHidConfiguration {
     sequence<DOMString> payloadBase64;
+    sequence<DOMString> expectedCommandsBase64;
+    boolean validateExpectedCommands;
     MockHidStage stage = "info";
     MockHidSubStage subStage = "init";
     MockHidError error = "success";

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6626,6 +6626,8 @@ header: <WebCore/ISOVTTCue.h>
 
 [Nested] struct WebCore::MockWebAuthenticationConfiguration::HidConfiguration {
     Vector<String> payloadBase64;
+    Vector<String> expectedCommandsBase64;
+    bool validateExpectedCommands;
     WebCore::MockWebAuthenticationConfiguration::HidStage stage;
     WebCore::MockWebAuthenticationConfiguration::HidSubStage subStage;
     WebCore::MockWebAuthenticationConfiguration::HidError error;

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -303,14 +303,9 @@ void AuthenticatorManager::respondReceived(Respond&& respond)
         auto code = std::get<ExceptionData>(respond).code;
         shouldComplete = code == ExceptionCode::InvalidStateError || code == ExceptionCode::NotSupportedError;
     }
-    if (shouldComplete) {
-        invokePendingCompletionHandler(WTFMove(respond));
-        clearStateAsync();
-        m_requestTimeOutTimer.stop();
-        return;
-    }
-    respondReceivedInternal(WTFMove(respond));
-    restartDiscovery();
+    respondReceivedInternal(WTFMove(respond), shouldComplete);
+    if (!shouldComplete)
+        restartDiscovery();
 }
 
 void AuthenticatorManager::downgrade(Authenticator& id, Ref<Authenticator>&& downgradedAuthenticator)

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -90,6 +90,9 @@ protected:
     void selectAssertionResponse(Vector<Ref<WebCore::AuthenticatorAssertionResponse>>&&, WebAuthenticationSource, CompletionHandler<void(WebCore::AuthenticatorAssertionResponse*)>&&);
     void startDiscovery(const TransportSet&);
 
+protected:
+    const Vector<Ref<AuthenticatorTransportService>>& services() const { return m_services; }
+
 private:
     enum class Mode {
         Compatible,
@@ -113,7 +116,7 @@ private:
     // Overriden by MockAuthenticatorManager.
     virtual Ref<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const;
     // Overriden to return every exception for tests to confirm.
-    virtual void respondReceivedInternal(Respond&&) { }
+    virtual void respondReceivedInternal(Respond&&, bool shouldComplete) { }
     virtual void filterTransports(TransportSet&) const;
     virtual void runPresenterInternal(const TransportSet&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
@@ -68,6 +68,8 @@ public:
     void startDiscovery();
     void restartDiscovery();
 
+    virtual void validateExpectedCommandsCompleted() { }
+
 protected:
     explicit AuthenticatorTransportService(AuthenticatorTransportServiceObserver&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
@@ -44,9 +44,11 @@ private:
     explicit MockAuthenticatorManager(WebCore::MockWebAuthenticationConfiguration&&);
 
     Ref<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const final;
-    void respondReceivedInternal(Respond&&) final;
+    void respondReceivedInternal(Respond&&, bool shouldComplete) final;
     void filterTransports(TransportSet&) const;
     void runPresenterInternal(const TransportSet&) final { }
+
+    void validateHidExpectedCommands();
 
     WebCore::MockWebAuthenticationConfiguration m_testConfiguration;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
@@ -48,6 +48,8 @@ public:
     static Ref<MockHidConnection> create(IOHIDDeviceRef, const WebCore::MockWebAuthenticationConfiguration&);
     virtual ~MockHidConnection() = default;
 
+    void validateExpectedCommandsCompleted();
+
 private:
     MockHidConnection(IOHIDDeviceRef, const WebCore::MockWebAuthenticationConfiguration&);
 
@@ -64,6 +66,8 @@ private:
     bool stagesMatch() const;
     void shouldContinueFeedReports();
     void continueFeedReports();
+    void validateExpectedCommand(const Vector<uint8_t>& actualCommand);
+    void initializeExpectedCommands();
 
     WebCore::MockWebAuthenticationConfiguration m_configuration;
     std::optional<fido::FidoHidMessage> m_requestMessage;
@@ -73,6 +77,8 @@ private:
     bool m_requireResidentKey { false };
     bool m_requireUserVerification  { false };
     Vector<uint8_t> m_nonce;
+    Vector<Vector<uint8_t>> m_expectedCommands;
+    size_t m_currentExpectedCommandIndex { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
@@ -55,9 +55,19 @@ void MockHidService::platformStartDiscovery()
 
 Ref<HidConnection> MockHidService::createHidConnection(IOHIDDeviceRef device) const
 {
-    return MockHidConnection::create(device, m_configuration);
+    Ref connection = MockHidConnection::create(device, m_configuration);
+    m_activeConnection = connection.get();
+    return connection;
+}
+
+void MockHidService::validateExpectedCommandsCompleted()
+{
+    if (RefPtr connection = m_activeConnection.get()) {
+        RELEASE_LOG(WebAuthn, "MockHidService: Found active connection, calling validation");
+        connection->validateExpectedCommandsCompleted();
+    } else
+        RELEASE_LOG(WebAuthn, "MockHidService: No active connection found");
 }
 
 } // namespace WebKit
-
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
@@ -32,9 +32,13 @@
 
 namespace WebKit {
 
+class MockHidConnection;
+
 class MockHidService final : public HidService {
 public:
     static Ref<MockHidService> create(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
+
+    void validateExpectedCommandsCompleted() final;
 
 private:
     MockHidService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
@@ -43,6 +47,7 @@ private:
     Ref<HidConnection> createHidConnection(IOHIDDeviceRef) const final;
 
     WebCore::MockWebAuthenticationConfiguration m_configuration;
+    mutable WeakPtr<MockHidConnection> m_activeConnection;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -190,7 +190,7 @@ void CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials(bool
 {
     Vector<uint8_t> cborCmd;
     auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
-    std::optional<Vector<PublicKeyCredentialDescriptor>> overrideExcludeCredentials;
+    Vector<PublicKeyCredentialDescriptor> overrideExcludeCredentials;
     if (includeCurrentBatch) {
         ASSERT(m_currentBatch < m_batches.size());
         overrideExcludeCredentials = m_batches[m_currentBatch];


### PR DESCRIPTION
#### 3e8718b56658175b35cceb569d7e73560f85d0ca
<pre>
[WebAuthn] Full exclude list sent after batching during makeCredential
<a href="https://bugs.webkit.org/show_bug.cgi?id=298423">https://bugs.webkit.org/show_bug.cgi?id=298423</a>
<a href="https://rdar.apple.com/157668547">rdar://157668547</a>

Reviewed by Charlie Wolfe.

We have a bug where if we did not find a matching credential, we send the full excludeList
after checking each credential in the excludeList silently. This patch fixes that by passing
an empty exclude list in the makeCredential request.

This patch also adds testing infrastructure to make sure we don&apos;t regress this
fix. There is now the ability to verify the messages that the platform sends the
authenticator, previously we could only specify what the authenticator sends the platform.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::respondReceived):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
(WebKit::AuthenticatorManager::services const):
(WebKit::AuthenticatorManager::respondReceivedInternal):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h:
(WebKit::AuthenticatorTransportService::validateExpectedCommandsCompleted):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp:
(WebKit::MockAuthenticatorManager::respondReceivedInternal):
(WebKit::MockAuthenticatorManager::validateHidExpectedCommands):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp:
(WebKit::MockHidConnection::MockHidConnection):
(WebKit::MockHidConnection::parseRequest):
(WebKit::MockHidConnection::initializeExpectedCommands):
(WebKit::MockHidConnection::validateExpectedCommand):
(WebKit::MockHidConnection::validateAllExpectedCommandsConsumed):
(WebKit::MockHidConnection::validateExpectedCommandsCompleted):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp:
(WebKit::MockHidService::createHidConnection const):
(WebKit::MockHidService::validateExpectedCommandsCompleted):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):

Canonical link: <a href="https://commits.webkit.org/299725@main">https://commits.webkit.org/299725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dbd3ca50be80ea767890b53f861a3cafa95a4b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72042 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59992fcb-cbfa-4e7c-bbae-02d2a592cda6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91102 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60415 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6ec0cf8-9063-4404-ad02-0761f41ee7fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71658 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7d065a7-66b1-4c93-84ef-5fccf31ec321) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129219 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35552 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25282 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52457 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46217 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49566 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->