### PR TITLE
Remove redundant sandbox rules in the GPU process

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -90,12 +90,6 @@
         (require-all
             (extension-class "com.apple.mediaserverd.read")
             (subpath "/System/Library")))
-    (let ((hw-identifying-paths
-            (require-any
-                (literal "/System/Library/Caches/apticket.der")
-                (subpath "/System/Library/Caches/com.apple.kernelcaches")
-                (subpath "/System/Library/Caches/com.apple.factorydata"))))
-        (deny file-issue-extension file-read* hw-identifying-paths))
     
     (allow file-map-executable
            (subpath "/System/Library")
@@ -117,12 +111,6 @@
     (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
 
     (allow-read-and-issue-generic-extensions (executable-bundle))
-
-    ;; <rdar://problem/13963294>
-    (deny file-read-data file-issue-extension file-map-executable
-        (require-all
-            (executable-bundle)
-            (regex #"/[^/]+/SC_Info/")))
 
     (unless (defined? 'restrictive-extension)
         (with-filter
@@ -355,13 +343,6 @@
 (deny mach-lookup NO_REPORT
     (global-name "com.apple.audio.AudioComponentRegistrar"))
 
-(deny mach-lookup
-    (xpc-service-name "com.apple.iconservices")
-    (global-name
-        "com.apple.PowerManagement.control"
-        "com.apple.iconservices"
-        "com.apple.frontboard.systemappservices"))
-
 (allow mach-lookup
     (global-name "com.apple.systemstatus.activityattribution"))
 
@@ -369,13 +350,6 @@
 
 (allow mach-lookup
     (global-name "com.apple.audio.AudioQueueServer"))
-
-;; These services have been identified as unused during living-on.
-;; This list overrides some definitions above and in common.sb.
-;; FIXME: remove overridden rules once the final list has been
-;; established, see https://bugs.webkit.org/show_bug.cgi?id=193840
-(deny mach-lookup
-    (global-name "com.apple.webkit.camera"))
 
 (deny syscall-unix (with telemetry))
 (when (defined? 'SYS_crossarch_trap)

--- a/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
@@ -196,9 +196,6 @@
         "com.apple.Metal")) ;; <rdar://problem/25535471>
 
 (define-once (device-access)
-    (deny file-read* file-write*
-          (vnode-type BLOCK-DEVICE CHARACTER-DEVICE))
-
     (allow file-read* file-write-data file-ioctl
            (literal "/dev/dtracehelper"))
 


### PR DESCRIPTION
#### b37182aef35f38c4e762624a1a57a81e82eec701
<pre>
Remove redundant sandbox rules in the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=298440">https://bugs.webkit.org/show_bug.cgi?id=298440</a>
<a href="https://rdar.apple.com/159937816">rdar://159937816</a>

Reviewed by Sihui Liu.

Since the default is to deny access, there is no need to have explicit deny rules, unless they have modifiers that are not default.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb:

Canonical link: <a href="https://commits.webkit.org/299663@main">https://commits.webkit.org/299663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/841d231c45374d0f984b51d8b0b23e52516b3c8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71693 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0156e24-c3fc-463d-81f4-232418ef3b0a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90856 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60156 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62a59de3-6ba3-439d-b40e-9d3bc729f563) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/293cdd31-2c7d-4e20-bea0-e803fc74e99b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30972 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69548 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99452 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99294 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22743 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43105 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19052 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52109 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49218 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->