### PR TITLE
Reduce size of Development sandboxes

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in
@@ -21,7 +21,197 @@
 ; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
-#define deny allow (with report)
-#define NO_REPORT
+#include "Shared/Sandbox/iOS/common.sb"
+#include "Shared/Sandbox/iOS/gpu-defines.sb"
 
-#include "Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in"
+(allow-for-development-rules)
+
+(allow system-fcntl
+    (system-fcntl-allowed))
+
+(with-filter (mac-policy-name "Sandbox")
+    (allow system-mac-syscall (mac-syscall-number 5 65)))
+
+(allow iokit-open-service
+    (iokit-open-service-allowed))
+(allow iokit-open-service
+    (iokit-registry-entry-class-prefix "AGXAcceleratorG"))
+
+(allow darwin-notification-post
+    (darwin-notification-post-allowed))
+
+(allow process-info-codesignature (target others))
+
+(allow file-map-executable (executable-bundle))
+
+(allow file-read-metadata
+    (vnode-type DIRECTORY))
+
+(rules-with-elevated-precedence)
+
+(allow file-read*
+    required-etc-files)
+
+(allow file-read*
+    (literal "/"))
+
+(device-access)
+
+(allow file-issue-extension (with telemetry)
+    (require-all
+        (extension-class "com.apple.app-sandbox.read-write" "com.apple.app-sandbox.read")
+        (extension "com.apple.fileprovider.read-write")))
+
+(allow mach-lookup
+    (mach-lookup-allowed))
+
+(allow mach-lookup
+    (require-all
+        (extension "com.apple.webkit.extension.mach")
+        (global-name "com.apple.mobilegestalt.xpc")))
+
+#if PLATFORM(VISION) && ENABLE(MODEL_PROCESS)
+(allow mach-lookup
+    (global-name "com.apple.surfboard.applicationservice"))
+#endif
+
+;; <rdar://problem/12413942>
+(allow file-read*
+    (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))
+
+(allow ipc-posix-sem-open (with telemetry)
+    (ipc-posix-name "containermanagerd.fb_check"))
+
+(with-filter (ipc-posix-name "purplebuddy.sentinel")
+    (allow ipc-posix-sem-open (with telemetry)))
+
+(allow system-sched (with telemetry)
+    (require-entitlement "com.apple.private.kernel.override-cpumon"))
+
+(allow ipc-posix-shm-read*
+    (ipc-posix-name "apple.shm.notification_center"))
+
+(managed-configuration-read-public)
+
+(allow-well-known-system-group-container-subpath-read
+    "/systemgroup.com.apple.icloud.findmydevice.managed/Library")
+
+(allow mach-task-name (with telemetry) (target self))
+
+(allow process-info-pidinfo)
+(allow process-info-pidfdinfo (target self))
+(allow process-info-pidfileportinfo (target self))
+(allow process-info-setcontrol (target self))
+(allow process-info-dirtycontrol (target self))
+(allow process-info-rusage (target self))
+(allow process-info-codesignature (target self))
+
+(play-audio)
+(play-media)
+
+;; Access to media controls
+(media-remote)
+
+;; Permit reading assets via MobileAsset framework.
+(asset-access 'with-media-playback)
+
+(allow file-read*
+    (subpath "/private/var/MobileAsset/AssetsV2/com_apple_MobileAsset_Font7")
+    (subpath "/private/var/MobileAsset/AssetsV2/com_apple_MobileAsset_Font8"))
+
+;; allow 3rd party applications to access nsurlstoraged's top level domain data cache
+(allow-well-known-system-group-container-literal-read
+    "/systemgroup.com.apple.nsurlstoragedresources/Library/dafsaData.bin")
+
+(allow file-read*
+    (home-subpath "/Library/Fonts"))
+
+(allow-preferences-common)
+
+;; Home Button
+(with-filter (iokit-registry-entry-class "IOPlatformDevice")
+    (allow iokit-get-properties
+        (iokit-property "home-button-type")))
+
+(uikit-requirements)
+
+; <rdar://problem/7595408> , <rdar://problem/7643881>
+(opengl)
+
+(allow sysctl-read
+    (sysctl-read-allowed)
+    (sysctl-name-prefix "hw.perflevel")) ;; <rdar://problem/76782530>
+
+(allow iokit-get-properties
+    (iokit-get-property-allowed))
+
+; IOPlatformExpertDevice
+(with-filter (iokit-registry-entry-class "IOPlatformExpertDevice")
+    (allow iokit-get-properties
+        (iokit-property
+            "model"
+            "model-number"
+            "platform-name" ;; <rdar://problem/79334360>
+            "region-info" ;; <rdar://problem/52903475>
+            "regulatory-model-number"))) ;; <rdar://problem/52903475>
+
+;; Read-only preferences and data
+(mobile-preferences-read
+    "com.apple.avfoundation.videoperformancehud") ;; <rdar://problem/31594568>
+
+;; Sandbox extensions
+(read-only-and-issue-extensions (extension "com.apple.app-sandbox.read"))
+(read-write-and-issue-extensions (extension "com.apple.app-sandbox.read-write"))
+
+;; Access to client's cache folder & re-vending to CFNetwork.
+(allow file-issue-extension (with telemetry) (require-all
+    (extension "com.apple.app-sandbox.read-write")
+    (extension-class "com.apple.nsurlstorage.extension-cache")))
+
+(accessibility-support)
+
+(media-accessibility-support)
+
+(log-streaming)
+
+(media-capture-support)
+
+;; The mkdtemp function requires this syscall.
+(with-filter (require-not (process-attribute is-apple-signed-executable))
+    (allow syscall-unix
+        (syscall-number SYS_mkdirat)))
+
+(allow syscall-unix (syscall-unix-allowed))
+
+(allow syscall-mach (syscall-mach-allowed))
+
+(allow syscall-mig (syscall-mig-allowed))
+
+#if ENABLE(SYSTEM_CONTENT_PATH_SANDBOX_RULES)
+#include <WebKitAdditions/SystemContentSandbox-ios.defs>
+
+(allow file-read* file-test-existence
+    (apply subpath file-read-existence-secondary-paths))
+
+(allow file-map-executable
+    (apply subpath secondary-framework-and-dylib-paths))
+
+(allow-read-and-issue-generic-extensions
+    (apply subpath issue-extension-secondary-paths))
+
+(allow file-issue-extension
+    (require-all
+        (extension-class "com.apple.mediaserverd.read")
+        (apply subpath issue-extension-secondary-paths)))
+#endif
+
+#if __has_include(<WebKitAdditions/com.apple.WebKit.GPU.sb.in>)
+#include <WebKitAdditions/com.apple.WebKit.GPU.sb.in>
+#endif
+
+(with-filter (require-not (state-flag "local:FeatureCoreMLDisabled"))
+    (allow file-clone)
+    (allow syscall-unix
+        (syscall-number
+            SYS_mkdirat
+            SYS_rmdir)))

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -24,51 +24,21 @@
 #include "Shared/Sandbox/iOS/common.sb"
 #include "Shared/Sandbox/iOS/gpu-defines.sb"
 
-#if USE(SANDBOX_VERSION_3)
 (allow system-fcntl
-    (fcntl-command
-        F_ADDFILESIGS_RETURN
-        F_CHECK_LV
-        F_GETFL
-        F_GETPATH
-        F_GETPROTECTIONCLASS
-        F_SETFD
-        F_SETFL
-        F_SETNOSIGPIPE))
+    (system-fcntl-allowed))
 
 (with-filter (mac-policy-name "Sandbox")
     (allow system-mac-syscall (mac-syscall-number 5 65)))
 
 (allow iokit-open-service
-    (iokit-registry-entry-class
-        "AppleM2ScalerCSCDriver"
-        "AppleParavirtGPU"
-        "AppleVideoToolboxParavirtualizationDriver"
-        "IOSurfaceRoot"))
+    (iokit-open-service-allowed))
 (allow iokit-open-service
     (iokit-registry-entry-class-prefix "AGXAcceleratorG"))
 
 (allow darwin-notification-post
-    (notification-name
-        "AppleDatePreferencesChangedNotification"
-        "AppleLanguagePreferencesChangedNotification"
-        "AppleMeasurementSystemPreferencesChangedNotification"
-        "AppleNumberPreferencesChangedNotification"
-        "AppleTemperatureUnitPreferencesChangedNotification"
-        "AppleTextBehaviorPreferencesChangedNotification"
-        "AppleTimePreferencesChangedNotification"
-        "com.apple.CFPreferences._domainsChangedExternally"
-        "com.apple.Metal.AGXEnableOSSignposts"
-        "com.apple.WebKit.LibraryPathDiagnostics"
-        "com.apple.gpumemd.check_in_request"
-        "com.apple.mobile.keybagd.user_changed"
-        "com.apple.system.logging.prefschanged"
-        "org.WebKit.lowMemory"
-        "org.WebKit.lowMemory.begin"
-        "org.WebKit.lowMemory.end"))
+    (darwin-notification-post-allowed))
 
 (allow process-info-codesignature (target others))
-#endif
 
 (deny file-map-executable)
 (allow file-map-executable (executable-bundle))
@@ -78,73 +48,7 @@
 (allow file-read-metadata
     (vnode-type DIRECTORY))
 
-(with-elevated-precedence
-    (allow file-read*
-           (subpath "/usr/lib"
-                    "/usr/share"
-                    "/private/var/db/timezone"))
-    (allow-read-and-issue-generic-extensions
-        (subpath "/Library/RegionFeatures"
-                 "/System/Library"))
-    (allow file-issue-extension (with telemetry)
-        (require-all
-            (extension-class "com.apple.mediaserverd.read")
-            (subpath "/System/Library")))
-    
-    (allow file-map-executable
-           (subpath "/System/Library")
-           (subpath "/usr/lib"))
-    (allow file-read-metadata
-           (vnode-type SYMLINK))
-
-    ;;; <rdar://problem/24144418>
-    (allow file-read*
-           (subpath "/private/var/preferences/Logging"))
-
-    (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication"))
-    (allow file-read*
-           (front-user-home-literal "/Library/Preferences/.GlobalPreferences.plist")
-           (front-user-home-literal "/Library/Preferences/.GlobalPreferences_m.plist"))
-
-    (allow file-read*
-           (literal "/private/var/Managed Preferences/mobile/.GlobalPreferences.plist"))
-    (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
-
-    (allow-read-and-issue-generic-extensions (executable-bundle))
-
-    (unless (defined? 'restrictive-extension)
-        (with-filter
-            (extension
-                "com.apple.app-sandbox.read"
-                "com.apple.app-sandbox.read-write"
-                "com.apple.sharing.airdrop.readonly")
-            (allow file-read* file-read-metadata)
-            (allow file-issue-extension
-                   (extension-class "com.apple.app-sandbox.read"
-                                    "com.apple.mediaserverd.read"
-                                    "com.apple.sharing.airdrop.readonly")))
-        (with-filter
-            (extension
-                "com.apple.app-sandbox.read-write")
-            (allow file-write*)
-            (allow file-issue-extension
-                   (extension-class "com.apple.app-sandbox.read-write"
-                                    "com.apple.mediaserverd.read-write"))))
-
-    ;; <rdar://problem/16079361>
-    (allow managed-preference-read
-           (extension "com.apple.security.exception.managed-preference.read-only"))
-    (allow user-preference-read
-           (extension "com.apple.security.exception.shared-preference.read-only"))
-
-    (allow file-issue-extension (with telemetry)
-          (require-all
-              (extension-class "com.apple.nsurlstorage.extension-cache")
-              (extension "com.apple.security.exception.files.home-relative-path.read-write")
-              (require-any
-                  (prefix "/private/var/root/Library/Caches/")
-                  (front-user-home-prefix "/Library/Caches/"))))
-)
+(rules-with-elevated-precedence)
 
 (with-filter (system-attribute apple-internal)
     (internal-debugging-support))
@@ -157,28 +61,43 @@
 
 (device-access)
 
+;; <rdar://problem/14215718>
+(deny file-write-data NO_REPORT
+      (literal "/dev/random")
+      (literal "/dev/urandom"))
+
 (allow file-issue-extension (with telemetry)
     (require-all
         (extension-class "com.apple.app-sandbox.read-write" "com.apple.app-sandbox.read")
         (extension "com.apple.fileprovider.read-write")))
 
 (allow mach-lookup
-    (global-name "com.apple.logd")
-    (global-name "com.apple.logd.events"))
-
-(allow mach-lookup
-    (global-name "com.apple.tccd"))
+    (mach-lookup-allowed))
 
 (allow mach-lookup
     (require-all
         (extension "com.apple.webkit.extension.mach")
         (global-name "com.apple.mobilegestalt.xpc")))
 
+(with-filter (system-attribute apple-internal)
+    (allow mach-lookup
+        (global-name "com.apple.analyticsd")))
+
+(deny mach-lookup NO_REPORT
+    (global-name
+        "com.apple.audio.AudioComponentRegistrar"
+        "com.apple.audioanalyticsd"
+        "com.apple.coremedia.mediaparserd.utilities"
+        "com.apple.fontservicesd"))
+
+(deny mach-lookup (xpc-service-name-prefix ""))
+
+(deny mach-lookup NO_REPORT
+    (xpc-service-name "com.apple.audio.toolbox.reporting.service"))
+
 ;; <rdar://problem/12413942>
 (allow file-read*
        (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))
-(allow iokit-get-properties
-       (iokit-property "IORegistryEntryPropertyKeys"))
 
 (allow ipc-posix-sem-open (with telemetry)
        (ipc-posix-name "containermanagerd.fb_check"))
@@ -186,9 +105,6 @@
 (with-filter (ipc-posix-name "purplebuddy.sentinel")
     (deny ipc-posix-sem-create ipc-posix-sem-post ipc-posix-sem-unlink ipc-posix-sem-wait)
     (allow ipc-posix-sem-open (with telemetry)))
-
-(allow mach-lookup
-    (global-name "com.apple.runningboard")) ;; Needed by process assertion code (ProcessTaskStateObserver).
 
 (allow system-sched (with telemetry)
        (require-entitlement "com.apple.private.kernel.override-cpumon"))
@@ -201,16 +117,13 @@
 (with-filter (system-attribute apple-internal)
     (allow sysctl-read sysctl-write
            (sysctl-name "vm.footprint_suspend"))
-    (allow nvram-get (with telemetry) (nvram-variable "emu")) ;; <rdar://problem/78363040>
-)
+    (allow nvram-get (with telemetry) (nvram-variable "emu"))) ;; <rdar://problem/78363040>
 
 ;; ObjC map_images needs to send logging data to syslog. <rdar://problem/39778918>
 (with-filter (system-attribute apple-internal)
     (allow network-outbound
        (literal "/private/var/run/syslog")))
 
-(allow mach-lookup
-       (global-name "com.apple.system.notification_center"))
 (allow ipc-posix-shm-read*
        (ipc-posix-name "apple.shm.notification_center"))
 
@@ -233,7 +146,6 @@
 (allow process-info-rusage (target self))
 (allow process-info-codesignature (target self))
 
-(deny mach-lookup (xpc-service-name-prefix ""))
 (deny iokit-get-properties)
 (deny lsopen)
 
@@ -271,6 +183,12 @@
         (iokit-property "home-button-type")))
 
 (uikit-requirements)
+
+;; Silence sandbox violations from apps trying to create the empty plist if it doesn't exist.
+;; <rdar://problem/13796537>
+(deny file-write-create
+    (home-prefix "/Library/Preferences/com.apple.UIKit.plist")
+    NO_REPORT)
 
 ; Silently deny writes when CFData attempts to write to the cache directory.
 (deny file-write* NO_REPORT
@@ -319,37 +237,19 @@
 
 (accessibility-support)
 
+;; <rdar://problem/10809394>
+(deny file-write-create
+    (home-prefix "/Library/Preferences/com.apple.Accessibility.plist")
+    NO_REPORT)
+
 (media-accessibility-support)
 
 (log-streaming)
 
-(with-filter (system-attribute apple-internal)
-    (allow mach-lookup
-        (global-name "com.apple.analyticsd")))
-
-;; Silence reports about things we do not want access to:
-(deny mach-lookup NO_REPORT
-    (global-name
-        "com.apple.audioanalyticsd"
-        "com.apple.coremedia.mediaparserd.utilities"
-        "com.apple.fontservicesd"))
-
 (deny file-write-create (vnode-type SYMLINK))
 (deny file-read-xattr file-write-xattr (xattr-prefix "com.apple.security.private."))
 
-(deny mach-lookup NO_REPORT
-    (xpc-service-name "com.apple.audio.toolbox.reporting.service"))
-
-(deny mach-lookup NO_REPORT
-    (global-name "com.apple.audio.AudioComponentRegistrar"))
-
-(allow mach-lookup
-    (global-name "com.apple.systemstatus.activityattribution"))
-
 (media-capture-support)
-
-(allow mach-lookup
-    (global-name "com.apple.audio.AudioQueueServer"))
 
 (deny syscall-unix (with telemetry))
 (when (defined? 'SYS_crossarch_trap)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
@@ -21,8 +21,159 @@
 ; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
-#define deny allow (with report)
-#define NO_REPORT
+#include "Shared/Sandbox/iOS/common.sb"
+#include "Shared/Sandbox/iOS/networking-defines.sb"
 
-#include "Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in"
+(allow-for-development-rules)
 
+(allow system-fcntl
+    (system-fcntl-allowed))
+
+(allow file-link)
+
+(allow system-necp-client-action)
+(allow necp-client-open)
+
+(allow socket-ioctl)
+
+(allow socket-option-set (with telemetry) (with report))
+(allow socket-option-get (with telemetry) (with report))
+
+(with-filter (mac-policy-name "vnguard")
+    (allow system-mac-syscall (mac-syscall-number 1)))
+
+(with-filter (mac-policy-name "Sandbox")
+    (allow system-mac-syscall (mac-syscall-number 5)))
+
+(allow file-link
+    (subpath "/private/var/mobile/Containers/Data/Application"))
+
+(allow iokit-open-service
+    (iokit-registry-entry-class "AppleKeyStore"))
+
+(allow darwin-notification-post (darwin-notification-post-allowed))
+
+(allow file-clone
+    (subpath
+        "/private/var/mobile/Containers/Data"
+        "/private/var/mobile/Library/Caches"
+        "/private/var/mobile/Library/WebClips"))
+
+(allow system-privilege (with grant)
+    (require-all
+        (privilege-id PRIV_NET_PRIVILEGED_SOCKET_DELEGATE)
+        (require-entitlement "com.apple.private.network.socket-delegate")))
+
+(allow file-read-metadata
+    (vnode-type DIRECTORY))
+
+(rules-with-elevated-precedence)
+
+(allow file-read*
+    required-etc-files)
+
+(allow file-read* (with message "Allowing read access to root")
+    (literal "/"))
+
+(allow mach-lookup
+    (mach-lookup-allowed))
+
+(allow mach-lookup (with telemetry) (global-name "com.apple.webkit.adattributiond.service"))
+(allow mach-lookup (with telemetry) (global-name "com.apple.webkit.webpushd.service"))
+
+(allow system-sched
+    (require-entitlement "com.apple.private.kernel.override-cpumon"))
+
+(allow ipc-posix-shm-read*
+    (ipc-posix-name "apple.shm.notification_center")) ;; Needed by os_log_create
+
+(managed-configuration-read-public)
+
+(allow mach-task-name (target self))
+
+(allow process-info-pidinfo)
+(allow process-info-pidfdinfo (target self))
+(allow process-info-pidfileportinfo (target self))
+(allow process-info-setcontrol (target self))
+(allow process-info-dirtycontrol (target self))
+(allow process-info-rusage (target self))
+(allow process-info-codesignature (target self))
+(allow process-info-codesignature (target others))
+
+(allow sysctl-read (sysctl-read-allowed))
+
+;; Access to client's cache folder & re-vending to CFNetwork.
+;; FIXME: Remove the webkit specific extension classes <rdar://problem/17755931>
+(allow file-issue-extension (require-all
+    (extension "com.apple.app-sandbox.read-write")
+    (extension-class "com.apple.nsurlstorage.extension-cache")))
+
+;; App sandbox extensions
+(allow file-read* file-write* (extension "com.apple.app-sandbox.read-write"))
+(allow file-read* (extension "com.apple.app-sandbox.read"))
+
+;; FIXME: <rdar://problem/17909681> SSO expects to be able to walk the parent
+;; bundle to find Info plists, so we jump through a few hoops here to provide
+;; enough access to make it possible.
+
+(network-client (remote tcp) (remote udp))
+
+;; allow 3rd party applications to access nsurlstoraged's top level domain data cache
+(allow-well-known-system-group-container-subpath-read
+    "/systemgroup.com.apple.nsurlstoragedresources/Library/dafsaData.bin")
+
+(allow file-read-data
+    (literal "/usr/local/lib/log")) ; <rdar://problem/36629495>
+
+;; FIXME should be removed when <rdar://problem/30498072> is fixed.
+(allow network* 
+    (local udp)
+    (remote udp)
+    (local tcp)
+    (remote tcp))
+
+(log-streaming)
+
+;; <rdar://problem/103895412>
+(allow file-read*
+    (subpath "/private/var/MobileAsset/AssetsV2/com_apple_MobileAsset_WebContentRestrictions"))
+
+(allow ipc-posix-sem-open
+    (ipc-posix-name "containermanagerd.fb_check"))
+
+(allow file-read*
+    (literal "/dev/urandom"))
+
+(allow file-read*
+    (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))
+(allow iokit-get-properties
+    (iokit-property "IORegistryEntryPropertyKeys"))
+
+(allow syscall-unix (syscall-unix-allowed))
+
+(allow syscall-mach (syscall-mach-allowed))
+        
+(kernel-mig-allowed)
+
+#if ENABLE(SYSTEM_CONTENT_PATH_SANDBOX_RULES)
+#include <WebKitAdditions/SystemContentSandbox-ios.defs>
+
+(allow file-read* file-test-existence
+    (apply subpath file-read-existence-secondary-paths))
+
+(allow file-map-executable
+    (apply subpath secondary-framework-and-dylib-paths))
+
+(allow-read-and-issue-generic-extensions
+    (apply subpath issue-extension-secondary-paths))
+#endif
+
+#if ENABLE(SYSTEM_SERVICES_SANDBOX_RULES)
+#include <WebKitAdditions/SystemServicesSandbox-ios.defs>
+#endif
+
+;; Allow re-issuing file extensions we were vended
+(allow file-issue-extension
+    (require-all
+        (extension-class "com.apple.app-sandbox.read" "com.apple.app-sandbox.read-write")
+        (extension "com.apple.app-sandbox.read-write")))

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -111,8 +111,6 @@
         "/private/var/mobile/Containers/Data"
         "/private/var/mobile/Library/Caches"
         "/private/var/mobile/Library/WebClips"))
-
-(allow process-info-codesignature (target others))
 #endif
 
 (allow system-privilege (with grant)
@@ -126,68 +124,17 @@
 (allow file-read-metadata 
     (vnode-type DIRECTORY))
 
+(rules-with-elevated-precedence)
+
 (with-elevated-precedence
-    ;; System files.
-    (allow file-read*
-        (subpath "/usr/lib"
-                 "/usr/share"
-                 "/private/var/db/timezone"
-                 "/private/var/preferences/Logging"))
-
-    (allow-read-and-issue-generic-extensions
-         (subpath "/Library/RegionFeatures"
-                  "/System/Library"))
-    
-    (allow file-map-executable
-        (subpath "/System/Library")
-        (subpath "/usr/lib"))
-
-    (allow file-read-metadata 
-        (vnode-type SYMLINK))
-
-    (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication"))
-    (allow file-read*
-           (front-user-home-literal "/Library/Preferences/.GlobalPreferences.plist")
-           (front-user-home-literal "/Library/Preferences/.GlobalPreferences_m.plist"))
-
-    (allow file-read*
-           (literal "/private/var/Managed Preferences/mobile/.GlobalPreferences.plist"))
-    (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
-
     (deny file-read-metadata
         (home-literal "/Library/Caches/powerlog.launchd"))
-
-    (allow-read-and-issue-generic-extensions (executable-bundle))
-    (allow file-map-executable  (executable-bundle))
-
     (with-filter (global-name-prefix "")
-        (deny mach-lookup 
-               (extension "com.apple.security.exception.mach-lookup.global-name")))
+        (deny mach-lookup
+            (extension "com.apple.security.exception.mach-lookup.global-name")))
     (with-filter (local-name-prefix "")
-        (deny mach-lookup 
-               (extension "com.apple.security.exception.mach-lookup.local-name")))
-    (allow managed-preference-read
-           (extension "com.apple.security.exception.managed-preference.read-only"))
-    (allow user-preference-read
-           (extension "com.apple.security.exception.shared-preference.read-only"))
-    (allow sysctl-read
-           (extension "com.apple.security.exception.sysctl.read-only"))
-    (allow sysctl-read sysctl-write
-           (extension "com.apple.security.exception.sysctl.read-write"))
-
-    (allow file-issue-extension
-          (require-all
-              (extension-class "com.apple.nsurlstorage.extension-cache")
-              (extension "com.apple.security.exception.files.home-relative-path.read-write")
-              (require-any
-                  (prefix "/private/var/root/Library/Caches/")
-                  (front-user-home-prefix "/Library/Caches/"))))
-
-    (with-filter (require-entitlement "com.apple.security.exception.process-info")
-        (allow process-info-pidinfo process-info-pidfdinfo process-info-pidfileportinfo process-info-rusage process-info-codesignature)
-        (allow sysctl-read 
-               (sysctl-name-prefix "kern.proc.")
-               (sysctl-name-prefix "kern.procargs2."))))
+        (deny mach-lookup
+            (extension "com.apple.security.exception.mach-lookup.local-name"))))
 
 (with-filter (system-attribute apple-internal)
     (internal-debugging-support))
@@ -199,11 +146,17 @@
     (literal "/"))
 
 (allow mach-lookup
-    (global-name "com.apple.logd")
-    (global-name "com.apple.logd.events"))
+    (mach-lookup-allowed))
 
-(allow mach-lookup 
-    (global-name "com.apple.runningboard")) ;; Needed by process assertion code (ProcessTaskStateObserver).
+(allow mach-lookup (with telemetry) (global-name "com.apple.webkit.adattributiond.service"))
+(allow mach-lookup (with telemetry) (global-name "com.apple.webkit.webpushd.service"))
+
+(with-filter (system-attribute apple-internal)
+    (allow mach-lookup
+        (global-name "com.apple.aggregated")
+        (global-name "com.apple.analyticsd")
+        (global-name "com.apple.hangtracerd")
+        (global-name "com.apple.osanalytics.osanalyticshelper")))
 
 (allow system-sched
     (require-entitlement "com.apple.private.kernel.override-cpumon"))
@@ -223,8 +176,6 @@
     (allow network-outbound
         (literal "/private/var/run/syslog")))
 
-(allow mach-lookup
-    (global-name "com.apple.system.notification_center"))
 (allow ipc-posix-shm-read*
     (ipc-posix-name "apple.shm.notification_center")) ;; Needed by os_log_create
 
@@ -232,13 +183,6 @@
 
 (deny system-info NO_REPORT
     (info-type "net.link.addr"))
-
-(allow mach-lookup
-    (global-name "com.apple.system.libinfo.muser"))
-
-#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 180000)
-(allow mach-lookup (global-name "com.apple.duetactivityscheduler"))
-#endif
 
 (allow mach-task-name (target self))
 
@@ -250,6 +194,7 @@
 (allow process-info-dirtycontrol (target self))
 (allow process-info-rusage (target self))
 (allow process-info-codesignature (target self))
+(allow process-info-codesignature (target others))
 
 (deny mach-lookup (xpc-service-name-prefix ""))
 
@@ -270,21 +215,16 @@
 
 (network-client (remote tcp) (remote udp))
 
+;; <rdar://problem/12620714>
+(deny file-write-create NO_REPORT
+      (home-prefix "/Library/Logs/CrashReporter/CFNetwork_"))
+
 ;; allow 3rd party applications to access nsurlstoraged's top level domain data cache
 (allow-well-known-system-group-container-subpath-read
     "/systemgroup.com.apple.nsurlstoragedresources/Library/dafsaData.bin")
 
 (allow file-read-data
     (literal "/usr/local/lib/log")) ; <rdar://problem/36629495>
-
-;; PassKit framework
-(allow mach-lookup
-    (global-name "com.apple.passd.in-app-payment")
-    (global-name "com.apple.passd.library"))
-
-(allow mach-lookup
-    (global-name "com.apple.siri.context.service")
-    (global-name "com.apple.ctcategories.service"))
 
 (deny file-write-create
     (vnode-type SYMLINK))
@@ -301,46 +241,13 @@
 
 ;;; <rdar://problem/9876970>
 (deny network-outbound
-      (remote tcp "localhost:62078"))
-
-;; Various services required by system frameworks
-(allow mach-lookup 
-    (global-name "com.apple.lsd.mapdb"))
+    (remote tcp "localhost:62078"))
 
 (log-streaming)
-
-(with-filter (system-attribute apple-internal)
-    (allow mach-lookup
-        (global-name "com.apple.aggregated")
-        (global-name "com.apple.analyticsd")
-        (global-name "com.apple.hangtracerd")
-        (global-name "com.apple.osanalytics.osanalyticshelper")))
-
-;; For reporting progress for active downloads <rdar://problem/44405661>
-(allow mach-lookup
-    (global-name "com.apple.ProgressReporting"))
-
- ;; <rdar://problem/47598758>
-(allow mach-lookup 
-    (global-name "com.apple.nesessionmanager.content-filter"))
-
- ;; <rdar://problem/101780002>
-(allow mach-lookup 
-    (global-name "com.apple.mobileasset.autoasset"))
-
-;; <rdar://106216542>
-(allow mach-lookup
-    (global-name "com.apple.ciphermld"))
 
 ;; <rdar://problem/103895412>
 (allow file-read*
     (subpath "/private/var/MobileAsset/AssetsV2/com_apple_MobileAsset_WebContentRestrictions"))
-
-;; Access to ContainerManager
-(allow mach-lookup 
-    (global-name
-        "com.apple.containermanagerd"
-        "com.apple.containermanagerd.system"))
 
 (allow ipc-posix-sem-open
     (ipc-posix-name "containermanagerd.fb_check"))
@@ -355,17 +262,10 @@
     (deny NO_REPORT file-read* file-write-data file-ioctl
         (literal "/dev/dtracehelper")))
 
-(allow mach-lookup (with telemetry) (global-name "com.apple.webkit.adattributiond.service"))
-(allow mach-lookup (with telemetry) (global-name "com.apple.webkit.webpushd.service"))
-
 (allow file-read*
     (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))
 (allow iokit-get-properties
     (iokit-property "IORegistryEntryPropertyKeys"))
-
-;; Needed for TCC.
-(allow mach-lookup
-    (global-name "com.apple.tccd"))
 
 (deny syscall-unix (with telemetry))
 (when (defined? 'SYS_crossarch_trap)
@@ -392,14 +292,6 @@
 
 (allow-read-and-issue-generic-extensions
     (apply subpath issue-extension-secondary-paths))
-#endif
-
-#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-
-(allow mach-lookup
-    (global-name "com.apple.webprivacyd")
-    (global-name "com.apple.WebPrivacy.Service"))
-
 #endif
 
 #if ENABLE(SYSTEM_SERVICES_SANDBOX_RULES)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
@@ -21,7 +21,289 @@
 ; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
-#define deny allow (with report)
-#define NO_REPORT
+#include "Shared/Sandbox/iOS/common.sb"
+#include "Shared/Sandbox/iOS/webcontent-defines.sb"
 
-#include "Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in"
+(allow-for-development-rules)
+
+(allow dynamic-code-generation)
+
+(with-filter (mac-policy-name "Sandbox")
+    (allow system-mac-syscall (mac-syscall-number 5 65)))
+
+(allow file-read-metadata
+    (vnode-type DIRECTORY))
+
+(rules-with-elevated-precedence)
+
+(allow file-read*
+    required-etc-files
+    (literal "/"))
+
+(allow file-read*
+    (subpath "/private/var/MobileAsset/PreinstalledAssetsV2/InstallWithOs"))
+
+;; FIXME: Remove when rdar://141156558 has been fixed.
+#if ENABLE(REMOVE_XPC_AND_MACH_SANDBOX_EXTENSIONS_IN_WEBCONTENT)
+(allow file-read*
+    (subpath "/private/var/MobileAsset/AssetsV2/com_apple_MobileAsset_Font7")
+    (subpath "/private/var/MobileAsset/AssetsV2/com_apple_MobileAsset_Font8"))
+#endif
+
+(device-access)
+
+(allow file-issue-extension
+    (require-all
+        (extension-class "com.apple.app-sandbox.read-write" "com.apple.app-sandbox.read")
+        (extension "com.apple.fileprovider.read-write")))
+
+;; <rdar://problem/12413942>
+(allow file-read*
+   (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))
+
+(allow system-sched
+    (require-entitlement "com.apple.private.kernel.override-cpumon"))
+
+#if ENABLE(NOTIFY_BLOCKING)
+(with-filter (require-not (notify-blocking))
+    (allow-notifyd))
+#else
+(allow-notifyd)
+#endif
+
+(managed-configuration-read-public)
+
+(allow file-read*
+    (subpath "/private/var/db/datadetectors/sys"))
+
+(allow-well-known-system-group-container-subpath-read
+    "/systemgroup.com.apple.icloud.findmydevice.managed/Library")
+
+(allow mach-task-name (target self))
+
+;;; process-info* defaults to allow; deny it and then allow operations we actually need.
+(allow process-info-pidinfo (target self))
+(allow process-info-pidfdinfo (target self))
+(allow process-info-pidfileportinfo (target self))
+(allow process-info-setcontrol (target self))
+(allow process-info-dirtycontrol (target self))
+(allow process-info-rusage (target self))
+
+;; Any app can play audio & movies.
+(play-media)
+
+;; Access to media controls
+(media-remote)
+
+(url-translation)
+
+(speech-synthesis-and-voiceover)
+
+;; Permit reading assets via MobileAsset framework.
+(asset-access 'with-media-playback)
+
+;; allow 3rd party applications to access nsurlstoraged's top level domain data cache
+(allow-well-known-system-group-container-literal-read
+    "/systemgroup.com.apple.nsurlstoragedresources/Library/dafsaData.bin")
+
+;; Access the keyboards
+(allow file-read*
+    (home-subpath "/Library/Caches/com.apple.keyboards"))
+
+(mobile-preferences-read-allowed)
+
+;; <rdar://problem/12985925> Need read access to /var/mobile/Library/Fonts to all apps
+(allow file-read*
+    (home-subpath "/Library/Fonts"))
+
+;; <rdar://problem/7344719&26323449> LaunchServices app icons
+(allow file-read*
+    (well-known-system-group-container-subpath "/systemgroup.com.apple.lsd.iconscache"))
+
+(allow-preferences-common)
+
+;; Home Button
+(with-filter (iokit-registry-entry-class "IOPlatformDevice")
+    (allow iokit-get-properties
+        (iokit-property "home-button-type")))
+
+(uikit-requirements)
+
+(dictionary-support)
+
+; <rdar://problem/8440231>
+(allow file-read*
+    (home-literal "/Library/Caches/DateFormats.plist"))
+
+(framebuffer-access)
+
+; <rdar://problem/7595408> , <rdar://problem/7643881>
+(opengl)
+
+(allow sysctl-read
+    (sysctl-read-allowed)
+    (sysctl-read-prefix-allowed))
+
+(with-filter (require-not (webcontent-process-launched))
+    (allow sysctl-read (sysctl-name "vm.malloc_ranges"))) ;; <rdar://problem/105161083>
+
+(allow iokit-get-properties
+    (iokit-get-property-allowed))
+
+; IOPlatformExpertDevice
+(with-filter (iokit-registry-entry-class "IOPlatformExpertDevice")
+    (allow iokit-get-properties
+        (iokit-property
+            "platform-name" ;; <rdar://problem/79334360>
+            "region-info" ;; <rdar://problem/52903475>
+            "regulatory-model-number"))) ;; <rdar://problem/52903475>
+
+;; Sandbox extensions
+(read-only-and-issue-extensions (extension "com.apple.app-sandbox.read"))
+(define (read-write-extension-with-telemetry) (with report) (with telemetry) (extension "com.apple.app-sandbox.read-write"))
+(read-write-and-issue-extensions (read-write-extension-with-telemetry))
+
+;; Access to client's cache folder & re-vending to CFNetwork.
+(allow file-issue-extension (require-all
+    (extension "com.apple.app-sandbox.read-write")
+    (extension-class "com.apple.nsurlstorage.extension-cache")))
+
+(accessibility-support)
+
+(media-accessibility-support)
+
+;; Allow loading injected bundles.
+(with-filter (require-not (webcontent-process-launched))
+    (allow file-map-executable))
+
+(allow file-read-data
+    (literal "/usr/local/lib/log")) ; <rdar://problem/36629495>
+
+(disable-syscall-inference)
+
+(allow syscall-unix
+    (syscall-unix-in-use-after-launch)
+    (syscall-unix-in-use-after-launch-blocked-in-lockdown-mode))
+
+(with-filter (require-not (webcontent-process-launched))
+    (allow syscall-unix (syscall-unix-only-in-use-during-launch)))
+
+(allow syscall-unix
+    (syscall-unix-rarely-in-use)
+    (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)
+    (syscall-quicklook))
+
+(when (defined? 'SYS_map_with_linking_np)
+    (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
+
+(allow system-fcntl (system-fcntl-allowed))
+
+;; csops/csops_audittoken
+(allow-for-development process-codesigning*)
+(allow process-codesigning-identity-get (target self)) ;; codeSigningIdentifierForCurrentProcess
+(allow process-codesigning-entitlements-blob-get) ;; WK reading entitlments via SecTaskCopyValueForEntitlement and _getSelfParsedEntitlements (accessibility)
+(allow process-codesigning-status-get) ;; _xpc_get_entitlements
+(allow process-codesigning-status-set (target self))
+
+(allow mach-bootstrap
+    (apply-message-filter
+        (allow-for-development mach-message-send)
+#if PLATFORM(IOS) || PLATFORM(VISION)
+        (with-filter (extension "com.apple.webkit.mach-bootstrap")
+            (allow mach-message-send (mach-bootstrap-message-numbers-post-launch)))
+#else
+        (allow mach-message-send (mach-bootstrap-message-numbers-post-launch))
+#endif
+        (with-filter (require-not (webcontent-process-launched))
+            (allow mach-message-send (mach-bootstrap-message-numbers)))))
+
+(allow syscall-mach
+    (syscall-mach-blocked-in-lockdown-mode)
+    (syscall-mach-only-in-use-during-launch)
+    (syscall-mach-in-use-after-launch))
+
+(when (defined? 'MSC_mach_msg2_trap)
+    (allow syscall-mach (machtrap-number MSC_mach_msg2_trap)))
+
+(with-filter (require-not (webcontent-process-launched))
+    (allow syscall-mach
+        (syscall-mach-only-in-use-during-launch)))
+
+(allow syscall-mig (with telemetry-backtrace)
+    (kernel-mig-routine-rarely-used-need-backtrace)
+    (kernel-mig-routine-rarely-used-need-backtrace-blocked-in-lockdown-mode))
+
+(allow syscall-mig (with telemetry)
+    (kernel-mig-routine-rarely-used))
+
+(allow syscall-mig
+    (kernel-mig-routine-blocked-in-lockdown-mode)
+    (kernel-mig-routine-in-use))
+
+#if PLATFORM(WATCHOS)
+(allow syscall-mig
+    (kernel-mig-routine-in-use-watchos))
+#endif
+
+(with-filter (require-not (webcontent-process-launched))
+    (allow syscall-mig
+        (kernel-mig-routine-only-in-use-during-launch)))
+#if !ENABLE(WEBCONTENT_GPU_SANDBOX_EXTENSIONS_BLOCKING)
+(with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+    (allow syscall-mig (kernel-mig-routines-iokit-service)))
+#endif
+
+#if HAVE(HARDENED_MACH_EXCEPTIONS)
+(with-filter (require-not (lockdown-mode))
+    (allow syscall-mig (kernel-mig-routine thread_adopt_exception_handler))
+    (with-filter (require-not (webcontent-process-launched))
+        (allow syscall-mig (kernel-mig-routine task_register_hardened_exception_handler))))
+#else
+(with-filter (require-not (lockdown-mode))
+    (allow syscall-mig (kernel-mig-routine thread_set_exception_ports)))
+#endif ;; HAVE(HARDENED_MACH_EXCEPTIONS)
+
+(when (defined? 'mach_port_is_connection_for_service)
+    (allow syscall-mig (kernel-mig-routine mach_port_is_connection_for_service)))
+
+(allow darwin-notification-post
+    (notification-name
+#if ENABLE(NOTIFY_BLOCKING)
+#define WK_NOTIFICATION_COMMENT(...)
+#define WK_NOTIFICATION(name) name
+#include "Resources/cocoa/NotificationAllowList/ForwardedNotifications.def"
+#include "Resources/cocoa/NotificationAllowList/EmbeddedForwardedNotifications.def"
+#include "Resources/cocoa/NotificationAllowList/NonForwardedNotifications.def"
+#undef WK_NOTIFICATION
+#undef WK_NOTIFICATION_COMMENT
+#endif
+        (darwin-notification-post-allowed)))
+
+(allow-for-development mach-task-special-port-get)
+(allow-for-development mach-task-special-port-set)
+(with-filter (require-not (webcontent-process-launched))
+    (allow mach-task-special-port-get)
+    (allow mach-task-special-port-set))
+
+#if ENABLE(SYSTEM_CONTENT_PATH_SANDBOX_RULES)
+#include <WebKitAdditions/SystemContentSandbox-ios.defs>
+
+(allow file-read* file-test-existence
+    (apply subpath file-read-existence-secondary-paths))
+
+(allow file-map-executable
+    (apply subpath secondary-framework-and-dylib-paths))
+
+(allow-read-and-issue-generic-extensions
+    (apply subpath issue-extension-secondary-paths))
+    
+(allow file-issue-extension
+    (require-all
+        (extension-class "com.apple.mediaserverd.read")
+        (require-any
+            (apply subpath issue-extension-secondary-paths))))
+#endif
+
+#if __has_include(<WebKitAdditions/WebContentSandbox-ios.defs>)
+#include <WebKitAdditions/WebContentSandbox-ios.defs>
+#endif

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -45,74 +45,10 @@
 (allow file-read-metadata
     (vnode-type DIRECTORY))
 
-(mobile-preferences-read "com.apple.security")
-
 (with-filter (system-attribute apple-internal)
   (mobile-preferences-read "com.apple.PrototypeTools"))
 
-(with-elevated-precedence
-    (allow file-read*
-           (subpath "/usr/lib"
-                    "/usr/share"
-                    "/private/var/db/timezone"))
-    (allow-read-and-issue-generic-extensions
-        (subpath "/Library/RegionFeatures"
-                 "/System/Library"))
-    (allow file-issue-extension
-        (require-all
-            (extension-class "com.apple.mediaserverd.read")
-            (subpath "/System/Library")))
-    
-    (allow file-map-executable
-           (subpath "/System/Library")
-           (subpath "/usr/lib"))
-    (allow file-read-metadata
-           (vnode-type SYMLINK))
-
-    ;;; <rdar://problem/24144418>
-    (allow file-read*
-           (subpath "/private/var/preferences/Logging"))
-
-    (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication"))
-    (allow file-read*
-           (front-user-home-literal "/Library/Preferences/.GlobalPreferences.plist")
-           (front-user-home-literal "/Library/Preferences/.GlobalPreferences_m.plist"))
-
-    (allow file-read*
-           (literal "/private/var/Managed Preferences/mobile/.GlobalPreferences.plist"))
-    (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
-
-    (allow file-read-metadata
-           (home-literal "/Library/Caches/powerlog.launchd"))
-
-    (allow-read-and-issue-generic-extensions (executable-bundle))
-    (allow file-map-executable (executable-bundle))
-
-    (unless (defined? 'restrictive-extension)
-        (with-filter
-            (extension
-                "com.apple.app-sandbox.read"
-                "com.apple.app-sandbox.read-write"
-                "com.apple.sharing.airdrop.readonly")
-            (allow file-read* file-read-metadata)
-            (allow file-issue-extension
-                   (extension-class "com.apple.app-sandbox.read"
-                                    "com.apple.mediaserverd.read"
-                                    "com.apple.sharing.airdrop.readonly")))
-        (with-filter
-            (extension
-                "com.apple.app-sandbox.read-write")
-            (allow file-write* (with report) (with telemetry))
-            (allow file-issue-extension
-                   (extension-class "com.apple.app-sandbox.read-write"
-                                    "com.apple.mediaserverd.read-write"))))
-
-    ;; <rdar://problem/16079361>
-    (allow managed-preference-read
-           (extension "com.apple.security.exception.managed-preference.read-only"))
-    (allow user-preference-read
-           (extension "com.apple.security.exception.shared-preference.read-only"))
-)
+(rules-with-elevated-precedence)
 
 (with-filter (system-attribute apple-internal)
     (internal-debugging-support))
@@ -132,6 +68,11 @@
 #endif
 
 (device-access)
+
+;; <rdar://problem/14215718>
+(deny file-write-data NO_REPORT
+    (literal "/dev/random")
+    (literal "/dev/urandom"))
 
 (allow file-issue-extension
     (require-all
@@ -174,9 +115,6 @@
 ;; <rdar://problem/12413942>
 (allow file-read*
    (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))
-
-(allow iokit-get-properties
-       (iokit-property "IORegistryEntryPropertyKeys"))
 
 (allow system-sched
        (require-entitlement "com.apple.private.kernel.override-cpumon"))
@@ -236,8 +174,6 @@
 
 (url-translation)
 
-(mobile-preferences-read "com.apple.da")
-
 (speech-synthesis-and-voiceover)
 
 ;; Permit reading assets via MobileAsset framework.
@@ -251,16 +187,7 @@
 (allow file-read*
     (home-subpath "/Library/Caches/com.apple.keyboards"))
 
-(mobile-preferences-read
-    "com.apple.EmojiPreferences"
-    ; <rdar://problem/8477596> com.apple.InputModePreferences
-    "com.apple.InputModePreferences"
-    ; <rdar://problem/8206632> Weather(1038) deny file-read-data ~/Library/Preferences/com.apple.keyboard.plist
-    "com.apple.keyboard"
-    ; <rdar://problem/9384085>
-    "com.apple.Preferences"
-    "com.apple.lookup.shared" ; Needed for DataDetector (Spotlight) support
-)
+(mobile-preferences-read-allowed)
 
 ;; Silently deny unnecessary accesses caused by MessageUI framework.
 ;; This can be removed once <rdar://problem/47038102> is resolved.
@@ -284,6 +211,12 @@
 
 (uikit-requirements)
 
+;; Silence sandbox violations from apps trying to create the empty plist if it doesn't exist.
+;; <rdar://problem/13796537>
+(deny file-write-create
+    (home-prefix "/Library/Preferences/com.apple.UIKit.plist")
+    NO_REPORT)
+
 (dictionary-support)
 
 ; <rdar://problem/8440231>
@@ -304,11 +237,6 @@
 ; See <rdar://problem/9375027> for sample backtraces.
 (deny file-write* NO_REPORT
     (home-prefix "/Library/Preferences/com.apple.springboard.plist"))
-
-;; <rdar://problem/34986314>
-(mobile-preferences-read "com.apple.indigo")
-
-(mobile-preferences-read "com.apple.AdLib.plist")
 
 (deny file-read* NO_REPORT
     (home-literal
@@ -341,14 +269,6 @@
             "region-info" ;; <rdar://problem/52903475>
             "regulatory-model-number"))) ;; <rdar://problem/52903475>
 
-;; Read-only preferences and data
-(mobile-preferences-read
-    "com.apple.LaunchServices"
-    "com.apple.WebFoundation"
-    "com.apple.avfoundation.frecents" ;; <rdar://problem/33137029>
-    "com.apple.avfoundation.videoperformancehud" ;; <rdar://problem/31594568>
-    "com.apple.voiceservices.logging")
-
 ;; Sandbox extensions
 (read-only-and-issue-extensions (extension "com.apple.app-sandbox.read"))
 (define (read-write-extension-with-telemetry) (with report) (with telemetry) (extension "com.apple.app-sandbox.read-write"))
@@ -360,6 +280,11 @@
     (extension-class "com.apple.nsurlstorage.extension-cache")))
 
 (accessibility-support)
+
+;; <rdar://problem/10809394>
+(deny file-write-create
+    (home-prefix "/Library/Preferences/com.apple.Accessibility.plist")
+    NO_REPORT)
 
 (media-accessibility-support)
 
@@ -374,8 +299,7 @@
 (deny necp-client-open)
 
 (allow file-read-data
-    (literal "/usr/local/lib/log") ; <rdar://problem/36629495>
-)
+    (literal "/usr/local/lib/log")) ; <rdar://problem/36629495>
 
 ;; <rdar://problem/60983812>
 (deny file-write* NO_REPORT
@@ -481,12 +405,10 @@
     (allow process-codesigning-entitlements-blob-get) ;; WK reading entitlments via SecTaskCopyValueForEntitlement and _getSelfParsedEntitlements (accessibility)
     (allow process-codesigning-status-get) ;; _xpc_get_entitlements
     (allow process-codesigning-status-set (target self))
-    (deny process-info-codesignature NO_REPORT) ;; SecTaskCopyValueForEntitlement - granting this grants all the process-codesign-* checks
-)
+    (deny process-info-codesignature NO_REPORT)) ;; SecTaskCopyValueForEntitlement - granting this grants all the process-codesign-* checks
 
 (when (not (defined? 'process-codesigning*))
-    (allow process-info-codesignature (target self))
-)
+    (allow process-info-codesignature (target self)))
 
 (allow mach-bootstrap
     (apply-message-filter
@@ -588,22 +510,7 @@
 #undef WK_NOTIFICATION
 #undef WK_NOTIFICATION_COMMENT
 #endif
-        "_AXNotification_AXSClassicInvertColorsPreference"
-        "com.apple.WebContentFilter.remoteUI.WebContentAnalysisUI-com.apple.uikit.viewService.connectionRequest"
-        "com.apple.accessibility.AirPodsSpatialAudioLockToDeviceChanged"
-        "com.apple.accessibility.QuickSpeakEnabled"
-        "com.apple.accessibility.application.status"
-        "com.apple.accessibility.automation.enabled.status"
-        "com.apple.accessibility.darken.system.colors"
-        "com.apple.accessibility.enhance.background.contrast.status"
-        "com.apple.accessibility.monoaudio.status"
-        "com.apple.accessibility.reduce.motion.status"
-        "com.apple.accessibility.status"
-        "com.apple.accessibility.text.legibility.status"
-        "com.apple.accessibility.voiceovertouch.status"
-        "com.apple.accessibility.wob.status"
-        "com.apple.automation.stringlookupinfoenabled"
-        "com.apple.webinspectord.availability_check"))
+        (darwin-notification-post-allowed)))
 
 (with-filter (webcontent-process-launched)
     (deny mach-task-special-port-get (with telemetry))
@@ -625,8 +532,7 @@
     (require-all
         (extension-class "com.apple.mediaserverd.read")
         (require-any
-            (apply subpath issue-extension-secondary-paths)
-        )))
+            (apply subpath issue-extension-secondary-paths))))
 #endif
 
 #if __has_include(<WebKitAdditions/WebContentSandbox-ios.defs>)

--- a/Source/WebKit/Shared/Sandbox/iOS/common.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/common.sb
@@ -89,6 +89,11 @@
                 (home-literal (string-append "/Library/Preferences/" domain ".plist")))))
         domains))
 
+(define-once (xcode-build-products-access)
+    (with-elevated-precedence
+        (allow file-read* file-map-executable file-issue-extension
+            (front-user-home-subpath "/XcodeBuiltProducts"))))
+
 (define-once (internal-debugging-support)
         (allow file-read* file-map-executable
                (subpath "/Developer"))
@@ -108,9 +113,8 @@
                (subpath "/AppleInternal")
                (subpath "/usr/local/lib")
                (subpath "/usr/appleinternal/lib"))
-        (with-elevated-precedence
-            (allow file-read* file-map-executable file-issue-extension
-               (front-user-home-subpath "/XcodeBuiltProducts")))
+
+        (xcode-build-products-access)
 
         ;; <rdar://problem/8107758>
         (allow file-read* file-map-executable
@@ -122,3 +126,26 @@
 
 (define (sandbox-version-2)
     (state-flag "local:tested_version_2.0"))
+
+(define (allow-for-development op)
+    (with-filter (system-attribute developer-mode)
+        (allow op (with report)))
+    (with-filter (require-not (system-attribute developer-mode))
+        (deny op)))
+
+(define (allow-for-development-rules)
+    (xcode-build-products-access)
+    (allow-for-development user-preference-read)
+    (allow-for-development system-fcntl)
+    (allow-for-development system-mac-syscall)
+    (allow-for-development iokit-open-user-client)
+    (allow-for-development iokit-open-service)
+    (allow-for-development darwin-notification-post)
+    (allow-for-development file-map-executable)
+    (allow-for-development mach-lookup)
+    (allow-for-development process-info*)
+    (allow-for-development sysctl-read)
+    (allow-for-development iokit-get-properties)
+    (allow-for-development syscall-unix)
+    (allow-for-development syscall-mach)
+    (allow-for-development syscall-mig))

--- a/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
@@ -151,13 +151,8 @@
         (allow device-camera)))
 
 (define-once (accessibility-support)
-    (mobile-preferences-read "com.apple.Accessibility")
+    (mobile-preferences-read "com.apple.Accessibility"))
     
-    ;; <rdar://problem/10809394>
-    (deny file-write-create
-        (home-prefix "/Library/Preferences/com.apple.Accessibility.plist")
-        NO_REPORT))
-
 (define-once (media-accessibility-support)
     ;; <rdar://problem/12801477>
     (allow mach-lookup (with telemetry)
@@ -201,11 +196,7 @@
 
     (allow file-read* (with telemetry)
            (literal "/dev/random")
-           (literal "/dev/urandom"))
-    ;; <rdar://problem/14215718>
-    (deny file-write-data NO_REPORT
-          (literal "/dev/random")
-          (literal "/dev/urandom")))
+           (literal "/dev/urandom")))
 
 (define required-etc-files
   (literal "/private/etc/passwd"))
@@ -242,14 +233,8 @@
             (allow iokit-external-trap
                 (iokit-trap-number 0 1 2 3 4 5 8 9))
             (allow iokit-external-method
-                (iokit-method-number 0 4 5 9 10 11 12 13 20 27 32 34 35 36 38 39 41 44 54 58 59))))
+                (iokit-method-number 0 4 5 9 10 11 12 13 20 27 32 34 35 36 38 39 41 44 54 58 59)))))
 
-    ;; Silence sandbox violations from apps trying to create the empty plist if it doesn't exist.
-    ;; <rdar://problem/13796537>
-    (deny file-write-create
-        (home-prefix "/Library/Preferences/com.apple.UIKit.plist")
-        NO_REPORT))
- 
 (define (syscall-unix-allowed)
      (syscall-number
         SYS___disable_threadsignal
@@ -509,6 +494,7 @@
         "IOGVAScaler"
         "IOClassNameOverride"
         "IOPlatformUUID"
+        "IORegistryEntryPropertyKeys"
         "IOSurfaceAcceleratorCapabilitiesDict"
         "Protocol Characteristics"
         "als-colorCfg" ;; <rdar://problem/52903475>
@@ -572,3 +558,118 @@
         "machdep.ptrauth_enabled"
         "vm.footprint_suspend"
         "vm.malloc_ranges")) ;; <rdar://problem/105161083>
+
+(define (system-fcntl-allowed)
+    (fcntl-command
+        F_ADDFILESIGS_RETURN
+        F_CHECK_LV
+        F_GETFL
+        F_GETPATH
+        F_GETPROTECTIONCLASS
+        F_SETFD
+        F_SETFL
+        F_SETNOSIGPIPE))
+
+(define (darwin-notification-post-allowed)
+    (notification-name
+        "AppleDatePreferencesChangedNotification"
+        "AppleLanguagePreferencesChangedNotification"
+        "AppleMeasurementSystemPreferencesChangedNotification"
+        "AppleNumberPreferencesChangedNotification"
+        "AppleTemperatureUnitPreferencesChangedNotification"
+        "AppleTextBehaviorPreferencesChangedNotification"
+        "AppleTimePreferencesChangedNotification"
+        "com.apple.CFPreferences._domainsChangedExternally"
+        "com.apple.Metal.AGXEnableOSSignposts"
+        "com.apple.WebKit.LibraryPathDiagnostics"
+        "com.apple.gpumemd.check_in_request"
+        "com.apple.mobile.keybagd.user_changed"
+        "com.apple.system.logging.prefschanged"
+        "org.WebKit.lowMemory"
+        "org.WebKit.lowMemory.begin"
+        "org.WebKit.lowMemory.end"))
+
+(define (rules-with-elevated-precedence)
+    (with-elevated-precedence
+        (allow file-read*
+               (subpath "/usr/lib"
+                        "/usr/share"
+                        "/private/var/db/timezone"))
+        (allow-read-and-issue-generic-extensions
+            (subpath "/Library/RegionFeatures"
+                     "/System/Library"))
+        (allow file-issue-extension (with telemetry)
+            (require-all
+                (extension-class "com.apple.mediaserverd.read")
+                (subpath "/System/Library")))
+        
+        (allow file-map-executable
+               (subpath "/System/Library")
+               (subpath "/usr/lib"))
+        (allow file-read-metadata
+               (vnode-type SYMLINK))
+
+        ;;; <rdar://problem/24144418>
+        (allow file-read*
+               (subpath "/private/var/preferences/Logging"))
+
+        (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication"))
+        (allow file-read*
+               (front-user-home-literal "/Library/Preferences/.GlobalPreferences.plist")
+               (front-user-home-literal "/Library/Preferences/.GlobalPreferences_m.plist"))
+
+        (allow file-read*
+               (literal "/private/var/Managed Preferences/mobile/.GlobalPreferences.plist"))
+        (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
+
+        (allow-read-and-issue-generic-extensions (executable-bundle))
+
+        (unless (defined? 'restrictive-extension)
+            (with-filter
+                (extension
+                    "com.apple.app-sandbox.read"
+                    "com.apple.app-sandbox.read-write"
+                    "com.apple.sharing.airdrop.readonly")
+                (allow file-read* file-read-metadata)
+                (allow file-issue-extension
+                       (extension-class "com.apple.app-sandbox.read"
+                                        "com.apple.mediaserverd.read"
+                                        "com.apple.sharing.airdrop.readonly")))
+            (with-filter
+                (extension
+                    "com.apple.app-sandbox.read-write")
+                (allow file-write*)
+                (allow file-issue-extension
+                       (extension-class "com.apple.app-sandbox.read-write"
+                                        "com.apple.mediaserverd.read-write"))))
+
+        ;; <rdar://problem/16079361>
+        (allow managed-preference-read
+               (extension "com.apple.security.exception.managed-preference.read-only"))
+        (allow user-preference-read
+               (extension "com.apple.security.exception.shared-preference.read-only"))
+
+        (allow file-issue-extension (with telemetry)
+              (require-all
+                  (extension-class "com.apple.nsurlstorage.extension-cache")
+                  (extension "com.apple.security.exception.files.home-relative-path.read-write")
+                  (require-any
+                      (prefix "/private/var/root/Library/Caches/")
+                      (front-user-home-prefix "/Library/Caches/"))))))
+
+(define (mach-lookup-allowed)
+    (global-name
+        "com.apple.audio.AudioQueueServer"
+        "com.apple.logd"
+        "com.apple.logd.events"
+        "com.apple.runningboard"
+        "com.apple.system.notification_center"
+        "com.apple.systemstatus.activityattribution"
+        "com.apple.tccd"))
+
+(define (iokit-open-service-allowed)
+    (iokit-registry-entry-class
+        "AppleM2ScalerCSCDriver"
+        "AppleParavirtGPU"
+        "AppleVideoToolboxParavirtualizationDriver"
+        "IOSurfaceRoot"))

--- a/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb
@@ -126,10 +126,6 @@
     (allow mach-lookup
            (global-name "com.apple.cfnetwork.cfnetworkagent"))
 
-    ;; <rdar://problem/12620714>
-    (deny file-write-create NO_REPORT
-          (home-prefix "/Library/Logs/CrashReporter/CFNetwork_"))
-
     ;; <rdar://problem/17910466>
     (allow mach-lookup
            (global-name "com.apple.accountsd.accountmanager"))
@@ -490,3 +486,85 @@
 
 (define (sysctl-read-prefix-allowed)
     (sysctl-name-prefix "kern.proc.pid."))
+
+(define (mach-lookup-allowed)
+    (global-name
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 180000)
+        "com.apple.duetactivityscheduler"
+#endif
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+        "com.apple.WebPrivacy.Service"
+        "com.apple.webprivacyd"
+#endif
+        "com.apple.ciphermld" ;; <rdar://106216542>
+        "com.apple.containermanagerd"
+        "com.apple.containermanagerd.system"
+        "com.apple.ctcategories.service"
+        "com.apple.logd"
+        "com.apple.logd.events"
+        "com.apple.lsd.mapdb"
+        "com.apple.mobileasset.autoasset" ;; <rdar://problem/101780002>
+        "com.apple.nesessionmanager.content-filter" ;; <rdar://problem/47598758>
+        "com.apple.passd.in-app-payment" ;; PassKit framework
+        "com.apple.passd.library"
+        "com.apple.ProgressReporting" ;; For reporting progress for active downloads <rdar://problem/44405661>
+        "com.apple.runningboard" ;; Needed by process assertion code (ProcessTaskStateObserver).
+        "com.apple.siri.context.service"
+        "com.apple.system.libinfo.muser"
+        "com.apple.system.notification_center"
+        "com.apple.tccd"))
+
+(define (rules-with-elevated-precedence)
+    (with-elevated-precedence
+        ;; System files.
+        (allow file-read*
+            (subpath "/usr/lib"
+                     "/usr/share"
+                     "/private/var/db/timezone"
+                     "/private/var/preferences/Logging"))
+
+        (allow-read-and-issue-generic-extensions
+             (subpath "/Library/RegionFeatures"
+                      "/System/Library"))
+        
+        (allow file-map-executable
+            (subpath "/System/Library")
+            (subpath "/usr/lib"))
+
+        (allow file-read-metadata
+            (vnode-type SYMLINK))
+
+        (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication"))
+        (allow file-read*
+               (front-user-home-literal "/Library/Preferences/.GlobalPreferences.plist")
+               (front-user-home-literal "/Library/Preferences/.GlobalPreferences_m.plist"))
+
+        (allow file-read*
+               (literal "/private/var/Managed Preferences/mobile/.GlobalPreferences.plist"))
+        (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
+
+        (allow-read-and-issue-generic-extensions (executable-bundle))
+        (allow file-map-executable  (executable-bundle))
+
+        (allow managed-preference-read
+               (extension "com.apple.security.exception.managed-preference.read-only"))
+        (allow user-preference-read
+               (extension "com.apple.security.exception.shared-preference.read-only"))
+        (allow sysctl-read
+               (extension "com.apple.security.exception.sysctl.read-only"))
+        (allow sysctl-read sysctl-write
+               (extension "com.apple.security.exception.sysctl.read-write"))
+
+        (allow file-issue-extension
+              (require-all
+                  (extension-class "com.apple.nsurlstorage.extension-cache")
+                  (extension "com.apple.security.exception.files.home-relative-path.read-write")
+                  (require-any
+                      (prefix "/private/var/root/Library/Caches/")
+                      (front-user-home-prefix "/Library/Caches/"))))
+
+        (with-filter (require-entitlement "com.apple.security.exception.process-info")
+            (allow process-info-pidinfo process-info-pidfdinfo process-info-pidfileportinfo process-info-rusage process-info-codesignature)
+            (allow sysctl-read
+                   (sysctl-name-prefix "kern.proc.")
+                   (sysctl-name-prefix "kern.procargs2.")))))

--- a/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
@@ -88,13 +88,8 @@
         (require-all
             (extension "com.apple.webkit.mach-bootstrap")
             (local-name "com.apple.iphone.axserver")))
-    (mobile-preferences-read "com.apple.Accessibility")
+    (mobile-preferences-read "com.apple.Accessibility"))
     
-    ;; <rdar://problem/10809394>
-    (deny file-write-create
-        (home-prefix "/Library/Preferences/com.apple.Accessibility.plist")
-        NO_REPORT))
-
 (define-once (media-accessibility-support)
     ;; <rdar://problem/12250145>
     (mobile-preferences-read "com.apple.mediaaccessibility")
@@ -170,11 +165,7 @@
 
     (allow file-read*
            (literal "/dev/random")
-           (literal "/dev/urandom"))
-    ;; <rdar://problem/14215718>
-    (deny file-write-data NO_REPORT
-          (literal "/dev/random")
-          (literal "/dev/urandom")))
+           (literal "/dev/urandom")))
 
 (define required-etc-files
   (literal "/private/etc/fstab"
@@ -201,15 +192,6 @@
 
 ;; Things required by UIKit
 (define-once (uikit-requirements)
-    (mobile-preferences-read
-        "com.apple.UIKit"
-        "com.apple.WebUI"
-        "com.apple.airplay"
-        "com.apple.avkit"
-        "com.apple.coreanimation"
-        "com.apple.mt"
-        "com.apple.preferences.sounds")
-
 #if !ENABLE(CARENDERSERVER_BLOCKING_IN_WEBCONTENT)
     (with-filter (require-not (state-flag "EnableExperimentalSandbox"))
         (allow mach-lookup (with report) (with telemetry-backtrace) (global-name "com.apple.CARenderServer")))
@@ -238,11 +220,14 @@
             (iokit-user-client-class "IOSurfaceRootUserClient"))) ;; Needed by Tiled Grid code.
 #endif
 
-    ;; Silence sandbox violations from apps trying to create the empty plist if it doesn't exist.
-    ;; <rdar://problem/13796537>
-    (deny file-write-create
-        (home-prefix "/Library/Preferences/com.apple.UIKit.plist")
-        NO_REPORT))
+    (mobile-preferences-read
+        "com.apple.UIKit"
+        "com.apple.WebUI"
+        "com.apple.airplay"
+        "com.apple.avkit"
+        "com.apple.coreanimation"
+        "com.apple.mt"
+        "com.apple.preferences.sounds"))
 
 (define-once (dictionary-support)
     ; <rdar://problem/8548856> Sub-TLF: Sandbox change for apps for read-only access to the dictionary directory/data
@@ -649,6 +634,7 @@
         "IOGVAEncoderRestricted"
         "IOGVAScaler"
         "IOClassNameOverride"
+        "IORegistryEntryPropertyKeys"
         "IOSurfaceAcceleratorCapabilitiesDict"
         "LGHSupported"
         "Protocol Characteristics"
@@ -704,3 +690,102 @@
         F_SETFL ;; CMCapture uses when camera is enabled
         F_SETNOSIGPIPE
         F_SETPROTECTIONCLASS)) ;; CMCapture uses when camera is enabled
+
+(define (rules-with-elevated-precedence)
+    (with-elevated-precedence
+        (allow file-read*
+               (subpath "/usr/lib"
+                        "/usr/share"
+                        "/private/var/db/timezone"))
+        (allow-read-and-issue-generic-extensions
+            (subpath "/Library/RegionFeatures"
+                     "/System/Library"))
+        (allow file-issue-extension
+            (require-all
+                (extension-class "com.apple.mediaserverd.read")
+                (subpath "/System/Library")))
+        
+        (allow file-map-executable
+               (subpath "/System/Library")
+               (subpath "/usr/lib"))
+        (allow file-read-metadata
+               (vnode-type SYMLINK))
+
+        ;;; <rdar://problem/24144418>
+        (allow file-read*
+               (subpath "/private/var/preferences/Logging"))
+
+        (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication"))
+        (allow file-read*
+               (front-user-home-literal "/Library/Preferences/.GlobalPreferences.plist")
+               (front-user-home-literal "/Library/Preferences/.GlobalPreferences_m.plist"))
+
+        (allow file-read*
+               (literal "/private/var/Managed Preferences/mobile/.GlobalPreferences.plist"))
+        (allow managed-preference-read (preference-domain "kCFPreferencesAnyApplication"))
+
+        (allow file-read-metadata
+               (home-literal "/Library/Caches/powerlog.launchd"))
+
+        (allow-read-and-issue-generic-extensions (executable-bundle))
+        (allow file-map-executable (executable-bundle))
+
+        (unless (defined? 'restrictive-extension)
+            (with-filter
+                (extension
+                    "com.apple.app-sandbox.read"
+                    "com.apple.app-sandbox.read-write"
+                    "com.apple.sharing.airdrop.readonly")
+                (allow file-read* file-read-metadata)
+                (allow file-issue-extension
+                       (extension-class "com.apple.app-sandbox.read"
+                                        "com.apple.mediaserverd.read"
+                                        "com.apple.sharing.airdrop.readonly")))
+            (with-filter
+                (extension
+                    "com.apple.app-sandbox.read-write")
+                (allow file-write* (with report) (with telemetry))
+                (allow file-issue-extension
+                       (extension-class "com.apple.app-sandbox.read-write"
+                                        "com.apple.mediaserverd.read-write"))))
+
+        ;; <rdar://problem/16079361>
+        (allow managed-preference-read
+               (extension "com.apple.security.exception.managed-preference.read-only"))
+        (allow user-preference-read
+               (extension "com.apple.security.exception.shared-preference.read-only"))))
+
+(define (darwin-notification-post-allowed)
+    "_AXNotification_AXSClassicInvertColorsPreference"
+    "com.apple.WebContentFilter.remoteUI.WebContentAnalysisUI-com.apple.uikit.viewService.connectionRequest"
+    "com.apple.accessibility.AirPodsSpatialAudioLockToDeviceChanged"
+    "com.apple.accessibility.QuickSpeakEnabled"
+    "com.apple.accessibility.application.status"
+    "com.apple.accessibility.automation.enabled.status"
+    "com.apple.accessibility.darken.system.colors"
+    "com.apple.accessibility.enhance.background.contrast.status"
+    "com.apple.accessibility.monoaudio.status"
+    "com.apple.accessibility.reduce.motion.status"
+    "com.apple.accessibility.status"
+    "com.apple.accessibility.text.legibility.status"
+    "com.apple.accessibility.voiceovertouch.status"
+    "com.apple.accessibility.wob.status"
+    "com.apple.automation.stringlookupinfoenabled"
+    "com.apple.webinspectord.availability_check")
+
+(define (mobile-preferences-read-allowed)
+    (mobile-preferences-read
+        "com.apple.AdLib.plist"
+        "com.apple.EmojiPreferences" ; <rdar://problem/8477596> com.apple.InputModePreferences
+        "com.apple.InputModePreferences" ; <rdar://problem/8206632> Weather(1038) deny file-read-data ~/Library/Preferences/com.apple.keyboard.plist
+        "com.apple.LaunchServices"
+        "com.apple.Preferences"
+        "com.apple.WebFoundation"
+        "com.apple.avfoundation.frecents" ;; <rdar://problem/33137029>
+        "com.apple.avfoundation.videoperformancehud" ;; <rdar://problem/31594568>
+        "com.apple.da"
+        "com.apple.indigo" ;; <rdar://problem/34986314>
+        "com.apple.keyboard" ; <rdar://problem/9384085>
+        "com.apple.lookup.shared" ; Needed for DataDetector (Spotlight) support
+        "com.apple.security"
+        "com.apple.voiceservices.logging"))


### PR DESCRIPTION
#### e0c788b57e1db6001fe923da9370d0c4d2095e02
<pre>
Reduce size of Development sandboxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=298469">https://bugs.webkit.org/show_bug.cgi?id=298469</a>
<a href="https://rdar.apple.com/158907488">rdar://158907488</a>

Reviewed by Sihui Liu.

Currently, the development sandboxes include their original counterpart, and replace blocking rules with
rules that allow the operation, but emit a report. This causes the development sandboxes to be larger
than necessary, since the original sandboxes have complexity that is not required in the development
versions. This patch creates a custom development sandbox for each process, and only allows the
operations in developer mode.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Shared/Sandbox/iOS/common.sb:
* Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb:
* Source/WebKit/Shared/Sandbox/iOS/networking-defines.sb:
* Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb:

Canonical link: <a href="https://commits.webkit.org/299698@main">https://commits.webkit.org/299698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f940e448e2d843db6ca59294010a8f44db159dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71993 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0dc635f6-5c1d-41e7-a6ed-41c88fd58717) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91062 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60372 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71e75d68-93c9-4269-9819-e9e12ff5c1b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71619 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02c6daba-5208-4dfb-a79c-d52bcbc0737d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31217 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69881 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99685 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99530 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44977 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22990 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43457 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19066 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52408 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46168 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->