### PR TITLE
[Liquid Glass] [iOS] github.com: visible gap above sticky top header while scrolling on PRs with long branch names

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-horizontal-overflow-with-viewport-meta-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-horizontal-overflow-with-viewport-meta-expected.txt
@@ -1,0 +1,5 @@
+PASS color is "rgb(0, 122, 255)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-horizontal-overflow-with-viewport-meta.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-horizontal-overflow-with-viewport-meta.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 ] -->
+<html>
+<meta name="viewport" content="width=device-width">
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+    margin: 0;
+    padding: 0;
+    background: rgb(42, 42, 42);
+    width: 100%;
+    height: 100%;
+}
+
+.fixed-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 60px;
+    background: rgb(0, 122, 255);
+    z-index: 100;
+}
+
+.wide {
+    width: 640px;
+    height: 100px;
+    background: red;
+    margin-top: 50vw;
+}
+
+.tall {
+    height: 1000px;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(50, 0, 0, 0);
+    await UIHelper.ensurePresentationUpdate();
+
+    color = (await UIHelper.fixedContainerEdgeColors()).top;
+    shouldBeEqualToString("color", "rgb(0, 122, 255)");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="fixed-header"></div>
+    <div class="tall"></div>
+    <div class="wide"></div>
+    <div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2192,6 +2192,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         Color backgroundColor;
     };
 
+    auto sizeForViewportUnits = LayoutSize { sizeForCSSDefaultViewportUnits() };
     auto unclampedFixedRect = rectForFixedPositionLayout();
     auto fixedRect = unclampedFixedRect;
     if (CheckedPtr view = renderView())
@@ -2214,14 +2215,14 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         return side;
     };
 
-    auto lengthOnSide = [](BoxSide side, const LayoutRect& rect) -> LayoutUnit {
+    auto lengthOnSide = [](BoxSide side, auto& rectOrSize) -> LayoutUnit {
         switch (side) {
         case BoxSide::Top:
         case BoxSide::Bottom:
-            return rect.width();
+            return rectOrSize.width();
         case BoxSide::Right:
         case BoxSide::Left:
-            return rect.height();
+            return rectOrSize.height();
         }
         return { };
     };
@@ -2238,7 +2239,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         static constexpr auto maximumRatio = 1.05;
         auto elementRect = enclosingLayoutRect(renderer.absoluteBoundingBoxRect());
         auto containerLength = lengthOnSide(side, elementRect);
-        auto viewportLength = lengthOnSide(side, fixedRect);
+        auto viewportLength = std::min(lengthOnSide(side, fixedRect), lengthOnSide(side, sizeForViewportUnits));
         if (containerLength < viewportLength * minimumRatio)
             return Smaller;
 


### PR DESCRIPTION
#### 84fc0edf9e8649a56cca35cc48c73f211e310d14
<pre>
[Liquid Glass] [iOS] github.com: visible gap above sticky top header while scrolling on PRs with long branch names
<a href="https://bugs.webkit.org/show_bug.cgi?id=298485">https://bugs.webkit.org/show_bug.cgi?id=298485</a>
<a href="https://rdar.apple.com/159857229">rdar://159857229</a>

Reviewed by Abrar Rahman Protyasha.

On iPhone, when rendering pages where:

1. The viewport meta width is set to `device-width`
2. The viewport meta initial scale is unset (auto)
3. The contents of the page lay out wider than the viewport width

...we sometimes end up failing to extend the colors of top fixed/sticky headers that are intended to
span the entire viewport width (e.g. `width: 100vw;`) but end up falling short due to the fact that
we needed to shrink to fit content (initial scale &lt; 1). This is because the heuristic to figure out
whether a viewport-constrained element spans the length of the viewport checks the dimensions of the
element against the fixed-position layout rect, which may be larger than the viewport rect for CSS
units (`vw`, `vh`) in the scenario described above.

To fix this, we use the smaller of the viewport width for CSS units and the actual viewport width
(layout rect for fixed elements) when determining whether a candidate element is meant to span the
entire viewport.

* LayoutTests/fast/page-color-sampling/color-sampling-horizontal-overflow-with-viewport-meta-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-horizontal-overflow-with-viewport-meta.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/299658@main">https://commits.webkit.org/299658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52f1119b2e75b27923de224efd917d8a84b3b185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71817 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0f3088b-010f-44dc-a4af-c0d01d80a79a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90952 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/168c241c-c318-4427-ab0d-a05ca5021243) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71488 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1778748f-f23c-41f6-b2f0-a4c65a1d92ee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69680 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128991 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99548 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52233 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45993 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->