### PR TITLE
[Filters] Applying CoreGraphics filters on different tiles may result in white borders around the tiles

### DIFF
--- a/LayoutTests/css3/filters/effect-graphics-context-blur-tile-boundaries-expected.html
+++ b/LayoutTests/css3/filters/effect-graphics-context-blur-tile-boundaries-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+    <style>
+        img {
+            transform: translate(400%, 400%) scale(8, 8);
+        }
+    </style>
+</head>
+<body>
+    <img src="resources/reference.png" style="filter: blur(5px)"> 
+</body>
+</html>

--- a/LayoutTests/css3/filters/effect-graphics-context-blur-tile-boundaries.html
+++ b/LayoutTests/css3/filters/effect-graphics-context-blur-tile-boundaries.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-452017" />
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+    <style>
+        img {
+            transform: translate(400%, 400%) scale(8, 8);
+        }
+    </style>
+</head>
+<script>
+    if (window.internals)
+        internals.settings.setGraphicsContextBlurFilterEnabled?.(true);
+</script>
+<body>
+    <img src="resources/reference.png" style="filter: blur(5px)"> 
+</body>
+</html>

--- a/Source/WebCore/rendering/LayerFragment.h
+++ b/Source/WebCore/rendering/LayerFragment.h
@@ -51,6 +51,7 @@ public:
 
         LayoutRect layerBounds() const { return m_layerBounds; }
 
+        ClipRect backgroundRect() const { return m_backgroundRect; }
         ClipRect dirtyBackgroundRect() const { return intersection(m_paintDirtyRect, m_backgroundRect); }
         ClipRect dirtyForegroundRect() const { return intersection(m_paintDirtyRect, m_foregroundRect); }
 
@@ -93,6 +94,7 @@ public:
 
     LayoutRect layerBounds() const { return rects.layerBounds(); }
 
+    ClipRect backgroundRect() const { return rects.backgroundRect(); }
     ClipRect dirtyBackgroundRect() const { return rects.dirtyBackgroundRect(); }
     ClipRect dirtyForegroundRect() const { return rects.dirtyForegroundRect(); }
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3879,7 +3879,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             updatePaintingInfoForFragments(layerFragments, paintingInfo, localPaintFlags, shouldPaintContent, offsetFromRoot);
 
             // FIXME: Handle more than one fragment.
-            backgroundRect = layerFragments.isEmpty() ? ClipRect() : layerFragments[0].dirtyBackgroundRect();
+            backgroundRect = layerFragments.isEmpty() ? ClipRect() : layerFragments[0].backgroundRect();
 
             if (haveTransparency) {
                 // If we have a filter and transparency, we have to eagerly start a transparency layer here, rather than risk a child layer lazily starts one with the wrong context.


### PR DESCRIPTION
#### 0bd4123974c84dfb807360523c27aa73a4afb92f
<pre>
[Filters] Applying CoreGraphics filters on different tiles may result in white borders around the tiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=298453">https://bugs.webkit.org/show_bug.cgi?id=298453</a>
<a href="https://rdar.apple.com/159951868">rdar://159951868</a>

Reviewed by Simon Fraser.

The transparency layer of the CoreGraphics filter should be clipped to the layer
backgroundClipRect without intersecting it with the paintDirtyRect. CoreGraphics
expects the context is set to the coordinates of the target filtered renderer
not only the dirty rectangle only.

Test: css3/filters/effect-graphics-context-blur-tile-boundaries.html
* LayoutTests/css3/filters/effect-graphics-context-blur-tile-boundaries-expected.html: Added.
* LayoutTests/css3/filters/effect-graphics-context-blur-tile-boundaries.html: Added.
* Source/WebCore/rendering/LayerFragment.h:
(WebCore::LayerFragment::Rects::backgroundRect const):
(WebCore::LayerFragment::backgroundRect const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):

Canonical link: <a href="https://commits.webkit.org/300038@main">https://commits.webkit.org/300038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dd209d18bd617e47e9f64414d823da738796e0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73161 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8edca93b-529d-4bab-b929-5baaea9f78d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91971 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61185 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d75f635-59a9-46f2-89b6-d37d60c0feb3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac7f21c2-5fdc-48a2-b54d-13a4894d5fa4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26640 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71090 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100580 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25479 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44701 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53578 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47336 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->