### PR TITLE
[Filters] Scale the radius of the CG blur style relative to the CTM of the context

### DIFF
--- a/LayoutTests/css3/filters/effect-scaled-graphics-context-blur-expected.html
+++ b/LayoutTests/css3/filters/effect-scaled-graphics-context-blur-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+    <style>
+        img {
+            transform: translate(200%, 200%) scale(4, 4);
+        }
+    </style>
+</head>
+<body>
+    <img src="resources/reference.png" style="filter: blur(5px)"> 
+</body>
+</html>

--- a/LayoutTests/css3/filters/effect-scaled-graphics-context-blur.html
+++ b/LayoutTests/css3/filters/effect-scaled-graphics-context-blur.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-323091" />
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+    <style>
+        img {
+            transform: translate(200%, 200%) scale(4, 4);
+        }
+    </style>
+</head>
+<script>
+    if (window.internals)
+        internals.settings.setGraphicsContextBlurFilterEnabled?.(true);
+</script>
+<body>
+    <img src="resources/reference.png" style="filter: blur(5px)"> 
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -154,14 +154,17 @@ public:
     void setMaxEDRHeadroom(std::optional<float>) final;
 #endif
 
-protected:
-    void setCGShadow(const std::optional<GraphicsDropShadow>&, bool shadowsIgnoreTransforms);
-    void setCGStyle(const std::optional<GraphicsStyle>&, bool shadowsIgnoreTransforms);
-
 private:
     void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions = { }) final;
 
-    void clearCGShadow();
+    void setCGDropShadow(const std::optional<GraphicsDropShadow>&, bool shadowsIgnoreTransforms);
+    void clearCGDropShadow();
+#if HAVE(CGSTYLE_COLORMATRIX_BLUR)
+    void setCGGaussianBlur(const GraphicsGaussianBlur&, bool shadowsIgnoreTransforms);
+    void setCGColorMatrix(const GraphicsColorMatrix&);
+#endif
+    void setCGStyle(const std::optional<GraphicsStyle>&, bool shadowsIgnoreTransforms);
+
     // Returns the platform context for purposes of context state change, not draws.
     CGContextRef contextForState() const;
 


### PR DESCRIPTION
#### 140f98d39c7b96d843902be6ef46269f44d6635b
<pre>
[Filters] Scale the radius of the CG blur style relative to the CTM of the context
<a href="https://bugs.webkit.org/show_bug.cgi?id=298425">https://bugs.webkit.org/show_bug.cgi?id=298425</a>
<a href="https://rdar.apple.com/159900551">rdar://159900551</a>

Reviewed by Simon Fraser.

Apply the same scaling we do for CG drop-shadow radius to the blur radius.
Refactor the code in GraphicsContextCG to avoid duplicating the code. Use
similar names for setting the CG style functions.

Test: css3/filters/effect-scaled-graphics-context-blur.html
* LayoutTests/css3/filters/effect-scaled-graphics-context-blur-expected.html: Added.
* LayoutTests/css3/filters/effect-scaled-graphics-context-blur.html: Added.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::fillRect):
(WebCore::GraphicsContextCG::fillRoundedRectImpl):
(WebCore::GraphicsContextCG::fillRectWithRoundedHole):
(WebCore::scaledBlurRadius):
(WebCore::GraphicsContextCG::setCGDropShadow):
(WebCore::GraphicsContextCG::clearCGDropShadow):
(WebCore::GraphicsContextCG::setCGGaussianBlur):
(WebCore::GraphicsContextCG::setCGColorMatrix):
(WebCore::GraphicsContextCG::setCGStyle):
(WebCore::GraphicsContextCG::didUpdateState):
(WebCore::GraphicsContextCG::setCGShadow): Deleted.
(WebCore::GraphicsContextCG::clearCGShadow): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:

Canonical link: <a href="https://commits.webkit.org/299917@main">https://commits.webkit.org/299917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d635109accde92f373769674fc69f7783a907d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127080 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/72762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fdaaadb-0f07-4d61-9fd6-0b3942a47b26) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41078 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48958 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/72762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c1de744-5c05-4d44-af0e-a02ec2a111b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123639 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/32806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/72219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/077a027b-cb46-4a3e-9ec3-91b43e83df33) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70685 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/26473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129948 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36146 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47976 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/104366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/100127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/45578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19152 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47470 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53175 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/46939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50285 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/48625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->