### PR TITLE
AX: Auto-expand details and hidden="until-found" elements containing search text provided in a AXUIElementsForSearchPredicate request

### DIFF
--- a/LayoutTests/accessibility/mac/text-search-auto-expands-revealable-elements-expected.txt
+++ b/LayoutTests/accessibility/mac/text-search-auto-expands-revealable-elements-expected.txt
@@ -1,0 +1,21 @@
+This test ensures that AXUIElementsForSearchPredicate queries with a search-text component auto-expands collapsed details and hidden='until-found' elements if a match is found within them.
+
+PASS: resultElement.role === 'AXRole: AXStaticText'
+PASS: resultElement.stringValue === 'AXValue: First'
+PASS: document.getElementById('details').hasAttribute('open') === true
+PASS: !!resultElement === false
+PASS: document.getElementById('details-2').hasAttribute('open') === false
+PASS: resultElement.role === 'AXRole: AXStaticText'
+PASS: resultElement.stringValue === 'AXValue: Third'
+PASS: document.getElementById('hidden').hasAttribute('hidden') === false
+PASS: !!resultElement === false
+PASS: document.getElementById('permanent-hidden').hasAttribute('hidden') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo
+First
+Foo
+Third
+

--- a/LayoutTests/accessibility/mac/text-search-auto-expands-revealable-elements.html
+++ b/LayoutTests/accessibility/mac/text-search-auto-expands-revealable-elements.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<details id="details">
+    <summary>Foo</summary>
+    First
+</details>
+
+<details id="details-2">
+    <summary>Foo</summary>
+    Second
+</details>
+
+<div id="hidden" hidden="until-found">
+    Third
+</div>
+
+<div aria-hidden="true">
+    <div id="permanent-hidden" hidden="until-found">
+        Fourth
+    </div>
+</div>
+
+<script>
+var output = "This test ensures that AXUIElementsForSearchPredicate queries with a search-text component auto-expands collapsed details and hidden='until-found' elements if a match is found within them.\n\n";
+
+// Normally, tests that perform dynamic page changes must be async, allowing time for updates to the isolated tree.
+// However, the expansion behavior being tested here tries to perform the expansion via synchronous main-thread hit
+// with a timeout. We should never even get close to the timeout when running layout tests.
+
+if (window.accessibilityController) {
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+    var resultElement = webarea.uiElementForSearchPredicate(webarea,
+        /* isDirectionNext */ true,
+        "AXAnyTypeSearchKey",
+        "First",
+        /* visibleOnly */ false,
+        /* immediateDescendantsOnly */ false
+    );
+    output += expect("resultElement.role", "'AXRole: AXStaticText'");
+    output += expect("resultElement.stringValue", "'AXValue: First'");
+    output += expect("document.getElementById('details').hasAttribute('open')", "true");
+
+    // Ensure we respect the visibleOnly flag, which shouldn't auto-expand revealable elements.
+    var resultElement = webarea.uiElementForSearchPredicate(webarea,
+        /* isDirectionNext */ true,
+        "AXAnyTypeSearchKey",
+        "Second",
+        /* visibleOnly */ true,
+        /* immediateDescendantsOnly */ false
+    );
+    output += expect("!!resultElement", "false");
+    output += expect("document.getElementById('details-2').hasAttribute('open')", "false");
+
+    // We should expand a hidden="until-found" container.
+    var resultElement = webarea.uiElementForSearchPredicate(webarea,
+        /* isDirectionNext */ true,
+        "AXAnyTypeSearchKey",
+        "Third",
+        /* visibleOnly */ false,
+        /* immediateDescendantsOnly */ false
+    );
+    output += expect("resultElement.role", "'AXRole: AXStaticText'");
+    output += expect("resultElement.stringValue", "'AXValue: Third'");
+    output += expect("document.getElementById('hidden').hasAttribute('hidden')", "false");
+
+    // Don't auto-expand aria-hidden hidden="until-found" containers.
+    var resultElement = webarea.uiElementForSearchPredicate(webarea,
+        /* isDirectionNext */ true,
+        "AXAnyTypeSearchKey",
+        "Fourth",
+        /* visibleOnly */ false,
+        /* immediateDescendantsOnly */ false
+    );
+    output += expect("!!resultElement", "false");
+    output += expect("document.getElementById('permanent-hidden').hasAttribute('hidden')", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -815,6 +815,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::IsEditableWebArea:
         stream << "IsEditableWebArea";
         break;
+    case AXProperty::IsHiddenUntilFoundContainer:
+        stream << "IsHiddenUntilFoundContainer";
+        break;
     case AXProperty::IsSubscript:
         stream << "IsSubscript";
         break;
@@ -1106,6 +1109,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         stream << "RemoteParent";
         break;
 #endif
+    case AXProperty::RevealableText:
+        stream << "RevealableText";
+        break;
     case AXProperty::RolePlatformString:
         stream << "RolePlatformString";
         break;

--- a/Source/WebCore/accessibility/AXNotifications.h
+++ b/Source/WebCore/accessibility/AXNotifications.h
@@ -65,6 +65,7 @@ namespace WebCore {
     macro(FrameLoadComplete) \
     macro(GrabbedStateChanged) \
     macro(HasPopupChanged) \
+    macro(HiddenStateChanged) \
     macro(IdAttributeChanged) \
     macro(ImageOverlayChanged) \
     macro(InertOrVisibilityChanged) \

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -464,5 +464,13 @@ String roleToString(AccessibilityRole role)
     return ""_s;
 }
 
-} // WebCore
+bool needsLayoutOrStyleRecalc(const Document& document)
+{
+    if (RefPtr frameView = document.view()) {
+        if (frameView->needsLayout() || frameView->checkedLayoutContext()->isLayoutPending())
+            return true;
+    }
+    return document.hasPendingStyleRecalc();
+}
 
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -65,6 +65,8 @@ bool hasAccNameAttribute(Element&);
 
 bool isNodeFocused(Node&);
 
+bool needsLayoutOrStyleRecalc(const Document&);
+
 bool isRenderHidden(const RenderStyle*);
 // Checks both CSS display properties, and CSS visibility properties.
 bool isRenderHidden(const RenderStyle&);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -180,6 +180,8 @@ public:
     String accessibilityDescriptionForChildren() const;
     String description() const override;
     String helpText() const override;
+    String revealableText() const final;
+    bool isHiddenUntilFoundContainer() const final;
     String text() const final;
     void alternativeText(Vector<AccessibilityText>&) const;
     void helpText(Vector<AccessibilityText>&) const;
@@ -213,6 +215,7 @@ public:
     void increment() override;
     void decrement() override;
     bool toggleDetailsAncestor() final;
+    void revealAncestors() final;
 
     LayoutRect elementRect() const override;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -406,6 +406,8 @@ public:
     String textUnderElement(TextUnderElementMode = { }) const override { return { }; }
     String text() const override { return { }; }
     unsigned textLength() const final;
+    String revealableText() const override { return nullString(); }
+    bool isHiddenUntilFoundContainer() const override { return false; }
 #if ENABLE(AX_THREAD_TEXT_APIS)
     virtual AXTextRuns textRuns() { return { }; }
     bool hasTextRuns() final { return textRuns().size(); }
@@ -540,6 +542,8 @@ public:
     void increment() override { }
     void decrement() override { }
     virtual bool toggleDetailsAncestor() { return false; }
+    // Reveals details elements and hidden="until-found" elements.
+    virtual void revealAncestors() { }
 
     void updateRole();
     bool childrenInitialized() const { return m_childrenInitialized; }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -323,6 +323,7 @@ private:
     bool supportsDropping() const final { return boolAttributeValue(AXProperty::SupportsDropping); }
     bool supportsDragging() const final { return boolAttributeValue(AXProperty::SupportsDragging); }
     bool isGrabbed() final { return boolAttributeValue(AXProperty::IsGrabbed); }
+    bool isHiddenUntilFoundContainer() const final { return boolAttributeValue(AXProperty::IsHiddenUntilFoundContainer); }
     Vector<String> determineDropEffects() const final;
     AXIsolatedObject* accessibilityHitTest(const IntPoint&) const final;
     AXIsolatedObject* focusedUIElement() const final;
@@ -542,6 +543,7 @@ private:
 
     String text() const final;
     unsigned textLength() const final;
+    String revealableText() const final { return stringAttributeValue(AXProperty::RevealableText); }
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const final;
 #endif

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -57,7 +57,7 @@ class AccessibilityObject;
 class Page;
 enum class AXStreamOptions : uint16_t;
 
-static constexpr uint16_t lastPropertyFlagIndex = 24;
+static constexpr uint16_t lastPropertyFlagIndex = 25;
 // The most common boolean properties are stored in a bitfield rather than in a HashMap.
 // If you edit these, make sure the corresponding AXProperty is ordered correctly in that
 // enum, and update lastPropertyFlagIndex above.
@@ -73,20 +73,21 @@ enum class AXPropertyFlag : uint32_t {
     IsExposedTableCell                            = 1 << 8,
     IsExposedTableRow                             = 1 << 9,
     IsGrabbed                                     = 1 << 10,
-    IsIgnored                                     = 1 << 11,
-    IsInlineText                                  = 1 << 12,
-    IsKeyboardFocusable                           = 1 << 13,
-    IsNonLayerSVGObject                           = 1 << 14,
+    IsHiddenUntilFoundContainer                   = 1 << 11,
+    IsIgnored                                     = 1 << 12,
+    IsInlineText                                  = 1 << 13,
+    IsKeyboardFocusable                           = 1 << 14,
+    IsNonLayerSVGObject                           = 1 << 15,
     // These IsTextEmissionBehavior flags are the variants of enum TextEmissionBehavior.
-    IsTextEmissionBehaviorTab                     = 1 << 15,
-    IsTextEmissionBehaviorNewline                 = 1 << 16,
-    IsTextEmissionBehaviorDoubleNewline           = 1 << 17,
-    IsVisited                                     = 1 << 18,
-    SupportsCheckedState                          = 1 << 19,
-    SupportsDragging                              = 1 << 20,
-    SupportsExpanded                              = 1 << 21,
-    SupportsPath                                  = 1 << 22,
-    SupportsPosInSet                              = 1 << 23,
+    IsTextEmissionBehaviorTab                     = 1 << 16,
+    IsTextEmissionBehaviorNewline                 = 1 << 17,
+    IsTextEmissionBehaviorDoubleNewline           = 1 << 18,
+    IsVisited                                     = 1 << 19,
+    SupportsCheckedState                          = 1 << 20,
+    SupportsDragging                              = 1 << 21,
+    SupportsExpanded                              = 1 << 22,
+    SupportsPath                                  = 1 << 23,
+    SupportsPosInSet                              = 1 << 24,
     SupportsSetSize                               = 1 << lastPropertyFlagIndex
 };
 
@@ -102,19 +103,20 @@ enum class AXProperty : uint16_t {
     IsExposedTableCell = 8,
     IsExposedTableRow = 9,
     IsGrabbed = 10,
-    IsIgnored = 11,
-    IsInlineText = 12,
-    IsKeyboardFocusable = 13,
-    IsNonLayerSVGObject = 14,
-    IsTextEmissionBehaviorTab = 15,
-    IsTextEmissionBehaviorNewline = 16,
-    IsTextEmissionBehaviorDoubleNewline = 17,
-    IsVisited = 18,
-    SupportsCheckedState = 19,
-    SupportsDragging = 20,
-    SupportsExpanded = 21,
-    SupportsPath = 22,
-    SupportsPosInSet = 23,
+    IsHiddenUntilFoundContainer = 11,
+    IsIgnored = 12,
+    IsInlineText = 13,
+    IsKeyboardFocusable = 14,
+    IsNonLayerSVGObject = 15,
+    IsTextEmissionBehaviorTab = 16,
+    IsTextEmissionBehaviorNewline = 17,
+    IsTextEmissionBehaviorDoubleNewline = 18,
+    IsVisited = 19,
+    SupportsCheckedState = 20,
+    SupportsDragging = 21,
+    SupportsExpanded = 22,
+    SupportsPath = 23,
+    SupportsPosInSet = 24,
     SupportsSetSize = lastPropertyFlagIndex,
     // End bool attributes that are matched in order by AXPropertyFlag.
 
@@ -268,6 +270,7 @@ enum class AXProperty : uint16_t {
 #if PLATFORM(COCOA)
     RemoteParent,
 #endif
+    RevealableText,
     RolePlatformString,
     Rows,
     RowHeaders,
@@ -491,7 +494,7 @@ public:
 
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
         objectChangedIgnoredState(object);
-        queueNodeUpdate(object.objectID(), { AXProperty::IsIgnored });
+        queueNodeUpdate(object.objectID(), { { AXProperty::IsIgnored, AXProperty::RevealableText } });
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     }
     void objectBecameUnignored(const AccessibilityObject& object)


### PR DESCRIPTION
#### bec672f7d9f7fbd72f27dbf598ae69badafcaa75
<pre>
AX: Auto-expand details and hidden=&quot;until-found&quot; elements containing search text provided in a AXUIElementsForSearchPredicate request
<a href="https://bugs.webkit.org/show_bug.cgi?id=298432">https://bugs.webkit.org/show_bug.cgi?id=298432</a>
<a href="https://rdar.apple.com/159913471">rdar://159913471</a>

Reviewed by Joshua Hoffman.

If the user is searching for a specific string, as indicated by search text being present in a AXUIElementsForSearchPredicate
request, we should provide matches if said string is inside a collapsed details element or hidden=&quot;until-found&quot; container,
making sure to expand them as well.

This gets a bit tricky in the case of the accessibility thread, which obviously cannot inherently synchronously expand
an element. This patch adds a new `performFunctionOnMainThreadAndWaitWithTimeout` function to attempt allow
the accessibility thread to attempt a synchronous action, but bail after a timeout if the main-thread is busy. We use
this to try to expand revealable elements synchronously, but if we can&apos;t, we&apos;ll continue on with the search.

If we do timeout trying to reveal a container, we won&apos;t perform any further synchronous trips to the main-thread for
the remainder of the search, with the assumption being that the main-thread is busy doing other things.

New property AXProperty::RevealableText is added and cached for text objects within an auto-revealable container. Another
property, AXProperty::IsHiddenUntilFoundContainer, is also added to indicate that we should search within the given object
for revealable text.

* LayoutTests/accessibility/mac/text-search-auto-expands-revealable-elements-expected.txt: Added.
* LayoutTests/accessibility/mac/text-search-auto-expands-revealable-elements.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::revealableContainers):
(WebCore::AXCoreObject::detailsAncestor const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::performFunctionOnMainThreadAndWaitWithTimeout):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXNotifications.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::documentNeedsLayoutOrStyleRecalc): Deleted.
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::revealHiddenMatchWithTimeout):
(WebCore::AXSearchManager::findMatchingObjectsInternal):
* Source/WebCore/accessibility/AXSearchManager.h:
(WebCore::AXSearchManager::lastRevealAttemptTimedOut):
(WebCore::AXSearchManager::setLastRevealAttemptTimedOut):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::needsLayoutOrStyleRecalc):
* Source/WebCore/accessibility/AXUtilities.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::revealAncestors):
(WebCore::AccessibilityNodeObject::isHiddenUntilFoundContainer const):
(WebCore::AccessibilityNodeObject::revealableText const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::defaultObjectInclusion const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::revealAncestors):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::convertToPropertyFlag):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::objectBecameIgnored):

Canonical link: <a href="https://commits.webkit.org/299649@main">https://commits.webkit.org/299649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1e994ee0cf84ade5306aaf2dfcc3c704445539e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71759 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce17d6c1-7e39-4db5-b2aa-5edd10770b71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90908 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c66d7380-b0b4-47e3-a5bf-4f3af5fef398) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71435 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e17e9e07-3e42-4832-887a-ba3827b548ac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69619 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128933 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46607 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35308 "Found 1 new test failure: http/tests/cache/disk-cache/disk-cache-302-status-code.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99504 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99347 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25234 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22798 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43172 "Hash d1e994ee for PR 50347 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52175 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45935 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->