### PR TITLE
Limit the scope of invalidation traversal for `:has(.changed) > .subject`

### DIFF
--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -56,6 +56,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
             return isChild;
         case MatchElement::HasDescendant:
         case MatchElement::HasSiblingDescendant:
+        case MatchElement::HasDescendantParent:
         case MatchElement::HasNonSubject:
         case MatchElement::HasScopeBreaking:
             return true;

--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -131,6 +131,7 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
         case MatchElement::HasChild:
         case MatchElement::HasChildParent:
         case MatchElement::HasChildAncestor:
+        case MatchElement::HasDescendantParent:
         case MatchElement::HasDescendant:
         case MatchElement::HasSibling:
         case MatchElement::HasSiblingDescendant:

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -61,6 +61,7 @@ static bool isSiblingOrSubject(MatchElement matchElement)
     case MatchElement::HasSiblingDescendant:
     case MatchElement::HasChildParent:
     case MatchElement::HasChildAncestor:
+    case MatchElement::HasDescendantParent:
     case MatchElement::HasNonSubject:
     case MatchElement::HasScopeBreaking:
         return false;
@@ -109,6 +110,7 @@ static bool isScopeBreaking(MatchElement matchElement)
     case MatchElement::HasSiblingDescendant:
     case MatchElement::HasChildParent:
     case MatchElement::HasChildAncestor:
+    case MatchElement::HasDescendantParent:
     case MatchElement::HasNonSubject:
         return false;
     }
@@ -237,6 +239,7 @@ MatchElement computeHasPseudoClassMatchElement(const CSSSelector& hasSelector)
     case MatchElement::HasAnySibling:
     case MatchElement::HasChildParent:
     case MatchElement::HasChildAncestor:
+    case MatchElement::HasDescendantParent:
     case MatchElement::HasNonSubject:
     case MatchElement::HasScopeBreaking:
     case MatchElement::Host:
@@ -275,6 +278,12 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
                 if (matchElement == MatchElement::Ancestor)
                     return MatchElement::HasChildAncestor;
             }
+
+            if (hasSelectorMatchElement == MatchElement::HasDescendant) {
+                if (matchElement == MatchElement::Parent)
+                    return MatchElement::HasDescendantParent;
+            }
+
 
             if (matchElement != MatchElement::Subject)
                 return MatchElement::HasNonSubject;

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -38,29 +38,35 @@ namespace Style {
 
 class RuleData;
 
-// FIXME: Has* values should be separated so we could describe both the :has() argument and its position in the selector.
+// MatchElement characterizes which elements a change in an element matched by a simple selector (as a part of a complex selector) may affect.
+// Style::Invalidator uses these classifications to traverse a minimal number of elements after a DOM mutation.
+// In the examples below the '.changed' simple selector will be classified with the given enum value.
+// FIXME: Has* values should be separated so we could better describe both the :has() argument and its position in the selector.
 enum class MatchElement : uint8_t {
-    Subject,
-    Parent,
-    Ancestor,
-    DirectSibling,
-    IndirectSibling,
-    AnySibling,
-    ParentSibling,
-    AncestorSibling,
-    ParentAnySibling,
-    AncestorAnySibling,
-    HasChild,
-    HasDescendant,
-    HasSibling,
-    HasSiblingDescendant,
-    HasAnySibling,
-    HasChildParent,
-    HasChildAncestor,
-    HasNonSubject, // FIXME: This is a catch-all for the rest of cases where :has() is in a non-subject position.
-    HasScopeBreaking, // FIXME: This is a catch-all for cases where :has() contains a scope breaking sub-selector like, like :has(:is(.x .y)).
-    Host,
-    HostChild
+    Subject, // .changed
+    Parent, // .changed > .subject
+    Ancestor, // .changed .subject
+    DirectSibling, // .changed + .subject
+    IndirectSibling, // .changed ~ .subject
+    AnySibling, // :nth-last-child(even of .changed)
+    ParentSibling, // .changed ~ .a > .subject
+    AncestorSibling, // .changed ~ .a .subject
+    ParentAnySibling, // :nth-last-child(even of .changed) > .subject
+    AncestorAnySibling, // :nth-last-child(even of .changed) .subject
+    HasChild, // :has(> .changed)
+    HasDescendant, // :has(.changed)
+    HasSibling, // :has(~ .changed)
+    HasSiblingDescendant, // :has(~ .a .changed)
+    HasAnySibling, // :has(~ :is(.changed ~ .x))
+    HasChildParent, // :has(> .changed) > .subject
+    HasChildAncestor, // :has(> .changed) .subject
+    HasDescendantParent, // :has(.changed) > .subject
+    // FIXME: This is a catch-all for the rest of cases where :has() is in a non-subject position.
+    HasNonSubject, // :has(.changed) .subject
+    // FIXME: This is a catch-all for cases where :has() contains a scope breaking sub-selector.
+    HasScopeBreaking, // :has(:is(.changed .a))
+    Host, // :host(.changed) .subject
+    HostChild // ::slotted(.changed)
 };
 constexpr unsigned matchElementCount = static_cast<unsigned>(MatchElement::HostChild) + 1;
 

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -401,6 +401,21 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         }
         break;
     }
+    case MatchElement::HasDescendantParent: {
+        // :has(.changed) > .subject
+        Vector<Element*, 16> ancestors;
+        for (auto* parent = element.parentElement(); parent; parent = parent->parentElement())
+            ancestors.append(parent);
+
+        SelectorMatchingState selectorMatchingState;
+        selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(ancestors.size());
+        for (auto* ancestor : makeReversedRange(ancestors)) {
+            selectorMatchingState.selectorFilter.pushParent(ancestor);
+            for (auto& ancestorChild : childrenOfType<Element>(*ancestor))
+                invalidateIfNeeded(ancestorChild, &selectorMatchingState);
+        }
+        break;
+    }
     case MatchElement::HasChildAncestor: {
         // :has(> .changed) .subject
         if (CheckedPtr parent = element.parentElement()) {


### PR DESCRIPTION
#### 1053d8eb088342f96f0ff8a888b6eefedde46ef4
<pre>
Limit the scope of invalidation traversal for `:has(.changed) &gt; .subject`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298442">https://bugs.webkit.org/show_bug.cgi?id=298442</a>
<a href="https://rdar.apple.com/problem/159946487">rdar://problem/159946487</a>

Reviewed by Alan Baradlay.

Similar to <a href="https://commits.webkit.org/299162@main">https://commits.webkit.org/299162@main</a>, optimize `:has(.changed) &gt; .subject` too.

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::ClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::isSiblingOrSubject):
(WebCore::Style::isScopeBreaking):
(WebCore::Style::computeHasPseudoClassMatchElement):
(WebCore::Style::computeSubSelectorMatchElement):
* Source/WebCore/style/RuleFeature.h:

Add a new enum value for this case.
Also added some documentation.

* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

Traverse the direct children of the ancestors only.

Canonical link: <a href="https://commits.webkit.org/299685@main">https://commits.webkit.org/299685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db1b22140121e7335bc6bbc1bae2189ff0daa8ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71717 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90877 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60177 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71392 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25383 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69575 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128891 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46565 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35273 "Found 1 new test failure: http/tests/cache/disk-cache/disk-cache-302-status-code.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99476 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99317 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44740 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43129 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46427 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52133 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45893 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49242 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->