### PR TITLE
Expand AudioVideoRenderer class so that it fulfils all requirement for the MSE player

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2170,14 +2170,14 @@ void HTMLMediaElement::updateActiveTextTrackCues(const MediaTime& movieTime)
     INFO_LOG(identifier, "nextInterestingTime:", nextInterestingTime);
 
     if (RefPtr player = m_player; nextInterestingTime.isValid() && player) {
-        player->performTaskAtTime([weakThis = WeakPtr { *this }, identifier] {
+        player->performTaskAtTime([weakThis = WeakPtr { *this }, identifier](auto&) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
 
-            auto currentMediaTime = protectedThis->currentMediaTime();
-            INFO_LOG_WITH_THIS(protectedThis, identifier, "lambda(), currentMediaTime: ", currentMediaTime);
-            protectedThis->updateActiveTextTrackCues(currentMediaTime);
+            auto currentTime = protectedThis->currentMediaTime();
+            INFO_LOG_WITH_THIS(protectedThis, identifier, "lambda(), currentMediaTime: ", currentTime);
+            protectedThis->updateActiveTextTrackCues(currentTime);
         }, nextInterestingTime);
     }
 

--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class EffectiveRateChangedListener final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<EffectiveRateChangedListener> {
 public:
-    static Ref<EffectiveRateChangedListener> create(Function<void()>&& callback, CMTimebaseRef timebase)
+    static Ref<EffectiveRateChangedListener> create(Function<void(double)>&& callback, CMTimebaseRef timebase)
     {
         return adoptRef(*new EffectiveRateChangedListener(WTFMove(callback), timebase));
     }
@@ -45,9 +45,9 @@ public:
     void stop();
 
 private:
-    EffectiveRateChangedListener(Function<void()>&&, CMTimebaseRef);
+    EffectiveRateChangedListener(Function<void(double)>&&, CMTimebaseRef);
 
-    const Function<void()> m_callback;
+    const Function<void(double)> m_callback;
     const RetainPtr<WebEffectiveRateChangedListenerObjCAdapter> m_objcAdapter;
     const RetainPtr<CMTimebaseRef> m_timebase;
     std::atomic<bool> m_stopped { false };

--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
@@ -69,7 +69,7 @@ static void timebaseEffectiveRateChangedCallback(CFNotificationCenterRef, void* 
         protectedListener->effectiveRateChanged();
 }
 
-EffectiveRateChangedListener::EffectiveRateChangedListener(Function<void()>&& callback, CMTimebaseRef timebase)
+EffectiveRateChangedListener::EffectiveRateChangedListener(Function<void(double)>&& callback, CMTimebaseRef timebase)
     : m_callback(WTFMove(callback))
     , m_objcAdapter(adoptNS([[WebEffectiveRateChangedListenerObjCAdapter alloc] initWithEffectiveRateChangedListener:*this]))
     , m_timebase(timebase)
@@ -85,7 +85,7 @@ EffectiveRateChangedListener::~EffectiveRateChangedListener()
 
 void EffectiveRateChangedListener::effectiveRateChanged()
 {
-    m_callback();
+    m_callback(PAL::CMTimebaseGetRate(m_timebase.get()));
 }
 
 void EffectiveRateChangedListener::stop()

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1868,7 +1868,7 @@ AVPlayer* MediaPlayer::objCAVFoundationAVPlayer() const
 
 #endif
 
-bool MediaPlayer::performTaskAtTime(Function<void()>&& task, const MediaTime& time)
+bool MediaPlayer::performTaskAtTime(Function<void(const MediaTime&)>&& task, const MediaTime& time)
 {
     return protectedPrivate()->performTaskAtTime(WTFMove(task), time);
 }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -726,7 +726,7 @@ public:
     AVPlayer *objCAVFoundationAVPlayer() const;
 #endif
 
-    bool performTaskAtTime(Function<void()>&&, const MediaTime&);
+    bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&);
 
     bool shouldIgnoreIntrinsicSize();
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -320,7 +320,7 @@ public:
     virtual AVPlayer *objCAVFoundationAVPlayer() const { return nullptr; }
 #endif
 
-    virtual bool performTaskAtTime(Function<void()>&&, const MediaTime&) { return false; }
+    virtual bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&) { return false; }
 
     virtual bool shouldIgnoreIntrinsicSize() { return false; }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -339,7 +339,7 @@ private:
 
     AVPlayer *objCAVFoundationAVPlayer() const final { return m_avPlayer.get(); }
 
-    bool performTaskAtTime(Function<void()>&&, const MediaTime&) final;
+    bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&) final;
     void setShouldObserveTimeControlStatus(bool);
 
     void setPreferredDynamicRangeMode(DynamicRangeMode) final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -290,7 +290,7 @@ private:
     bool wirelessVideoPlaybackDisabled() const override { return false; }
 #endif
 
-    bool performTaskAtTime(Function<void()>&&, const MediaTime&) final;
+    bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&) final;
     void audioOutputDeviceChanged() final;
 
     void ensureLayer();

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -113,7 +113,7 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     if (RefPtr protectedPlayer = player) {
         m_renderer->setVolume(protectedPlayer->volume());
         m_renderer->setVolume(protectedPlayer->muted());
-        m_renderer->setPreservesPitch(protectedPlayer->preservesPitch());
+        m_renderer->setPreservesPitchAndCorrectionAlgorithm(protectedPlayer->preservesPitch(), protectedPlayer->pitchCorrectionAlgorithm());
 #if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
         m_renderer->setOutputDeviceId(protectedPlayer->audioOutputDeviceIdOverride());
 #endif
@@ -135,12 +135,18 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
                 player->renderingModeChanged();
         }
     });
-    m_renderer->setPreferences(VideoMediaSampleRendererPreference::PrefersDecompressionSession);
 
     m_renderer->notifySizeChanged([weakThis = WeakPtr { *this }](const MediaTime&, FloatSize size) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->setNaturalSize(size);
     });
+
+    m_renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }](double) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->effectiveRateChanged();
+    });
+
+    m_renderer->setPreferences(VideoMediaSampleRendererPreference::PrefersDecompressionSession);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     m_defaultSpatialTrackingLabel = player->defaultSpatialTrackingLabel();
@@ -195,7 +201,7 @@ void MediaPlayerPrivateWebM::doPreload()
         return;
     }
 
-    auto player = m_player.get();
+    RefPtr player = m_player.get();
     if (!player)
         return;
 
@@ -349,9 +355,40 @@ void MediaPlayerPrivateWebM::prepareToPlay()
 void MediaPlayerPrivateWebM::play()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+    playInternal();
+}
+
+void MediaPlayerPrivateWebM::pause()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_renderer->pause();
+}
+
+bool MediaPlayerPrivateWebM::paused() const
+{
+    return m_renderer->paused();
+}
+
+bool MediaPlayerPrivateWebM::playAtHostTime(const MonotonicTime& hostTime)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    playInternal(hostTime);
+    return true;
+}
+
+bool MediaPlayerPrivateWebM::pauseAtHostTime(const MonotonicTime& hostTime)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_renderer->pause(hostTime);
+    return true;
+}
+
+void MediaPlayerPrivateWebM::playInternal(std::optional<MonotonicTime> hostTime)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
     flushVideoIfNeeded();
 
-    m_renderer->play();
+    m_renderer->play(hostTime);
 
     if (!shouldBePlaying())
         return;
@@ -360,14 +397,20 @@ void MediaPlayerPrivateWebM::play()
         seekToTarget(SeekTarget::zero());
 }
 
-void MediaPlayerPrivateWebM::pause()
+bool MediaPlayerPrivateWebM::performTaskAtTime(Function<void(const MediaTime&)>&& task, const MediaTime& time)
 {
-    m_renderer->pause();
+    ALWAYS_LOG(LOGIDENTIFIER, time);
+
+    m_renderer->performTaskAtTime(time, WTFMove(task));
+    return true;
 }
 
-bool MediaPlayerPrivateWebM::paused() const
+void MediaPlayerPrivateWebM::audioOutputDeviceChanged()
 {
-    return m_renderer->paused();
+#if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
+    if (RefPtr player = m_player.get())
+        m_renderer->setOutputDeviceId(player->audioOutputDeviceId());
+#endif
 }
 
 bool MediaPlayerPrivateWebM::timeIsProgressing() const
@@ -383,6 +426,10 @@ void MediaPlayerPrivateWebM::setPageIsVisible(bool visible)
     ALWAYS_LOG(LOGIDENTIFIER, visible);
     m_visible = visible;
     m_renderer->setIsVisible(visible);
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    updateSpatialTrackingLabel();
+#endif
 }
 
 MediaTime MediaPlayerPrivateWebM::currentTime() const
@@ -463,7 +510,7 @@ void MediaPlayerPrivateWebM::completeSeek(const MediaTime& seekedTime)
 
     m_seeking = false;
 
-    if (auto player = m_player.get()) {
+    if (RefPtr player = m_player.get()) {
         player->seeked(seekedTime);
         player->timeChanged();
     }
@@ -504,7 +551,7 @@ void MediaPlayerPrivateWebM::setRateDouble(double rate)
 
     m_renderer->setRate(m_rate);
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->rateChanged();
 }
 
@@ -533,7 +580,7 @@ void MediaPlayerPrivateWebM::setBufferedRanges(PlatformTimeRanges timeRanges)
     if (m_buffered == timeRanges)
         return;
     m_buffered = WTFMove(timeRanges);
-    if (auto player = m_player.get()) {
+    if (RefPtr player = m_player.get()) {
         player->bufferedTimeRangesChanged();
         player->seekableTimeRangesChanged();
     }
@@ -678,9 +725,16 @@ void MediaPlayerPrivateWebM::setNaturalSize(FloatSize size)
     m_naturalSize = size;
     if (oldSize != m_naturalSize) {
         INFO_LOG(LOGIDENTIFIER, "was ", oldSize, ", is ", size);
-        if (auto player = m_player.get())
+        if (RefPtr player = m_player.get())
             player->sizeChanged();
     }
+}
+
+void MediaPlayerPrivateWebM::effectiveRateChanged()
+{
+    ALWAYS_LOG(LOGIDENTIFIER, effectiveRate());
+    if (RefPtr player = m_player.get())
+        player->rateChanged();
 }
 
 void MediaPlayerPrivateWebM::setHasAudio(bool hasAudio)
@@ -712,7 +766,7 @@ void MediaPlayerPrivateWebM::setHasAvailableVideoFrame(bool hasAvailableVideoFra
     if (!m_hasAvailableVideoFrame)
         return;
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->firstVideoFrameAvailable();
 
     setReadyState(MediaPlayer::ReadyState::HaveEnoughData);
@@ -723,16 +777,16 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
     if (duration == m_duration)
         return;
 
-    m_renderer->notifyDurationReached([weakThis = ThreadSafeWeakPtr { *this }](const MediaTime&) {
+    m_renderer->notifyTimeReachedAndStall(duration, [weakThis = ThreadSafeWeakPtr { *this }](const MediaTime&) {
         if (RefPtr protectedThis = weakThis.get()) {
+            protectedThis->m_renderer->pause();
             if (RefPtr player = protectedThis->m_player.get())
                 player->timeChanged();
         }
     });
-    m_renderer->setDuration(duration);
 
     m_duration = WTFMove(duration);
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->durationChanged();
 }
 
@@ -743,7 +797,7 @@ void MediaPlayerPrivateWebM::setNetworkState(MediaPlayer::NetworkState state)
 
     ALWAYS_LOG(LOGIDENTIFIER, state);
     m_networkState = state;
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->networkStateChanged();
 }
 
@@ -755,14 +809,21 @@ void MediaPlayerPrivateWebM::setReadyState(MediaPlayer::ReadyState state)
     ALWAYS_LOG(LOGIDENTIFIER, state);
     m_readyState = state;
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->readyStateChanged();
 }
 
 void MediaPlayerPrivateWebM::characteristicsChanged()
 {
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->characteristicChanged();
+}
+
+void MediaPlayerPrivateWebM::setPreservesPitch(bool preservesPitch)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, preservesPitch);
+    if (RefPtr player = m_player.get())
+        m_renderer->setPreservesPitchAndCorrectionAlgorithm(preservesPitch, player->pitchCorrectionAlgorithm());
 }
 
 void MediaPlayerPrivateWebM::setPresentationSize(const IntSize& newSize)
@@ -822,7 +883,7 @@ void MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget(bool shouldPlayToTarg
     ALWAYS_LOG(LOGIDENTIFIER, shouldPlayToTarget);
     m_shouldPlayToTarget = shouldPlayToTarget;
 
-    if (auto player = m_player.get())
+    if (RefPtr player = m_player.get())
         player->currentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless());
 }
 
@@ -1047,11 +1108,16 @@ void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, boo
     ALWAYS_LOG(LOGIDENTIFIER, "audio trackID = ", trackId, ", enabled = ", enabled);
 
     if (enabled) {
-        m_trackIdentifiers.emplace(trackId, m_renderer->addTrack(TrackType::Audio));
+        auto trackIdentifier = m_renderer->addTrack(TrackType::Audio);
+        m_trackIdentifiers.emplace(trackId, trackIdentifier);
         if (!m_errored) {
             m_readyForMoreSamplesMap[trackId] = true;
             characteristicsChanged();
         }
+        m_renderer->notifyTrackNeedsReenqueuing(trackIdentifier, [weakThis = WeakPtr { *this }, trackId](TrackIdentifier, const MediaTime&) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->reenqueSamples(trackId, NeedsFlush::No);
+        });
         return;
     }
 
@@ -1074,7 +1140,7 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
     else
         setDuration(MediaTime::positiveInfiniteTime());
 
-    auto player = m_player.get();
+    RefPtr player = m_player.get();
     for (auto videoTrackInfo : segment.videoTracks) {
         if (videoTrackInfo.track) {
             auto track = static_pointer_cast<VideoTrackPrivateWebM>(videoTrackInfo.track);
@@ -1216,7 +1282,7 @@ void MediaPlayerPrivateWebM::addTrackBuffer(TrackID trackId, RefPtr<MediaDescrip
 
 void MediaPlayerPrivateWebM::clearTracks()
 {
-    auto player = m_player.get();
+    RefPtr player = m_player.get();
     for (auto& track : m_videoTracks) {
         track->setSelectedChangedCallback(nullptr);
         if (player)
@@ -1250,7 +1316,7 @@ void MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering()
 
 void MediaPlayerPrivateWebM::checkNewVideoFrameMetadata(const MediaTime& presentationTime, double displayTime)
 {
-    auto player = m_player.get();
+    RefPtr player = m_player.get();
     if (!player)
         return;
 
@@ -1429,7 +1495,7 @@ void MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged(bool isInFu
     m_renderer->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
 }
 
-AudioVideoRenderer::TrackIdentifier MediaPlayerPrivateWebM::trackIdentifierFor(TrackID trackID)
+AudioVideoRenderer::TrackIdentifier MediaPlayerPrivateWebM::trackIdentifierFor(TrackID trackID) const
 {
     auto it = m_trackIdentifiers.find(trackID);
     ASSERT(it != m_trackIdentifiers.end());

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -358,15 +358,10 @@ void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
     });
     dispatch_activate(timerSource.get());
     PAL::CMTimebaseAddTimerDispatchSource(timebase.get(), timerSource.get());
-    m_effectiveRateChangedListener = EffectiveRateChangedListener::create([weakThis = ThreadSafeWeakPtr { *this }, dispatcher = dispatcher()] {
-        dispatcher->dispatch([weakThis] {
-            if (RefPtr protectedThis = weakThis.get()) {
-                RetainPtr timebase = protectedThis->timebase();
-                if (!timebase)
-                    return;
-                if (PAL::CMTimebaseGetRate(timebase.get()))
+    m_effectiveRateChangedListener = EffectiveRateChangedListener::create([weakThis = ThreadSafeWeakPtr { *this }, dispatcher = dispatcher()](double rate) {
+        dispatcher->dispatch([weakThis, rate] {
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && rate)
                     protectedThis->purgeDecodedSampleQueue(protectedThis->m_flushId);
-            }
         });
     }, timebase.get());
     m_timebaseAndTimerSource = { WTFMove(timebase), WTFMove(timerSource) };

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -184,7 +184,7 @@ public:
     unsigned decodedFrameCount() const final;
     unsigned droppedFrameCount() const final;
     void acceleratedRenderingStateChanged() final;
-    bool performTaskAtTime(Function<void()>&&, const MediaTime&) override;
+    bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&) override;
     void isLoopingChanged() final;
     void audioOutputDeviceChanged() final;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1170,13 +1170,13 @@ void RemoteMediaPlayerProxy::performTaskAtTime(const MediaTime& taskTime, Perfor
     }
 
     m_performTaskAtTimeCompletionHandler = WTFMove(completionHandler);
-    player->performTaskAtTime([weakThis = WeakPtr { *this }]() mutable {
+    player->performTaskAtTime([weakThis = WeakPtr { *this }](const MediaTime& time) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !protectedThis->m_performTaskAtTimeCompletionHandler)
             return;
 
         auto completionHandler = std::exchange(protectedThis->m_performTaskAtTimeCompletionHandler, nullptr);
-        completionHandler(protectedThis->protectedPlayer()->currentTime());
+        completionHandler(time);
     }, taskTime);
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1601,14 +1601,14 @@ void MediaPlayerPrivateRemote::setPlatformDynamicRangeLimit(WebCore::PlatformDyn
     connection().send(Messages::RemoteMediaPlayerProxy::SetPlatformDynamicRangeLimit(platformDynamicRangeLimit), m_id);
 }
 
-bool MediaPlayerPrivateRemote::performTaskAtTime(WTF::Function<void()>&& task, const MediaTime& mediaTime)
+bool MediaPlayerPrivateRemote::performTaskAtTime(WTF::Function<void(const MediaTime&)>&& task, const MediaTime& mediaTime)
 {
     auto asyncReplyHandler = [weakThis = ThreadSafeWeakPtr { *this }, task = WTFMove(task)](std::optional<MediaTime> currentTime) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !currentTime)
             return;
 
-        task();
+        task(*currentTime);
     };
 
     connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::PerformTaskAtTime(mediaTime), WTFMove(asyncReplyHandler), m_id);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -458,7 +458,7 @@ private:
     AVPlayer *objCAVFoundationAVPlayer() const final { return nullptr; }
 #endif
 
-    bool performTaskAtTime(Function<void()>&&, const MediaTime&) final;
+    bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&) final;
 
     bool supportsPlayAtHostTime() const final { return m_configuration.supportsPlayAtHostTime; }
     bool supportsPauseAtHostTime() const final { return m_configuration.supportsPauseAtHostTime; }


### PR DESCRIPTION
#### 9c0cce267dc25b4478cf7be838d15d241f4953e7
<pre>
Expand AudioVideoRenderer class so that it fulfils all requirement for the MSE player
<a href="https://bugs.webkit.org/show_bug.cgi?id=298438">https://bugs.webkit.org/show_bug.cgi?id=298438</a>
<a href="https://rdar.apple.com/159930540">rdar://159930540</a>

Reviewed by Youenn Fablet.

We add several methods to the AudioVideoRenderer class which are functionalities
needed by the MSE player.
We adopt those new methods in the WebM player that had been missing those functionalities since
it was first implemented.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::updateActiveTextTrackCues):
* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h:
* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm:
(WebCore::EffectiveRateChangedListener::EffectiveRateChangedListener):
(WebCore::EffectiveRateChangedListener::effectiveRateChanged):
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::AudioInterface::setPreservesPitchAndCorrectionAlgorithm):
(WebCore::VideoInterface::expectMinimumUpcomingPresentationTime):
(WebCore::SynchronizerInterface::stall):
(WebCore::TracksRendererManager::notifyTrackNeedsReenqueuing):
(WebCore::TracksRendererManager::notifyEffectiveRateChanged):
(WebCore::TracksRendererManager::notifyTimeReachedAndStall):
(WebCore::TracksRendererManager::cancelTimeReachedAction):
(WebCore::TracksRendererManager::performTaskAtTime):
(WebCore::AudioInterface::setPreservesPitch): Deleted.
(WebCore::VideoInterface::setMinimumUpcomingPresentationTime): Deleted.
(WebCore::TracksRendererManager::setDuration): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::performTaskAtTime):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::performTaskAtTime):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::addTrack):
(WebCore::AudioVideoRendererAVFObjC::removeTrack):
(WebCore::AudioVideoRendererAVFObjC::isReadyForMoreSamples):
(WebCore::AudioVideoRendererAVFObjC::notifyTrackNeedsReenqueuing):
(WebCore::AudioVideoRendererAVFObjC::play):
(WebCore::AudioVideoRendererAVFObjC::pause):
(WebCore::AudioVideoRendererAVFObjC::setRate):
(WebCore::AudioVideoRendererAVFObjC::stall):
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
(WebCore::AudioVideoRendererAVFObjC::cancelTimeReachedAction):
(WebCore::AudioVideoRendererAVFObjC::performTaskAtTime):
(WebCore::AudioVideoRendererAVFObjC::prepareToSeek):
(WebCore::AudioVideoRendererAVFObjC::notifyEffectiveRateChanged):
(WebCore::AudioVideoRendererAVFObjC::setPreservesPitchAndCorrectionAlgorithm):
(WebCore::AudioVideoRendererAVFObjC::setAudioTimePitchAlgorithm const):
(WebCore::AudioVideoRendererAVFObjC::expectMinimumUpcomingPresentationTime):
(WebCore::AudioVideoRendererAVFObjC::addAudioRenderer):
(WebCore::AudioVideoRendererAVFObjC::removeAudioRenderer):
(WebCore::AudioVideoRendererAVFObjC::maybeCompleteSeek):
(WebCore::AudioVideoRendererAVFObjC::updateAllRenderersHaveAvailableSamples):
(WebCore::AudioVideoRendererAVFObjC::setHasAvailableVideoFrame):
(WebCore::AudioVideoRendererAVFObjC::destroyVideoTrack):
(WebCore::AudioVideoRendererAVFObjC::audioRendererWasAutomaticallyFlushed):
(WebCore::AudioVideoRendererAVFObjC::setSynchronizerRate):
(WebCore::AudioVideoRendererAVFObjC::updateLastPixelBuffer):
(WebCore::AudioVideoRendererAVFObjC::maybePurgeLastPixelBuffer):
(WebCore::AudioVideoRendererAVFObjC::setNeedsPlaceholderImage):
(WebCore::AudioVideoRendererAVFObjC::notifyRequiresFlushToResume):
(WebCore::AudioVideoRendererAVFObjC::setDuration): Deleted.
(WebCore::AudioVideoRendererAVFObjC::notifyDurationReached): Deleted.
(WebCore::AudioVideoRendererAVFObjC::setPreservesPitch): Deleted.
(WebCore::AudioVideoRendererAVFObjC::setMinimumUpcomingPresentationTime): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::performTaskAtTime):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtTime):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::play):
(WebCore::MediaPlayerPrivateWebM::pause):
(WebCore::MediaPlayerPrivateWebM::paused const):
(WebCore::MediaPlayerPrivateWebM::playAtHostTime):
(WebCore::MediaPlayerPrivateWebM::pauseAtHostTime):
(WebCore::MediaPlayerPrivateWebM::playInternal):
(WebCore::MediaPlayerPrivateWebM::performTaskAtTime):
(WebCore::MediaPlayerPrivateWebM::audioOutputDeviceChanged):
(WebCore::MediaPlayerPrivateWebM::setPageIsVisible):
(WebCore::MediaPlayerPrivateWebM::effectiveRateChanged):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::setPreservesPitch):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeEnabled):
(WebCore::MediaPlayerPrivateWebM::trackIdentifierFor const):
(WebCore::MediaPlayerPrivateWebM::trackIdentifierFor): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::setTimebase):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::performTaskAtTime):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::performTaskAtTime):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::performTaskAtTime):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/299989@main">https://commits.webkit.org/299989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/050ff6bb4847b6596228b225432b5e847825fbbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127430 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b50ab353-ac59-4d69-abb4-7cee2f2fa71b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6594070f-97e2-4af2-8ef8-500d3769d4fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0344e676-a3ff-4384-b177-398e8f9f71fe) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26580 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71019 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130284 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47939 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104643 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/100426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25451 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23878 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47797 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/53510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50615 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/48952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->