### PR TITLE
Temporal: Reimplement TemporalPlainTime::since() and TemporalPlainTime::until()

### DIFF
--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1748,8 +1748,7 @@ static Int128 roundTimeDurationToIncrement(JSGlobalObject* globalObject, Int128 
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-roundtimeduration
-static Int128 roundTimeDuration(JSGlobalObject* globalObject, Int128 timeDuration, unsigned increment,
-    TemporalUnit unit, RoundingMode roundingMode)
+Int128 roundTimeDuration(JSGlobalObject* globalObject, Int128 timeDuration, unsigned increment, TemporalUnit unit, RoundingMode roundingMode)
 {
     auto divisor = lengthInNanoseconds(unit);
 

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -327,6 +327,8 @@ std::optional<ExactTime> parseInstant(StringView);
 bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond);
 bool isYearWithinLimits(double year);
 
+Int128 roundTimeDuration(JSGlobalObject*, Int128, unsigned, TemporalUnit, RoundingMode);
+
 } // namespace ISO8601
 
 using CheckedInt128 = Checked<Int128, RecordOverflow>;

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -127,6 +127,11 @@ enum class Inclusivity : bool {
     Exclusive
 };
 
+enum class DifferenceOperation : bool {
+    Since,
+    Until
+};
+
 double nonNegativeModulo(double x, double y);
 WTF::String ellipsizeAt(unsigned maxLength, const WTF::String&);
 PropertyName temporalUnitPluralPropertyName(VM&, TemporalUnit);

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -517,7 +517,8 @@ ISO8601::PlainTime TemporalPlainTime::with(JSGlobalObject* globalObject, JSObjec
     RELEASE_AND_RETURN(scope, regulateTime(globalObject, WTFMove(duration), overflow));
 }
 
-static ISO8601::Duration differenceTime(ISO8601::PlainTime time1, ISO8601::PlainTime time2)
+// https://tc39.es/proposal-temporal/#sec-temporal-differencetime
+static Int128 differenceTime(ISO8601::PlainTime time1, ISO8601::PlainTime time2)
 {
     double hours = static_cast<double>(time2.hour()) - static_cast<double>(time1.hour());
     double minutes = static_cast<double>(time2.minute()) - static_cast<double>(time1.minute());
@@ -526,52 +527,46 @@ static ISO8601::Duration differenceTime(ISO8601::PlainTime time1, ISO8601::Plain
     double microseconds = static_cast<double>(time2.microsecond()) - static_cast<double>(time1.microsecond());
     double nanoseconds = static_cast<double>(time2.nanosecond()) - static_cast<double>(time1.nanosecond());
     dataLogLnIf(TemporalPlainTimeInternal::verbose, "Diff ", hours, " ", minutes, " ", seconds, " ", milliseconds, " ", microseconds, " ", nanoseconds);
-    int32_t sign = TemporalDuration::sign(ISO8601::Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds));
-    auto duration = balanceTime(hours * sign, minutes * sign, seconds * sign, milliseconds * sign, microseconds * sign, nanoseconds * sign);
-    dataLogLnIf(TemporalPlainTimeInternal::verbose, "Balanced ", duration.days(), " ", duration.hours(), " ", duration.minutes(), " ", duration.seconds(), " ", duration.milliseconds(), " ", duration.microseconds(), " ", duration.nanoseconds());
-    if (sign == -1)
-        return -duration;
-    return duration;
+
+    return TemporalDuration::timeDurationFromComponents(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaintime
+// DifferenceTemporalPlainTime ( operation, temporalTime, other, options )
+ISO8601::Duration TemporalPlainTime::differenceTemporalPlainTime(DifferenceOperation operation, JSGlobalObject* globalObject, TemporalPlainTime* other, JSValue optionsValue) const
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Time, TemporalUnit::Nanosecond, TemporalUnit::Hour);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    Int128 timeDuration;
+
+    // The sign of the argument to roundTimeDuration() determines the choice
+    // of rounding mode, so the sign should be preserved here instead of
+    // negating the duration at the end
+    if (operation == DifferenceOperation::Since)
+        timeDuration = differenceTime(other->plainTime(), plainTime());
+    else
+        timeDuration = differenceTime(plainTime(), other->plainTime());
+
+    auto d = ISO8601::roundTimeDuration(globalObject, timeDuration, increment, smallestUnit, roundingMode);
+    RETURN_IF_EXCEPTION(scope, { });
+    auto duration = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), d);
+    return TemporalDuration::temporalDurationFromInternal(duration, largestUnit);
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until
 ISO8601::Duration TemporalPlainTime::until(JSGlobalObject* globalObject, TemporalPlainTime* other, JSValue optionsValue) const
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Time, TemporalUnit::Nanosecond, TemporalUnit::Hour);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    auto result = differenceTime(plainTime(), other->plainTime());
-    result.setYears(0);
-    result.setMonths(0);
-    result.setWeeks(0);
-    result.setDays(0);
-    TemporalDuration::round(result, increment, smallestUnit, roundingMode);
-    TemporalDuration::balance(result, largestUnit);
-    return result;
+    return differenceTemporalPlainTime(DifferenceOperation::Until, globalObject, other, optionsValue);
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since
 ISO8601::Duration TemporalPlainTime::since(JSGlobalObject* globalObject, TemporalPlainTime* other, JSValue optionsValue) const
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Time, TemporalUnit::Nanosecond, TemporalUnit::Hour);
-    RETURN_IF_EXCEPTION(scope, { });
-    roundingMode = negateTemporalRoundingMode(roundingMode);
-
-    auto result = differenceTime(other->plainTime(), plainTime());
-    result = -result;
-    result.setYears(0);
-    result.setMonths(0);
-    result.setWeeks(0);
-    result.setDays(0);
-    TemporalDuration::round(result, increment, smallestUnit, roundingMode);
-    result = -result;
-    result.setDays(0);
-    TemporalDuration::balance(result, largestUnit);
-    return result;
+    return differenceTemporalPlainTime(DifferenceOperation::Since, globalObject, other, optionsValue);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.h
@@ -86,6 +86,8 @@ private:
     static std::optional<ISO8601::PlainTime> parse(StringParsingBuffer<CharacterType>&);
     static ISO8601::PlainTime fromObject(JSGlobalObject*, JSObject*);
 
+    ISO8601::Duration differenceTemporalPlainTime(DifferenceOperation, JSGlobalObject*, TemporalPlainTime*, JSValue) const;
+
     ISO8601::PlainTime m_plainTime;
     LazyProperty<TemporalPlainTime, TemporalCalendar> m_calendar;
 };


### PR DESCRIPTION
#### 6fcf0414ac9c5422707483c18f31147b42e468e0
<pre>
Temporal: Reimplement TemporalPlainTime::since() and TemporalPlainTime::until()
<a href="https://bugs.webkit.org/show_bug.cgi?id=223166">https://bugs.webkit.org/show_bug.cgi?id=223166</a>

Reviewed by BJ Burg and Yusuke Suzuki.

Implement these operations according to the spec, adding
TemporalPlainTime::differenceTemporalPlainTime().

This is a refactor and shouldn&apos;t change anything observable.

* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::roundTimeDuration):
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/TemporalObject.h:
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::differenceTime):
(JSC::TemporalPlainTime::differenceTemporalPlainTime const):
(JSC::TemporalPlainTime::until const):
(JSC::TemporalPlainTime::since const):
* Source/JavaScriptCore/runtime/TemporalPlainTime.h:

Canonical link: <a href="https://commits.webkit.org/299723@main">https://commits.webkit.org/299723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21abfbc475a0e96e0e44637a89e1eaa2e28f1fcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60240 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25484 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69692 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111878 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128999 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118269 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25280 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44834 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22851 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43239 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46535 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52241 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146967 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46001 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37768 "Found 1 new JSC binary failure: testapi, Found 18670 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->