### PR TITLE
TZoneHeapManager::init() should use CC_SHA256_DIGEST_LENGTH for its CC_SHA256 seed size.

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -260,26 +260,25 @@ void TZoneHeapManager::init()
         TZONE_LOG_DEBUG("\n");
     }
 
-    alignas(8) unsigned char seed[CC_SHA1_DIGEST_LENGTH];
-    (void)CC_SHA256(&rawSeed, rawSeedLength, seed);
+    alignas(8) std::array<unsigned char, CC_SHA256_DIGEST_LENGTH> defaultSeed;
+    (void)CC_SHA256(&rawSeed, rawSeedLength, defaultSeed.data());
 #else // OS(DARWIN) => !OS(DARWIN)
     if constexpr (verbose)
         TZONE_LOG_DEBUG("using static seed\n");
 
-    const unsigned char defaultSeed[CC_SHA1_DIGEST_LENGTH] = { "DefaultSeed\x12\x34\x56\x78\x9a\xbc\xde\xf0" };
-    memcpy(m_tzoneKey.seed, defaultSeed, CC_SHA1_DIGEST_LENGTH);
+    const std::array<unsigned char, CC_SHA1_DIGEST_LENGTH> defaultSeed = { "DefaultSeed\x12\x34\x56\x78\x9a\xbc\xde\xf0" };
 #endif // OS(DARWIN) => !OS(DARWIN)
 
-    uint64_t* seedPtr = reinterpret_cast<uint64_t*>(seed);
+    const uint64_t* seedPtr = reinterpret_cast<const uint64_t*>(defaultSeed.data());
     m_tzoneKeySeed = 0;
-    unsigned remainingBytes = CC_SHA1_DIGEST_LENGTH;
+    unsigned remainingBytes = defaultSeed.size();
     while (remainingBytes > sizeof(m_tzoneKeySeed)) {
         m_tzoneKeySeed = m_tzoneKeySeed ^ *seedPtr++;
         remainingBytes -= sizeof(m_tzoneKeySeed);
     }
     uint64_t remainingSeed = 0;
-    unsigned char* seedBytes = reinterpret_cast<unsigned char*>(seedPtr);
-    while (remainingBytes > sizeof(m_tzoneKeySeed)) {
+    const unsigned char* seedBytes = reinterpret_cast<const unsigned char*>(seedPtr);
+    while (remainingBytes) {
         remainingSeed = (remainingSeed << 8) | *seedBytes++;
         remainingBytes--;
     }
@@ -287,8 +286,8 @@ void TZoneHeapManager::init()
 
     if constexpr (verbose) {
         TZONE_LOG_DEBUG("    Computed key {");
-        for (unsigned i = 0; i < CC_SHA1_DIGEST_LENGTH; ++i)
-            TZONE_LOG_DEBUG(" %02x", seed[i]);
+        for (unsigned char byte : defaultSeed)
+            TZONE_LOG_DEBUG(" %02x", byte);
         TZONE_LOG_DEBUG(" }\n");
     }
 


### PR DESCRIPTION
#### b386e6352b372656f14966dce0a91e08f878921e
<pre>
TZoneHeapManager::init() should use CC_SHA256_DIGEST_LENGTH for its CC_SHA256 seed size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298479">https://bugs.webkit.org/show_bug.cgi?id=298479</a>
<a href="https://rdar.apple.com/159973958">rdar://159973958</a>

Reviewed by Yijia Huang and Yusuke Suzuki.

CC_SHA256_DIGEST_LENGTH is 32 bytes in size.  It was previously allocating CC_SHA1_DIGEST_LENGTH
which is 20 bytes in size.  This is a theoretical OOB write bug.  However, disassembly of the
function shows that this bug is benign: the extra 12 bytes of stack memory written to by
CC_SHA256 is unused.  Regardless, we&apos;ll fix this.

Also fixed the following:

1. The 2nd while loop for computing m_tzoneKeySeed was checking:
       while (remainingBytes &gt; sizeof(m_tzoneKeySeed))
   ... but should be checking:
       while (remainingBytes)

   This is because it is intended to drain the remaining bytes in the defaultSeed that don&apos;t
   fit in sizeof(m_tzoneKeySeed).

2. Fixed the initialization of defaultSeed for !BOS(DARWIN) ports.  This code would not have
   compiled previously, but no other ports were using TZone yet and hence did not fail on this.

* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::init):

Canonical link: <a href="https://commits.webkit.org/299666@main">https://commits.webkit.org/299666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/163f2474f75e8a99ba8feadc4830a35f88cfecb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71805 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4aa2564-d915-4c19-b097-04182e23a572) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60226 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8422f477-9fa1-4ad6-aa8c-6574129f52eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71470 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2b336fa-acab-48ac-8bbd-821959aa6f61) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69667 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111858 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128979 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118249 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99534 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99378 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22830 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43219 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19054 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46515 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146947 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45981 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37761 "Found 1 new JSC binary failure: testapi, Found 18675 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->