### PR TITLE
(New-Test) [ iOS Debug ] TestWebKitAPI.WKDownload.PlaceholderPolicyDisable is a constant timeout

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKDownloadDelegatePrivate.h>
+#import <WebKit/WKDownloadDelegate.h>
 #import <WebKit/WebKit.h>
 
 enum class DownloadCallback : uint8_t {
@@ -43,7 +43,7 @@ enum class DownloadCallback : uint8_t {
     NavigationResponse,
 };
 
-@interface TestDownloadDelegate : NSObject<WKDownloadDelegatePrivate, WKNavigationDelegate>
+@interface TestDownloadDelegate : NSObject<WKDownloadDelegate, WKNavigationDelegate>
 
 @property (nonatomic, copy) void (^willPerformHTTPRedirection)(WKDownload *, NSHTTPURLResponse *, NSURLRequest *, void (^)(WKDownloadRedirectPolicy));
 @property (nonatomic, copy) void (^didReceiveAuthenticationChallenge)(WKDownload *, NSURLAuthenticationChallenge *, void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential*));
@@ -57,7 +57,7 @@ enum class DownloadCallback : uint8_t {
 @property (nonatomic, copy) void (^decidePolicyForNavigationResponse)(WKNavigationResponse *, void (^)(WKNavigationResponsePolicy));
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-@property (nonatomic, copy) void (^decidePlaceholderPolicy)(WKDownload *, void (^)(_WKPlaceholderPolicy, NSURL *));
+@property (nonatomic, copy) void (^decidePlaceholderPolicy)(WKDownload *, void (^)(WKDownloadPlaceholderPolicy, NSURL *));
 #endif
 
 - (void)waitForDownloadDidFinish;

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
@@ -60,10 +60,10 @@
 }
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(_WKPlaceholderPolicy, NSURL *))completionHandler
+- (void)_download:(WKDownload *)download decidePlaceholderPolicy:(void (^)(WKDownloadPlaceholderPolicy, NSURL *))completionHandler
 {
     _callbackRecord.append(DownloadCallback::DecidePlaceholderPolicy);
-    completionHandler(_WKPlaceholderPolicyDisable, nil);
+    completionHandler(WKDownloadPlaceholderPolicyDisable, nil);
 }
 
 - (void)_download:(WKDownload *)download didReceivePlaceholderURL:(NSURL *)url completionHandler:(void (^)(void))completionHandler


### PR DESCRIPTION
#### 898eb53bceb3c431c7516e2e4bc09b3e55ed7e99
<pre>
(New-Test) [ iOS Debug ] TestWebKitAPI.WKDownload.PlaceholderPolicyDisable is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=298464">https://bugs.webkit.org/show_bug.cgi?id=298464</a>
<a href="https://rdar.apple.com/156426293">rdar://156426293</a>

Reviewed by Per Arne Vollan.

This test was timing out because the attached observer is never notified of any progress on the file downloads.
It needs to track the progress from the WKDownload object rather than the file itself.

But we are changing the test to better validate the placeholder policy during downloads. Rather than check the progress
of the downloads, instead we will check that the destination file correctly downloads and confirm that the
provided placeholder file is deleted after a successful download.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::PlaceholderPolicyEnable)):
(TestWebKitAPI::PlaceholderPolicyDisable)):
(-[ProgressObserver init]): Deleted.
(-[ProgressObserver observeValueForKeyPath:ofObject:change:context:]): Deleted.
(-[ProgressObserver waitForProgress]): Deleted.
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm:
(-[TestDownloadDelegate _download:decidePlaceholderPolicy:]):

Canonical link: <a href="https://commits.webkit.org/299651@main">https://commits.webkit.org/299651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcb724b1603c85b048a1d27e3fcf49fe2973c15e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71754 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b993a3f-61eb-4d51-9118-9d87e67ecb35) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90901 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abcea749-02ed-43c9-8e39-4e08c6f173a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b95c43c5-399d-4bd0-b1b6-2626cbacff5a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25419 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69614 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128928 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46602 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35304 "Found 1 new test failure: http/tests/cache/disk-cache/disk-cache-302-status-code.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99499 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99342 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43166 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19046 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46464 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45930 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49279 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->