### PR TITLE
[GTK][WPE][OpenXR] Support running OpenXR API tests on bots

### DIFF
--- a/Tools/Scripts/webkitpy/port/monadodriver.py
+++ b/Tools/Scripts/webkitpy/port/monadodriver.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2025 Igalia S.L. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import os
+
+from webkitpy.port.driver import Driver
+
+_log = logging.getLogger(__name__)
+
+
+class MonadoDriver(Driver):
+    @staticmethod
+    def check_driver(port):
+        monado_findcmd = ['which', 'monado-service']
+        monado_found = port.host.executive.run_command(monado_findcmd, return_exit_code=True) == 0
+        if not monado_found:
+            _log.error("No monado-service found. Cannot run OpenXR API tests.")
+        return monado_found
+
+    def __init__(self, *args, **kwargs):
+        Driver.__init__(self, *args, **kwargs)
+
+    def _setup_environ_for_test(self):
+        driver_environment = super(MonadoDriver, self)._setup_environ_for_test()
+        driver_environment['WITH_OPENXR_RUNTIME'] = 'y'
+        driver_environment['XRT_COMPOSITOR_NULL'] = 'TRUE'
+
+        monado_command = ['monado-service']
+        with open(os.devnull, 'w') as devnull:
+            self._monado_service_process = self._port.host.executive.popen(monado_command, stderr=devnull, env=driver_environment)
+
+        return driver_environment
+
+    def stop(self):
+        super(MonadoDriver, self).stop()
+        if getattr(self, '_monado_service_process', None):
+            self._monado_service_process.terminate()
+            self._monado_service_process = None

--- a/Tools/Scripts/webkitpy/port/monadodriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/monadodriver_unittest.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2025 Igalia S.L. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import re
+import unittest
+
+from webkitpy.port.monadodriver import MonadoDriver
+from webkitpy.common.system.systemhost_mock import MockSystemHost
+from webkitpy.port import Port
+from webkitpy.port.server_process_mock import MockServerProcess
+from webkitpy.tool.mocktool import MockOptions
+
+from webkitcorepy import OutputCapture
+
+_log = logging.getLogger(__name__)
+
+
+class MonadoDriverTest(unittest.TestCase):
+    def make_driver(self):
+        port = Port(MockSystemHost(log_executive=True), 'monadodrivertestport', options=MockOptions(configuration='Release'))
+        port._config.build_directory = lambda configuration: "/mock_build"
+        port._test_runner_process_constructor = MockServerProcess
+
+        driver = MonadoDriver(port, worker_number=0, pixel_tests=True)
+        driver._startup_delay_secs = 0
+        driver._environment = port.setup_environ_for_server(port.driver_name())
+        return driver
+
+    def test_start(self):
+        driver = self.make_driver()
+        with OutputCapture(level=logging.INFO) as captured:
+            driver.start(pixel_tests=True, per_test_args=[])
+
+        self.assertTrue(
+            re.match(
+                r"MOCK popen: \['monado-service'\], env=.*\n",
+                captured.root.log.getvalue(),
+            ),
+            None,
+        )
+        self.assertEqual(driver._server_process.env['WITH_OPENXR_RUNTIME'], 'y')
+        self.assertTrue(driver._server_process.started)
+
+        driver._monado_service_process = None
+
+    def test_stop(self):
+        class FakeMonadoServiceProcess(object):
+            def terminate(self):
+                _log.info("MOCK FakeMonadoServiceProcess.terminate")
+
+        driver = self.make_driver()
+        driver._monado_service_process = FakeMonadoServiceProcess()
+
+        with OutputCapture(level=logging.INFO) as captured:
+            driver.stop()
+        self.assertEqual(captured.root.log.getvalue(), 'MOCK FakeMonadoServiceProcess.terminate\n')
+
+        self.assertIsNone(driver._monado_service_process)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp
@@ -38,17 +38,17 @@ static const char indexHTML[] =
 "});"
 "</script></body></html>";
 
-class ImmersiveModeTest : public WebViewTest {
+class WebXRTest : public WebViewTest {
 public:
-    MAKE_GLIB_TEST_FIXTURE(ImmersiveModeTest);
+    MAKE_GLIB_TEST_FIXTURE(WebXRTest);
 
-    static void isImmersiveModeEnabledChanged(GObject*, GParamSpec*, ImmersiveModeTest* test)
+    static void isImmersiveModeEnabledChanged(GObject*, GParamSpec*, WebXRTest* test)
     {
         g_signal_handlers_disconnect_by_func(test->webView(), reinterpret_cast<void*>(isImmersiveModeEnabledChanged), test);
         g_main_loop_quit(test->m_mainLoop);
     }
 
-    static gboolean permissionRequestCallback(WebKitWebView*, WebKitPermissionRequest *request, ImmersiveModeTest* test)
+    static gboolean permissionRequestCallback(WebKitWebView*, WebKitPermissionRequest *request, WebXRTest* test)
     {
         g_assert_true(WEBKIT_IS_XR_PERMISSION_REQUEST(request));
         g_assert_true(test->m_isExpectingPermissionRequest);
@@ -108,7 +108,7 @@ static void serverCallback(SoupServer*, SoupServerMessage* message, const char* 
         g_assert_not_reached();
 }
 
-static void testWebKitImmersiveModeLeaveImmersiveModeAndWaitUntilImmersiveModeChanged(ImmersiveModeTest* test, gconstpointer)
+static void testWebKitWebXRLeaveImmersiveModeAndWaitUntilImmersiveModeChanged(WebXRTest* test, gconstpointer)
 {
     if (!g_getenv("WITH_OPENXR_RUNTIME")) {
         g_test_skip("Unable to run without an OpenXR runtime");
@@ -135,7 +135,7 @@ void beforeAll()
     kHttpsServer = new WebKitTestServer(WebKitTestServer::ServerHTTPS);
     kHttpsServer->run(serverCallback);
 
-    ImmersiveModeTest::add("WebKitImmersiveMode", "leave-immersive-mode", testWebKitImmersiveModeLeaveImmersiveModeAndWaitUntilImmersiveModeChanged);
+    WebXRTest::add("WebKitWebXR", "leave-immersive-mode", testWebKitWebXRLeaveImmersiveModeAndWaitUntilImmersiveModeChanged);
 }
 
 void afterAll()

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -169,7 +169,7 @@ ADD_WK2_TEST(TestGeolocationManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/
 ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp)
 
 if (ENABLE_WEBXR AND USE_OPENXR)
-    ADD_WK2_TEST(TestWebKitImmersiveMode ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImmersiveMode.cpp)
+    ADD_WK2_TEST(TestWebKitWebXR ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp)
 endif ()
 
 if (ENABLE_WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -517,10 +517,10 @@
             }
         }
     },
-    "TestWebKitImmersiveMode": {
+    "TestWebKitWebXR": {
         "subtests": {
-            "/webkit/WebKitImmersiveMode/leave-immersive-mode": {
-                "expected": {"all" : {"status": ["SKIP"], "bug": "webkit.org/b/297261"}}
+            "/webkit/WebKitWebXR/leave-immersive-mode": {
+                "expected": {"gtk" : {"status": ["SKIP"], "bug": "webkit.org/b/299080"}}
             }
         }
     }


### PR DESCRIPTION
#### 29adb1630b2ab13438013d0a2fcd64a7d2bd6fc8
<pre>
[GTK][WPE][OpenXR] Support running OpenXR API tests on bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=297261">https://bugs.webkit.org/show_bug.cgi?id=297261</a>

Reviewed by Carlos Alberto Lopez Perez.

This adds support for running OpenXR API tests to the bots using
monado-service.

A new Monado driver (in a ~loose way) is added. This checks if
monado-service is available on the given port, and launches it with
XRT_COMPOSITOR_NULL, removing any dependency against Wayland, X11 or
other compositors, and so allowing run-{gtk,wpe}-tests to still handle
the --display-server they receive.

The existing TestWebKitImmersiveMode.cpp is renamed to
TestWebKitWebXR.cpp, allowing the test runner to check is_openxr_test
by name. The TestExpectations are updated to mark the test as passing on
WPE, where the bots have been updated to support monado-service, the GTK
ones will follow later.

* Tools/Scripts/webkitpy/port/monadodriver.py: Added.
(MonadoDriver):
(MonadoDriver.check_driver):
(MonadoDriver.__init__):
(MonadoDriver._setup_environ_for_test):
(MonadoDriver.stop):
* Tools/Scripts/webkitpy/port/monadodriver_unittest.py: Added.
(MonadoDriverTest):
(MonadoDriverTest.make_driver):
(MonadoDriverTest.test_start):
(MonadoDriverTest.test_stop):
(MonadoDriverTest.test_stop.FakeMonadoServiceProcess):
(MonadoDriverTest.test_stop.FakeMonadoServiceProcess.terminate):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp: Renamed from Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImmersiveMode.cpp.
(WebXRTest::isImmersiveModeEnabledChanged):
(WebXRTest::permissionRequestCallback):
(testWebKitWebXRLeaveImmersiveModeAndWaitUntilImmersiveModeChanged):
(beforeAll):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/TestWebKitAPI/glib/TestExpectations.json:
* Tools/glib/api_test_runner.py:
(TestRunner.__init__):
(TestRunner._tear_down_testing_environment):
(TestRunner._run_test_glib):
(TestRunner.is_webxr_test):
(TestRunner.run_tests):

Canonical link: <a href="https://commits.webkit.org/300454@main">https://commits.webkit.org/300454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fe0d1bf0418a2c1f0becf6e02abb04eab1b57a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92517 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61507 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73181 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/121113 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27208 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131071 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101107 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100980 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45392 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48549 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->