### PR TITLE
AX: For dynamic changes requiring a full-object update, swap out IsolatedObjectData rather than fully destroying and recreating a new AXIsolatedObject to avoid stale object bugs

### DIFF
--- a/LayoutTests/accessibility/dynamic-selected-radio-button-expected.txt
+++ b/LayoutTests/accessibility/dynamic-selected-radio-button-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we compute the correct selected radio button after dynamic page changes.
+
+PASS: radiogroup.uiElementAttributeValue('AXValue').domIdentifier.includes('cat') === true
+PASS: radiogroup.uiElementAttributeValue('AXValue')?.domIdentifier?.includes('dog') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ Cat   Dog

--- a/LayoutTests/accessibility/dynamic-selected-radio-button.html
+++ b/LayoutTests/accessibility/dynamic-selected-radio-button.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="radiogroup" role="radiogroup">
+    <input type="radio" id="cat" name="pet" value="cat" checked />
+    <label id="cat-label" for="cat">Cat</label>
+
+    <input type="radio" id="dog" name="pet" value="dog" />
+    <label for="dog">Dog</label>
+</div>
+
+<script>
+var output = "This test ensures we compute the correct selected radio button after dynamic page changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var radiogroup = accessibilityController.accessibleElementById("radiogroup");
+    output += expect("radiogroup.uiElementAttributeValue('AXValue').domIdentifier.includes('cat')", "true");
+    // Change the object's accessibility text, causing a full AXIsolatedObject update.
+    document.getElementById("cat").setAttribute("title", "Cats label");
+
+    setTimeout(async function() {
+        document.getElementById("cat").removeAttribute("checked");
+        document.getElementById("dog").setAttribute("checked", "");
+        output += await expectAsync("radiogroup.uiElementAttributeValue('AXValue')?.domIdentifier?.includes('dog')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -765,6 +765,7 @@ accessibility/clip-path-bounding-box.html [ Skip ]
 accessibility/dynamic-expanded-text.html [ Skip ]
 
 accessibility/dynamic-content-visibility.html [ Skip ]
+accessibility/dynamic-selected-radio-button.html [ Skip ]
 accessibility/password-notifications-timing.html [ Skip ]
 
 # Timed out since it was introduced.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -77,6 +77,26 @@ AXIsolatedObject::~AXIsolatedObject()
     AX_BROKEN_ASSERT(!wrapper());
 }
 
+void AXIsolatedObject::updateFromData(IsolatedObjectData&& data)
+{
+    ASSERT(!isMainThread());
+
+    if (data.axID != objectID() || data.tree->treeID() != treeID()) {
+        // Our data should only be updated from the same main-thread equivalent object.
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    m_role = data.role;
+    m_parentID = data.parentID;
+    m_unresolvedChildrenIDs = WTFMove(data.childrenIDs);
+    m_childrenDirty = true;
+    m_getsGeometryFromChildren = data.getsGeometryFromChildren;
+
+    m_properties = WTFMove(data.properties);
+    m_propertyFlags = data.propertyFlags;
+}
+
 String AXIsolatedObject::debugDescriptionInternal(bool verbose, std::optional<OptionSet<AXDebugStringOption>> debugOptions) const
 {
     StringBuilder result;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -61,6 +61,8 @@ public:
     std::optional<AXID> treeID() const final { return tree()->treeID(); }
     String debugDescriptionInternal(bool, std::optional<OptionSet<AXDebugStringOption>> = std::nullopt) const final;
 
+    void updateFromData(IsolatedObjectData&&);
+
     void attachPlatformWrapper(AccessibilityObjectWrapper*);
     bool isDetached() const final;
     bool isTable() const final { return boolAttributeValue(AXProperty::IsTable); }


### PR DESCRIPTION
#### c8b3efb0d6614f69e7acaa815b6b8ea8b3311180
<pre>
AX: For dynamic changes requiring a full-object update, swap out IsolatedObjectData rather than fully destroying and recreating a new AXIsolatedObject to avoid stale object bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=298481">https://bugs.webkit.org/show_bug.cgi?id=298481</a>
<a href="https://rdar.apple.com/159975526">rdar://159975526</a>

Reviewed by Joshua Hoffman.

For some types of dynamic page updates, like value changes in text fields or accessibility text changes, we will not
try to invalidate individual properties and instead create a full-object update. We do this by creating a new
AXIsolatedObject, and swapping out the wrapper and AXIsolatedTree::m_readerThreadNodeMap membership in AXIsolatedTree::applyPendingChanges.

The downside of this approach is that just because an AXIsolatedObject is removed from AXIsolatedTree::m_readerThreadNodeMap
doesn&apos;t mean it will be destroyed, as various persistent data structures can hold a strong reference to the old AXIsolatedObject.
One of the most prevalent examples of this is an object&apos;s m_children. This means it&apos;s possible to use the old, stale version
of the object to serve accessibility requests, which can result in incorrect behavior.

Fix this by only swapping out IsolatedObjectData for an object in these full-update circumstances, rather than creating
a whole new AXIsolatedObject.

* LayoutTests/accessibility/dynamic-selected-radio-button-expected.txt: Added.
* LayoutTests/accessibility/dynamic-selected-radio-button.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::updateFromData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::applyPendingChangesLocked):

Canonical link: <a href="https://commits.webkit.org/299712@main">https://commits.webkit.org/299712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eff75b16ecf8def08a49507476dd52494a42c79d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71815 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90949 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60230 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71484 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25474 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69678 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128989 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46663 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35354 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99388 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44825 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43229 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52231 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45991 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47677 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->