### PR TITLE
Combine WTF clang submodules into one where possible.

### DIFF
--- a/Source/WTF/Configurations/modulemap.toml
+++ b/Source/WTF/Configurations/modulemap.toml
@@ -1,46 +1,47 @@
 module-name = 'wtf'
-config-macros = ['UCHAR_TYPE']
-requirements = ['cplusplus11']
-
-# Swift's C++ import struggles with some of the templates found in
-# WTF. To avoid Swift trying to import everything, we divide WTF
-# into lots of submodules. This is why we can't use features such
-# as an umbrella directory.
-one-submodule-per-header = true
-
+default-module = 'Cpp'
 # This header depends on surrounding preprocessor context.
 textual-headers = ['spi/mac/MetadataSPI.h']
 
-# Some WTF modules can be used in C contexts
-[module.Assertions]
-attributes = ['extern_c']
-requirements = []
+# Nearly all of WTF depends upon C++ and thus goes in this submodule.
+[module.Cpp]
+requirements = ['cplusplus11']
+
+# The following WTF headers can be used in C contexts as well as C++
+# so we put them in a separate submodule. We'll call it Platform
+# since the majority of the files are Platform-related.
+# (Some are interdependent so we couldn't split them into
+# totally standalone submodules even if we wanted to.)
+[module.Platform]
+headers = ['Assertions.h',
+    'Compiler.h', 'ExportMacros.h', 'spi/cocoa/IOSurfaceSPI.h', 'SwiftBridging.h',
+    'Platform.h', 'PlatformCallingConventions.h', 'PlatformCPU.h',
+    'PlatformEnable.h', 'PlatformEnableCocoa.h', 'PlatformHave.h',
+    'PlatformLegacy.h', 'PlatformOS.h', 'PlatformUse.h']
+
+# AutodrainedPool must never be parsed in an objective-C
+# context.
 [module.AutodrainedPool]
 requirements = ['cplusplus11', '!objc']
-[module.Compiler]
-attributes = ['extern_c']
-requirements = []
-[module.ExportMacros]
-attributes = ['extern_c']
-requirements = []
-[module.IOSurfaceSPI]
-attributes = ['extern_c']
-requirements = []
-[module.SwiftBridging]
-attributes = ['extern_c']
-requirements = []
-[module.HashMap]
-# These two headers depend on one another in a circular fashion
-# so we need to keep them together in the same submodule.
-headers = ['HashMap.h', 'RobinHoodHashTable.h']
-[module.Platform]
-requirements = []
-# These headers depend on one another in a circular fashion
-# so we need to keep them together in the same submodule.
-headers = ['Platform.h', 'PlatformCallingConventions.h', 'PlatformCPU.h',
-           'PlatformEnable.h', 'PlatformEnableCocoa.h', 'PlatformHave.h',
-           'PlatformLegacy.h', 'PlatformOS.h', 'PlatformUse.h']
-[module.SoftLinking]
-# These two headers depend on one another in a circular fashion
-# so we need to keep them together in the same submodule.
-headers = ['SoftLinking.h', 'cocoa/SoftLinking.h']
+headers = ['AutodrainedPool.h']
+
+# Works only on some platforms.
+[module.MetadataSPI]
+requirements = ['cplusplus11']
+headers = ['spi/mac/MetadataSPI.h']
+
+# Swiftc cannot currently parse various bits of WTF so we have to
+# exile them outside the main WTF module.
+
+# Swift cannot understand a std::optional in here, rdar://152718041.
+[module.TextBreakIterator]
+headers = ['text/TextBreakIterator.h']
+requirements = ['cplusplus11']
+
+# Due to conflict between wtf::Task and Swift.Task.
+# FIXME: resolve this using a typealias in Foundation+Extras.swift,
+# as we have done for other similarly conflicting types, but
+# which for some reason doesn't seem to work for Task.
+[module.CoroutineUtilities]
+headers = ['CoroutineUtilities.h']
+requirements = ['cplusplus11']

--- a/Source/WTF/Scripts/modulemap-from-tapi-filelist.py
+++ b/Source/WTF/Scripts/modulemap-from-tapi-filelist.py
@@ -29,10 +29,10 @@ else:
 
 config.setdefault('attributes', [])
 config.setdefault('config-macros', [])
-config.setdefault('one-submodule-per-header', False)
 config.setdefault('requirements', [])
 config.setdefault('textual-headers', [])
 config.setdefault('module', {})
+config.setdefault('default-module', '')
 
 submodule_mappings = {path: module_name
                       for module_name, module in config['module'].items()
@@ -45,11 +45,7 @@ for header in filelist['headers']:
         path_to_header = (path_to_header.removeprefix('PrivateHeaders/')
                           .removeprefix('Headers/'))
     if path_to_header not in submodule_mappings:
-        if config['one-submodule-per-header']:
-            default_submodule_name = os.path.splitext(os.path.basename(path_to_header))[0].replace('-', '')
-            submodule_mappings[path_to_header] = default_submodule_name
-        else:
-            submodule_mappings[path_to_header] = ''
+        submodule_mappings[path_to_header] = config.get('default-module')
 
 if config.get('framework-module'):
     sys.stdout.write('framework ')
@@ -83,7 +79,8 @@ for module_name, paths in itertools.groupby(
         sys.stdout.write(indent)
         if path in config['textual-headers']:
             sys.stdout.write('textual ')
-        sys.stdout.write(f'header "{path}"\nexport *\n')
+        sys.stdout.write(f'header "{path}"\n')
+    sys.stdout.write(f'{indent}export *\n')
     if in_submodule:
         sys.stdout.write('    }\n')
 


### PR DESCRIPTION
#### b41b7e718111d895fe022a4f325b59d086be684f
<pre>
Combine WTF clang submodules into one where possible.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298441">https://bugs.webkit.org/show_bug.cgi?id=298441</a>
<a href="https://rdar.apple.com/159939714">rdar://159939714</a>

Reviewed by Elliott Williams.

This commit significantly changes the modulemap made for the WTF component of
WebKit. Previously, each WTF header (with a few exceptions) ended up in its
own explicit clang module - essentially there were hundreds of small
modules. With this change, we combine all headers into a single module
except for a small number of exceptions, as outlined in
the modulemap.toml comments.

It is hoped that this demands less precision from users of WTF about which
exact header files they include.

There are two other intentional functional changes in this commit.
Previously, the outermost &quot;requires cplusplus11&quot; directive
accidentally applied even to the Platform submodule which was OK
to be included in plain C code. This has been fixed; there is no
longer such an outermost &quot;requires cplusplus11&quot; directive and
all parts of WTF which require C++ are now in a single large
submodule.

In addition, the config macro UCHAR_TYPE is no longer necessary to build
WTF properly, and has been removed.

* Source/WTF/Configurations/modulemap.toml:
* Source/WTF/Scripts/modulemap-from-tapi-filelist.py:

Canonical link: <a href="https://commits.webkit.org/299795@main">https://commits.webkit.org/299795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6883c55f0c59e878b4a391f8fa6364ddab2987df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72184 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fab5e71c-3185-48e9-95c8-5c16d3068a81) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91220 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60526 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a96be29-a50f-4981-9ab7-35533fed63fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107695 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71771 "2 api tests failed or timed out") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16dc15ce-0680-43ab-8950-87e078e18e50) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70087 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112236 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129364 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118627 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99835 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25323 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52599 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147326 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46361 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37858 "Found 1 new JSC binary failure: testapi, Found 18674 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49708 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->