### PR TITLE
HDR 2D Canvas: Use final HTML spec names

### DIFF
--- a/LayoutTests/compositing/hdr/hdr-basic-canvas.html
+++ b/LayoutTests/compositing/hdr/hdr-basic-canvas.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CanvasPixelFormatEnabled=true ] -->
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
 <style>
     canvas {
         border: 1px solid black;
@@ -22,7 +22,7 @@
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
 
         let canvas1 = document.getElementById("canvas1");
-        let context1 = canvas1.getContext("2d", { pixelFormat: "float16" });
+        let context1 = canvas1.getContext("2d", { colorType: "float16" });
         context1.fillStyle = "green";
         context1.fillRect(0, 0, 100, 100);
 
@@ -32,7 +32,7 @@
         context2.fillRect(0, 0, 100, 100);
 
         let canvas3 = document.getElementById("canvas3");
-        let context3 = canvas3.getContext("2d", { pixelFormat: "float16" });
+        let context3 = canvas3.getContext("2d", { colorType: "float16" });
         context3.fillStyle = "green";
         context3.fillRect(0, 0, 100, 100);
 

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled-expected.txt
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled-expected.txt
@@ -1,12 +1,12 @@
-Test that the pixelFormat member of CanvasRenderingContext2DSettings is unsupported when CanvasPixelFormatEnabled=false.
+Test that the colorType member of CanvasRenderingContext2DSettings is unsupported when CanvasColorTypeEnabled=false.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS testSettings.pixelFormat is undefined.
-PASS testSettings.pixelFormat is undefined.
-PASS testSettings.pixelFormat is undefined.
-PASS testSettings.pixelFormat is undefined.
+PASS testSettings.colorType is undefined.
+PASS testSettings.colorType is undefined.
+PASS testSettings.colorType is undefined.
+PASS testSettings.colorType is undefined.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html
@@ -1,22 +1,22 @@
-<!-- webkit-test-runner [ CanvasPixelFormatEnabled=false ] -->
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=false ] -->
 <html>
     <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
 <script>
-    description("Test that the pixelFormat member of CanvasRenderingContext2DSettings is unsupported when CanvasPixelFormatEnabled=false.");
+    description("Test that the colorType member of CanvasRenderingContext2DSettings is unsupported when CanvasColorTypeEnabled=false.");
 
-    function testPixelFormatUnsupported(settings) {
+    function testColorTypeUnsupported(settings) {
         let canvas = document.createElement("canvas");
         let context = canvas.getContext("2d", settings);
         window.testSettings = context.getContextAttributes();
-        shouldBeUndefined("testSettings.pixelFormat");
+        shouldBeUndefined("testSettings.colorType");
     }
 
-    testPixelFormatUnsupported(undefined);
-    testPixelFormatUnsupported({ pixelFormat: "uint8" });
-    testPixelFormatUnsupported({ pixelFormat: "float16" });
-    testPixelFormatUnsupported({ pixelFormat: "foo" });
+    testColorTypeUnsupported(undefined);
+    testColorTypeUnsupported({ colorType: "unorm8" });
+    testColorTypeUnsupported({ colorType: "float16" });
+    testColorTypeUnsupported({ colorType: "foo" });
 </script>
 
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt
@@ -1,12 +1,12 @@
-Test that the pixelFormat member of CanvasRenderingContext2DSettings is supported when CanvasPixelFormatEnabled=true.
+Test that the colorType member of CanvasRenderingContext2DSettings is supported when CanvasColorTypeEnabled=true.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS testSettings.pixelFormat is "uint8"
-PASS testSettings.pixelFormat is "uint8"
-PASS testSettings.pixelFormat is "float16"
-PASS document.createElement("canvas").getContext("2d", { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS testSettings.colorType is "unorm8"
+PASS testSettings.colorType is "unorm8"
+PASS testSettings.colorType is "float16"
+PASS document.createElement("canvas").getContext("2d", { colorType: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled.html
@@ -1,27 +1,27 @@
-<!-- webkit-test-runner [ CanvasPixelFormatEnabled=true ] -->
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
 <html>
     <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
 <script>
-    description("Test that the pixelFormat member of CanvasRenderingContext2DSettings is supported when CanvasPixelFormatEnabled=true.");
+    description("Test that the colorType member of CanvasRenderingContext2DSettings is supported when CanvasColorTypeEnabled=true.");
 
-    function testpixelFormat(settings, expectedpixelFormat) {
+    function testColorType(settings, expectedColorType) {
         let canvas = document.createElement("canvas");
         let context = canvas.getContext("2d", settings);
         window.testSettings = context.getContextAttributes();
-        shouldBeEqualToString("testSettings.pixelFormat", expectedpixelFormat);
+        shouldBeEqualToString("testSettings.colorType", expectedColorType);
     }
 
-    // Test default value of pixelFormat is "uint8".
-    testpixelFormat(undefined, "uint8");
+    // Test default value of colorType is "unorm8".
+    testColorType(undefined, "unorm8");
 
-    // Test setting pixelFormat to a valid value works.
-    testpixelFormat({ pixelFormat: "uint8" }, "uint8");
-    testpixelFormat({ pixelFormat: "float16" }, "float16");
+    // Test setting colorType to a valid value works.
+    testColorType({ colorType: "unorm8" }, "unorm8");
+    testColorType({ colorType: "float16" }, "float16");
 
-    // Test setting pixelFormat to an unsupported value.
-    shouldThrowErrorName(`document.createElement("canvas").getContext("2d", { pixelFormat: "foo" })`, "TypeError")
+    // Test setting colorType to an unsupported value.
+    shouldThrowErrorName(`document.createElement("canvas").getContext("2d", { colorType: "foo" })`, "TypeError")
 </script>
 
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt
@@ -99,8 +99,8 @@ PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.dat
 PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
 PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
 PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
-PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
-PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
+PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CanvasPixelFormatEnabled=true ] -->
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -11,7 +11,7 @@ description("Tests that put/getImageData work with float16 canvas.");
 var canvas = document.createElement("canvas");
 canvas.width = 10;
 canvas.height = 10;
-var context = canvas.getContext("2d", { pixelFormat: "float16" });
+var context = canvas.getContext("2d", { colorType: "float16" });
 var r = 0;
 var g = 128;
 var b = 255;
@@ -65,17 +65,17 @@ const float16_bytes_per_element = 2;
 // Less than half the range of a color component [0..255]/255 unit.
 const float16_nonzero_tolerance = (1 / 256) / 2;
 
-var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
+var created_imageData_float16 = context.createImageData(1, 1, { pixelFormat: "rgba-float16" });
 verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_element, 0, 0, 0, 0, 0);
 
-var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
 verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
 
-var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
+var created_imageData_uint8 = context.createImageData(1, 1, { pixelFormat: "rgba-unorm8" });
 verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, 0, 0, 0, 0);
 
 // This verifies the basic float16->uint8 conversion:
-var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
+var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-unorm8" });
 verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
 // Put the float16 ImageData back into the (uint8-backed) canvas, and get a default (uint8) ImageData.
@@ -93,7 +93,7 @@ shouldBeTrue('canvas.width * canvas.height >= 256 * componentsToTest');
 
 var input_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
 var expected_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
-var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 
 var pixelOffset = 0;
 for (let v = 0; v < 256; ++v) {
@@ -127,16 +127,16 @@ for (let v = 0; v < 256; ++v) {
 shouldBe('pixelOffset', '256 * componentsToTest');
 
 context.putImageData(input_imageData_uint8, 0, 0);
-gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
 areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
-gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
 
 context.clearRect(0, 0, canvas.width, canvas.height);
 context.putImageData(gotten_imageData_float16, 0, 0);
-gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
-gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
 areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
 
 // Deeper float16->(same)float16->uint8->(nearby)float16 round-trip test for many possible individual component values. Only log errors.
@@ -149,9 +149,9 @@ const maxValue = 2;
 const extraValues = [ 6.097555160522461e-5, 6.103515625e-5, 0.99951171875, 1.0009765625, 65504, -1, -65504, Infinity, -Infinity ];
 shouldBeTrue('canvas.width * canvas.height >= (extraValues.length + divisions) * componentsToTest');
 
-input_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+input_imageData_float16 = context.createImageData(canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 expected_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
-expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 
 pixelOffset = 0;
 const uint8_nonzero_tolerance = 1 / 2;
@@ -197,17 +197,17 @@ shouldBe('pixelOffset', '(extraValues.length + divisions) * componentsToTest');
 
 context.putImageData(input_imageData_float16, 0, 0);
 
-gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
 areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
 
 context.putImageData(gotten_imageData_uint8, 0, 0);
-gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
 areEqualImageData('gotten_imageData_uint8_from_float16', 'expected_imageData_uint8', 0);
-gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
 
-shouldThrowErrorName(`context.createImageData(1, 1, { storageFormat: "foo" })`, "TypeError")
-shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { storageFormat: "foo" })`, "TypeError")
+shouldThrowErrorName(`context.createImageData(1, 1, { pixelFormat: "foo" })`, "TypeError")
+shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" })`, "TypeError")
 </script>
 <script src="../../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/canvas/imagedata-storageformat-disabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-disabled-expected.txt
@@ -1,10 +1,10 @@
-Tests that ImageDataSettings with CanvasPixelFormatEnabled=false ignores storageFormat.
+Tests that ImageDataSettings with CanvasColorTypeEnabled=false ignores pixelFormat.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
-PASS gotten_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS created_imageData_unorm8.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_unorm8.data.constructor is Uint8ClampedArray
 PASS created_imageData_float16.data.constructor is Uint8ClampedArray
 PASS gotten_imageData_float16.data.constructor is Uint8ClampedArray
 PASS created_imageData_foo.data.constructor is Uint8ClampedArray

--- a/LayoutTests/fast/canvas/imagedata-storageformat-disabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-disabled.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CanvasPixelFormatEnabled=false ] -->
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -6,29 +6,29 @@
 </head>
 <body>
 <script>
-description("Tests that ImageDataSettings with CanvasPixelFormatEnabled=false ignores storageFormat.");
+description("Tests that ImageDataSettings with CanvasColorTypeEnabled=false ignores pixelFormat.");
 
 var canvas = document.createElement("canvas");
 canvas.width = 10;
 canvas.height = 10;
 var context = canvas.getContext("2d");
 
-var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
-shouldBe('created_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+var created_imageData_unorm8 = context.createImageData(1, 1, { pixelFormat: "rgba-unorm8" });
+shouldBe('created_imageData_unorm8.data.constructor', 'Uint8ClampedArray');
 
-var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-shouldBe('gotten_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+var gotten_imageData_unorm8 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-unorm8" });
+shouldBe('gotten_imageData_unorm8.data.constructor', 'Uint8ClampedArray');
 
-var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
+var created_imageData_float16 = context.createImageData(1, 1, { pixelFormat: "rgba-float16" });
 shouldBe('created_imageData_float16.data.constructor', 'Uint8ClampedArray');
 
-var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
 shouldBe('gotten_imageData_float16.data.constructor', 'Uint8ClampedArray');
 
-var created_imageData_foo = context.createImageData(1, 1, { storageFormat: "foo" });
+var created_imageData_foo = context.createImageData(1, 1, { pixelFormat: "foo" });
 shouldBe('created_imageData_foo.data.constructor', 'Uint8ClampedArray');
 
-var gotten_imageData_foo = context.getImageData(0, 0, 1, 1, { storageFormat: "foo" });
+var gotten_imageData_foo = context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" });
 shouldBe('gotten_imageData_foo.data.constructor', 'Uint8ClampedArray');
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
@@ -1,28 +1,28 @@
-Tests that ImageDataSettings contains storageFormat.
+Tests that ImageDataSettings contains pixelFormat.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS created_imageData_uint8.width is 1
-PASS created_imageData_uint8.height is 1
-PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
-PASS created_imageData_uint8.data.BYTES_PER_ELEMENT is 1
-PASS created_imageData_uint8.data.length is 4
-PASS created_imageData_uint8.data.byteLength is 4
-PASS created_imageData_uint8.data.at(0) is 0
-PASS created_imageData_uint8.data.at(1) is 0
-PASS created_imageData_uint8.data.at(2) is 0
-PASS created_imageData_uint8.data.at(3) is 0
-PASS gotten_imageData_uint8.width is 1
-PASS gotten_imageData_uint8.height is 1
-PASS gotten_imageData_uint8.data.constructor is Uint8ClampedArray
-PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is 1
-PASS gotten_imageData_uint8.data.length is 4
-PASS gotten_imageData_uint8.data.byteLength is 4
-PASS gotten_imageData_uint8.data.at(0) is 0
-PASS gotten_imageData_uint8.data.at(1) is 128
-PASS gotten_imageData_uint8.data.at(2) is 255
-PASS gotten_imageData_uint8.data.at(3) is 255
+PASS created_imageData_unorm8.width is 1
+PASS created_imageData_unorm8.height is 1
+PASS created_imageData_unorm8.data.constructor is Uint8ClampedArray
+PASS created_imageData_unorm8.data.BYTES_PER_ELEMENT is 1
+PASS created_imageData_unorm8.data.length is 4
+PASS created_imageData_unorm8.data.byteLength is 4
+PASS created_imageData_unorm8.data.at(0) is 0
+PASS created_imageData_unorm8.data.at(1) is 0
+PASS created_imageData_unorm8.data.at(2) is 0
+PASS created_imageData_unorm8.data.at(3) is 0
+PASS gotten_imageData_unorm8.width is 1
+PASS gotten_imageData_unorm8.height is 1
+PASS gotten_imageData_unorm8.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_unorm8.data.length is 4
+PASS gotten_imageData_unorm8.data.byteLength is 4
+PASS gotten_imageData_unorm8.data.at(0) is 0
+PASS gotten_imageData_unorm8.data.at(1) is 128
+PASS gotten_imageData_unorm8.data.at(2) is 255
+PASS gotten_imageData_unorm8.data.at(3) is 255
 PASS created_imageData_float16.width is 1
 PASS created_imageData_float16.height is 1
 PASS created_imageData_float16.data.constructor is Float16Array
@@ -43,24 +43,24 @@ PASS gotten_imageData_float16.data.at(0) is within 0.001953125 of 0
 PASS gotten_imageData_float16.data.at(1) is within 0.001953125 of 0.5019607843137255
 PASS gotten_imageData_float16.data.at(2) is within 0.001953125 of 1
 PASS gotten_imageData_float16.data.at(3) is within 0.001953125 of 1
-PASS gotten_imageData_uint8_from_float16.width is 1
-PASS gotten_imageData_uint8_from_float16.height is 1
-PASS gotten_imageData_uint8_from_float16.data.constructor is Uint8ClampedArray
-PASS gotten_imageData_uint8_from_float16.data.BYTES_PER_ELEMENT is 1
-PASS gotten_imageData_uint8_from_float16.data.length is 4
-PASS gotten_imageData_uint8_from_float16.data.byteLength is 4
-PASS gotten_imageData_uint8_from_float16.data.at(0) is 0
-PASS gotten_imageData_uint8_from_float16.data.at(1) is 128
-PASS gotten_imageData_uint8_from_float16.data.at(2) is 255
-PASS gotten_imageData_uint8_from_float16.data.at(3) is 255
+PASS gotten_imageData_unorm8_from_float16.width is 1
+PASS gotten_imageData_unorm8_from_float16.height is 1
+PASS gotten_imageData_unorm8_from_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_unorm8_from_float16.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_unorm8_from_float16.data.length is 4
+PASS gotten_imageData_unorm8_from_float16.data.byteLength is 4
+PASS gotten_imageData_unorm8_from_float16.data.at(0) is 0
+PASS gotten_imageData_unorm8_from_float16.data.at(1) is 128
+PASS gotten_imageData_unorm8_from_float16.data.at(2) is 255
+PASS gotten_imageData_unorm8_from_float16.data.at(3) is 255
 PASS canvas.width * canvas.height >= 256 * componentsToTest is true
 PASS pixelOffset is 256 * componentsToTest
-PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
-PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
-PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
-PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
-PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
-PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_unorm8.width is expected_imageData_unorm8.width
+PASS gotten_imageData_unorm8.height is expected_imageData_unorm8.height
+PASS gotten_imageData_unorm8.data.constructor is expected_imageData_unorm8.data.constructor
+PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is expected_imageData_unorm8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_unorm8.data.length is expected_imageData_unorm8.data.length
+PASS gotten_imageData_unorm8.data.byteLength is expected_imageData_unorm8.data.byteLength
 PASS gotten_imageData_float16.width is expected_imageData_float16.width
 PASS gotten_imageData_float16.height is expected_imageData_float16.height
 PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
@@ -73,14 +73,14 @@ PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.dat
 PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
 PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
 PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
-PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
-PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
-PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
-PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
-PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
-PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
-PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
-PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
+PASS gotten_imageData_unorm8.width is expected_imageData_unorm8.width
+PASS gotten_imageData_unorm8.height is expected_imageData_unorm8.height
+PASS gotten_imageData_unorm8.data.constructor is expected_imageData_unorm8.data.constructor
+PASS gotten_imageData_unorm8.data.BYTES_PER_ELEMENT is expected_imageData_unorm8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_unorm8.data.length is expected_imageData_unorm8.data.length
+PASS gotten_imageData_unorm8.data.byteLength is expected_imageData_unorm8.data.byteLength
+PASS context.createImageData(1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CanvasPixelFormatEnabled=true ] -->
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -6,7 +6,7 @@
 </head>
 <body>
 <script>
-description("Tests that ImageDataSettings contains storageFormat.");
+description("Tests that ImageDataSettings contains pixelFormat.");
 
 var canvas = document.createElement("canvas");
 canvas.width = 10;
@@ -58,40 +58,40 @@ function areEqualImageData(imageDataActual, imageDataExpected, tolerance)
     }
 }
 
-const uint8_bytes_per_element = 1;
+const unorm8_bytes_per_element = 1;
 const float16_bytes_per_element = 2;
 // Less than half the range of a color component [0..255]/255 unit.
 const float16_nonzero_tolerance = (1 / 256) / 2;
 
-var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
-verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, 0, 0, 0, 0);
+var created_imageData_unorm8 = context.createImageData(1, 1, { pixelFormat: "rgba-unorm8" });
+verifyImageData('created_imageData_unorm8', 'Uint8ClampedArray', unorm8_bytes_per_element, 0, 0, 0, 0);
 
-var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
+var gotten_imageData_unorm8 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-unorm8" });
+verifyImageData('gotten_imageData_unorm8', 'Uint8ClampedArray', unorm8_bytes_per_element, r, g, b, a);
 
-var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
+var created_imageData_float16 = context.createImageData(1, 1, { pixelFormat: "rgba-float16" });
 verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_element, 0, 0, 0, 0, 0);
 
-// This verifies the basic uint8->float16 conversion.
-var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+// This verifies the basic unorm8->float16 conversion.
+var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
 verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
 
-// Put the float16 ImageData back into the (uint8-backed) canvas, and get a default (uint8) ImageData.
-// This verifies the basic float16->uint8 conversion:
+// Put the float16 ImageData back into the (unorm8-backed) canvas, and get a default (unorm8) ImageData.
+// This verifies the basic float16->unorm8 conversion:
 context.clearRect(0, 0, 1, 1);
 context.putImageData(gotten_imageData_float16, 0, 0);
-var gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, 1, 1);
-verifyImageData('gotten_imageData_uint8_from_float16', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
+var gotten_imageData_unorm8_from_float16 = context.getImageData(0, 0, 1, 1);
+verifyImageData('gotten_imageData_unorm8_from_float16', 'Uint8ClampedArray', unorm8_bytes_per_element, r, g, b, a);
 
-// Exhaustive uint8->float16->uint8 round-trip test for all possible individual SRGB/uint8 component values. Only log errors.
+// Exhaustive unorm8->float16->unorm8 round-trip test for all possible individual rgba-unorm8 component values. Only log errors.
 canvas.width = 64;
 canvas.height = 16;
 var componentsToTest = componentsPerPixel;
 shouldBeTrue('canvas.width * canvas.height >= 256 * componentsToTest');
 
-var input_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
-var expected_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
-var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+var input_imageData_unorm8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_unorm8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 
 var pixelOffset = 0;
 for (let v = 0; v < 256; ++v) {
@@ -104,15 +104,15 @@ for (let v = 0; v < 256; ++v) {
         case 2: b = v; break;
         case 3: r = g = b = (v ? 255 : 0); a = v; break;
         }
-        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 0] = r;
-        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 1] = g;
-        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 2] = b;
-        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 3] = a;
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 0] = r;
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 1] = g;
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 2] = b;
+        input_imageData_unorm8.data[pixelOffset * componentsPerPixel + 3] = a;
 
-        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 0] = r;
-        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 1] = g;
-        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 2] = b;
-        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 3] = a;
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 0] = r;
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 1] = g;
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 2] = b;
+        expected_imageData_unorm8.data[pixelOffset * componentsPerPixel + 3] = a;
 
         expected_imageData_float16.data[pixelOffset * componentsPerPixel + 0] = r / 255;
         expected_imageData_float16.data[pixelOffset * componentsPerPixel + 1] = g / 255;
@@ -124,21 +124,21 @@ for (let v = 0; v < 256; ++v) {
 }
 shouldBe('pixelOffset', '256 * componentsToTest');
 
-context.putImageData(input_imageData_uint8, 0, 0);
-gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
-areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
-gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+context.putImageData(input_imageData_unorm8, 0, 0);
+gotten_imageData_unorm8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
+areEqualImageData('gotten_imageData_unorm8', 'expected_imageData_unorm8', 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
 
 context.clearRect(0, 0, canvas.width, canvas.height);
 context.putImageData(gotten_imageData_float16, 0, 0);
-gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-float16" });
 areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
-gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
-areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
+gotten_imageData_unorm8 = context.getImageData(0, 0, canvas.width, canvas.height, { pixelFormat: "rgba-unorm8" });
+areEqualImageData('gotten_imageData_unorm8', 'expected_imageData_unorm8', 0);
 
-shouldThrowErrorName(`context.createImageData(1, 1, { storageFormat: "foo" })`, "TypeError")
-shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { storageFormat: "foo" })`, "TypeError")
+shouldThrowErrorName(`context.createImageData(1, 1, { pixelFormat: "foo" })`, "TypeError")
+shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { pixelFormat: "foo" })`, "TypeError")
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -1256,14 +1256,14 @@ PASS ImageData interface: existence and properties of interface prototype object
 PASS ImageData interface: attribute width
 PASS ImageData interface: attribute height
 PASS ImageData interface: attribute data
-FAIL ImageData interface: attribute pixelFormat assert_true: The prototype object must have a property "pixelFormat" expected true got false
+PASS ImageData interface: attribute pixelFormat
 PASS ImageData interface: attribute colorSpace
 PASS ImageData must be primary interface of new ImageData(10, 10)
 PASS Stringification of new ImageData(10, 10)
 PASS ImageData interface: new ImageData(10, 10) must inherit property "width" with the proper type
 PASS ImageData interface: new ImageData(10, 10) must inherit property "height" with the proper type
 FAIL ImageData interface: new ImageData(10, 10) must inherit property "data" with the proper type assert_inherits: property "data" found on object expected in prototype chain
-FAIL ImageData interface: new ImageData(10, 10) must inherit property "pixelFormat" with the proper type assert_inherits: property "pixelFormat" not found in prototype chain
+PASS ImageData interface: new ImageData(10, 10) must inherit property "pixelFormat" with the proper type
 PASS ImageData interface: new ImageData(10, 10) must inherit property "colorSpace" with the proper type
 PASS ImageBitmap interface: existence and properties of interface object
 PASS ImageBitmap interface object length

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -489,7 +489,7 @@ PASS ImageData interface: existence and properties of interface prototype object
 PASS ImageData interface: attribute width
 PASS ImageData interface: attribute height
 PASS ImageData interface: attribute data
-FAIL ImageData interface: attribute pixelFormat assert_true: The prototype object must have a property "pixelFormat" expected true got false
+PASS ImageData interface: attribute pixelFormat
 PASS ImageData interface: attribute colorSpace
 PASS ImageBitmap interface: existence and properties of interface object
 PASS ImageBitmap interface object length

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -1256,14 +1256,14 @@ PASS ImageData interface: existence and properties of interface prototype object
 PASS ImageData interface: attribute width
 PASS ImageData interface: attribute height
 PASS ImageData interface: attribute data
-FAIL ImageData interface: attribute pixelFormat assert_true: The prototype object must have a property "pixelFormat" expected true got false
+PASS ImageData interface: attribute pixelFormat
 PASS ImageData interface: attribute colorSpace
 PASS ImageData must be primary interface of new ImageData(10, 10)
 PASS Stringification of new ImageData(10, 10)
 PASS ImageData interface: new ImageData(10, 10) must inherit property "width" with the proper type
 PASS ImageData interface: new ImageData(10, 10) must inherit property "height" with the proper type
 FAIL ImageData interface: new ImageData(10, 10) must inherit property "data" with the proper type assert_inherits: property "data" found on object expected in prototype chain
-FAIL ImageData interface: new ImageData(10, 10) must inherit property "pixelFormat" with the proper type assert_inherits: property "pixelFormat" not found in prototype chain
+PASS ImageData interface: new ImageData(10, 10) must inherit property "pixelFormat" with the proper type
 PASS ImageData interface: new ImageData(10, 10) must inherit property "colorSpace" with the proper type
 PASS ImageBitmap interface: existence and properties of interface object
 PASS ImageBitmap interface object length

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -489,7 +489,7 @@ PASS ImageData interface: existence and properties of interface prototype object
 PASS ImageData interface: attribute width
 PASS ImageData interface: attribute height
 PASS ImageData interface: attribute data
-FAIL ImageData interface: attribute pixelFormat assert_true: The prototype object must have a property "pixelFormat" expected true got false
+PASS ImageData interface: attribute pixelFormat
 PASS ImageData interface: attribute colorSpace
 PASS ImageBitmap interface: existence and properties of interface object
 PASS ImageBitmap interface object length

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -489,7 +489,7 @@ PASS ImageData interface: existence and properties of interface prototype object
 PASS ImageData interface: attribute width
 PASS ImageData interface: attribute height
 PASS ImageData interface: attribute data
-FAIL ImageData interface: attribute pixelFormat assert_true: The prototype object must have a property "pixelFormat" expected true got false
+PASS ImageData interface: attribute pixelFormat
 PASS ImageData interface: attribute colorSpace
 PASS ImageBitmap interface: existence and properties of interface object
 PASS ImageBitmap interface object length

--- a/LayoutTests/storage/indexeddb/modern/objectstore-autoincrement-types-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/objectstore-autoincrement-types-expected.txt
@@ -27,7 +27,7 @@ PASS request.result.primaryKey is imageData.primaryKey
 PASS request.result.width is imageData.width
 PASS request.result.height is imageData.height
 PASS request.result.colorSpace is imageData.colorSpace
-PASS request.result.storageFormat is imageData.storageFormat
+PASS request.result.pixelFormat is imageData.pixelFormat
 PASS key is 4
 PASS request.result.primaryKey is fileList.primaryKey
 PASS request.result.length is fileList.length
@@ -43,7 +43,7 @@ PASS request.result[2].primaryKey is imageData.primaryKey
 PASS request.result[2].width is imageData.width
 PASS request.result[2].height is imageData.height
 PASS request.result[2].colorSpace is imageData.colorSpace
-PASS request.result[2].storageFormat is imageData.storageFormat
+PASS request.result[2].pixelFormat is imageData.pixelFormat
 PASS request.result[3].primaryKey is fileList.primaryKey
 PASS request.result[3].length is fileList.length
 PASS successfullyParsed is true

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1645,6 +1645,22 @@ CanvasColorSpaceEnabled:
     WebCore:
       default: false
 
+CanvasColorTypeEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Canvas Color Types and ImageData Pixel Formats"
+  humanReadableDescription: "Allow different color types and pixel formats in 2D canvas"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  disableInLockdownMode: true
+  sharedPreferenceForWebProcess: true
+
 CanvasFiltersEnabled:
   type: bool
   status: testable
@@ -1686,22 +1702,6 @@ CanvasLayersEnabled:
       default: false
     WebCore:
       default: false
-
-CanvasPixelFormatEnabled:
-  type: bool
-  status: testable
-  category: dom
-  humanReadableName: "CanvasRenderingContext2DSettings.pixelFormat"
-  humanReadableDescription: "Allow different pixel formats in 2D canvas"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-  disableInLockdownMode: true
-  sharedPreferenceForWebProcess: true
 
 CanvasUsesAcceleratedDrawing:
   type: bool

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1395,8 +1395,8 @@ set(WebCore_NON_SVG_IDL_FILES
     html/ImageBitmap.idl
     html/ImageBitmapOptions.idl
     html/ImageData.idl
+    html/ImageDataPixelFormat.idl
     html/ImageDataSettings.idl
-    html/ImageDataStorageFormat.idl
     html/MediaController.idl
     html/MediaEncryptedEvent.idl
     html/MediaError.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1682,7 +1682,7 @@ $(PROJECT_DIR)/html/ImageBitmap.idl
 $(PROJECT_DIR)/html/ImageBitmapOptions.idl
 $(PROJECT_DIR)/html/ImageData.idl
 $(PROJECT_DIR)/html/ImageDataSettings.idl
-$(PROJECT_DIR)/html/ImageDataStorageFormat.idl
+$(PROJECT_DIR)/html/ImageDataPixelFormat.idl
 $(PROJECT_DIR)/html/MediaController.idl
 $(PROJECT_DIR)/html/MediaEncryptedEvent.idl
 $(PROJECT_DIR)/html/MediaError.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1748,8 +1748,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageData.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageData.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataSettings.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataSettings.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataStorageFormat.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataStorageFormat.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataPixelFormat.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataPixelFormat.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageResource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageResource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageSmoothingQuality.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1359,7 +1359,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/ImageBitmapOptions.idl \
     $(WebCore)/html/ImageData.idl \
     $(WebCore)/html/ImageDataSettings.idl \
-    $(WebCore)/html/ImageDataStorageFormat.idl \
+    $(WebCore)/html/ImageDataPixelFormat.idl \
     $(WebCore)/html/MediaController.idl \
     $(WebCore)/html/MediaEncryptedEvent.idl \
     $(WebCore)/html/MediaError.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1667,8 +1667,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/ImageBitmap.h
     html/ImageData.h
     html/ImageDataArray.h
+    html/ImageDataPixelFormat.h
     html/ImageDataSettings.h
-    html/ImageDataStorageFormat.h
     html/ImageDocument.h
     html/InputMode.h
     html/InputType.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4279,7 +4279,7 @@ JSImageBitmapRenderingContextSettings.cpp
 JSImageCapture.cpp
 JSImageData.cpp
 JSImageDataSettings.cpp
-JSImageDataStorageFormat.cpp
+JSImageDataPixelFormat.cpp
 JSImageResource.cpp
 JSImageSmoothingQuality.cpp
 JSImportNodeOptions.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8020,7 +8020,7 @@ void Document::setHasHDRContent()
 
 bool Document::drawsHDRContent() const
 {
-    if (!(settings().supportHDRDisplayEnabled() || settings().canvasPixelFormatEnabled()))
+    if (!(settings().supportHDRDisplayEnabled() || settings().canvasColorTypeEnabled()))
         return false;
 
     if (!hasHDRContent())

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -43,13 +43,13 @@ template<typename> class ExceptionOr;
 
 class ImageData : public RefCounted<ImageData> {
 public:
-    WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    WEBCORE_EXPORT static Ref<ImageData> create(Ref<Float16ArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static Ref<ImageData> create(Ref<Float16ArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
 #endif
-    WEBCORE_EXPORT static RefPtr<ImageData> create(Ref<PixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
-    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
-    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace, ImageDataStorageFormat = ImageDataStorageFormat::Uint8);
+    WEBCORE_EXPORT static RefPtr<ImageData> create(Ref<PixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
+    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&, std::optional<ImageDataPixelFormat> = { });
+    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace, ImageDataPixelFormat = ImageDataPixelFormat::RgbaUnorm8);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
 
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> = std::nullopt, std::span<const uint8_t> = { });
@@ -66,7 +66,7 @@ public:
     int height() const { return m_size.height(); }
     const ImageDataArray& data() const { return m_data; }
     PredefinedColorSpace colorSpace() const { return m_colorSpace; }
-    ImageDataStorageFormat storageFormat() const { return m_data.storageFormat(); }
+    ImageDataPixelFormat pixelFormat() const { return m_data.pixelFormat(); }
 
     Ref<ByteArrayPixelBuffer> byteArrayPixelBuffer() const;
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
@@ -76,7 +76,7 @@ public:
 
 private:
     explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
-    explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace, std::optional<ImageDataStorageFormat>);
+    explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace, std::optional<ImageDataPixelFormat>);
 
     IntSize m_size;
     ImageDataArray m_data;

--- a/Source/WebCore/html/ImageData.idl
+++ b/Source/WebCore/html/ImageData.idl
@@ -35,11 +35,11 @@ typedef (Uint8ClampedArray or Float16Array) ImageDataArray;
 ] interface ImageData {
     constructor(unsigned long sw, unsigned long sh, optional ImageDataSettings settings);
     constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings);
-    [EnabledBySetting=CanvasPixelFormatEnabled] constructor(Float16Array data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings);
+    [EnabledBySetting=CanvasColorTypeEnabled] constructor(Float16Array data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings);
 
     readonly attribute unsigned long width;
     readonly attribute unsigned long height;
     readonly attribute ImageDataArray data;
     [EnabledBySetting=CanvasColorSpaceEnabled] readonly attribute PredefinedColorSpace colorSpace;
-    [EnabledBySetting=CanvasPixelFormatEnabled] readonly attribute ImageDataStorageFormat storageFormat;
+    [EnabledBySetting=CanvasColorTypeEnabled] readonly attribute ImageDataPixelFormat pixelFormat;
 };

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -30,7 +30,7 @@
 
 #include <JavaScriptCore/Float16Array.h>
 #include <JavaScriptCore/Uint8ClampedArray.h>
-#include <WebCore/ImageDataStorageFormat.h>
+#include <WebCore/ImageDataPixelFormat.h>
 #include <optional>
 #include <wtf/JSONValues.h>
 
@@ -38,16 +38,16 @@ namespace WebCore {
 
 class ImageDataArray {
 public:
-    static constexpr bool isSupported(JSC::TypedArrayType type) { return !!toImageDataStorageFormat(type); }
+    static constexpr bool isSupported(JSC::TypedArrayType type) { return !!toImageDataPixelFormat(type); }
     static bool isSupported(const JSC::ArrayBufferView&);
 
     ImageDataArray(Ref<JSC::Uint8ClampedArray>&&);
     ImageDataArray(Ref<JSC::Float16Array>&&);
-    ImageDataArray(ImageDataArray&& original, std::optional<ImageDataStorageFormat> overridingStorageFormat);
+    ImageDataArray(ImageDataArray&& original, std::optional<ImageDataPixelFormat> overridingPixelFormat);
 
-    static std::optional<ImageDataArray> tryCreate(size_t, ImageDataStorageFormat, std::span<const uint8_t> = { });
+    static std::optional<ImageDataArray> tryCreate(size_t, ImageDataPixelFormat, std::span<const uint8_t> = { });
 
-    ImageDataStorageFormat storageFormat() const;
+    ImageDataPixelFormat pixelFormat() const;
     size_t length() const;
 
     JSC::ArrayBufferView& arrayBufferView() const { return m_arrayBufferView.get(); }
@@ -64,7 +64,7 @@ public:
 private:
     ImageDataArray(Ref<JSC::ArrayBufferView>&&);
 
-    Ref<ArrayBufferView> extractBufferViewWithStorageFormat(std::optional<ImageDataStorageFormat>) &&;
+    Ref<ArrayBufferView> extractBufferViewWithPixelFormat(std::optional<ImageDataPixelFormat>) &&;
 
     // Needed by `toJS<IDLUnion<IDLUint8ClampedArray, ...>, const ImageDataArray&>()`
     template<typename IDL, bool needsState, bool needsGlobalObject> friend struct JSConverterOverloader;

--- a/Source/WebCore/html/ImageDataPixelFormat.h
+++ b/Source/WebCore/html/ImageDataPixelFormat.h
@@ -30,17 +30,17 @@
 
 namespace WebCore {
 
-enum class ImageDataStorageFormat : bool {
-    Uint8,
-    Float16,
+enum class ImageDataPixelFormat : bool {
+    RgbaUnorm8,
+    RgbaFloat16,
 };
 
-constexpr PixelFormat toPixelFormat(ImageDataStorageFormat storageFormat)
+constexpr PixelFormat toPixelFormat(ImageDataPixelFormat pixelFormat)
 {
-    switch (storageFormat) {
-    case ImageDataStorageFormat::Uint8:
+    switch (pixelFormat) {
+    case ImageDataPixelFormat::RgbaUnorm8:
         break;
-    case ImageDataStorageFormat::Float16:
+    case ImageDataPixelFormat::RgbaFloat16:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
         return PixelFormat::RGBA16F;
 #else
@@ -50,11 +50,11 @@ constexpr PixelFormat toPixelFormat(ImageDataStorageFormat storageFormat)
     return PixelFormat::RGBA8;
 }
 
-constexpr std::optional<ImageDataStorageFormat> toImageDataStorageFormat(JSC::TypedArrayType typedArrayType)
+constexpr std::optional<ImageDataPixelFormat> toImageDataPixelFormat(JSC::TypedArrayType typedArrayType)
 {
     switch (typedArrayType) {
-    case JSC::TypeUint8Clamped: return ImageDataStorageFormat::Uint8;
-    case JSC::TypeFloat16: return ImageDataStorageFormat::Float16;
+    case JSC::TypeUint8Clamped: return ImageDataPixelFormat::RgbaUnorm8;
+    case JSC::TypeFloat16: return ImageDataPixelFormat::RgbaFloat16;
     default: return std::nullopt;
     }
 }

--- a/Source/WebCore/html/ImageDataPixelFormat.idl
+++ b/Source/WebCore/html/ImageDataPixelFormat.idl
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md with Chromium renaming (subject to change)
-enum ImageDataStorageFormat {
-    "uint8",
-    "float16",
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagedatapixelformat
+enum ImageDataPixelFormat {
+    "rgba-unorm8",
+    "rgba-float16",
 };

--- a/Source/WebCore/html/ImageDataSettings.h
+++ b/Source/WebCore/html/ImageDataSettings.h
@@ -25,14 +25,14 @@
 
 #pragma once
 
-#include <WebCore/ImageDataStorageFormat.h>
+#include <WebCore/ImageDataPixelFormat.h>
 #include <WebCore/PredefinedColorSpace.h>
 
 namespace WebCore {
 
 struct ImageDataSettings {
     std::optional<PredefinedColorSpace> colorSpace;
-    ImageDataStorageFormat storageFormat { ImageDataStorageFormat::Uint8 };
+    ImageDataPixelFormat pixelFormat { ImageDataPixelFormat::RgbaUnorm8 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/ImageDataSettings.idl
+++ b/Source/WebCore/html/ImageDataSettings.idl
@@ -26,5 +26,5 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#imagedatasettings
 dictionary ImageDataSettings {
     [EnabledBySetting=CanvasColorSpaceEnabled] PredefinedColorSpace colorSpace;
-    [EnabledBySetting=CanvasPixelFormatEnabled] ImageDataStorageFormat storageFormat = "uint8";
+    [EnabledBySetting=CanvasColorTypeEnabled] ImageDataPixelFormat pixelFormat = "rgba-unorm8";
 };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
@@ -35,11 +35,11 @@ struct CanvasRenderingContext2DSettings {
     bool desynchronized { false };
     bool willReadFrequently { false };
     PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
-    enum class PixelFormat : bool {
-        Uint8,
+    enum class ColorType : bool {
+        Unorm8,
         Float16,
     };
-    PixelFormat pixelFormat { PixelFormat::Uint8 };
+    ColorType colorType { ColorType::Unorm8 };
     enum class RenderingMode {
         Unaccelerated,
         Accelerated

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
@@ -23,9 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md with Chromium renaming (subject to change)
-enum CanvasPixelFormat {
-    "uint8",
+// https://html.spec.whatwg.org/multipage/canvas.html#canvascolortype
+enum CanvasColorType {
+    "unorm8",
     "float16",
 };
 
@@ -44,6 +44,6 @@ enum RenderingMode {
     boolean desynchronized = false;
     boolean willReadFrequently = false;
     [EnabledBySetting=CanvasColorSpaceEnabled] PredefinedColorSpace colorSpace = "srgb";
-    [EnabledBySetting=CanvasPixelFormatEnabled] CanvasPixelFormat pixelFormat = "uint8";
+    [EnabledBySetting=CanvasColorTypeEnabled] CanvasColorType colorType = "unorm8";
     [EnabledBySetting=DOMTestingAPIsEnabled] RenderingMode? renderingModeForTesting;
 };


### PR DESCRIPTION
#### 206ef8a13d8068024c979660d07976a68d0ec4d0
<pre>
HDR 2D Canvas: Use final HTML spec names
<a href="https://bugs.webkit.org/show_bug.cgi?id=287139">https://bugs.webkit.org/show_bug.cgi?id=287139</a>
<a href="https://rdar.apple.com/144769810">rdar://144769810</a>

Reviewed by Mike Wyrzykowski.

<a href="https://github.com/whatwg/html/pull/10951">https://github.com/whatwg/html/pull/10951</a>
<a href="https://html.spec.whatwg.org/multipage/canvas.html#canvascolortype">https://html.spec.whatwg.org/multipage/canvas.html#canvascolortype</a>
CanvasRenderingContext2DSettings:
had pixelFormat of type CanvasPixelFormat: &quot;uint8&quot; &quot;float16&quot;
now colorType of type CanvasColorType: &quot;unorm8&quot; &quot;float16&quot;

<a href="https://github.com/whatwg/html/pull/11143">https://github.com/whatwg/html/pull/11143</a>
<a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagedatapixelformat">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagedatapixelformat</a>
ImageData and ImageDataSettings:
had storageFormat of type ImageDataStorageFormat: &quot;uint8&quot; &quot;float16&quot;
now pixelfFormat of type ImageDataPixelFormat: &quot;rgba-unorm8&quot; &quot;rgba-float16&quot;

* LayoutTests/compositing/hdr/hdr-basic-canvas.html:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled-expected.txt:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled.html:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html:
* LayoutTests/fast/canvas/imagedata-storageformat-disabled-expected.txt:
* LayoutTests/fast/canvas/imagedata-storageformat-disabled.html:
* LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt:
* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/storage/indexeddb/modern/objectstore-autoincrement-types-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::drawsHDRContent const):
* Source/WebCore/html/ImageData.cpp:
(WebCore::computeDataSize):
(WebCore::computePixelFormat):
(WebCore::ImageData::create):
(WebCore::ImageData::ImageData):
(WebCore::ImageData::pixelBuffer const):
(WebCore::computeStorageFormat):
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::create):
(WebCore::ImageData::pixelFormat const):
(WebCore::ImageData::storageFormat const):
* Source/WebCore/html/ImageData.idl:
* Source/WebCore/html/ImageDataArray.cpp:
(WebCore::ImageDataArray::ImageDataArray):
(WebCore::ImageDataArray::tryCreate):
(WebCore::ImageDataArray::pixelFormat const):
(WebCore::ImageDataArray::extractBufferViewWithPixelFormat):
(WebCore::ImageDataArray::storageFormat const):
(WebCore::ImageDataArray::extractBufferViewWithStorageFormat):
* Source/WebCore/html/ImageDataArray.h:
(WebCore::ImageDataArray::isSupported):
(WebCore::ImageDataArray::tryCreate):
* Source/WebCore/html/ImageDataPixelFormat.h: Renamed from Source/WebCore/html/ImageDataStorageFormat.h.
(WebCore::toPixelFormat):
(WebCore::toImageDataPixelFormat):
* Source/WebCore/html/ImageDataPixelFormat.idl: Renamed from Source/WebCore/html/ImageDataStorageFormat.idl.
* Source/WebCore/html/ImageDataSettings.h:
* Source/WebCore/html/ImageDataSettings.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::pixelFormat const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl:

Canonical link: <a href="https://commits.webkit.org/299673@main">https://commits.webkit.org/299673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb6c1986a011be889789f508c8802fbc8bcabf1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119824 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71897 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72236767-5c15-4052-b393-e1f7d7c48847) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60296 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d89ef78-34d0-470c-bbef-d4e20f5086b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71561 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b618a75c-3e49-429f-8878-f21c1415caf8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25552 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69780 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129070 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118340 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99613 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25244 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44898 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46606 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52312 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147038 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46072 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37781 "Found 1 new JSC binary failure: testapi, Found 18641 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49421 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47758 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->