### PR TITLE
[WebGPU Swift] Fix build

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -923,28 +923,9 @@ extension WebGPU.CommandEncoder {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "color attachment is not renderable")
                     }
 
-            mtlAttachment.depthPlane = Int(textureDimension == WGPUTextureViewDimension_3D ? depthSliceOrArrayLayer : 0)
-            mtlAttachment.slice = 0
-            mtlAttachment.loadAction = loadAction(loadOp: attachment.loadOp)
-            mtlAttachment.storeAction = storeAction(storeOp: attachment.storeOp, hasResolveTarget: attachment.resolveTarget != nil)
-
-            zeroColorTargets = false
-            var textureToClear: MTLTexture? = nil
-            if mtlAttachment.loadAction == MTLLoadAction.load && !texture.previouslyCleared() {
-                textureToClear = mtlAttachment.texture
-            }
-
-            if let rateMap = texture.rasterizationMapForSlice(texture.parentRelativeSlice()) {
-                mtlDescriptor.rasterizationRateMap = rateMap
-            }
-
-            var compositorTexture = texture
-            if attachment.resolveTarget != nil {
-                let resolveTarget = WebGPU.fromAPI(attachment.resolveTarget)
-                compositorTexture = resolveTarget
-
-                if !WebGPU_Internal.isValidToUseWithTextureViewCommandEncoder(resolveTarget, self) {
-                    return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "resolve target created from different device")
+                    if !isRenderableTextureView(texture: texture) {
+                        return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "texture view is not renderable")
+                    }
                 }
                 texture.setCommandEncoder(self)
 
@@ -996,19 +977,9 @@ extension WebGPU.CommandEncoder {
                 if mtlAttachment.loadAction == MTLLoadAction.load && !texture.previouslyCleared() {
                     textureToClear = mtlAttachment.texture
                 }
-            }
 
-            if let rateMap = compositorTexture.rasterizationMapForSlice(compositorTexture.parentRelativeSlice()) {
-                mtlDescriptor.rasterizationRateMap = rateMap
-                compositorTextureSlice = compositorTexture.parentRelativeSlice()
-            }
-
-            if textureToClear != nil {
-                let textureWithResolve = TextureAndClearColor(texture: textureToClear!)
-                attachmentsToClear[i as NSNumber] = textureWithResolve
-                if textureToClear != nil {
-                    // FIXME: rdar://138042799 remove default argument.
-                    texture.setPreviouslyCleared(0, 0)
+                if let rateMap = texture.rasterizationMapForSlice(texture.parentRelativeSlice()) {
+                    mtlDescriptor.rasterizationRateMap = rateMap
                 }
 
                 var compositorTexture = texture
@@ -1206,8 +1177,8 @@ extension WebGPU.CommandEncoder {
         }
         setExistingEncoder(mtlRenderCommandEncoder)
         return WebGPU.RenderPassEncoder.create(mtlRenderCommandEncoder, descriptor, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, self, visibilityResultBuffer, maxDrawCount, m_device.ptr(), mtlDescriptor)
-
     }
+
     static func hasValidDimensions(dimension: WGPUTextureDimension, width: UInt, height: UInt, depth: UInt) -> Bool {
         switch (dimension.rawValue) {
             case WGPUTextureDimension_1D.rawValue:


### PR DESCRIPTION
#### d9891b005e2d916ac9fd90a3945d11fcca8f137e
<pre>
[WebGPU Swift] Fix build
<a href="https://bugs.webkit.org/show_bug.cgi?id=298436">https://bugs.webkit.org/show_bug.cgi?id=298436</a>
<a href="https://rdar.apple.com/159922411">rdar://159922411</a>

Reviewed by Mike Wyrzykowski.

Fix what seems to have been a merge issue on CommandEncoder.swift that broke the Swift build.

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):

Canonical link: <a href="https://commits.webkit.org/299687@main">https://commits.webkit.org/299687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b4d1dbb773ee910c26f8314dd0f34af03cda9a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71657 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3643780-728d-467b-9e34-0fc2e1691348) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90831 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60127 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c6499a8-33d1-460d-85d8-864ec3eee764) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01592064-ddae-48e0-96e3-3b883c3356fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30937 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69510 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128831 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99421 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99260 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25254 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43069 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52073 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49182 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->