### PR TITLE
Layout Test security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html is flaky

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1370,6 +1370,9 @@ imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynam
 imported/w3c/web-platform-tests/css/css-view-transitions/start-skip-start.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/start-view-transtion-skips-active.html [ Failure ]
 
+# Not supported on this platform.
+security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html [ Skip ]
+
 # These tests are passing in WebKitGTK, but failing on WPE (timeout).
 http/tests/websocket/tests/hybi/inspector/before-load.html [ Skip ]
 http/tests/websocket/tests/hybi/inspector/binary.html [ Skip ]

--- a/LayoutTests/security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html
+++ b/LayoutTests/security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html
@@ -8,11 +8,12 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-// Waiting at least 100ms seems to ensure that YouTube plugin replacement has loaded.
-window.setTimeout(function () {
-    if (window.testRunner)
-        testRunner.notifyDone();
-}, 100);
+if (window.internals) {
+    internals.setConsoleMessageListener((message) => {
+        if (message.startsWith("Blocked access to external URL"))
+            testRunner.notifyDone();
+    });
+}
 </script>
 </head>
 <body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8566,12 +8566,8 @@ void Document::addConsoleMessage(MessageSource source, MessageLevel level, const
         postTask(AddConsoleMessageTask(source, level, message));
         return;
     }
-
     if (RefPtr page = this->page())
         page->console().addMessage(source, level, message, requestIdentifier, this);
-
-    if (RefPtr consoleMessageListener = m_consoleMessageListener)
-        consoleMessageListener->scheduleCallback(*this, message);
 }
 
 void Document::addMessage(MessageSource source, MessageLevel level, const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber, RefPtr<Inspector::ScriptCallStack>&& callStack, JSC::JSGlobalObject* state, unsigned long requestIdentifier)
@@ -10615,11 +10611,6 @@ void Document::downgradeReferrerToRegistrableDomain()
         m_referrerOverride = makeString(referrerURL.protocol(), "://"_s, domainString, ':', *port, '/');
     else
         m_referrerOverride = makeString(referrerURL.protocol(), "://"_s, domainString, '/');
-}
-
-void Document::setConsoleMessageListener(RefPtr<StringCallback>&& listener)
-{
-    m_consoleMessageListener = listener;
 }
 
 AnimationTimelinesController& Document::ensureTimelinesController()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1802,8 +1802,6 @@ public:
     const Logger& logger() const { return const_cast<Document&>(*this).logger(); }
     WEBCORE_EXPORT static const Logger& sharedLogger();
 
-    WEBCORE_EXPORT void setConsoleMessageListener(RefPtr<StringCallback>&&); // For testing.
-
     void updateAnimationsAndSendEvents();
     void updateStaleScrollTimelines();
     WEBCORE_EXPORT DocumentTimeline& timeline();
@@ -2483,7 +2481,6 @@ private:
 
     const std::unique_ptr<OrientationNotifier> m_orientationNotifier;
     mutable RefPtr<Logger> m_logger;
-    RefPtr<StringCallback> m_consoleMessageListener;
 
     RefPtr<DocumentTimeline> m_timeline;
     const std::unique_ptr<AnimationTimelinesController> m_timelinesController;

--- a/Source/WebCore/page/PageConsoleClient.h
+++ b/Source/WebCore/page/PageConsoleClient.h
@@ -48,6 +48,7 @@ namespace WebCore {
 
 class Document;
 class Page;
+class StringCallback;
 
 class WEBCORE_EXPORT PageConsoleClient final : public JSC::ConsoleClient, public CanMakeCheckedPtr<PageConsoleClient> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PageConsoleClient, WEBCORE_EXPORT);
@@ -56,12 +57,18 @@ public:
     explicit PageConsoleClient(Page&);
     virtual ~PageConsoleClient();
 
+    PageConsoleClient(const PageConsoleClient&) = delete;
+    PageConsoleClient& operator=(const PageConsoleClient&) = delete;
+    PageConsoleClient(PageConsoleClient&&) = delete;
+    PageConsoleClient& operator=(PageConsoleClient&&) = delete;
+
     static bool shouldPrintExceptions();
     static void setShouldPrintExceptions(bool);
 
     static void mute();
     static void unmute();
 
+    void setConsoleMessageListener(RefPtr<StringCallback>&&); // For testing.
     void addMessage(std::unique_ptr<Inspector::ConsoleMessage>&&);
 
     // The following addMessage function are deprecated.
@@ -90,6 +97,7 @@ private:
     Ref<Page> protectedPage() const;
 
     WeakRef<Page> m_page;
+    RefPtr<StringCallback> m_consoleMessageListener;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -586,6 +586,8 @@ void Internals::resetToConsistentState(Page& page)
     page.setDefersLoading(false);
     page.setResourceCachingDisabledByWebInspector(false);
 
+    page.console().setConsoleMessageListener(nullptr);
+
     RefPtr localMainFrame = page.localMainFrame();
     if (!localMainFrame)
         return;
@@ -749,8 +751,6 @@ Internals::Internals(Document& document)
         setAutomaticLinkDetectionEnabled(false);
         setAutomaticTextReplacementEnabled(true);
     }
-
-    setConsoleMessageListener(nullptr);
 
 #if ENABLE(APPLE_PAY)
     auto* frame = document.frame();
@@ -6662,10 +6662,11 @@ void Internals::updateQuotaBasedOnSpaceUsage()
 
 void Internals::setConsoleMessageListener(RefPtr<StringCallback>&& listener)
 {
-    if (!contextDocument())
+    RefPtr page = contextDocument() ? contextDocument()->page() : nullptr;
+    if (!page)
         return;
 
-    contextDocument()->setConsoleMessageListener(WTFMove(listener));
+    page->console().setConsoleMessageListener(WTFMove(listener));
 }
 
 void Internals::setResponseSizeWithPadding(FetchResponse& response, uint64_t size)


### PR DESCRIPTION
#### 32660e42d5be9adeaa3128ff2d1c5d73ad625134
<pre>
Layout Test security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=173742">https://bugs.webkit.org/show_bug.cgi?id=173742</a>
<a href="https://rdar.apple.com/42793011">rdar://42793011</a>

Reviewed by Alexey Proskuryakov.

* LayoutTests/platform/wpe/TestExpectations:
* LayoutTests/security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html:
The test was flaky because it was relying on a 100ms timer to check if something was loaded.
We instead now rely on a console logging listener since the load in question generates such logging
and it was the presence of this logging that was causing the flakiness.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addConsoleMessage):
(WebCore::Document::setConsoleMessageListener): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::setConsoleMessageListener):
(WebCore::PageConsoleClient::addMessage):
(WebCore::PageConsoleClient::messageWithTypeAndLevel):
* Source/WebCore/page/PageConsoleClient.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::Internals):
(WebCore::Internals::setConsoleMessageListener):
Fix issue where the console message listener was not reliably called for all console
messages.

Canonical link: <a href="https://commits.webkit.org/299676@main">https://commits.webkit.org/299676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/155d976adc1c6200a5d67c9d143e52b2d14b68ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71842 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b2de6e7-0946-412a-bdb1-c68ffd3768d1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90968 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60250 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a32480f-5a9a-4c9a-9014-06822be1a1b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6621abd-b2cc-46d2-8725-064582b5b67b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25499 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69715 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129016 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99565 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99409 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25247 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43259 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46552 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52258 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46018 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->