### PR TITLE
[Style] Convert the internal marquee properties to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3290,6 +3290,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/non-standard/StyleWebKitBorderSpacing.h
     style/values/non-standard/StyleWebKitBoxReflect.h
     style/values/non-standard/StyleWebKitLineClamp.h
+    style/values/non-standard/StyleWebKitMarqueeIncrement.h
+    style/values/non-standard/StyleWebKitMarqueeRepetition.h
+    style/values/non-standard/StyleWebKitMarqueeSpeed.h
     style/values/non-standard/StyleWebKitOverflowScrolling.h
     style/values/non-standard/StyleWebKitTextStrokeWidth.h
     style/values/non-standard/StyleWebKitTouchCallout.h

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10400,7 +10400,7 @@
             "initial": "6px",
             "codegen-properties": {
                 "accepts-quirky-length": true,
-                "style-builder-converter": "Length",
+                "style-converter": "StyleType<WebkitMarqueeIncrement>",
                 "internal-only": true,
                 "parser-grammar": "<length-percentage>"
             },
@@ -10408,20 +10408,19 @@
         },
         "-webkit-marquee-repetition": {
             "animation-type": "not animatable (internal)",
-            "initial": "-1",
+            "initial": "infinite",
             "codegen-properties": {
-                "render-style-name-for-methods": "MarqueeLoopCount",
-                "style-builder-converter": "MarqueeRepetition",
+                "style-converter": "StyleType<WebkitMarqueeRepetition>",
                 "internal-only": true,
-                "parser-grammar": "<number [0,inf]>"
+                "parser-grammar": "infinite | <integer [0,inf]>"
             },
             "status": "non-standard"
         },
         "-webkit-marquee-speed": {
             "animation-type": "not animatable (internal)",
-            "initial": "85",
+            "initial": "85ms",
             "codegen-properties": {
-                "style-builder-converter": "MarqueeSpeed",
+                "style-converter": "StyleType<WebkitMarqueeSpeed>",
                 "internal-only": true,
                 "parser-grammar": "<time [0,inf]>"
             },

--- a/Source/WebCore/html/HTMLMarqueeElement.cpp
+++ b/Source/WebCore/html/HTMLMarqueeElement.cpp
@@ -43,6 +43,9 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HTMLMarqueeElement);
 
 using namespace HTMLNames;
 
+static constexpr unsigned defaultScrollAmount = 6;
+static constexpr unsigned defaultScrollDelay = 85;
+
 inline HTMLMarqueeElement::HTMLMarqueeElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
@@ -119,7 +122,7 @@ void HTMLMarqueeElement::collectPresentationalHintsForAttribute(const QualifiedN
         break;
     case AttributeNames::scrolldelayAttr:
         if (!value.isEmpty())
-            addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitMarqueeSpeed, limitToOnlyHTMLNonNegative(value, RenderStyle::initialMarqueeSpeed()), CSSUnitType::CSS_MS);
+            addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitMarqueeSpeed, limitToOnlyHTMLNonNegative(value, defaultScrollDelay), CSSUnitType::CSS_MS);
         break;
     case AttributeNames::loopAttr:
         if (!value.isEmpty()) {
@@ -157,24 +160,24 @@ void HTMLMarqueeElement::stop()
 
 unsigned HTMLMarqueeElement::scrollAmount() const
 {
-    return limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(scrollamountAttr), RenderStyle::initialMarqueeIncrement().intValue());
+    return limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(scrollamountAttr), defaultScrollAmount);
 }
-    
+
 void HTMLMarqueeElement::setScrollAmount(unsigned scrollAmount)
 {
-    setUnsignedIntegralAttribute(scrollamountAttr, limitToOnlyHTMLNonNegative(scrollAmount, RenderStyle::initialMarqueeIncrement().intValue()));
+    setUnsignedIntegralAttribute(scrollamountAttr, limitToOnlyHTMLNonNegative(scrollAmount, defaultScrollAmount));
 }
-    
+
 unsigned HTMLMarqueeElement::scrollDelay() const
 {
-    return limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(scrolldelayAttr), RenderStyle::initialMarqueeSpeed());
+    return limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(scrolldelayAttr), defaultScrollDelay);
 }
 
 void HTMLMarqueeElement::setScrollDelay(unsigned scrollDelay)
 {
-    setUnsignedIntegralAttribute(scrolldelayAttr, limitToOnlyHTMLNonNegative(scrollDelay, RenderStyle::initialMarqueeSpeed()));
+    setUnsignedIntegralAttribute(scrolldelayAttr, limitToOnlyHTMLNonNegative(scrollDelay, defaultScrollDelay));
 }
-    
+
 int HTMLMarqueeElement::loop() const
 {
     int loopValue = integralAttribute(loopAttr);

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -43,7 +43,6 @@
 
 #pragma once
 
-#include "Length.h"
 #include "RenderStyleConstants.h"
 #include "Timer.h"
 #include <wtf/CheckedPtr.h>
@@ -72,7 +71,6 @@ public:
     void updateMarqueePosition();
 
 private:
-
     int speed() const { return m_speed; }
     int marqueeSpeed() const;
 
@@ -91,7 +89,6 @@ private:
     int m_start { 0 };
     int m_end { 0 };
     int m_speed { 0 };
-    Length m_height;
     MarqueeDirection m_direction { MarqueeDirection::Auto };
     bool m_reset { false };
     bool m_suspended { false };

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -352,6 +352,9 @@ struct WebkitBoxReflect;
 struct WebkitInitialLetter;
 struct WebkitLineClamp;
 struct WebkitLineGrid;
+struct WebkitMarqueeIncrement;
+struct WebkitMarqueeRepetition;
+struct WebkitMarqueeSpeed;
 struct WebkitTextStrokeWidth;
 struct Widows;
 struct ZIndex;
@@ -946,9 +949,9 @@ public:
 
     inline BoxSizing boxSizing() const;
     inline BoxSizing boxSizingForAspectRatio() const;
-    inline const Length& marqueeIncrement() const;
-    inline int marqueeSpeed() const;
-    inline int marqueeLoopCount() const;
+    inline const Style::WebkitMarqueeIncrement& marqueeIncrement() const;
+    inline Style::WebkitMarqueeRepetition marqueeRepetition() const;
+    inline Style::WebkitMarqueeSpeed marqueeSpeed() const;
     inline MarqueeBehavior marqueeBehavior() const;
     inline MarqueeDirection marqueeDirection() const;
     inline UserModify usedUserModify() const;
@@ -1530,11 +1533,11 @@ public:
     inline void setGridItemRowStart(Style::GridPosition&&);
     inline void setGridItemRowEnd(Style::GridPosition&&);
 
-    inline void setMarqueeIncrement(Length&&);
-    inline void setMarqueeSpeed(int);
-    inline void setMarqueeDirection(MarqueeDirection);
     inline void setMarqueeBehavior(MarqueeBehavior);
-    inline void setMarqueeLoopCount(int);
+    inline void setMarqueeDirection(MarqueeDirection);
+    inline void setMarqueeIncrement(Style::WebkitMarqueeIncrement&&);
+    inline void setMarqueeRepetition(Style::WebkitMarqueeRepetition);
+    inline void setMarqueeSpeed(Style::WebkitMarqueeSpeed);
     inline void setUserModify(UserModify);
     inline void setUserDrag(UserDrag);
     inline void setUserSelect(UserSelect);
@@ -2026,11 +2029,11 @@ public:
     static constexpr StyleContentAlignmentData initialContentAlignment();
     static constexpr FlexDirection initialFlexDirection();
     static constexpr FlexWrap initialFlexWrap();
-    static int initialMarqueeLoopCount() { return -1; }
-    static int initialMarqueeSpeed() { return 85; }
-    static inline Length initialMarqueeIncrement();
     static constexpr MarqueeBehavior initialMarqueeBehavior();
     static constexpr MarqueeDirection initialMarqueeDirection();
+    static inline Style::WebkitMarqueeIncrement initialMarqueeIncrement();
+    static constexpr Style::WebkitMarqueeRepetition initialMarqueeRepetition();
+    static constexpr Style::WebkitMarqueeSpeed initialMarqueeSpeed();
     static constexpr UserModify initialUserModify();
     static constexpr UserDrag initialUserDrag();
     static constexpr UserSelect initialUserSelect();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -432,7 +432,9 @@ inline Style::MarginEdge RenderStyle::initialMargin() { return 0_css_px; }
 constexpr OptionSet<MarginTrimType> RenderStyle::initialMarginTrim() { return { }; }
 constexpr MarqueeBehavior RenderStyle::initialMarqueeBehavior() { return MarqueeBehavior::Scroll; }
 constexpr MarqueeDirection RenderStyle::initialMarqueeDirection() { return MarqueeDirection::Auto; }
-inline Length RenderStyle::initialMarqueeIncrement() { return { 6, LengthType::Fixed }; }
+inline Style::WebkitMarqueeIncrement RenderStyle::initialMarqueeIncrement() { return 6_css_px; }
+constexpr Style::WebkitMarqueeRepetition RenderStyle::initialMarqueeRepetition() { return CSS::Keyword::Infinite { }; }
+constexpr Style::WebkitMarqueeSpeed RenderStyle::initialMarqueeSpeed() { return 85_css_ms; }
 inline Style::MaskBorder RenderStyle::initialMaskBorder() { return Style::MaskBorder { }; }
 inline Style::MaskBorderSource RenderStyle::initialMaskBorderSource() { return CSS::Keyword::None { }; }
 inline Style::MaskLayers RenderStyle::initialMaskLayers() { return { }; }
@@ -638,9 +640,9 @@ inline const Style::MarginEdge& RenderStyle::marginTop() const { return m_nonInh
 inline OptionSet<MarginTrimType> RenderStyle::marginTrim() const { return m_nonInheritedData->rareData->marginTrim; }
 inline MarqueeBehavior RenderStyle::marqueeBehavior() const { return static_cast<MarqueeBehavior>(m_nonInheritedData->rareData->marquee->behavior); }
 inline MarqueeDirection RenderStyle::marqueeDirection() const { return static_cast<MarqueeDirection>(m_nonInheritedData->rareData->marquee->direction); }
-inline const Length& RenderStyle::marqueeIncrement() const { return m_nonInheritedData->rareData->marquee->increment; }
-inline int RenderStyle::marqueeLoopCount() const { return m_nonInheritedData->rareData->marquee->loops; }
-inline int RenderStyle::marqueeSpeed() const { return m_nonInheritedData->rareData->marquee->speed; }
+inline const Style::WebkitMarqueeIncrement& RenderStyle::marqueeIncrement() const { return m_nonInheritedData->rareData->marquee->increment; }
+inline Style::WebkitMarqueeRepetition RenderStyle::marqueeRepetition() const { return m_nonInheritedData->rareData->marquee->repetition; }
+inline Style::WebkitMarqueeSpeed RenderStyle::marqueeSpeed() const { return m_nonInheritedData->rareData->marquee->speed; }
 inline const Style::MaskBorder& RenderStyle::maskBorder() const { return m_nonInheritedData->rareData->maskBorder; }
 inline NinePieceImageRule RenderStyle::maskBorderHorizontalRule() const { return maskBorderRepeat().horizontalRule(); }
 inline const Style::MaskBorderOutset& RenderStyle::maskBorderOutset() const { return maskBorder().outset(); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -210,9 +210,9 @@ inline void RenderStyle::setMarginTop(Style::MarginEdge&& edge) { SET_NESTED(m_n
 inline void RenderStyle::setMarginTrim(OptionSet<MarginTrimType> value) { SET_NESTED(m_nonInheritedData, rareData, marginTrim, value); }
 inline void RenderStyle::setMarqueeBehavior(MarqueeBehavior b) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, behavior, static_cast<unsigned>(b)); }
 inline void RenderStyle::setMarqueeDirection(MarqueeDirection d) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, direction, static_cast<unsigned>(d)); }
-inline void RenderStyle::setMarqueeIncrement(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, increment, WTFMove(length)); }
-inline void RenderStyle::setMarqueeLoopCount(int i) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, loops, i); }
-inline void RenderStyle::setMarqueeSpeed(int speed) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, speed, speed); }
+inline void RenderStyle::setMarqueeIncrement(Style::WebkitMarqueeIncrement&& increment) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, increment, WTFMove(increment)); }
+inline void RenderStyle::setMarqueeRepetition(Style::WebkitMarqueeRepetition repetition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, repetition, repetition); }
+inline void RenderStyle::setMarqueeSpeed(Style::WebkitMarqueeSpeed speed) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, speed, speed); }
 inline void RenderStyle::setMaskBorder(Style::MaskBorder&& image) { SET_NESTED(m_nonInheritedData, rareData, maskBorder, WTFMove(image)); }
 inline void RenderStyle::setMaskLayers(Style::MaskLayers&& layers) { SET_NESTED(m_nonInheritedData, miscData, mask, WTFMove(layers)); }
 inline void RenderStyle::setMathShift(const MathShift& shift) { SET(m_rareInheritedData, mathShift, static_cast<unsigned>(shift)); }

--- a/Source/WebCore/rendering/style/StyleMarqueeData.cpp
+++ b/Source/WebCore/rendering/style/StyleMarqueeData.cpp
@@ -25,13 +25,14 @@
 #include "RenderStyleConstants.h"
 #include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 
 StyleMarqueeData::StyleMarqueeData()
     : increment(RenderStyle::initialMarqueeIncrement())
     , speed(RenderStyle::initialMarqueeSpeed())
-    , loops(RenderStyle::initialMarqueeLoopCount())
+    , repetition(RenderStyle::initialMarqueeRepetition())
     , behavior(static_cast<unsigned>(RenderStyle::initialMarqueeBehavior()))
     , direction(static_cast<unsigned>(RenderStyle::initialMarqueeDirection()))
 {
@@ -41,7 +42,7 @@ inline StyleMarqueeData::StyleMarqueeData(const StyleMarqueeData& o)
     : RefCounted<StyleMarqueeData>()
     , increment(o.increment)
     , speed(o.speed)
-    , loops(o.loops)
+    , repetition(o.repetition)
     , behavior(o.behavior)
     , direction(o.direction) 
 {
@@ -59,8 +60,11 @@ Ref<StyleMarqueeData> StyleMarqueeData::copy() const
 
 bool StyleMarqueeData::operator==(const StyleMarqueeData& o) const
 {
-    return increment == o.increment && speed == o.speed && direction == o.direction &&
-           behavior == o.behavior && loops == o.loops;
+    return increment == o.increment
+        && speed == o.speed
+        && repetition == o.repetition
+        && behavior == o.behavior
+        && direction == o.direction;
 }
 
 #if !LOG_DISABLED
@@ -68,6 +72,7 @@ void StyleMarqueeData::dumpDifferences(TextStream& ts, const StyleMarqueeData& o
 {
     LOG_IF_DIFFERENT(increment);
     LOG_IF_DIFFERENT(speed);
+    LOG_IF_DIFFERENT(repetition);
     LOG_IF_DIFFERENT_WITH_CAST(MarqueeBehavior, behavior);
     LOG_IF_DIFFERENT_WITH_CAST(MarqueeDirection, direction);
 }

--- a/Source/WebCore/rendering/style/StyleMarqueeData.h
+++ b/Source/WebCore/rendering/style/StyleMarqueeData.h
@@ -24,7 +24,10 @@
 
 #pragma once
 
-#include <WebCore/Length.h>
+#include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleWebKitMarqueeIncrement.h>
+#include <WebCore/StyleWebKitMarqueeRepetition.h>
+#include <WebCore/StyleWebKitMarqueeSpeed.h>
 #include <wtf/RefCounted.h>
 
 namespace WTF {
@@ -43,11 +46,12 @@ struct StyleMarqueeData : RefCounted<StyleMarqueeData> {
     void dumpDifferences(TextStream&, const StyleMarqueeData&) const;
 #endif
 
-    Length increment;
-    int speed;
-    int loops; // -1 means infinite.
-    unsigned behavior : 2; // MarqueeBehavior 
-    unsigned direction : 3; // MarqueeDirection
+    Style::WebkitMarqueeIncrement increment;
+    Style::WebkitMarqueeSpeed speed;
+    Style::WebkitMarqueeRepetition repetition;
+
+    PREFERRED_TYPE(MarqueeBehavior) unsigned behavior : 2;
+    PREFERRED_TYPE(MarqueeDirection) unsigned direction : 3;
 
 private:
     StyleMarqueeData();

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -141,8 +141,6 @@ public:
     static TextAlignLast convertTextAlignLast(BuilderState&, const CSSValue&);
     static RefPtr<StylePathData> convertDPath(BuilderState&, const CSSValue&);
     static Resize convertResize(BuilderState&, const CSSValue&);
-    static int convertMarqueeRepetition(BuilderState&, const CSSValue&);
-    static int convertMarqueeSpeed(BuilderState&, const CSSValue&);
     static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
     static TextEdge convertTextEdge(BuilderState&, const CSSValue&);
     static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
@@ -487,33 +485,6 @@ inline Resize BuilderConverter::convertResize(BuilderState& builderState, const 
         resize = fromCSSValue<Resize>(value);
 
     return resize;
-}
-
-inline int BuilderConverter::convertMarqueeRepetition(BuilderState& builderState, const CSSValue& value)
-{
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-    if (primitiveValue->valueID() == CSSValueInfinite)
-        return -1; // -1 means repeat forever.
-
-    ASSERT(primitiveValue->isNumber());
-    return primitiveValue->resolveAsNumber<int>(builderState.cssToLengthConversionData());
-}
-
-inline int BuilderConverter::convertMarqueeSpeed(BuilderState& builderState, const CSSValue& value)
-{
-    auto& conversionData = builderState.cssToLengthConversionData();
-
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-    if (primitiveValue->isTime())
-        return primitiveValue->resolveAsTime<int, CSS::TimeUnit::Ms>(conversionData);
-
-    // For scrollamount support.
-    ASSERT(primitiveValue->isNumber());
-    return primitiveValue->resolveAsNumber<int>(conversionData);
 }
 
 inline static OptionSet<TextUnderlinePosition> valueToUnderlinePosition(const CSSPrimitiveValue& primitiveValue)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -154,11 +154,11 @@ inline ViewTimelineInsets forwardInheritedValue(const ViewTimelineInsets& value)
 inline ViewTimelines forwardInheritedValue(const ViewTimelines& value) { auto copy = value; return copy; }
 inline ViewTransitionClasses forwardInheritedValue(const ViewTransitionClasses& value) { auto copy = value; return copy; }
 inline ViewTransitionName forwardInheritedValue(const ViewTransitionName& value) { auto copy = value; return copy; }
-inline Vector<GridTrackSize> forwardInheritedValue(const Vector<GridTrackSize>& value) { auto copy = value; return copy; }
 inline WebkitBoxReflect forwardInheritedValue(const WebkitBoxReflect& value) { auto copy = value; return copy; }
 inline WebkitInitialLetter forwardInheritedValue(const WebkitInitialLetter& value) { auto copy = value; return copy; }
 inline WebkitLineClamp forwardInheritedValue(const WebkitLineClamp& value) { auto copy = value; return copy; }
 inline WebkitLineGrid forwardInheritedValue(const WebkitLineGrid& value) { auto copy = value; return copy; }
+inline WebkitMarqueeIncrement forwardInheritedValue(const WebkitMarqueeIncrement& value) { auto copy = value; return copy; }
 
 // Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {

--- a/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeIncrement.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeIncrement.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleLengthWrapper.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'-webkit-marquee-increment'> = <length-percentage>
+// NOTE: There is no standard associated with this property. It exists to model the "marquee scroll distance" concept derived from the <marquee> element's `scrollamount` attribute.
+// https://html.spec.whatwg.org/multipage/obsolete.html#marquee-scroll-distance
+// FIXME: Consider changing this type (and the associated internal property `-webkit-marquee-increment`) to be named after the spec term "marquee scroll distance".
+struct WebkitMarqueeIncrement : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::WebkitMarqueeIncrement)

--- a/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeRepetition.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeRepetition.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'-webkit-marquee-repetition'> = infinite | <integer [0,∞]>
+// NOTE: There is no standard associated with this property. It exists to model the "marquee loop count" concept derived from the <marquee> element's `loop` attribute.
+// https://html.spec.whatwg.org/multipage/obsolete.html#marquee-loop-count
+// FIXME: Consider changing this type (and the associated internal property `-webkit-marquee-repetition`) to be named after the spec term "marquee loop count".
+struct WebkitMarqueeRepetition : ValueOrKeyword<Integer<CSS::Nonnegative>, CSS::Keyword::Infinite> {
+    using Base::Base;
+    using Integer = typename Base::Value;
+
+    bool isInfinite() const { return isKeyword(); }
+    bool isInteger() const { return isValue(); }
+    std::optional<Integer> tryInteger() const { return tryValue(); }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::WebkitMarqueeRepetition)

--- a/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeSpeed.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitMarqueeSpeed.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'-webkit-marquee-speed'> = <time [0,∞]>
+// NOTE: There is no standard associated with this property. It exists to model the "marquee scroll interval" concept derived from the <marquee> element's `scrolldelay` attribute.
+// https://html.spec.whatwg.org/multipage/obsolete.html#marquee-scroll-interval
+// FIXME: Consider changing this type (and the associated internal property `-webkit-marquee-speed`) to be named after the spec term "marquee scroll interval".
+struct WebkitMarqueeSpeed {
+    using Time = Style::Time<CSS::Nonnegative>;
+
+    Time value;
+
+    constexpr WebkitMarqueeSpeed(Time value) : value { value } { }
+    constexpr WebkitMarqueeSpeed(CSS::ValueLiteral<CSS::TimeUnit::S> literal) : value { literal } { }
+    constexpr WebkitMarqueeSpeed(CSS::ValueLiteral<CSS::TimeUnit::Ms> literal) : value { CSS::convertToValueInUnitsOf<CSS::TimeUnit::S>(literal) } { }
+
+    constexpr double asMilliseconds() const { return CSS::convertToValueInUnitsOf<CSS::TimeUnit::Ms>(value); }
+
+    constexpr bool operator==(const WebkitMarqueeSpeed&) const = default;
+    constexpr auto operator<=>(const WebkitMarqueeSpeed&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(WebkitMarqueeSpeed, value);
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::WebkitMarqueeSpeed)


### PR DESCRIPTION
#### 5a56bacea5f8e2caf229ce355689cf089372293b
<pre>
[Style] Convert the internal marquee properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=298475">https://bugs.webkit.org/show_bug.cgi?id=298475</a>

Reviewed by Darin Adler.

Converts the internal marquee properties, `-webkit-marquee-increment`,
`-webkit-marquee-repetition` and `-webkit-marquee-speed`, to strong
style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/html/HTMLMarqueeElement.cpp:
* Source/WebCore/rendering/RenderMarquee.cpp:
* Source/WebCore/rendering/RenderMarquee.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleMarqueeData.cpp:
* Source/WebCore/rendering/style/StyleMarqueeData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/values/non-standard/StyleWebKitMarqueeIncrement.h: Added.
* Source/WebCore/style/values/non-standard/StyleWebKitMarqueeRepetition.h: Added.
* Source/WebCore/style/values/non-standard/StyleWebKitMarqueeSpeed.h: Added.

Canonical link: <a href="https://commits.webkit.org/299776@main">https://commits.webkit.org/299776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/108a37c7bd5f4db873ddd25e20e68e5238eae118

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91216 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60523 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47028 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35675 "Found 1 new test failure: http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99838 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99681 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43659 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52596 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->