### PR TITLE
[JSC] Refactor `IteratorOperations.h`

### DIFF
--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -110,7 +110,7 @@ static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSVal
 }
 
 template<typename CallBackType>
-static ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject, IterationRecord iterationRecord, NOESCAPE const CallBackType& callback)
+ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject, IterationRecord iterationRecord, NOESCAPE const CallBackType& callback)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/JSSet.cpp
+++ b/Source/JavaScriptCore/runtime/JSSet.cpp
@@ -54,25 +54,4 @@ bool JSSet::isAddFastAndNonObservable(Structure* structure)
     return true;
 }
 
-bool JSSet::isIteratorProtocolFastAndNonObservable()
-{
-    JSGlobalObject* globalObject = this->globalObject();
-    if (!globalObject->isSetPrototypeIteratorProtocolFastAndNonObservable())
-        return false;
-
-    VM& vm = globalObject->vm();
-    Structure* structure = this->structure();
-    // This is the fast case. Many sets will be an original set.
-    if (structure == globalObject->setStructure())
-        return true;
-
-    if (getPrototypeDirect() != globalObject->jsSetPrototype())
-        return false;
-
-    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
-        return false;
-
-    return true;
-}
-
 }

--- a/Source/JavaScriptCore/runtime/JSSet.h
+++ b/Source/JavaScriptCore/runtime/JSSet.h
@@ -57,7 +57,7 @@ public:
     }
 
     static bool isAddFastAndNonObservable(Structure*);
-    JS_EXPORT_PRIVATE bool isIteratorProtocolFastAndNonObservable();
+    ALWAYS_INLINE bool isIteratorProtocolFastAndNonObservable();
     JSSet* clone(JSGlobalObject*, VM&, Structure*);
 
 private:

--- a/Source/JavaScriptCore/runtime/JSSetInlines.h
+++ b/Source/JavaScriptCore/runtime/JSSetInlines.h
@@ -34,4 +34,25 @@ inline Structure* JSSet::createStructure(VM& vm, JSGlobalObject* globalObject, J
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSSetType, StructureFlags), info());
 }
 
+ALWAYS_INLINE bool JSSet::isIteratorProtocolFastAndNonObservable()
+{
+    JSGlobalObject* globalObject = this->globalObject();
+    if (!globalObject->isSetPrototypeIteratorProtocolFastAndNonObservable())
+        return false;
+
+    VM& vm = globalObject->vm();
+    Structure* structure = this->structure();
+    // This is the fast case. Many sets will be an original set.
+    if (structure == globalObject->setStructure())
+        return true;
+
+    if (getPrototypeDirect() != globalObject->jsSetPrototype())
+        return false;
+
+    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
+        return false;
+
+    return true;
+}
+
 }


### PR DESCRIPTION
#### bb2cb133ba60ec72ca4ec4324df87fe6ef9ad999
<pre>
[JSC] Refactor `IteratorOperations.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298494">https://bugs.webkit.org/show_bug.cgi?id=298494</a>

Reviewed by Yusuke Suzuki.

This patch changes following:

- Remove `static` from `forEachInIterationRecord` since it is now used from `SetPrototype.cpp`
- Add `ALWAYS_INLINE` to `isIteratorProtocolFastAndNonObservable`

* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIterationRecord):
* Source/JavaScriptCore/runtime/JSSet.cpp:
(JSC::JSSet::isIteratorProtocolFastAndNonObservable): Deleted.
* Source/JavaScriptCore/runtime/JSSet.h:
* Source/JavaScriptCore/runtime/JSSetInlines.h:
(JSC::JSSet::isIteratorProtocolFastAndNonObservable):

Canonical link: <a href="https://commits.webkit.org/299730@main">https://commits.webkit.org/299730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30792697cbc46dde1767c3c91531a9aa95070262

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71831 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90962 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25487 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69702 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111884 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129005 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118275 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99560 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99404 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44839 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43245 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52247 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146973 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46007 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37769 "Found 1 new JSC binary failure: testapi, Found 18634 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->