### PR TITLE
Broaden Swift memory safety to all of WebKit

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -127,3 +127,9 @@ WK_LIBCPP_ASSERTIONS_CFLAGS[sdk=macosx14*] = -D_LIBCPP_ENABLE_ASSERTIONS=1;
 WK_LIBCPP_ASSERTIONS_CFLAGS[sdk=appletv*17*] = -D_LIBCPP_ENABLE_ASSERTIONS=1;
 WK_LIBCPP_ASSERTIONS_CFLAGS[sdk=watch*10*] = -D_LIBCPP_ENABLE_ASSERTIONS=1;
 
+// Enable strict memory safety in Swift, and treat any such warnings as errors.
+// Enable for sufficiently recent Xcode only.
+WK_SWIFT_MEMORY_SAFETY_FLAGS = $(WK_SWIFT_MEMORY_SAFETY_FLAGS_$(WK_XCODE_BEFORE_17));
+WK_SWIFT_MEMORY_SAFETY_FLAGS_ = -Werror StrictMemorySafety -strict-memory-safety -enable-experimental-feature Lifetimes -enable-experimental-feature LifetimeDependence;
+
+OTHER_SWIFT_FLAGS = $(inherited) $(WK_SWIFT_MEMORY_SAFETY_FLAGS);

--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -99,7 +99,8 @@ WK_SWIFT_OBJC_INTEROP_MODE_ENABLE_WEBGPU_SWIFT = objcxx;
 // FIXME: reenable this once rdar://154887575 lands
 // SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp $(OTHER_SWIFT_FLAGS_$(WK_PLATFORM_NAME)) -strict-memory-safety -enable-experimental-feature Lifetimes -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers -Xcc -fvisibility=hidden;
+// FIXME: broaden SafeInteropWrappers to all of WebKit; rdar://159439903
+OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp $(OTHER_SWIFT_FLAGS_$(WK_PLATFORM_NAME)) -enable-experimental-feature SafeInteropWrappers -Xcc -fvisibility=hidden;
 OTHER_SWIFT_FLAGS_macosx = $(OTHER_SWIFT_FLAGS$(WK_MACOS_1400));
 OTHER_SWIFT_FLAGS_maccatalyst = $(OTHER_SWIFT_FLAGS$(WK_MACCATALYST_14));
 OTHER_SWIFT_FLAGS_iphoneos = $(OTHER_SWIFT_FLAGS$(WK_IOS_17));

--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -64,12 +64,6 @@ BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 SWIFT_INSTALL_OBJC_HEADER = NO;
 SWIFT_LIBRARY_LEVEL = api;
 
-// Enable strict memory safety in Swift, and treat any such warnings as errors.
-// In time this should be promoted to CommonBase.xcconfig so it applies more broadly.
-// Enable for sufficiently recent Xcode only.
-WK_SWIFT_WERROR_FLAGS = $(WK_SWIFT_WERROR_FLAGS_$(WK_XCODE_BEFORE_17));
-WK_SWIFT_WERROR_FLAGS_ = -Werror StrictMemorySafety;
-
 // Use handwritten SPI modules on public SDKs.
 SWIFT_INCLUDE_PATHS = $(SRCROOT)/Modules/Internal $(SWIFT_INCLUDE_PATHS_$(USE_INTERNAL_SDK));
 SWIFT_INCLUDE_PATHS_ = $(SRCROOT)/Platform/spi/visionos $(SRCROOT)/Platform/spi/ios $(SRCROOT)/Platform/spi/Cocoa $(SRCROOT)/Platform/spi/Cocoa/Modules $(inherited);
@@ -389,7 +383,7 @@ SWIFT_OBJC_INTEROP_MODE_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = $(inherited);
 
 // FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
 // FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
-OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)) $(WK_SWIFT_WERROR_FLAGS);
+OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP));
 OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_YES = -Xcc -std=c++2b -no-verify-emitted-module-interface;
 OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = ;
 

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -236,7 +236,8 @@ struct ContentView: View {
                 .findNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
                     do {
-                        for try await event in viewModel.page.navigations {
+                        // Safety: this is actually safe; false positive is rdar://154775389
+                        for try await unsafe event in viewModel.page.navigations {
                             print(event)
                         }
                     } catch {

--- a/Tools/TestWebKitAPI/TestPDFDocument.swift
+++ b/Tools/TestWebKitAPI/TestPDFDocument.swift
@@ -120,16 +120,25 @@ typealias CocoaColor = NSColor
 
         CGContextDrawPDFPageWithAnnotations(context, cgPage, nil)
 
-        let pixels = UnsafeMutableRawBufferPointer(start: context.data, count: context.width * context.height * 4)
-
         let x = Int(point.x)
         let y = Int(point.y)
         let index = (y * x * 4) + (x * 4)
 
+        #if swift(>=6.2)
+        // FIXME: document safety invariants here. Is CGContext always guaranteed to
+        // contain a context.data of the right size at this point?
+        let pixels = unsafe UnsafeMutableRawBufferPointer(start: context.data, count: context.width * context.height * 4)
+        let r = unsafe pixels[index]
+        let g = unsafe pixels[index + 1]
+        let b = unsafe pixels[index + 2]
+        let a = unsafe pixels[index + 3]
+        #else
+        let pixels = UnsafeMutableRawBufferPointer(start: context.data, count: context.width * context.height * 4)
         let r = pixels[index]
         let g = pixels[index + 1]
         let b = pixels[index + 2]
         let a = pixels[index + 3]
+        #endif
 
         if a == 0 {
             return .clear

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
@@ -32,7 +32,8 @@ extension RangeReplaceableCollection {
     ) async throws(Failure) where Failure: Error {
         self.init()
 
-        for try await element in sequence {
+        // Safety: this is actually safe; false positive is rdar://154775389
+        for try await unsafe element in sequence {
             append(element)
         }
     }
@@ -40,7 +41,8 @@ extension RangeReplaceableCollection {
 
 extension AsyncSequence {
     func wait(isolation: isolated (any Actor)? = #isolation) async throws(Failure) {
-        for try await _ in self {
+        // Safety: this is actually safe; false positive is rdar://154775389
+        for try await unsafe _ in self {
         }
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -148,12 +148,14 @@ struct URLSchemeHandlerTests {
         var secondEvents: [WebPage.NavigationEvent] = []
 
         do {
-            for try await firstEvent in page.load(URL(string: "testing://main")) {
+            // Safety: this is actually safe; false positive is rdar://154775389
+            for try await unsafe firstEvent in page.load(URL(string: "testing://main")) {
                 firstEvents.append(firstEvent)
 
                 if firstEvent == .startedProvisionalNavigation {
                     do {
-                        for try await secondEvent in page.load(URL(string: "testing://main2")) {
+                        // Safety: this is actually safe; false positive is rdar://154775389
+                        for try await unsafe secondEvent in page.load(URL(string: "testing://main2")) {
                             secondEvents.append(secondEvent)
                         }
                     } catch {

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
@@ -62,7 +62,8 @@ struct WebPageNavigationTests {
         let expected: [WebPage.NavigationEvent] = [.startedProvisionalNavigation]
 
         await #expect(throws: (any Error).self) {
-            for try await event in sequence {
+            // Safety: this is actually safe; false positive is rdar://154775389
+            for try await unsafe event in sequence {
                 actual.append(event)
             }
         }
@@ -80,7 +81,8 @@ struct WebPageNavigationTests {
 
         // FIXME: `#expect` should work here, but due to a Swift Testing issue causes the test to hang.
         do {
-            for try await event in sequence where event == .startedProvisionalNavigation {
+            // Safety: this is actually safe; false positive is rdar://154775389
+            for try await unsafe event in sequence where event == .startedProvisionalNavigation {
                 page.stopLoading()
             }
             Issue.record("Stopping page load should trigger an error and therefore the loop should never finish.")
@@ -102,7 +104,8 @@ struct WebPageNavigationTests {
 
         await withCheckedContinuation { continuation in
             task = Task {
-                for try await event in sequence {
+                // Safety: this is actually safe; false positive is rdar://154775389
+                for try await unsafe event in sequence {
                     if event == .startedProvisionalNavigation {
                         continuation.resume()
                     } else {
@@ -119,7 +122,8 @@ struct WebPageNavigationTests {
 
         // FIXME: `#expect` should work here, but due to a Swift Testing issue causes the test to hang.
         do {
-            for try await event in allNavigations {
+            // Safety: this is actually safe; false positive is rdar://154775389
+            for try await unsafe event in allNavigations {
                 actualEvents.append(event)
             }
             Issue.record("The stream is indefinite and therefore should never reach here.")
@@ -140,7 +144,8 @@ struct WebPageNavigationTests {
 
         // FIXME: `#expect` should work here, but a Swift Testing issue causes the test to hang.
         do {
-            for try await event in sequence where event == .startedProvisionalNavigation {
+            // Safety: this is actually safe; false positive is rdar://154775389
+            for try await unsafe event in sequence where event == .startedProvisionalNavigation {
                 page.terminateWebContentProcess()
             }
             Issue.record("Terminating the web content process should trigger an error and therefore the loop should never finish.")


### PR DESCRIPTION
#### 7e93e3efdde45416d53639958ae522367bd2f4bd
<pre>
Broaden Swift memory safety to all of WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=297589">https://bugs.webkit.org/show_bug.cgi?id=297589</a>
<a href="https://rdar.apple.com/158673557">rdar://158673557</a>

Reviewed by Mike Wyrzykowski and Elliott Williams

This moves the Strict Memory Safety Swift compiler flag from WebKit.xcconfig to
an alternative config file that applies to nearly all WebKit targets.

It also broadens the set of flags we use to match those that WebGPU has
determined to be best.

This is the second attempt to land this change. The first one ran into an error
in older versions of the Swift @Test macro where it emitted unsafe code
(<a href="https://rdar.apple.com/151238560">rdar://151238560</a>). As it happens, WebKit&apos;s continuous integration
infrastructure already has a fix for that in place, but that fix isn&apos;t
being picked up due to some other problem where Swift is sometimes
using an older version of the macro dylib (<a href="https://rdar.apple.com/159858481">rdar://159858481</a>). This needs
to be resolved before we land this commit again. But, those problems
are unrelated to the content of this commit so it&apos;s identical to what
we landed last time.

Canonical link: <a href="https://commits.webkit.org/299897@main">https://commits.webkit.org/299897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31e2263574a036f926bf557c2eddc9e2eef00ac7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72682 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bf08014-3081-4778-884b-b58a814728cc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91599 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60860 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6bc3f50-7d6a-4992-9fd0-9544dde44cc4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72149 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce201d45-b81f-4ea8-b66e-6a84db822084) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26218 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70604 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129868 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100220 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100061 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23536 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44187 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53095 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46858 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50205 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48545 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->