### PR TITLE
[JSC] Skip more test in 32-bit JSC.

### DIFF
--- a/JSTests/wasm/lowExecutableMemory/executable-memory-oom.js
+++ b/JSTests/wasm/lowExecutableMemory/executable-memory-oom.js
@@ -1,6 +1,6 @@
 // FIXME: Consider making jump islands work with Options::jitMemoryReservationSize
 // https://bugs.webkit.org/show_bug.cgi?id=209037
-//@ skip if $architecture == "arm64"
+//@ skip if $architecture == "arm64" || $addressBits <= 32
 // This test will never fail to compile a module with this option enabled.
 
 import * as assert from '../assert.js'

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
@@ -1,3 +1,4 @@
+//@ skip if $addressBits <= 32
 //@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0")
 
 import { instantiate } from "../wabt-wrapper.js"

--- a/JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js
+++ b/JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js
@@ -1,3 +1,4 @@
+//@ skip if $addressBits <= 32
 //@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=1:2")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/wasm-js-string-builtins.js
+++ b/JSTests/wasm/stress/wasm-js-string-builtins.js
@@ -1,3 +1,4 @@
+//@ skip if $addressBits <= 32
 //@ requireOptions("--useWasmJSStringBuiltins=true")
 
 import * as assert from '../assert.js';


### PR DESCRIPTION
#### c636d4e8680ada22329650bc5dc84a73232f2c1a
<pre>
[JSC] Skip more test in 32-bit JSC.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298456">https://bugs.webkit.org/show_bug.cgi?id=298456</a>

Reviewed by Sosuke Suzuki.

For wasm-js-string-builtins.js we need to properly handle argument registers,
as the implementation always assumes 1 register per argument, which is not true
for 32-bit JSC. We need to change the implementation to also spill arguments,
which is currently not implemented in either IPInt or JITed code gen.

The other 3 need IPInt to work properly.

* JSTests/wasm/lowExecutableMemory/executable-memory-oom.js:
* JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js:
* JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js:
* JSTests/wasm/stress/wasm-js-string-builtins.js:

Canonical link: <a href="https://commits.webkit.org/299634@main">https://commits.webkit.org/299634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54fb3baba6acd290d3099468dfd037333bbb00e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71743 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47941 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/90898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107302 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/71419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69602 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111796 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128917 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118187 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46591 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/35294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99332 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25230 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44764 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/22783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46453 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146885 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45919 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37745 "Found 1 new JSC binary failure: testapi, Found 18659 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_splice_515632.js.default, ChakraCore.yaml/ChakraCore/test/Array/concat1.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->