### PR TITLE
Adopt safer CPP in SystemBattery.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -50,7 +50,6 @@ platform/cocoa/NetworkExtensionContentFilter.mm
 platform/cocoa/ParentalControlsContentFilter.mm
 platform/cocoa/PlatformPasteboardCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
-platform/cocoa/SystemBattery.mm
 platform/cocoa/UserAgentCocoa.mm
 platform/cocoa/WebAVPlayerLayer.mm
 platform/gamepad/cocoa/GameControllerGamepad.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -30,7 +30,6 @@ platform/cocoa/PlatformPasteboardCocoa.mm
 platform/cocoa/RemoteCommandListenerCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SerializedPlatformDataCueValue.mm
-platform/cocoa/SystemBattery.mm
 platform/cocoa/SystemVersion.mm
 platform/graphics/DestinationColorSpace.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm

--- a/Source/WebCore/platform/cocoa/SystemBattery.mm
+++ b/Source/WebCore/platform/cocoa/SystemBattery.mm
@@ -59,9 +59,10 @@ bool systemHasBattery()
             if (!powerSourcesList)
                 return false;
             for (CFIndex i = 0, count = CFArrayGetCount(powerSourcesList.get()); i < count; ++i) {
-                CFDictionaryRef description = IOPSGetPowerSourceDescription(powerSourcesInfo.get(), CFArrayGetValueAtIndex(powerSourcesList.get(), i));
-                CFTypeRef value = CFDictionaryGetValue(description, CFSTR(kIOPSTypeKey));
-                if (!value || CFEqual(value, CFSTR(kIOPSInternalBatteryType)))
+                RetainPtr valueAtIndex =  CFArrayGetValueAtIndex(powerSourcesList.get(), i);
+                RetainPtr description = IOPSGetPowerSourceDescription(powerSourcesInfo.get(), valueAtIndex.get());
+                RetainPtr value = CFDictionaryGetValue(description.get(), CFSTR(kIOPSTypeKey));
+                if (!value || CFEqual(value.get(), CFSTR(kIOPSInternalBatteryType)))
                     return true;
             }
             return false;
@@ -99,11 +100,12 @@ bool systemHasAC()
             if (!powerSourcesList)
                 return false;
             for (CFIndex i = 0, count = CFArrayGetCount(powerSourcesList.get()); i < count; ++i) {
-                CFDictionaryRef description = IOPSGetPowerSourceDescription(powerSourcesInfo.get(), CFArrayGetValueAtIndex(powerSourcesList.get(), i));
+                RetainPtr valueAtIndex = CFArrayGetValueAtIndex(powerSourcesList.get(), i);
+                RetainPtr description = IOPSGetPowerSourceDescription(powerSourcesInfo.get(), valueAtIndex.get());
                 if (!description)
                     continue;
-                CFTypeRef value = CFDictionaryGetValue(description, CFSTR(kIOPSPowerSourceStateKey));
-                if (value && CFEqual(value, CFSTR(kIOPSACPowerValue)))
+                RetainPtr value = CFDictionaryGetValue(description.get(), CFSTR(kIOPSPowerSourceStateKey));
+                if (value && CFEqual(value.get(), CFSTR(kIOPSACPowerValue)))
                     return true;
             }
             return false;


### PR DESCRIPTION
#### 2dddfc70065612b478b662954aa5c2535b77307d
<pre>
Adopt safer CPP in SystemBattery.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=298477">https://bugs.webkit.org/show_bug.cgi?id=298477</a>
<a href="https://rdar.apple.com/159971849">rdar://159971849</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines.</a>

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/cocoa/SystemBattery.mm:
(WebCore::systemHasBattery):
(WebCore::systemHasAC):

Canonical link: <a href="https://commits.webkit.org/300063@main">https://commits.webkit.org/300063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2b168dd1299ad25a259c75b6bbfcd775cdcc680

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73294 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/485f220a-f0eb-4252-b6bd-5a053bb51531) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49488 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92077 "23 flakes 76 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3084074-2023-44cc-a963-59641c32b75b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72755 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51ccca48-f1a6-47a0-8b93-b8bd221cb489) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26751 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71228 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130487 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100675 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100579 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45983 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44834 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19226 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53711 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47469 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->