### PR TITLE
[iOS] fast/forms/ios/remove-view-after-focus.html is a constant crash

### DIFF
--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp
@@ -141,11 +141,14 @@ void UIScriptContext::fireCallback(unsigned callbackID)
     JSValueRef exception = nullptr;
     JSObjectRef callbackObject = JSValueToObject(m_context.get(), task.callback, &exception);
 
-    m_currentScriptCallbackID = task.parentScriptCallbackID;
+    auto currentScriptCallbackID = task.parentScriptCallbackID;
+    m_currentScriptCallbackID = currentScriptCallbackID;
 
     exception = nullptr;
     JSObjectCallAsFunction(m_context.get(), callbackObject, JSContextGetGlobalObject(m_context.get()), 0, nullptr, &exception);
-    
+
+    m_currentScriptCallbackID = currentScriptCallbackID;
+
     tryToCompleteUIScriptForCurrentParentCallback();
     m_currentScriptCallbackID = 0;
 }


### PR DESCRIPTION
#### f8c1b2ca2c261898b09e248a03856678ea7947a3
<pre>
[iOS] fast/forms/ios/remove-view-after-focus.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=298454">https://bugs.webkit.org/show_bug.cgi?id=298454</a>
<a href="https://rdar.apple.com/158973297">rdar://158973297</a>

Reviewed by Richard Robinson.

fast/forms/ios/remove-view-after-focus.html is flakily crashing on iOS 18.4 and
constantly crashing on iOS 26. However, the crash is due to an issue with the
test runner and is not a bug in WebKit.

Specifically, `UIScriptContext` is not robust against callbacks that synchronously
invoke other callbacks. `UIScriptContext::fireCallback` sets
`m_currentScriptCallbackID`, invokes the callback, and then resets
`m_currentScriptCallbackID` to 0. This is problematic, since if the invoked
callback fires another callback, `m_currentScriptCallbackID` will be zeroed out
before the outer callback finishes processing. That is,
`tryToCompleteUIScriptForCurrentParentCallback` will be called when
`m_currentScriptCallbackID` is 0. This results in accessing the `HashMap`
`m_uiScriptResultsPendingCompletion` with a key of 0, which is disallowed for
`unsigned` traits, causing a crash.

For fast/forms/ios/remove-view-after-focus.html, UIKit changes have made it
so that keyboard show/hide notifications can be synchronously dispatched under
view addition/removal. This means that `didShowKeyboardCallback` gets invoked
under `willCreateNewPageCallback`, resulting in the issue described above.

Fix by restoring the current script callback ID after a callback is invoked.
An inner callback should not affect the processing of an outer callback.

* Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp:
(UIScriptContext::fireCallback):

Canonical link: <a href="https://commits.webkit.org/299654@main">https://commits.webkit.org/299654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee0537a84df1a8b4d8a0c1d978513c2b603fbf23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71736 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4782b6a3-78ad-4cc6-b7cf-ccda5752129a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47934 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90888 "Found 1 new test failure: http/wpt/service-workers/service-worker-spinning-activate.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60187 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af854e0c-80b6-4eb3-9b4e-41b80da2a858) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71406 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d37ca70-3894-4629-8475-0c942daf7f40) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69594 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128910 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99486 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99327 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44755 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22777 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43148 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19048 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46446 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45912 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->