### PR TITLE
Migrate convertToSpecifiedUnits to newer resolveValue routines

### DIFF
--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -196,76 +196,6 @@ float SVGLengthContext::valueForLength(const Style::StrokeWidth& size, SVGLength
     return valueForSizeType(size, lengthMode);
 }
 
-ExceptionOr<float> SVGLengthContext::convertValueToUserUnits(float value, SVGLengthType lengthType, SVGLengthMode lengthMode) const
-{
-    switch (lengthType) {
-    case SVGLengthType::Unknown:
-        return Exception { ExceptionCode::NotSupportedError };
-    case SVGLengthType::Number:
-        return value;
-    case SVGLengthType::Pixels:
-        return value;
-    case SVGLengthType::Percentage:
-        return convertValueFromPercentageToUserUnits(value / 100, lengthMode);
-    case SVGLengthType::Ems:
-        return convertValueFromEMSToUserUnits(value);
-    case SVGLengthType::Exs:
-        return convertValueFromEXSToUserUnits(value);
-    case SVGLengthType::Lh:
-        return convertValueFromLhToUserUnits(value);
-    case SVGLengthType::Ch:
-        return convertValueFromChToUserUnits(value);
-    case SVGLengthType::Centimeters:
-        return value * CSS::pixelsPerCm;
-    case SVGLengthType::Millimeters:
-        return value * CSS::pixelsPerMm;
-    case SVGLengthType::Inches:
-        return value * CSS::pixelsPerInch;
-    case SVGLengthType::Points:
-        return value * CSS::pixelsPerPt;
-    case SVGLengthType::Picas:
-        return value * CSS::pixelsPerPc;
-    }
-
-    ASSERT_NOT_REACHED();
-    return 0;
-}
-
-ExceptionOr<float> SVGLengthContext::convertValueFromUserUnits(float value, SVGLengthType lengthType, SVGLengthMode lengthMode) const
-{
-    switch (lengthType) {
-    case SVGLengthType::Unknown:
-        return Exception { ExceptionCode::NotSupportedError };
-    case SVGLengthType::Number:
-        return value;
-    case SVGLengthType::Percentage:
-        return convertValueFromUserUnitsToPercentage(value * 100, lengthMode);
-    case SVGLengthType::Ems:
-        return convertValueFromUserUnitsToEMS(value);
-    case SVGLengthType::Exs:
-        return convertValueFromUserUnitsToEXS(value);
-    case SVGLengthType::Lh:
-        return convertValueFromUserUnitsToLh(value);
-    case SVGLengthType::Ch:
-        return convertValueFromUserUnitsToCh(value);
-    case SVGLengthType::Pixels:
-        return value;
-    case SVGLengthType::Centimeters:
-        return value / CSS::pixelsPerCm;
-    case SVGLengthType::Millimeters:
-        return value / CSS::pixelsPerMm;
-    case SVGLengthType::Inches:
-        return value / CSS::pixelsPerInch;
-    case SVGLengthType::Points:
-        return value / CSS::pixelsPerPt;
-    case SVGLengthType::Picas:
-        return value / CSS::pixelsPerPc;
-    }
-
-    ASSERT_NOT_REACHED();
-    return 0;
-}
-
 float SVGLengthContext::computeNonCalcLength(float inputValue, CSS::LengthUnit unit) const
 {
     if (!conversionToCanonicalUnitRequiresConversionData(unit))
@@ -449,28 +379,6 @@ RefPtr<const SVGElement> SVGLengthContext::protectedContext() const
     return m_context.get();
 }
 
-ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEMS(float value) const
-{
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
-    if (!style)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    float fontSize = style->computedFontSize();
-    if (!fontSize)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    return value / fontSize;
-}
-
-ExceptionOr<float> SVGLengthContext::convertValueFromEMSToUserUnits(float value) const
-{
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
-    if (!style)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    return value * style->computedFontSize();
-}
-
 ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value) const
 {
     auto* style = renderStyleForLengthResolving(protectedContext().get());
@@ -495,46 +403,6 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEXSToUserUnits(float value)
     // Use of ceil allows a pixel match to the W3Cs expected output of coords-units-03-b.svg
     // if this causes problems in real world cases maybe it would be best to remove this
     return value * std::ceil(style->metricsOfPrimaryFont().xHeight().value_or(0));
-}
-
-ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToLh(float value) const
-{
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
-    if (!style)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    return value / adjustForAbsoluteZoom(style->computedLineHeight(), *style);
-}
-
-ExceptionOr<float> SVGLengthContext::convertValueFromLhToUserUnits(float value) const
-{
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
-    if (!style)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    return value * adjustForAbsoluteZoom(style->computedLineHeight(), *style);
-}
-
-ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToCh(float value) const
-{
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
-    if (!style)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    float zeroWidth = style->fontCascade().zeroWidth();
-    if (!zeroWidth)
-        return 0;
-
-    return value / zeroWidth;
-}
-
-ExceptionOr<float> SVGLengthContext::convertValueFromChToUserUnits(float value) const
-{
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
-    if (!style)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    return value * style->fontCascade().zeroWidth();
 }
 
 std::optional<FloatSize> SVGLengthContext::viewportSize() const

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -70,9 +70,6 @@ public:
     float valueForLength(const Style::SVGStrokeDashoffset&, SVGLengthMode = SVGLengthMode::Other);
     float valueForLength(const Style::StrokeWidth&, SVGLengthMode = SVGLengthMode::Other);
 
-    ExceptionOr<float> convertValueToUserUnits(float, SVGLengthType, SVGLengthMode) const;
-    ExceptionOr<float> convertValueFromUserUnits(float, SVGLengthType, SVGLengthMode) const;
-
     ExceptionOr<float> resolveValueToUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
     ExceptionOr<CSS::LengthPercentage<>> resolveValueFromUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
 
@@ -83,17 +80,8 @@ private:
     ExceptionOr<float> convertValueFromPercentageToUserUnits(float value, SVGLengthMode) const;
     static float convertValueFromPercentageToUserUnits(float value, SVGLengthMode, FloatSize);
 
-    ExceptionOr<float> convertValueFromUserUnitsToEMS(float) const;
-    ExceptionOr<float> convertValueFromEMSToUserUnits(float) const;
-
     ExceptionOr<float> convertValueFromUserUnitsToEXS(float) const;
     ExceptionOr<float> convertValueFromEXSToUserUnits(float) const;
-
-    ExceptionOr<float> convertValueFromUserUnitsToLh(float) const;
-    ExceptionOr<float> convertValueFromLhToUserUnits(float) const;
-
-    ExceptionOr<float> convertValueFromUserUnitsToCh(float) const;
-    ExceptionOr<float> convertValueFromChToUserUnits(float) const;
 
     std::optional<FloatSize> computeViewportSize() const;
     float computeNonCalcLength(float, CSS::LengthUnit) const;


### PR DESCRIPTION
#### 4fd64b9ecae86df1bfa4df9e56e860fd59b7b594
<pre>
Migrate convertToSpecifiedUnits to newer resolveValue routines
<a href="https://bugs.webkit.org/show_bug.cgi?id=298488">https://bugs.webkit.org/show_bug.cgi?id=298488</a>
<a href="https://rdar.apple.com/159979677">rdar://159979677</a>

Reviewed by Tim Nguyen.

After modernizing length conversion in 299087@main, the
convertToSpecifiedUnits API still relied on the legacy one-off
conversion routines. This change migrates it to use the
newer resolveValue routine.

* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueToUserUnits const): Deleted.
(WebCore::SVGLengthContext::convertValueFromUserUnits const): Deleted.
(WebCore::SVGLengthContext::convertValueFromUserUnitsToEMS const): Deleted.
(WebCore::SVGLengthContext::convertValueFromEMSToUserUnits const): Deleted.
(WebCore::SVGLengthContext::convertValueFromUserUnitsToLh const): Deleted.
(WebCore::SVGLengthContext::convertValueFromLhToUserUnits const): Deleted.
(WebCore::SVGLengthContext::convertValueFromUserUnitsToCh const): Deleted.
(WebCore::SVGLengthContext::convertValueFromChToUserUnits const): Deleted.
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::convertToSpecifiedUnits):
(WebCore::adjustValueForPercentageStorage): Deleted.

Canonical link: <a href="https://commits.webkit.org/299702@main">https://commits.webkit.org/299702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8789f87664c9599ddbb0414ecc3e952b2ab7ba3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71829 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4e53f65-51f5-44e0-a954-4706ef50d5ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90960 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60243 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6dc8c2b-276d-4dfe-a538-6fcc5ef0d6db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71496 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fc00167-2824-4ae2-9896-a34018132eba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69696 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129003 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99556 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99400 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25263 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43243 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52245 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46005 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47691 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->