### PR TITLE
REGRESSION (291055@main): Buttons with box shadow are broken

### DIFF
--- a/LayoutTests/fast/box-shadow/inset-shadow-large-spread-expected.html
+++ b/LayoutTests/fast/box-shadow/inset-shadow-large-spread-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style type="text/css">
+    .box {
+      width: 140px;
+      height: 100px;
+      margin: 20px;
+      background-color: green;
+    }
+    
+    .rounded {
+      border-radius: 10px;
+    }
+  </style>
+</head>
+<body>
+  
+  <!-- You should see no red -->
+  <div class="box"></div>
+  <div class="rounded box"></div>
+
+</body>
+</html>

--- a/LayoutTests/fast/box-shadow/inset-shadow-large-spread.html
+++ b/LayoutTests/fast/box-shadow/inset-shadow-large-spread.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style type="text/css">
+    .box {
+      width: 140px;
+      height: 100px;
+      margin: 20px;
+      background-color: green;
+      box-shadow: rgba(255, 0, 0, 0) 0px 0px 0px 100px inset;
+    }
+    
+    .rounded {
+      border-radius: 10px;
+    }
+  </style>
+</head>
+<body>
+  
+  <!-- You should see no red -->
+  <div class="box"></div>
+  <div class="rounded box"></div>
+
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -969,7 +969,7 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
                 outerRectExpandedToObscureOpenEdges.setHeight(outerRectExpandedToObscureOpenEdges.height() - std::min<LayoutUnit>(shadowOffset.height(), 0) + shadowInfluence);
 
             auto shapeForInnerHole = BorderShape(outerRectExpandedToObscureOpenEdges, borderWidthsWithSpread, borderShape.radii());
-            if (shapeForInnerHole.snappedOuterRect(deviceScaleFactor).isEmpty()) {
+            if (shapeForInnerHole.snappedInnerRect(deviceScaleFactor).isEmpty()) {
                 shapeForInnerHole.fillInnerShape(context, shadowColor, deviceScaleFactor);
                 continue;
             }


### PR DESCRIPTION
#### f3bffa9290901749c5b57fc89056dd94a5d75409
<pre>
REGRESSION (291055@main): Buttons with box shadow are broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=298341">https://bugs.webkit.org/show_bug.cgi?id=298341</a>
<a href="https://rdar.apple.com/159888287">rdar://159888287</a>

Reviewed by Aditya Keerthi.

The bug occurred with inset shadows that have large spread. The check that
the inner &quot;hole&quot; was empty was failing, because it checked the outer, instead
of the inner shape on the hole BorderShape.

This regressed with the adoption of BorderShape here (291055@main).

* LayoutTests/fast/box-shadow/inset-shadow-large-spread-expected.html: Added.
* LayoutTests/fast/box-shadow/inset-shadow-large-spread.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBoxShadow const):

Canonical link: <a href="https://commits.webkit.org/299603@main">https://commits.webkit.org/299603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dfc6176b489faeaf7a51f3cf3865dc6228df11c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71608 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf33f795-da9a-4c9c-8e1f-319dd77268b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47806 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90799 "Found 1 new test failure: http/wpt/service-workers/service-worker-spinning-activate.https.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/348ed280-c32c-4450-856a-c574f1909109) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71292 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ff27908-4a77-4e31-bd54-9ae51403572e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25287 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128782 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99391 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22671 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52024 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45782 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49133 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->