### PR TITLE
workers/empty-post-message-service-workers-crash.html spins hundreds of workers and causes flakiness

### DIFF
--- a/LayoutTests/workers/empty-post-message-service-workers-crash.html
+++ b/LayoutTests/workers/empty-post-message-service-workers-crash.html
@@ -5,9 +5,8 @@
     testRunner.waitUntilDone();
   }
   onload = () => {
-    document.createElement('audio').src = 'data:application/vnd.apple.mpegURL;base64,xx';
-    for (let i = 0; i <= 50; i++) {
-      if (50 == i) {
+    for (let i = 0; i <= 5; i++) {
+      if (5 == i) {
         if (window.testRunner)
           testRunner.notifyDone();
       }

--- a/LayoutTests/workers/empty-post-message-service-workers-crash.js
+++ b/LayoutTests/workers/empty-post-message-service-workers-crash.js
@@ -1,4 +1,4 @@
 onmessage = () => {
   postMessage(undefined)
 }
-new Worker('empty-post-message-service-workers-crash.js');
+new Worker('empty-post-message-service-workers-crash2.js');

--- a/LayoutTests/workers/empty-post-message-service-workers-crash2.js
+++ b/LayoutTests/workers/empty-post-message-service-workers-crash2.js
@@ -1,0 +1,3 @@
+onmessage = () => {
+  postMessage(undefined)
+}


### PR DESCRIPTION
#### a2a69622d397dbd384705122ab7764f022d862a3
<pre>
workers/empty-post-message-service-workers-crash.html spins hundreds of workers and causes flakiness
<a href="https://bugs.webkit.org/show_bug.cgi?id=298424">https://bugs.webkit.org/show_bug.cgi?id=298424</a>

Reviewed by Rupin Mittal.

The test spins 50 dedicated workers, each of these workers would recursively
relaunch a worker with the same script so it would infinitely launch new
scripts. This very large number of workers created could lead to flakiness
such as <a href="https://rdar.apple.com/158179134">rdar://158179134</a>.

To address the issue, the test now creates 5 workers, each of them now only
launches a single worker. We should thus end up with 10 workers (and 10 worker
threads) which is a lot more reasonable in terms of workload.

I am also dropping the audio element creation since it is not related to what
the test is covering and it was significantly slowing down the test as well.

* LayoutTests/workers/empty-post-message-service-workers-crash.html:
* LayoutTests/workers/empty-post-message-service-workers-crash.js:
* LayoutTests/workers/empty-post-message-service-workers-crash2.js: Added.
(onmessage):

Canonical link: <a href="https://commits.webkit.org/299616@main">https://commits.webkit.org/299616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff3a2d8a2ace0581363aa1b65efade7426d31c36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71665 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd814b5c-814a-4678-9393-bfbce8690565) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47863 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9990250-6c9c-4a2a-a7de-a451fa6cfc47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71342 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4767f13-0b09-4cbd-9e47-f9d08a914e39) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25338 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69518 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128839 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35230 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103427 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/99272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22718 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46375 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45841 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47527 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->