### PR TITLE
Remove redundant sandbox rule in the WebContent process on iOS

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -363,6 +363,9 @@
 
 (media-accessibility-support)
 
+(deny file-write-create (vnode-type SYMLINK))
+(deny file-read-xattr file-write-xattr (xattr-prefix "com.apple.security.private."))
+
 ;; Allow loading injected bundles.
 (with-filter (require-not (webcontent-process-launched))
     (allow file-map-executable))
@@ -424,12 +427,6 @@
     (allow mach-lookup
         (global-name "com.apple.osanalytics.osanalyticshelper")))
 
-(with-filter (require-not (sandbox-version-2))
-    (allow mach-lookup
-        (require-all
-            (extension "com.apple.webkit.extension.mach")
-            (global-name "com.apple.mobileassetd.v2"))))
-
 (disable-syscall-inference)
 
 (deny syscall-unix (with telemetry))
@@ -470,33 +467,8 @@
         (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)
         (syscall-quicklook)))
 
-(when (defined? 'system-fcntl)
-    (deny system-fcntl (with telemetry))
-    (allow system-fcntl
-        (fcntl-command
-            F_ADDFILESIGS_RETURN ;; ImageLoaderMachO::loadCodeSignature
-            F_BARRIERFSYNC
-            F_CHECK_LV ;; ImageLoaderMachO::loadCodeSignature
-            F_GETCONFINED
-            F_GETFD ;; libwebrtc.dylib (no backtrace)
-            F_GETFL ;; LibJPEGReadPlugin::copyImageBlockSetStandard
-            F_GETPATH ;; used by dyld4 and CGFontURLCreate, getcwd (at least)
-            F_GETSIGSINFO
-            F_RDADVISE
-            F_SETCONFINED
-            F_SETFD ;; libwebrtc.dylib (no backtrace)
-            F_SETFL ;; CMCapture uses when camera is enabled
-            F_SETNOSIGPIPE)) ;; CMCapture uses when camera is enabled
-
-    (allow system-fcntl
-        (fcntl-command
-            F_GETLK
-            F_OFD_SETLK))
-
-    (allow system-fcntl
-        (fcntl-command F_GETPROTECTIONCLASS)
-        (fcntl-command F_SETPROTECTIONCLASS))
-)
+(deny system-fcntl (with telemetry))
+(allow system-fcntl (system-fcntl-allowed))
 
 (when (defined? 'process-codesigning*)
     ;; csops/csops_audittoken

--- a/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
@@ -684,3 +684,23 @@
         "vendor-id"
         "udid-version" ;; <rdar://problem/52903475>
         "ui-pip")) ;; <rdar://problem/48867037>
+
+(define (system-fcntl-allowed)
+    (fcntl-command
+        F_ADDFILESIGS_RETURN ;; ImageLoaderMachO::loadCodeSignature
+        F_BARRIERFSYNC
+        F_CHECK_LV ;; ImageLoaderMachO::loadCodeSignature
+        F_GETCONFINED
+        F_GETFD ;; libwebrtc.dylib (no backtrace)
+        F_GETFL ;; LibJPEGReadPlugin::copyImageBlockSetStandard
+        F_GETLK
+        F_GETPATH ;; used by dyld4 and CGFontURLCreate, getcwd (at least)
+        F_GETPROTECTIONCLASS
+        F_GETSIGSINFO
+        F_OFD_SETLK
+        F_RDADVISE
+        F_SETCONFINED
+        F_SETFD ;; libwebrtc.dylib (no backtrace)
+        F_SETFL ;; CMCapture uses when camera is enabled
+        F_SETNOSIGPIPE
+        F_SETPROTECTIONCLASS)) ;; CMCapture uses when camera is enabled


### PR DESCRIPTION
#### 570e26522c2e9299bb74b139d17852384b153462
<pre>
Remove redundant sandbox rule in the WebContent process on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=298428">https://bugs.webkit.org/show_bug.cgi?id=298428</a>
<a href="https://rdar.apple.com/159909326">rdar://159909326</a>

Reviewed by Sihui Liu.

Remove a redundant Mach lookup rule. This patch also adds a macro for allowed system-fcntl.

In <a href="https://commits.webkit.org/299094@main">https://commits.webkit.org/299094@main</a>, two blocking sandbox rules were removed. In some
special cases, this leads to a behavior change, so we are adding those rules back.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb:

Canonical link: <a href="https://commits.webkit.org/299662@main">https://commits.webkit.org/299662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce7c05a4a23520d858d745643c65d86106da9f2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71631 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4495cba2-8a44-4e2d-955a-85c85d1702d6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90812 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60121 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01c79843-efe6-4a07-8d88-2c1ede95ff09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71307 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/360346f0-b45f-431c-882c-41e2b2aff665) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30918 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69484 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128805 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99240 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22692 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43043 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19051 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46341 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52047 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45806 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49156 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->