### PR TITLE
EditingStyle: Avoiding uncounted call arguments

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -413,7 +413,6 @@ editing/CustomUndoStep.cpp
 editing/DeleteSelectionCommand.cpp
 editing/EditCommand.cpp
 editing/Editing.cpp
-editing/EditingStyle.cpp
 editing/Editor.cpp
 editing/EditorCommand.cpp
 editing/FormatBlockCommand.cpp

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -108,7 +108,8 @@ public:
 
     WEBCORE_EXPORT ~EditingStyle();
 
-    MutableStyleProperties* style() { return m_mutableStyle.get(); }
+    MutableStyleProperties* style() const { return m_mutableStyle.get(); }
+    RefPtr<MutableStyleProperties> protectedStyle() const;
     RefPtr<MutableStyleProperties> protectedStyle();
     Ref<MutableStyleProperties> styleWithResolvedTextDecorations() const;
     std::optional<WritingDirection> textDirection() const;


### PR DESCRIPTION
#### c75f87ae1f43c93c505a99fec56a36d97aa7bda3
<pre>
EditingStyle: Avoiding uncounted call arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=298493">https://bugs.webkit.org/show_bug.cgi?id=298493</a>
<a href="https://rdar.apple.com/159983503">rdar://159983503</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::HTMLElementEquivalent::propertyExistsInStyle const):
(WebCore::HTMLElementEquivalent::valueIsPresentInStyle const):
(WebCore::HTMLFontWeightEquivalent::valueIsPresentInStyle const):
(WebCore::HTMLAttributeEquivalent::valueIsPresentInStyle const):
(WebCore::EditingStyle::EditingStyle):
(WebCore::EditingStyle::init):
(WebCore::EditingStyle::removeTextFillAndStrokeColorsIfNeeded):
(WebCore::EditingStyle::setProperty):
(WebCore::EditingStyle::extractFontSizeDelta):
(WebCore::EditingStyle::styleWithResolvedTextDecorations const):
(WebCore::EditingStyle::textDirection const):
(WebCore::EditingStyle::overrideTypingStyleAt):
(WebCore::EditingStyle::copy const):
(WebCore::EditingStyle::extractAndRemoveBlockProperties):
(WebCore::EditingStyle::extractAndRemoveTextDirection):
(WebCore::EditingStyle::removeBlockProperties):
(WebCore::EditingStyle::collapseTextDecorationProperties):
(WebCore::EditingStyle::triStateOfStyle const):
(WebCore::EditingStyle::styleIsPresentInComputedStyleOfNode const):
(WebCore::EditingStyle::mergeInlineAndImplicitStyleOfElement):
(WebCore::EditingStyle::mergeStyle):
(WebCore::styleFromMatchedRulesForElement):
(WebCore::EditingStyle::mergeStyleFromRulesForSerialization):
(WebCore::EditingStyle::removeInlineStyleRedundantDueToMatchedRules):
(WebCore::EditingStyle::removeStyleInContextNotOverridenByMatchedRules):
(WebCore::EditingStyle::removeEquivalentProperties):
(WebCore::EditingStyle::forceDisplayInline):
(WebCore::EditingStyle::addDisplayContents):
(WebCore::EditingStyle::convertPositionStyle):
(WebCore::EditingStyle::isFloating):
(WebCore::EditingStyle::legacyFontSize const):
(WebCore::EditingStyle::fontWeightIsBold):
(WebCore::EditingStyle::fontStyleIsItalic):
(WebCore::EditingStyle::webkitTextDecorationsInEffectIsUnderline):
(WebCore::EditingStyle::styleAtSelectionStart):
(WebCore::EditingStyle::inverseTransformColorIfNeeded):
(WebCore::StyleChange::StyleChange):
(WebCore::StyleChange::operator==):
* Source/WebCore/editing/EditingStyle.h:
(WebCore::EditingStyle::style const):
(WebCore::EditingStyle::style): Deleted.

Canonical link: <a href="https://commits.webkit.org/299718@main">https://commits.webkit.org/299718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdf1f7e8edf4996d4060de81f3f29600f905ecd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119762 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39454 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126062 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71834 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da6d3150-af49-4b43-9a7c-73c1b59dbd7c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90963 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60246 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e5865b2-989e-48b7-b8a9-1c69b6f2d54e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71499 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90f6511d-80f0-4094-b184-8a95f637ed80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69704 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129008 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99561 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99405 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25276 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44844 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43248 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->