### PR TITLE
New test: [ iOS ] imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative.html is a flaky failure.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -550,6 +550,7 @@ http/wpt/webauthn/public-key-credential-create-failure.https.html [ DumpJSConsol
 http/wpt/webauthn/public-key-credential-get-failure.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/WebIDL/current-realm.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/eventsource/format-mime-bogus.any.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -557,6 +557,7 @@ imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allow
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/failure-check-sequence.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/redirect-to-data.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: Blocked access to external URL http://www1.localhost:8801/css/cssom/stylesheet-same-origin.css
-CONSOLE MESSAGE: Blocked access to external URL http://www1.localhost:8801/common/redirect.py?location=http://localhost:8800/css/cssom/stylesheet-same-origin.css
-CONSOLE MESSAGE: Blocked access to external URL http://www1.localhost:8801/css/cssom/stylesheet-same-origin.css
-CONSOLE MESSAGE: Blocked access to external URL http://www1.localhost:8801/common/redirect.py?location=http://localhost:8800/css/cssom/stylesheet-same-origin.css
-CONSOLE MESSAGE: Blocked access to external URL http://www1.localhost:8801/css/cssom/stylesheet-same-origin.css
 
 FAIL Origin-clean check in cross-origin CSSOM Stylesheets assert_throws_dom: stylesheet.cssRules should throw SecurityError. function "function () {
                     sheet.cssRules;

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Blocked access to external URL https://www.localhost:9443/fetch/metadata/resources/record-headers.py?key=GENERATED_KEY
-CONSOLE MESSAGE: Blocked access to external URL https://www.localhost:9443/fetch/api/resources/redirect.py?location=https%3A%2F%2Flocalhost%3A9443%2Ffetch%2Fmetadata%2Fresources%2Frecord-headers.py%3Fkey%3DGENERATED_KEY&location=https%3A%2F%2Fwww.localhost%3A9443%2Ffetch%2Fapi%2Fresources%2Fredirect.py%3Flocation%3Dhttps%253A%252F%252Flocalhost%253A9443%252Ffetch%252Fmetadata%252Fresources%252Frecord-headers.py%253Fkey%253DGENERATED_KEY&count=1
-CONSOLE MESSAGE: Blocked access to external URL https://www.localhost:9443/fetch/metadata/resources/record-headers.py?key=GENERATED_KEY&location=https%3A%2F%2Fwww.localhost%3A9443%2Ffetch%2Fmetadata%2Fresources%2Frecord-headers.py%3Fkey%3DGENERATED_KEY&count=1
-CONSOLE MESSAGE: Blocked access to external URL https://www.localhost:9443/fetch/metadata/resources/record-headers.py?key=GENERATED_KEY&location=https%3A%2F%2Fwww.localhost%3A9443%2Ffetch%2Fmetadata%2Fresources%2Frecord-headers.py%3Fkey%3DGENERATED_KEY&count=1
-CONSOLE MESSAGE: Blocked access to external URL https://www.localhost:9443/fetch/api/resources/redirect.py?location=https%3A%2F%2Flocalhost%3A9443%2Ffetch%2Fmetadata%2Fresources%2Frecord-headers.py%3Fkey%3DGENERATED_KEY
-CONSOLE MESSAGE: Blocked access to external URL https://www.localhost:9443/fetch/api/resources/redirect.py?location=https%3A%2F%2Fwww.localhost%3A9443%2Ffetch%2Fmetadata%2Fresources%2Frecord-headers.py%3Fkey%3DGENERATED_KEY
-CONSOLE MESSAGE: Blocked access to external URL https://www.localhost:9443/fetch/api/resources/redirect.py?location=https%3A%2F%2F127.0.0.1%3A9443%2Ffetch%2Fmetadata%2Fresources%2Frecord-headers.py%3Fkey%3DGENERATED_KEY
 
 PASS sec-fetch-site - Same origin
 FAIL sec-fetch-site - Cross-site promise_test: Unhandled rejection with value: object "Error: Failed to query for recorded headers."

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4472,8 +4472,6 @@ http/tests/webgpu/webgpu/web_platform/copyToTexture/image.html [ Skip ]
 
 webkit.org/b/254637 fast/text/web-font-load-invisible-during-loading.html [ Pass Failure ]
 
-webkit.org/b/251417 imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative.html [ Pass Failure ]
-
 webkit.org/b/251533 imported/w3c/web-platform-tests/workers/baseurl/alpha/import-in-moduleworker.html [ Pass Timeout ]
 
 webkit.org/b/251876 editing/selection/selection-scrolling-in-multiple-nested-subframes.html [ Pass Crash ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2342,7 +2342,6 @@ webkit.org/b/214469 [ Debug ] imported/w3c/web-platform-tests/css/css-scoping/sl
 
 webkit.org/b/214703 imported/w3c/web-platform-tests/css/css-overflow/overflow-recalc-001.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/214682 imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-smooth.html [ Skip ]
 
 webkit.org/b/215033 imported/w3c/web-platform-tests/websockets/cookies/third-party-cookie-accepted.https.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1076,8 +1076,6 @@ webkit.org/b/214661 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCSctpTran
 
 webkit.org/b/230485 [ Release ] imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-events.html [ Pass Failure ]
 
-webkit.org/b/214682 imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html [ Pass Failure ]
-
 webkit.org/b/214683 [ Debug ] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html [ Pass Failure ]
 
 webkit.org/b/214824 [ Debug ] js/throw-large-string-oom.html [ Skip ]


### PR DESCRIPTION
#### e8d41ba23686bc02aa2a4e10d3079e400726751a
<pre>
New test: [ iOS ] imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251417">https://bugs.webkit.org/show_bug.cgi?id=251417</a>
<a href="https://rdar.apple.com/104850632">rdar://104850632</a>

Reviewed by NOBODY (OOPS!).

Address flakiness by silencing console messages.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
</pre>
----------------------------------------------------------------------
#### 01b344ba8810b8d6dadd7101265e975c600d30c7
<pre>
REGRESSION (r264522): [ macOS release wk2 macOS wk1 ] imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=214682">https://bugs.webkit.org/show_bug.cgi?id=214682</a>
<a href="https://rdar.apple.com/65985679">rdar://65985679</a>

Reviewed by NOBODY (OOPS!).

Address flakiness by silencing console logging.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8d41ba23686bc02aa2a4e10d3079e400726751a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71636 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3afb66fe-1621-4989-bae8-94a95f218188) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90816 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60119 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32b20e64-52fe-4849-8c6d-33d8783a0b9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/707d1e35-d2b7-4210-b366-24f2158d6a14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69489 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128810 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99410 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99243 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43048 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46346 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45811 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->