### PR TITLE
Internals should inherit CanMakeWeakPtr if MEDIA_STREAM is disabled

### DIFF
--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -206,6 +206,8 @@ class Internals final
     , public RealtimeMediaSourceObserver
     , private RealtimeMediaSource::AudioSampleObserver
     , private RealtimeMediaSource::VideoFrameObserver
+#else
+    , public CanMakeWeakPtr<Internals>
 #endif
     {
     WTF_MAKE_TZONE_ALLOCATED(Internals);


### PR DESCRIPTION
#### 6034fa91d835adc6c8a9d5e4ce342f5fa33684c6
<pre>
Internals should inherit CanMakeWeakPtr if MEDIA_STREAM is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=298445">https://bugs.webkit.org/show_bug.cgi?id=298445</a>

Reviewed by Michael Catanzaro.

If MEDIA_STREAM is enabled, then Internals inherits
RealtimeMediaSourceObserver, which inherits CanMakeWeakPtr. After R294499,
CanMakeWeakPtr is needed if MEDIA_CODECS is enabled, so it needs to be
inherited explicitly if MEDIA_STREAM is not also enabled.

* Source/WebCore/testing/Internals.h:

Canonical link: <a href="https://commits.webkit.org/306232@main">https://commits.webkit.org/306232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b81b3ecd72adf3c83f3a6caa8948a45aa7378a07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60170 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30987 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128887 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46561 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99470 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46926 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35269 "Found 1 new test failure: http/tests/cache/disk-cache/disk-cache-302-status-code.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44736 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103468 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43125 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46423 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22759 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45889 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52129 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->