### PR TITLE
[Style] Convert the @page size descriptor to strong style types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -227,6 +227,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/multicol"
     "${WEBCORE_DIR}/style/values/non-standard"
     "${WEBCORE_DIR}/style/values/overflow"
+    "${WEBCORE_DIR}/style/values/page"
     "${WEBCORE_DIR}/style/values/position"
     "${WEBCORE_DIR}/style/values/primitives"
     "${WEBCORE_DIR}/style/values/rhythm"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3300,6 +3300,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/overflow/StyleScrollBehavior.h
     style/values/overflow/StyleScrollbarGutter.h
 
+    style/values/page/StylePageSize.h
+
     style/values/position/StyleInset.h
 
     style/values/primitives/StyleLengthWrapper+Blending.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3241,6 +3241,7 @@ style/values/non-standard/StyleWebKitTouchCallout.cpp
 style/values/overflow/StyleBlockEllipsis.cpp
 style/values/overflow/StyleScrollBehavior.cpp
 style/values/overflow/StyleScrollbarGutter.cpp
+style/values/page/StylePageSize.cpp
 style/values/primitives/StyleLengthResolution.cpp
 style/values/primitives/StyleLengthWrapperData.cpp
 style/values/primitives/StylePosition.cpp

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -399,8 +399,22 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
         return String::number(style->fontDescription().computedSize());
     if (propertyName == "font-family"_s)
         return style->fontDescription().firstFamily();
-    if (propertyName == "size"_s)
-        return makeString(style->pageSize().width.value(), ' ', style->pageSize().height.value());
+    if (propertyName == "size"_s) {
+        return WTF::switchOn(style->pageSize(),
+            [&](const CSS::Keyword::Auto&) -> String {
+                return "auto"_s;
+            },
+            [&](const CSS::Keyword::Landscape&) -> String {
+                return "landscape"_s;
+            },
+            [&](const CSS::Keyword::Portrait&) -> String {
+                return "portrait"_s;
+            },
+            [&](const Style::PageSize::Lengths& lengths) {
+                return makeString(lengths.width().value, ' ', lengths.height().value);
+            }
+        );
+    }
 
     return makeString("pageProperty() unimplemented for: "_s, propertyName);
 }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2019,7 +2019,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // marquee
         // boxReflect
         // pageSize
-        // pageSizeType
         // overscrollBehaviorX
         // overscrollBehaviorY
         // applePayButtonStyle

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -164,7 +164,6 @@ enum class OverflowAnchor : bool;
 enum class OverflowContinue : bool;
 enum class OverflowWrap : uint8_t;
 enum class OverscrollBehavior : uint8_t;
-enum class PageSizeType : uint8_t;
 enum class PaginationMode : uint8_t;
 enum class PaintBehavior : uint32_t;
 enum class PaintOrder : uint8_t;
@@ -305,6 +304,7 @@ struct OffsetRotate;
 struct Opacity;
 struct Orphans;
 struct PaddingEdge;
+struct PageSize;
 struct Perspective;
 struct Position;
 struct PositionX;
@@ -1118,8 +1118,7 @@ public:
     inline const Style::PerspectiveOriginX& perspectiveOriginX() const;
     inline const Style::PerspectiveOriginY& perspectiveOriginY() const;
 
-    inline const LengthSize& pageSize() const;
-    inline PageSizeType pageSizeType() const;
+    inline const Style::PageSize& pageSize() const;
 
     inline OptionSet<Style::LineBoxContain> lineBoxContain() const;
     inline const Style::WebkitLineClamp& lineClamp() const;
@@ -1632,9 +1631,9 @@ public:
     inline void setPerspectiveOrigin(Style::PerspectiveOrigin&&);
     inline void setPerspectiveOriginX(Style::PerspectiveOriginX&&);
     inline void setPerspectiveOriginY(Style::PerspectiveOriginY&&);
-    inline void setPageSize(LengthSize);
-    inline void setPageSizeType(PageSizeType);
-    inline void resetPageSizeType();
+
+    inline void setPageSize(Style::PageSize&&);
+    inline void resetPageSize();
 
     inline void setLineBoxContain(OptionSet<Style::LineBoxContain>);
     inline void setLineClamp(Style::WebkitLineClamp&&);
@@ -1979,6 +1978,7 @@ public:
     static inline Style::MarginEdge initialMargin();
     static constexpr OptionSet<MarginTrimType> initialMarginTrim();
     static inline Style::PaddingEdge initialPadding();
+    static inline Style::PageSize initialPageSize();
     static inline Style::TextIndent initialTextIndent();
     static constexpr TextBoxTrim initialTextBoxTrim();
     static TextEdge initialTextBoxEdge();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -463,6 +463,7 @@ constexpr Overflow RenderStyle::initialOverflowY() { return Overflow::Visible; }
 constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorX() { return OverscrollBehavior::Auto; }
 constexpr OverscrollBehavior RenderStyle::initialOverscrollBehaviorY() { return OverscrollBehavior::Auto; }
 inline Style::PaddingEdge RenderStyle::initialPadding() { return 0_css_px; }
+inline Style::PageSize RenderStyle::initialPageSize() { return CSS::Keyword::Auto { }; }
 constexpr PaintOrder RenderStyle::initialPaintOrder() { return PaintOrder::Normal; }
 inline Style::Perspective RenderStyle::initialPerspective() { return CSS::Keyword::None { }; }
 inline Style::PerspectiveOrigin RenderStyle::initialPerspectiveOrigin() { return { initialPerspectiveOriginX(), initialPerspectiveOriginY() }; }
@@ -690,8 +691,7 @@ inline const Style::PaddingEdge& RenderStyle::paddingRight() const { return padd
 inline const Style::PaddingEdge& RenderStyle::paddingStart() const { return paddingStart(writingMode()); }
 inline const Style::PaddingEdge& RenderStyle::paddingStart(const WritingMode writingMode) const { return paddingBox().start(writingMode); }
 inline const Style::PaddingEdge& RenderStyle::paddingTop() const { return paddingBox().top(); }
-inline const LengthSize& RenderStyle::pageSize() const { return m_nonInheritedData->rareData->pageSize; }
-inline PageSizeType RenderStyle::pageSizeType() const { return static_cast<PageSizeType>(m_nonInheritedData->rareData->pageSizeType); }
+inline const Style::PageSize& RenderStyle::pageSize() const { return m_nonInheritedData->rareData->pageSize; }
 inline PaintOrder RenderStyle::paintOrder() const { return static_cast<PaintOrder>(m_rareInheritedData->paintOrder); }
 inline const Style::Perspective& RenderStyle::perspective() const { return m_nonInheritedData->rareData->perspective; }
 inline const Style::PerspectiveOrigin& RenderStyle::perspectiveOrigin() const { return m_nonInheritedData->rareData->perspectiveOrigin; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -63,7 +63,7 @@ inline void RenderStyle::resetBorderTopRightRadius() { SET_NESTED(m_nonInherited
 inline void RenderStyle::resetColumnRule() { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule, BorderValue()); }
 inline void RenderStyle::resetMargin() { SET_NESTED(m_nonInheritedData, surroundData, margin, Style::MarginBox { 0_css_px }); }
 inline void RenderStyle::resetPadding() { SET_NESTED(m_nonInheritedData, surroundData, padding, Style::PaddingBox { 0_css_px }); }
-inline void RenderStyle::resetPageSizeType() { SET_NESTED(m_nonInheritedData, rareData, pageSizeType, static_cast<unsigned>(PageSizeType::Auto)); }
+inline void RenderStyle::resetPageSize() { SET_NESTED(m_nonInheritedData, rareData, pageSize, Style::PageSize { CSS::Keyword::Auto { } }); }
 inline void RenderStyle::setAccentColor(Style::Color&& color) { SET_PAIR(m_rareInheritedData, accentColor, WTFMove(color), hasAutoAccentColor, false); }
 inline void RenderStyle::setAlignContent(const StyleContentAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignContent, data); }
 inline void RenderStyle::setAlignItems(const StyleSelfAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignItems, data); }
@@ -247,8 +247,7 @@ inline void RenderStyle::setPaddingBox(Style::PaddingBox&& box) { SET_NESTED(m_n
 inline void RenderStyle::setPaddingLeft(Style::PaddingEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, padding.left(), WTFMove(edge)); }
 inline void RenderStyle::setPaddingRight(Style::PaddingEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, padding.right(), WTFMove(edge)); }
 inline void RenderStyle::setPaddingTop(Style::PaddingEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, padding.top(), WTFMove(edge)); }
-inline void RenderStyle::setPageSize(LengthSize size) { SET_NESTED(m_nonInheritedData, rareData, pageSize, WTFMove(size)); }
-inline void RenderStyle::setPageSizeType(PageSizeType type) { SET_NESTED(m_nonInheritedData, rareData, pageSizeType, static_cast<unsigned>(type)); }
+inline void RenderStyle::setPageSize(Style::PageSize&& pageSize) { SET_NESTED(m_nonInheritedData, rareData, pageSize, WTFMove(pageSize)); }
 inline void RenderStyle::setPaintOrder(PaintOrder order) { SET(m_rareInheritedData, paintOrder, static_cast<unsigned>(order)); }
 inline void RenderStyle::setPerspective(Style::Perspective&& perspective) { SET_NESTED(m_nonInheritedData, rareData, perspective, WTFMove(perspective)); }
 inline void RenderStyle::setPerspectiveOrigin(Style::PerspectiveOrigin&& origin) { SET_NESTED(m_nonInheritedData, rareData, perspectiveOrigin, WTFMove(origin)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -62,7 +62,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , willChange(RenderStyle::initialWillChange())
     , boxReflect(RenderStyle::initialBoxReflect())
     , maskBorder(RenderStyle::initialMaskBorder())
-    // pageSize
+    , pageSize(RenderStyle::initialPageSize())
     , shapeOutside(RenderStyle::initialShapeOutside())
     , shapeMargin(RenderStyle::initialShapeMargin())
     , shapeImageThreshold(RenderStyle::initialShapeImageThreshold())
@@ -111,7 +111,6 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , blockStepRound(static_cast<unsigned>(RenderStyle::initialBlockStepRound()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
     , overscrollBehaviorY(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorY()))
-    , pageSizeType(static_cast<unsigned>(PageSizeType::Auto))
     , transformStyle3D(static_cast<unsigned>(RenderStyle::initialTransformStyle3D()))
     , transformStyleForcedToFlat(false)
     , backfaceVisibility(static_cast<unsigned>(RenderStyle::initialBackfaceVisibility()))
@@ -218,7 +217,6 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , blockStepRound(o.blockStepRound)
     , overscrollBehaviorX(o.overscrollBehaviorX)
     , overscrollBehaviorY(o.overscrollBehaviorY)
-    , pageSizeType(o.pageSizeType)
     , transformStyle3D(o.transformStyle3D)
     , transformStyleForcedToFlat(o.transformStyleForcedToFlat)
     , backfaceVisibility(o.backfaceVisibility)
@@ -330,7 +328,6 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && blockStepRound == o.blockStepRound
         && overscrollBehaviorX == o.overscrollBehaviorX
         && overscrollBehaviorY == o.overscrollBehaviorY
-        && pageSizeType == o.pageSizeType
         && transformStyle3D == o.transformStyle3D
         && transformStyleForcedToFlat == o.transformStyleForcedToFlat
         && backfaceVisibility == o.backfaceVisibility
@@ -494,8 +491,6 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
 
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorX);
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorY);
-
-    LOG_IF_DIFFERENT_WITH_CAST(PageSizeType, pageSizeType);
 
     LOG_IF_DIFFERENT_WITH_CAST(TransformStyle3D, transformStyle3D);
     LOG_IF_DIFFERENT_WITH_CAST(bool, transformStyleForcedToFlat);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -49,6 +49,7 @@
 #include <WebCore/StyleOffsetPath.h>
 #include <WebCore/StyleOffsetPosition.h>
 #include <WebCore/StyleOffsetRotate.h>
+#include <WebCore/StylePageSize.h>
 #include <WebCore/StylePerspective.h>
 #include <WebCore/StylePerspectiveOrigin.h>
 #include <WebCore/StylePrimitiveNumericTypes.h>
@@ -110,16 +111,6 @@ namespace Style {
 class CustomPropertyData;
 }
 
-// Page size type.
-// StyleRareNonInheritedData::pageSize is meaningful only when
-// StyleRareNonInheritedData::pageSizeType is PAGE_SIZE_RESOLVED.
-enum class PageSizeType : uint8_t {
-    Auto, // size: auto
-    AutoLandscape, // size: landscape
-    AutoPortrait, // size: portrait
-    Resolved // Size is fully resolved.
-};
-
 // This struct is for rarely used non-inherited CSS3, CSS2, and WebKit-specific properties.
 // By grouping them together, we save space, and only allocate this object when someone
 // actually uses one of these properties.
@@ -180,7 +171,7 @@ public:
 
     Style::MaskBorder maskBorder;
 
-    LengthSize pageSize;
+    Style::PageSize pageSize;
 
     Style::ShapeOutside shapeOutside;
     Style::ShapeMargin shapeMargin;
@@ -249,7 +240,6 @@ public:
     PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorX : 2;
     PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorY : 2;
 
-    PREFERRED_TYPE(PageSizeType) unsigned pageSizeType : 2;
     PREFERRED_TYPE(TransformStyle3D) unsigned transformStyle3D : 2;
     PREFERRED_TYPE(bool) unsigned transformStyleForcedToFlat : 1; // The used value for transform-style is forced to flat by a grouping property.
     PREFERRED_TYPE(BackfaceVisibility) unsigned backfaceVisibility : 1;

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -454,6 +454,7 @@ template<typename CSSType> struct CSSValueCreation<MinimallySerializingSpaceSepa
 //    template<> struct WebCore::Style::CSSValueConversion<StyleType> {
 //                   StyleType operator()(BuilderState&, const CSSValue&);
 //        [optional] StyleType operator()(BuilderState&, const CSSPrimitiveValue&);
+//        [optional] StyleType operator()(const CSSToLengthConversionData&, const CSSPrimitiveValue&);
 //    };
 
 template<typename StyleType> struct CSSValueConversion;
@@ -466,6 +467,10 @@ template<typename StyleType> struct CSSValueConversionInvoker {
     template<typename... Rest> StyleType operator()(BuilderState& builderState, const CSSPrimitiveValue& value, Rest&&... rest) const
     {
         return CSSValueConversion<StyleType>{}(builderState, value, std::forward<Rest>(rest)...);
+    }
+    template<typename... Rest> StyleType operator()(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value, Rest&&... rest) const
+    {
+        return CSSValueConversion<StyleType>{}(conversionData, value, std::forward<Rest>(rest)...);
     }
 };
 template<typename StyleType> inline constexpr CSSValueConversionInvoker<StyleType> toStyleFromCSSValue{};

--- a/Source/WebCore/style/values/page/StylePageSize.cpp
+++ b/Source/WebCore/style/values/page/StylePageSize.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StylePageSize.h"
+
+#include "CSSValuePair.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+static PageSize pageSizeFromName(BuilderState& state, const CSSPrimitiveValue& pageSizeName, RefPtr<const CSSPrimitiveValue> pageOrientation)
+{
+    auto mmLength = [](double mm) {
+        return Length<CSS::Nonnegative>(CSS::pixelsPerMm * mm);
+    };
+
+    auto inchLength = [](double inch) {
+        return Length<CSS::Nonnegative>(CSS::pixelsPerInch * inch);
+    };
+
+    static constexpr Length<CSS::Nonnegative> a5Width(mmLength(148));
+    static constexpr Length<CSS::Nonnegative> a5Height(mmLength(210));
+    static constexpr Length<CSS::Nonnegative> a4Width(mmLength(210));
+    static constexpr Length<CSS::Nonnegative> a4Height(mmLength(297));
+    static constexpr Length<CSS::Nonnegative> a3Width(mmLength(297));
+    static constexpr Length<CSS::Nonnegative> a3Height(mmLength(420));
+    static constexpr Length<CSS::Nonnegative> b5Width(mmLength(176));
+    static constexpr Length<CSS::Nonnegative> b5Height(mmLength(250));
+    static constexpr Length<CSS::Nonnegative> b4Width(mmLength(250));
+    static constexpr Length<CSS::Nonnegative> b4Height(mmLength(353));
+    static constexpr Length<CSS::Nonnegative> jisB5Width(mmLength(182));
+    static constexpr Length<CSS::Nonnegative> jisB5Height(mmLength(257));
+    static constexpr Length<CSS::Nonnegative> jisB4Width(mmLength(257));
+    static constexpr Length<CSS::Nonnegative> jisB4Height(mmLength(364));
+    static constexpr Length<CSS::Nonnegative> letterWidth(inchLength(8.5));
+    static constexpr Length<CSS::Nonnegative> letterHeight(inchLength(11));
+    static constexpr Length<CSS::Nonnegative> legalWidth(inchLength(8.5));
+    static constexpr Length<CSS::Nonnegative> legalHeight(inchLength(14));
+    static constexpr Length<CSS::Nonnegative> ledgerWidth(inchLength(11));
+    static constexpr Length<CSS::Nonnegative> ledgerHeight(inchLength(17));
+
+    Style::Length<CSS::Nonnegative> width { 0 };
+    Style::Length<CSS::Nonnegative> height { 0 };
+
+    switch (pageSizeName.valueID()) {
+    case CSSValueA5:
+        width = a5Width;
+        height = a5Height;
+        break;
+    case CSSValueA4:
+        width = a4Width;
+        height = a4Height;
+        break;
+    case CSSValueA3:
+        width = a3Width;
+        height = a3Height;
+        break;
+    case CSSValueB5:
+        width = b5Width;
+        height = b5Height;
+        break;
+    case CSSValueB4:
+        width = b4Width;
+        height = b4Height;
+        break;
+    case CSSValueJisB5:
+        width = jisB5Width;
+        height = jisB5Height;
+        break;
+    case CSSValueJisB4:
+        width = jisB4Width;
+        height = jisB4Height;
+        break;
+    case CSSValueLetter:
+        width = letterWidth;
+        height = letterHeight;
+        break;
+    case CSSValueLegal:
+        width = legalWidth;
+        height = legalHeight;
+        break;
+    case CSSValueLedger:
+        width = ledgerWidth;
+        height = ledgerHeight;
+        break;
+    default:
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Auto { };
+    }
+
+    if (pageOrientation) {
+        switch (pageOrientation->valueID()) {
+        case CSSValueLandscape:
+            std::swap(width, height);
+            break;
+        case CSSValuePortrait:
+            // Nothing to do.
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Auto { };
+        }
+    }
+
+    return PageSize::Lengths { width, height };
+}
+
+auto CSSValueConversion<PageSize>::operator()(BuilderState& state, const CSSValue& value) -> PageSize
+{
+    if (RefPtr pair = dynamicDowncast<CSSValuePair>(value)) {
+        // <length [0,∞]>{2} | [ <page-size> [ portrait | landscape ] ]
+        RefPtr first = requiredDowncast<CSSPrimitiveValue>(state, pair->first());
+        if (!first)
+            return CSS::Keyword::Auto { };
+        RefPtr second = requiredDowncast<CSSPrimitiveValue>(state, pair->second());
+        if (!second)
+            return CSS::Keyword::Auto { };
+
+        if (first->isLength()) {
+            // <length [0,∞]>{2}
+            if (!second->isLength()) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return CSS::Keyword::Auto { };
+            }
+
+            auto conversionData = state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            return PageSize::Lengths {
+                toStyleFromCSSValue<Length<CSS::Nonnegative>>(conversionData, *first),
+                toStyleFromCSSValue<Length<CSS::Nonnegative>>(conversionData, *second),
+            };
+        }
+
+        // [ <page-size> [ portrait | landscape ] ]
+        // The value order is guaranteed. See CSSParser::parseSizeParameter.
+        return pageSizeFromName(state, *first, second);
+    }
+
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        // <length [0,∞]> | auto | <page-size> | [ portrait | landscape]
+        if (primitiveValue->isLength()) {
+            // <length [0,∞]>
+            auto conversionData = state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            auto length = toStyleFromCSSValue<Length<CSS::Nonnegative>>(conversionData, *primitiveValue);
+            return PageSize::Lengths { length, length };
+        }
+
+        switch (primitiveValue->valueID()) {
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        case CSSValuePortrait:
+            return CSS::Keyword::Portrait { };
+        case CSSValueLandscape:
+            return CSS::Keyword::Landscape { };
+        default:
+            return pageSizeFromName(state, *primitiveValue, nullptr);
+        }
+    }
+
+    state.setCurrentPropertyInvalidAtComputedValueTime();
+    return CSS::Keyword::Auto { };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/page/StylePageSize.h
+++ b/Source/WebCore/style/values/page/StylePageSize.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'size'> (for @page) = <length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]
+// https://drafts.csswg.org/css-page-3/#descdef-page-size
+struct PageSize {
+    using Lengths = MinimallySerializingSpaceSeparatedSize<Length<CSS::Nonnegative>>;
+
+    PageSize(Lengths&& lengths) : m_value { WTFMove(lengths) } { }
+    PageSize(CSS::Keyword::Auto keyword) : m_value { keyword } { }
+    PageSize(CSS::Keyword::Portrait keyword) : m_value { keyword } { }
+    PageSize(CSS::Keyword::Landscape keyword) : m_value { keyword } { }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const PageSize&) const = default;
+
+private:
+    Variant<Lengths, CSS::Keyword::Auto, CSS::Keyword::Portrait, CSS::Keyword::Landscape> m_value { CSS::Keyword::Auto { } };
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<PageSize> { auto operator()(BuilderState&, const CSSValue&) -> PageSize; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::PageSize)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -114,6 +114,12 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
             : builderState.cssToLengthConversionData();
         return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
+
+    auto operator()(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value) -> Length<R, V>
+    {
+        Ref protectedValue = value;
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
+    }
 };
 
 template<auto R, typename V> struct CSSValueConversion<Time<R, V>> {


### PR DESCRIPTION
#### 3a95b4b3a45ce4cb1515b4355131456218593cec
<pre>
[Style] Convert the @page size descriptor to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=298480">https://bugs.webkit.org/show_bug.cgi?id=298480</a>

Reviewed by Darin Adler and Tim Nguyen.

Converts the @page `size` descriptor to use strong style types.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilder.cpp:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/page/StylePageSize.cpp: Added.
* Source/WebCore/style/values/page/StylePageSize.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:

Canonical link: <a href="https://commits.webkit.org/299726@main">https://commits.webkit.org/299726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb37ac767b73cc841ff8f67b782b506ab68121ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119955 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48225 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91095 "") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60403 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25662 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129201 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99711 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99556 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25283 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43496 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52443 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->