### PR TITLE
[Swift in WebKit] Work towards modularizing JSC private headers (Part 2)

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -99,6 +99,12 @@
 		072F53502E3C0F3300389E15 /* JITSubGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = FE98B5B61BB9AE110073E7A6 /* JITSubGenerator.h */; };
 		072F53512E3C3F8700389E15 /* BytecodeGeneratorBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C5AD6522F1866C00F1FB83 /* BytecodeGeneratorBase.h */; };
 		072F53522E3C3FDA00389E15 /* ProfileTypeBytecodeFlag.h in Headers */ = {isa = PBXBuildFile; fileRef = 14BA7752211A8E5F008D0B05 /* ProfileTypeBytecodeFlag.h */; };
+		07A995582E6ABED500157FC5 /* ExecutableAllocatorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A995572E6ABED500157FC5 /* ExecutableAllocatorInternal.h */; };
+		07A9955A2E6AC06800157FC5 /* ARM64AssemblerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A995592E6AC06800157FC5 /* ARM64AssemblerInternal.h */; };
+		07A9955C2E6BCF5900157FC5 /* AssemblerCommonInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A9955B2E6BCF5900157FC5 /* AssemblerCommonInternal.h */; };
+		07A9955E2E6BD5D400157FC5 /* MacroAssemblerARM64Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A9955D2E6BD5D400157FC5 /* MacroAssemblerARM64Internal.h */; };
+		07A995602E6BD7B500157FC5 /* AbstractMacroAssemblerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A9955F2E6BD7B500157FC5 /* AbstractMacroAssemblerInternal.h */; };
+		07A995622E6BE02000157FC5 /* LinkBufferInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A995612E6BE02000157FC5 /* LinkBufferInternal.h */; };
 		0F0123331944EA1B00843A0C /* DFGValueStrength.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0123311944EA1B00843A0C /* DFGValueStrength.h */; };
 		0F0332C418B01763005F979A /* GetByVariant.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0332C218B01763005F979A /* GetByVariant.h */; };
 		0F0332C618B53FA9005F979A /* FTLWeight.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0332C518B53FA9005F979A /* FTLWeight.h */; };
@@ -983,7 +989,7 @@
 		525C0DDA1E935847002184CD /* WasmCallee.h in Headers */ = {isa = PBXBuildFile; fileRef = 525C0DD81E935847002184CD /* WasmCallee.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52678F8F1A031009006A306D /* BasicBlockLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 52678F8D1A031009006A306D /* BasicBlockLocation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52678F911A04177C006A306D /* ControlFlowProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 52678F901A04177C006A306D /* ControlFlowProfiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5267CF82249316B10022BF6D /* FastJITPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5267CF81249316AD0022BF6D /* FastJITPermissions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5267CF82249316B10022BF6D /* FastJITPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5267CF81249316AD0022BF6D /* FastJITPermissions.h */; };
 		526AC4B71E977C5D003500E1 /* WasmCalleeGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 526AC4B51E977C5D003500E1 /* WasmCalleeGroup.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		527E6CEC2772B9CB005E0782 /* WasmOSREntryPlan.h in Headers */ = {isa = PBXBuildFile; fileRef = 527E6CEB2772B9C5005E0782 /* WasmOSREntryPlan.h */; };
 		52B310FB1974AE610080857C /* FunctionHasExecutedCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 52B310FA1974AE610080857C /* FunctionHasExecutedCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2675,6 +2681,12 @@
 		05517CA02C74004700ED0CD5 /* JSIteratorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIteratorConstructor.h; sourceTree = "<group>"; };
 		05517CA12C74004700ED0CD5 /* JSIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIterator.h; sourceTree = "<group>"; };
 		05517CA22C74004700ED0CD5 /* JSIteratorConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSIteratorConstructor.cpp; sourceTree = "<group>"; };
+		07A995572E6ABED500157FC5 /* ExecutableAllocatorInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutableAllocatorInternal.h; sourceTree = "<group>"; };
+		07A995592E6AC06800157FC5 /* ARM64AssemblerInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARM64AssemblerInternal.h; sourceTree = "<group>"; };
+		07A9955B2E6BCF5900157FC5 /* AssemblerCommonInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AssemblerCommonInternal.h; sourceTree = "<group>"; };
+		07A9955D2E6BD5D400157FC5 /* MacroAssemblerARM64Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MacroAssemblerARM64Internal.h; sourceTree = "<group>"; };
+		07A9955F2E6BD7B500157FC5 /* AbstractMacroAssemblerInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AbstractMacroAssemblerInternal.h; sourceTree = "<group>"; };
+		07A995612E6BE02000157FC5 /* LinkBufferInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LinkBufferInternal.h; sourceTree = "<group>"; };
 		0F0123301944EA1B00843A0C /* DFGValueStrength.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGValueStrength.cpp; path = dfg/DFGValueStrength.cpp; sourceTree = "<group>"; };
 		0F0123311944EA1B00843A0C /* DFGValueStrength.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGValueStrength.h; path = dfg/DFGValueStrength.h; sourceTree = "<group>"; };
 		0F0332BF18ADFAE1005F979A /* ExitingJITType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExitingJITType.cpp; sourceTree = "<group>"; };
@@ -7014,6 +7026,7 @@
 				0FF054F81AC35B4400E5BE57 /* ExecutableAllocationFuzz.h */,
 				A7B48DB60EE74CFC00DCBDB6 /* ExecutableAllocator.cpp */,
 				A7B48DB50EE74CFC00DCBDB6 /* ExecutableAllocator.h */,
+				07A995572E6ABED500157FC5 /* ExecutableAllocatorInternal.h */,
 				3245DC90298B40B900E2BE0B /* ExecutableMemoryHandle.cpp */,
 				0F5193F6266C432D00483A2C /* ExecutableMemoryHandle.h */,
 				0F24E53E17EA9F5900ABB217 /* FPRInfo.h */,
@@ -9600,9 +9613,11 @@
 				0F1FE51B1922A3BC006987C5 /* AbortReason.h */,
 				0F2C63BF1E660EA500C13839 /* AbstractMacroAssembler.cpp */,
 				860161DF0F3A83C100F84710 /* AbstractMacroAssembler.h */,
+				07A9955F2E6BD7B500157FC5 /* AbstractMacroAssemblerInternal.h */,
 				0F3730901C0CD70C00052BFA /* AllowMacroScratchRegisterUsage.h */,
 				AD412B351E7B57C0008AF157 /* AllowMacroScratchRegisterUsageIf.h */,
 				8640923B156EED3B00566CB2 /* ARM64Assembler.h */,
+				07A995592E6AC06800157FC5 /* ARM64AssemblerInternal.h */,
 				FE1E2C3D2240D2F600F6B729 /* ARM64EAssembler.h */,
 				8640923B156EED3B00566CC2 /* ARM64Registers.h */,
 				86ADD1430FDDEA980006EEC2 /* ARMv7Assembler.h */,
@@ -9610,6 +9625,7 @@
 				0FA6F39620CCB7A600A03DCD /* AssemblerBuffer.cpp */,
 				9688CB130ED12B4E001D649F /* AssemblerBuffer.h */,
 				43C392AA1C3BEB0000241F53 /* AssemblerCommon.h */,
+				07A9955B2E6BCF5900157FC5 /* AssemblerCommonInternal.h */,
 				4BDF3001289324AB00AE1DE3 /* AssemblyComments.cpp */,
 				4BDF3002289324AC00AE1DE3 /* AssemblyComments.h */,
 				86E116B00FE75AC800B512BC /* CodeLocation.h */,
@@ -9623,11 +9639,13 @@
 				6B2360CD26C6253C0054AEEC /* JITOperationValidation.h */,
 				0FF4275615914A20004CB9FF /* LinkBuffer.cpp */,
 				86D3B3C110159D7F002865E7 /* LinkBuffer.h */,
+				07A995612E6BE02000157FC5 /* LinkBufferInternal.h */,
 				0FEB3ECE16237F6700AB67AD /* MacroAssembler.cpp */,
 				86C36EE90EE1289D00B3DF59 /* MacroAssembler.h */,
 				FEB137561BB11EEE00CD5100 /* MacroAssemblerARM64.cpp */,
 				8640923C156EED3B00566CB2 /* MacroAssemblerARM64.h */,
 				FE1E2C3E2240D30B00F6B729 /* MacroAssemblerARM64E.h */,
+				07A9955D2E6BD5D400157FC5 /* MacroAssemblerARM64Internal.h */,
 				A729009B17976C6000317298 /* MacroAssemblerARMv7.cpp */,
 				86ADD1440FDDEA980006EEC2 /* MacroAssemblerARMv7.h */,
 				0F6DB7EB1D617D0F00CDBF8E /* MacroAssemblerCodeRef.cpp */,
@@ -10385,6 +10403,7 @@
 				0FFA549816B8835300B3A982 /* A64DOpcode.h in Headers */,
 				0F1FE51C1922A3BC006987C5 /* AbortReason.h in Headers */,
 				860161E30F3A83C100F84710 /* AbstractMacroAssembler.h in Headers */,
+				07A995602E6BD7B500157FC5 /* AbstractMacroAssemblerInternal.h in Headers */,
 				AD4937C41DDBE6140077C807 /* AbstractModuleRecord.h in Headers */,
 				FE912B4F2531193300FABDDF /* AbstractSlotVisitor.h in Headers */,
 				FE912B5125311AD100FABDDF /* AbstractSlotVisitorInlines.h in Headers */,
@@ -10477,6 +10496,7 @@
 				79A228361D35D71F00D8E067 /* ArithProfile.h in Headers */,
 				0F6B1CB91861244C00845D97 /* ArityCheckMode.h in Headers */,
 				A1A009C11831A26E00CF8711 /* ARM64Assembler.h in Headers */,
+				07A9955A2E6AC06800157FC5 /* ARM64AssemblerInternal.h in Headers */,
 				FE1E2C402240DD6200F6B729 /* ARM64EAssembler.h in Headers */,
 				A1A009C11831A26E00CF8722 /* ARM64Registers.h in Headers */,
 				86ADD1450FDDEA980006EEC2 /* ARMv7Assembler.h in Headers */,
@@ -10497,6 +10517,7 @@
 				FE1D6D7123625AB1007A5C26 /* ArrayStorageInlines.h in Headers */,
 				9688CB150ED12B4E001D649F /* AssemblerBuffer.h in Headers */,
 				43C392AB1C3BEB0500241F53 /* AssemblerCommon.h in Headers */,
+				07A9955C2E6BCF5900157FC5 /* AssemblerCommonInternal.h in Headers */,
 				4BDF3004289324AC00AE1DE3 /* AssemblyComments.h in Headers */,
 				0F24E54117EA9F5900ABB217 /* AssemblyHelpers.h in Headers */,
 				6B767E7B26791F270017F8D1 /* AssemblyHelpersSpoolers.h in Headers */,
@@ -11038,6 +11059,7 @@
 				FE6491371D78F01D00A694D4 /* ExceptionScope.h in Headers */,
 				0FF054FA1AC35B4400E5BE57 /* ExecutableAllocationFuzz.h in Headers */,
 				A766B44F0EE8DCD1009518CA /* ExecutableAllocator.h in Headers */,
+				07A995582E6ABED500157FC5 /* ExecutableAllocatorInternal.h in Headers */,
 				147341CC1DC02D7200AA29BA /* ExecutableBase.h in Headers */,
 				E35A0B9D220AD87A00AC4474 /* ExecutableBaseInlines.h in Headers */,
 				14142E531B796EDD00F4BF4B /* ExecutableInfo.h in Headers */,
@@ -11634,6 +11656,7 @@
 				BC18C4310E16F5CD00B34460 /* Lexer.h in Headers */,
 				FEC503FE2B51E09700176A93 /* LineColumn.h in Headers */,
 				86D3B3C310159D7F002865E7 /* LinkBuffer.h in Headers */,
+				07A995622E6BE02000157FC5 /* LinkBufferInternal.h in Headers */,
 				E3637EE9236E56B00096BD0A /* LinkTimeConstant.h in Headers */,
 				A7E2EA6B0FB460CF00601F06 /* LiteralParser.h in Headers */,
 				FE20CE9E15F04A9500DF3430 /* LLIntCLoop.h in Headers */,
@@ -11657,6 +11680,7 @@
 				86C36EEA0EE1289D00B3DF59 /* MacroAssembler.h in Headers */,
 				A1A009C01831A22D00CF8711 /* MacroAssemblerARM64.h in Headers */,
 				FE1E2C3F2240DD5800F6B729 /* MacroAssemblerARM64E.h in Headers */,
+				07A9955E2E6BD5D400157FC5 /* MacroAssemblerARM64Internal.h in Headers */,
 				86ADD1460FDDEA980006EEC2 /* MacroAssemblerARMv7.h in Headers */,
 				863B23E00FC6118900703AA4 /* MacroAssemblerCodeRef.h in Headers */,
 				E32AB2441DCD75F400D7533A /* MacroAssemblerHelpers.h in Headers */,

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -2344,32 +2344,10 @@ public:
     enum BranchTargetType { DirectBranch, IndirectBranch  };
 
     template<RepatchingInfo repatch>
-    ALWAYS_INLINE static void fillNops(void* base, size_t size)
-    {
-        static_assert(!(*repatch).contains(RepatchingFlag::Flush));
-        RELEASE_ASSERT(!(size % sizeof(int32_t)));
-        size_t n = size / sizeof(int32_t);
-        int32_t* ptr = static_cast<int32_t*>(base);
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(ptr) == ptr);
-        for (; n--;) {
-            int insn = nopPseudo();
-            machineCodeCopy<repatch>(ptr++, &insn, sizeof(int));
-        }
-    }
+    ALWAYS_INLINE static void fillNops(void* base, size_t);
 
     template<RepatchingInfo repatch>
-    ALWAYS_INLINE static void fillNearTailCall(void* from, void* to)
-    {
-        static_assert((*repatch).contains(RepatchingFlag::Flush));
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
-        intptr_t offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(from)) >> 2;
-        ASSERT(static_cast<int>(offset) == offset);
-        ASSERT(isInt<26>(offset));
-        constexpr bool isCall = false;
-        int insn = unconditionalBranchImmediate(isCall, static_cast<int>(offset));
-        machineCodeCopy<noFlush(repatch)>(from, &insn, sizeof(int));
-        cacheFlush(from, sizeof(int));
-    }
+    ALWAYS_INLINE static void fillNearTailCall(void* from, void* to);
 
     ALWAYS_INLINE void dmbISH()
     {
@@ -3596,44 +3574,13 @@ public:
         linkJumpOrCall<BranchType_CALL>(addressOf(code, from) - 1, addressOf(code, from) - 1, to);
     }
 
-    static void linkPointer(void* code, AssemblerLabel where, void* valuePtr)
-    {
-        linkPointer<jitMemcpyRepatch>(addressOf(code, where), valuePtr);
-    }
+    static void linkPointer(void* code, AssemblerLabel where, void* valuePtr);
 
-    static void replaceWithVMHalt(void* where)
-    {
-        // This should try to write to null which should always Segfault.
-        int insn = dataCacheZeroVirtualAddress(ARM64Registers::zr);
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(where) == where);
-        performJITMemcpy<jitMemcpyRepatchAtomic>(where, &insn, sizeof(int));
-        cacheFlush(where, sizeof(int));
-    }
+    static void replaceWithVMHalt(void* where);
 
-    static void replaceWithJump(void* where, void* to)
-    {
-        intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(where)) >> 2;
-        ASSERT(static_cast<int>(offset) == offset);
+    static void replaceWithJump(void* where, void* to);
 
-#if ENABLE(JUMP_ISLANDS)
-        if (!isInt<26>(offset)) {
-            to = ExecutableAllocator::singleton().getJumpIslandToUsingJITMemcpy(where, to);
-            offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(where)) >> 2;
-            RELEASE_ASSERT(isInt<26>(offset));
-        }
-#endif
-
-        int insn = unconditionalBranchImmediate(false, static_cast<int>(offset));
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(where) == where);
-        performJITMemcpy<jitMemcpyRepatchAtomic>(where, &insn, sizeof(int));
-        cacheFlush(where, sizeof(int));
-    }
-
-    static void replaceWithNops(void* where, size_t memoryToFillWithNopsInBytes)
-    {
-        fillNops<jitMemcpyRepatch>(where, memoryToFillWithNopsInBytes);
-        cacheFlush(where, memoryToFillWithNopsInBytes);
-    }
+    static void replaceWithNops(void* where, size_t memoryToFillWithNopsInBytes);
 
     static constexpr ptrdiff_t maxJumpReplacementSize()
     {
@@ -3645,28 +3592,10 @@ public:
         return 4;
     }
 
-    static void repatchPointer(void* where, void* valuePtr)
-    {
-        linkPointer<jitMemcpyRepatchFlush>(static_cast<int*>(where), valuePtr);
-    }
+    static void repatchPointer(void* where, void* valuePtr);
 
     template<RepatchingInfo repatch>
-    static void setPointer(int* address, void* valuePtr, RegisterID rd)
-    {
-        uintptr_t value = reinterpret_cast<uintptr_t>(valuePtr);
-        int buffer[NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS];
-        buffer[0] = moveWideImediate(Datasize_64, MoveWideOp_Z, 0, getHalfword(value, 0), rd);
-        buffer[1] = moveWideImediate(Datasize_64, MoveWideOp_K, 1, getHalfword(value, 1), rd);
-        if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 2)
-            buffer[2] = moveWideImediate(Datasize_64, MoveWideOp_K, 2, getHalfword(value, 2), rd);
-        if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
-            buffer[3] = moveWideImediate(Datasize_64, MoveWideOp_K, 3, getHalfword(value, 3), rd);
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(address) == address);
-        performJITMemcpy<noFlush(repatch)>(address, buffer, sizeof(int) * NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
-
-        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
-            cacheFlush(address, sizeof(int) * NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
-    }
+    static void setPointer(int* address, void* valuePtr, RegisterID rd);
 
     static void* readPointer(void* where)
     {
@@ -3943,137 +3872,19 @@ protected:
     }
 
     template<RepatchingInfo repatch>
-    static void linkPointer(int* address, void* valuePtr)
-    {
-        Datasize sf;
-        MoveWideOp opc;
-        int hw;
-        uint16_t imm16;
-        RegisterID rd;
-        bool expected = disassembleMoveWideImediate(address, sf, opc, hw, imm16, rd);
-        ASSERT_UNUSED(expected, expected && sf && opc == MoveWideOp_Z && !hw);
-        ASSERT(checkMovk<Datasize_64>(address[1], 1, rd));
-        if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 2)
-            ASSERT(checkMovk<Datasize_64>(address[2], 2, rd));
-        if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
-            ASSERT(checkMovk<Datasize_64>(address[3], 3, rd));
-
-        setPointer<repatch>(address, valuePtr, rd);
-    }
+    static void linkPointer(int* address, void* valuePtr);
 
     template<BranchType type, RepatchingInfo repatch = jitMemcpyRepatch>
-    static void linkJumpOrCall(int* from, const int* fromInstruction, void* to)
-    {
-        static_assert(type == BranchType_JMP || type == BranchType_CALL);
-
-        bool link;
-        int imm26;
-        bool isUnconditionalBranchImmediateOrNop = disassembleUnconditionalBranchImmediate(from, link, imm26) || disassembleNop(from);
-
-        ASSERT_UNUSED(isUnconditionalBranchImmediateOrNop, isUnconditionalBranchImmediateOrNop);
-        constexpr bool isCall = (type == BranchType_CALL);
-        ASSERT_UNUSED(isCall, (link == isCall) || disassembleNop(from));
-        ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
-        ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
-        assertIsNotTagged(to);
-        assertIsNotTagged(fromInstruction);
-        intptr_t offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(fromInstruction)) >> 2;
-        ASSERT(static_cast<int>(offset) == offset);
-
-#if ENABLE(JUMP_ISLANDS)
-        if (!isInt<26>(offset)) {
-            if constexpr (!(*repatch).contains(RepatchingFlag::Memcpy))
-                to = ExecutableAllocator::singleton().getJumpIslandToUsingJITMemcpy(std::bit_cast<void*>(fromInstruction), to);
-            else
-                to = ExecutableAllocator::singleton().getJumpIslandToUsingMemcpy(std::bit_cast<void*>(fromInstruction), to);
-            offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(fromInstruction)) >> 2;
-            RELEASE_ASSERT(isInt<26>(offset));
-        }
-#endif
-
-        int insn = unconditionalBranchImmediate(isCall, static_cast<int>(offset));
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
-        machineCodeCopy<repatch>(from, &insn, sizeof(int));
-    }
+    static void linkJumpOrCall(int* from, const int* fromInstruction, void* to);
 
     template<BranchTargetType type, RepatchingInfo repatch = jitMemcpyRepatch>
-    static void linkCompareAndBranch(Condition condition, bool is64Bit, RegisterID rt, int* from, const int* fromInstruction, void* to)
-    {
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
-        ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
-        ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
-        intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(fromInstruction)) >> 2;
-
-        bool useDirect = isInt<19>(offset);
-        ASSERT(type == IndirectBranch || useDirect);
-
-        if (useDirect || type == DirectBranch) {
-            ASSERT(isInt<19>(offset));
-            int insn = compareAndBranchImmediate(is64Bit ? Datasize_64 : Datasize_32, condition == ConditionNE, static_cast<int>(offset), rt);
-            machineCodeCopy<repatch>(from, &insn, sizeof(int));
-            if (type == IndirectBranch) {
-                insn = nopPseudo();
-                machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
-            }
-        } else {
-            int insn = compareAndBranchImmediate(is64Bit ? Datasize_64 : Datasize_32, invert(condition) == ConditionNE, 2, rt);
-            machineCodeCopy<repatch>(from, &insn, sizeof(int));
-            linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
-        }
-    }
+    static void linkCompareAndBranch(Condition, bool is64Bit, RegisterID rt, int* from, const int* fromInstruction, void* to);
 
     template<BranchTargetType type, RepatchingInfo repatch = jitMemcpyRepatch>
-    static void linkConditionalBranch(Condition condition, int* from, const int* fromInstruction, void* to)
-    {
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
-        ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
-        ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
-        intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(fromInstruction)) >> 2;
-
-        bool useDirect = isInt<19>(offset);
-        ASSERT(type == IndirectBranch || useDirect);
-
-        if (useDirect || type == DirectBranch) {
-            ASSERT(isInt<19>(offset));
-            int insn = conditionalBranchImmediate(static_cast<int>(offset), condition);
-            machineCodeCopy<repatch>(from, &insn, sizeof(int));
-            if (type == IndirectBranch) {
-                insn = nopPseudo();
-                machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
-            }
-        } else {
-            int insn = conditionalBranchImmediate(2, invert(condition));
-            machineCodeCopy<repatch>(from, &insn, sizeof(int));
-            linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
-        }
-    }
+    static void linkConditionalBranch(Condition, int* from, const int* fromInstruction, void* to);
 
     template<BranchTargetType type, RepatchingInfo repatch = jitMemcpyRepatch>
-    static void linkTestAndBranch(Condition condition, unsigned bitNumber, RegisterID rt, int* from, const int* fromInstruction, void* to)
-    {
-        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
-        ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
-        ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
-        intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(fromInstruction)) >> 2;
-        ASSERT(static_cast<int>(offset) == offset);
-
-        bool useDirect = isInt<14>(offset);
-        ASSERT(type == IndirectBranch || useDirect);
-
-        if (useDirect || type == DirectBranch) {
-            ASSERT(isInt<14>(offset));
-            int insn = testAndBranchImmediate(condition == ConditionNE, static_cast<int>(bitNumber), static_cast<int>(offset), rt);
-            machineCodeCopy<repatch>(from, &insn, sizeof(int));
-            if (type == IndirectBranch) {
-                insn = nopPseudo();
-                machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
-            }
-        } else {
-            int insn = testAndBranchImmediate(invert(condition) == ConditionNE, static_cast<int>(bitNumber), 2, rt);
-            machineCodeCopy<repatch>(from, &insn, sizeof(int));
-            linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
-        }
-    }
+    static void linkTestAndBranch(Condition, unsigned bitNumber, RegisterID rt, int* from, const int* fromInstruction, void* to);
 
     template<BranchType type>
     static void relinkJumpOrCall(int* from, const int* fromInstruction, void* to)

--- a/Source/JavaScriptCore/assembler/ARM64AssemblerInternal.h
+++ b/Source/JavaScriptCore/assembler/ARM64AssemblerInternal.h
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if ENABLE(ASSEMBLER) && CPU(ARM64)
+
+#include "AssemblerCommonInternal.h"
+#include "ExecutableAllocatorInternal.h"
+#include <JavaScriptCore/ARM64Assembler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+
+ALWAYS_INLINE void ARM64Assembler::linkPointer(void* code, AssemblerLabel where, void* valuePtr)
+{
+    linkPointer<jitMemcpyRepatch>(addressOf(code, where), valuePtr);
+}
+
+inline void ARM64Assembler::replaceWithVMHalt(void *where)
+{
+    // This should try to write to null which should always Segfault.
+    int insn = dataCacheZeroVirtualAddress(ARM64Registers::zr);
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(where) == where);
+    performJITMemcpy<jitMemcpyRepatchAtomic>(where, &insn, sizeof(int));
+    cacheFlush(where, sizeof(int));
+}
+
+inline void ARM64Assembler::replaceWithJump(void* where, void* to)
+{
+    intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(where)) >> 2;
+    ASSERT(static_cast<int>(offset) == offset);
+
+#if ENABLE(JUMP_ISLANDS)
+    if (!isInt<26>(offset)) {
+        to = ExecutableAllocator::singleton().getJumpIslandToUsingJITMemcpy(where, to);
+        offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(where)) >> 2;
+        RELEASE_ASSERT(isInt<26>(offset));
+    }
+#endif
+
+    int insn = unconditionalBranchImmediate(false, static_cast<int>(offset));
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(where) == where);
+    performJITMemcpy<jitMemcpyRepatchAtomic>(where, &insn, sizeof(int));
+    cacheFlush(where, sizeof(int));
+}
+
+ALWAYS_INLINE void ARM64Assembler::replaceWithNops(void* where, size_t memoryToFillWithNopsInBytes)
+{
+    fillNops<jitMemcpyRepatch>(where, memoryToFillWithNopsInBytes);
+    cacheFlush(where, memoryToFillWithNopsInBytes);
+}
+
+template<RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::fillNops(void* base, size_t size)
+{
+    static_assert(!(*repatch).contains(RepatchingFlag::Flush));
+    RELEASE_ASSERT(!(size % sizeof(int32_t)));
+    size_t n = size / sizeof(int32_t);
+    int32_t* ptr = static_cast<int32_t*>(base);
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(ptr) == ptr);
+    for (; n--;) {
+        int insn = nopPseudo();
+        machineCodeCopy<repatch>(ptr++, &insn, sizeof(int));
+    }
+}
+
+template<RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::fillNearTailCall(void* from, void* to)
+{
+    static_assert((*repatch).contains(RepatchingFlag::Flush));
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
+    intptr_t offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(from)) >> 2;
+    ASSERT(static_cast<int>(offset) == offset);
+    ASSERT(isInt<26>(offset));
+    constexpr bool isCall = false;
+    int insn = unconditionalBranchImmediate(isCall, static_cast<int>(offset));
+    machineCodeCopy<noFlush(repatch)>(from, &insn, sizeof(int));
+    cacheFlush(from, sizeof(int));
+}
+
+ALWAYS_INLINE void ARM64Assembler::repatchPointer(void* where, void* valuePtr)
+{
+    linkPointer<jitMemcpyRepatchFlush>(static_cast<int*>(where), valuePtr);
+}
+
+template<RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::setPointer(int* address, void* valuePtr, RegisterID rd)
+{
+    uintptr_t value = reinterpret_cast<uintptr_t>(valuePtr);
+    int buffer[NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS];
+    buffer[0] = moveWideImediate(Datasize_64, MoveWideOp_Z, 0, getHalfword(value, 0), rd);
+    buffer[1] = moveWideImediate(Datasize_64, MoveWideOp_K, 1, getHalfword(value, 1), rd);
+    if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 2)
+        buffer[2] = moveWideImediate(Datasize_64, MoveWideOp_K, 2, getHalfword(value, 2), rd);
+    if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
+        buffer[3] = moveWideImediate(Datasize_64, MoveWideOp_K, 3, getHalfword(value, 3), rd);
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(address) == address);
+    performJITMemcpy<noFlush(repatch)>(address, buffer, sizeof(int) * NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
+
+    if constexpr ((*repatch).contains(RepatchingFlag::Flush))
+        cacheFlush(address, sizeof(int) * NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
+}
+
+template<ARM64Assembler::BranchTargetType type, RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::linkCompareAndBranch(Condition condition, bool is64Bit, RegisterID rt, int* from, const int* fromInstruction, void* to)
+{
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
+    ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
+    ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
+    intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(fromInstruction)) >> 2;
+
+    bool useDirect = isInt<19>(offset);
+    ASSERT(type == IndirectBranch || useDirect);
+
+    if (useDirect || type == DirectBranch) {
+        ASSERT(isInt<19>(offset));
+        int insn = compareAndBranchImmediate(is64Bit ? Datasize_64 : Datasize_32, condition == ConditionNE, static_cast<int>(offset), rt);
+        machineCodeCopy<repatch>(from, &insn, sizeof(int));
+        if (type == IndirectBranch) {
+            insn = nopPseudo();
+            machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
+        }
+    } else {
+        int insn = compareAndBranchImmediate(is64Bit ? Datasize_64 : Datasize_32, invert(condition) == ConditionNE, 2, rt);
+        machineCodeCopy<repatch>(from, &insn, sizeof(int));
+        linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
+    }
+}
+
+template<ARM64Assembler::BranchTargetType type, RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::linkConditionalBranch(Condition condition, int* from, const int* fromInstruction, void* to)
+{
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
+    ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
+    ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
+    intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(fromInstruction)) >> 2;
+
+    bool useDirect = isInt<19>(offset);
+    ASSERT(type == IndirectBranch || useDirect);
+
+    if (useDirect || type == DirectBranch) {
+        ASSERT(isInt<19>(offset));
+        int insn = conditionalBranchImmediate(static_cast<int>(offset), condition);
+        machineCodeCopy<repatch>(from, &insn, sizeof(int));
+        if (type == IndirectBranch) {
+            insn = nopPseudo();
+            machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
+        }
+    } else {
+        int insn = conditionalBranchImmediate(2, invert(condition));
+        machineCodeCopy<repatch>(from, &insn, sizeof(int));
+        linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
+    }
+}
+
+template<ARM64Assembler::BranchTargetType type, RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::linkTestAndBranch(Condition condition, unsigned bitNumber, RegisterID rt, int* from, const int* fromInstruction, void* to)
+{
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
+    ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
+    ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
+    intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(fromInstruction)) >> 2;
+    ASSERT(static_cast<int>(offset) == offset);
+
+    bool useDirect = isInt<14>(offset);
+    ASSERT(type == IndirectBranch || useDirect);
+
+    if (useDirect || type == DirectBranch) {
+        ASSERT(isInt<14>(offset));
+        int insn = testAndBranchImmediate(condition == ConditionNE, static_cast<int>(bitNumber), static_cast<int>(offset), rt);
+        machineCodeCopy<repatch>(from, &insn, sizeof(int));
+        if (type == IndirectBranch) {
+            insn = nopPseudo();
+            machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
+        }
+    } else {
+        int insn = testAndBranchImmediate(invert(condition) == ConditionNE, static_cast<int>(bitNumber), 2, rt);
+        machineCodeCopy<repatch>(from, &insn, sizeof(int));
+        linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
+    }
+}
+
+template<RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::linkPointer(int* address, void* valuePtr)
+{
+    Datasize sf;
+    MoveWideOp opc;
+    int hw;
+    uint16_t imm16;
+    RegisterID rd;
+    bool expected = disassembleMoveWideImediate(address, sf, opc, hw, imm16, rd);
+    ASSERT_UNUSED(expected, expected && sf && opc == MoveWideOp_Z && !hw);
+    ASSERT(checkMovk<Datasize_64>(address[1], 1, rd));
+    if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 2)
+        ASSERT(checkMovk<Datasize_64>(address[2], 2, rd));
+    if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
+        ASSERT(checkMovk<Datasize_64>(address[3], 3, rd));
+
+    setPointer<repatch>(address, valuePtr, rd);
+}
+
+template<ARM64Assembler::BranchType type, RepatchingInfo repatch>
+ALWAYS_INLINE void ARM64Assembler::linkJumpOrCall(int* from, const int* fromInstruction, void* to)
+{
+    static_assert(type == BranchType_JMP || type == BranchType_CALL);
+
+    bool link;
+    int imm26;
+    bool isUnconditionalBranchImmediateOrNop = disassembleUnconditionalBranchImmediate(from, link, imm26) || disassembleNop(from);
+
+    ASSERT_UNUSED(isUnconditionalBranchImmediateOrNop, isUnconditionalBranchImmediateOrNop);
+    constexpr bool isCall = (type == BranchType_CALL);
+    ASSERT_UNUSED(isCall, (link == isCall) || disassembleNop(from));
+    ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
+    ASSERT(!(reinterpret_cast<intptr_t>(to) & 3));
+    assertIsNotTagged(to);
+    assertIsNotTagged(fromInstruction);
+    intptr_t offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(fromInstruction)) >> 2;
+    ASSERT(static_cast<int>(offset) == offset);
+
+#if ENABLE(JUMP_ISLANDS)
+    if (!isInt<26>(offset)) {
+        if constexpr (!(*repatch).contains(RepatchingFlag::Memcpy))
+            to = ExecutableAllocator::singleton().getJumpIslandToUsingJITMemcpy(std::bit_cast<void*>(fromInstruction), to);
+        else
+            to = ExecutableAllocator::singleton().getJumpIslandToUsingMemcpy(std::bit_cast<void*>(fromInstruction), to);
+        offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(fromInstruction)) >> 2;
+        RELEASE_ASSERT(isInt<26>(offset));
+    }
+#endif
+
+    int insn = unconditionalBranchImmediate(isCall, static_cast<int>(offset));
+    RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
+    machineCodeCopy<repatch>(from, &insn, sizeof(int));
+}
+
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(ASSEMBLER) && CPU(ARM64)

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -992,19 +992,13 @@ public:
         AssemblerType::linkJump(code, jump.m_label, target.dataLocation());
     }
 
-    static void linkPointer(void* code, AssemblerLabel label, void* value)
-    {
-        AssemblerType::linkPointer(code, label, value);
-    }
+    static void linkPointer(void* code, AssemblerLabel, void* value);
 
     template<PtrTag tag>
-    static void linkPointer(void* code, AssemblerLabel label, CodePtr<tag> value)
-    {
-        AssemblerType::linkPointer(code, label, value.taggedPtr());
-    }
+    static void linkPointer(void* code, AssemblerLabel label, CodePtr<tag> value);
 
     template<PtrTag tag>
-    static void* getLinkerAddress(void* code, AssemblerLabel label)
+    static void* getLinkerAddress(void* code, AssemblerLabel)
     {
         return tagCodePtr<tag>(AssemblerType::getRelocatedAddress(code, label));
     }
@@ -1052,10 +1046,7 @@ public:
     }
 
     template<PtrTag tag>
-    static void repatchPointer(CodeLocationDataLabelPtr<tag> dataLabelPtr, void* value)
-    {
-        AssemblerType::repatchPointer(dataLabelPtr.dataLocation(), value);
-    }
+    static void repatchPointer(CodeLocationDataLabelPtr<tag>, void* value);
 
     template<PtrTag tag>
     static void* readPointer(CodeLocationDataLabelPtr<tag> dataLabelPtr)

--- a/Source/JavaScriptCore/assembler/AssemblerCommon.h
+++ b/Source/JavaScriptCore/assembler/AssemblerCommon.h
@@ -423,25 +423,7 @@ static ALWAYS_INLINE void* memcpyAtomicIfPossible(void* dst, const void* src, si
 }
 
 template<RepatchingInfo repatch>
-void* performJITMemcpy(void* dst, const void* src, size_t n);
-
-template<RepatchingInfo repatch>
-ALWAYS_INLINE void* machineCodeCopy(void* dst, const void* src, size_t n)
-{
-    static_assert(!(*repatch).contains(RepatchingFlag::Flush));
-    if constexpr (is32Bit()) {
-        // Avoid unaligned accesses.
-        if (WTF::isAligned(dst, n))
-            return memcpyAtomicIfPossible(dst, src, n);
-        return memcpyTearing(dst, src, n);
-    }
-    if constexpr ((*repatch).contains(RepatchingFlag::Memcpy) && (*repatch).contains(RepatchingFlag::Atomic))
-        return memcpyAtomic(dst, src, n);
-    else if constexpr ((*repatch).contains(RepatchingFlag::Memcpy))
-        return memcpyAtomicIfPossible(dst, src, n);
-    else
-        return performJITMemcpy<repatch>(dst, src, n);
-}
+ALWAYS_INLINE void* machineCodeCopy(void* dst, const void* src, size_t n);
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -28,10 +28,13 @@
 
 #if ENABLE(ASSEMBLER)
 
+#include "ARM64AssemblerInternal.h"
 #include "CodeBlock.h"
 #include "Disassembler.h"
+#include "FastJITPermissions.h"
 #include "GdbJIT.h"
 #include "JITCode.h"
+#include "MacroAssemblerARM64Internal.h"
 #include "Options.h"
 #include "PerfLog.h"
 #include "WasmCallee.h"

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -159,52 +159,24 @@ public:
     // These methods are used to link or set values at code generation time.
 
     template<PtrTag tag, typename Func, typename = std::enable_if_t<std::is_function<typename std::remove_pointer<Func>::type>::value>>
-    void link(Call call, Func funcName)
-    {
-        CodePtr<tag> function(funcName);
-        link(call, function);
-    }
+    void link(Call, Func funcName);
 
     template<PtrTag tag>
-    void link(Call call, CodePtr<tag> function)
-    {
-        ASSERT(call.isFlagSet(Call::Linkable));
-        call.m_label = applyOffset(call.m_label);
-        MacroAssembler::linkCall(code(), call, function);
-    }
-    
-    template<PtrTag tag>
-    void link(Call call, CodeLocationLabel<tag> label)
-    {
-        link(call, CodePtr<tag>(label));
-    }
-    
-    template<PtrTag tag>
-    void link(Jump jump, CodeLocationLabel<tag> label)
-    {
-        jump.m_label = applyOffset(jump.m_label);
-        MacroAssembler::linkJump(code(), jump, label);
-    }
+    void link(Call, CodePtr<tag> function);
 
     template<PtrTag tag>
-    void link(const JumpList& list, CodeLocationLabel<tag> label)
-    {
-        for (const Jump& jump : list.jumps())
-            link(jump, label);
-    }
-
-    void patch(DataLabelPtr label, void* value)
-    {
-        AssemblerLabel target = applyOffset(label.m_label);
-        MacroAssembler::linkPointer(code(), target, value);
-    }
+    void link(Call, CodeLocationLabel<tag>);
 
     template<PtrTag tag>
-    void patch(DataLabelPtr label, CodeLocationLabel<tag> value)
-    {
-        AssemblerLabel target = applyOffset(label.m_label);
-        MacroAssembler::linkPointer(code(), target, value);
-    }
+    void link(Jump, CodeLocationLabel<tag>);
+
+    template<PtrTag tag>
+    void link(const JumpList&, CodeLocationLabel<tag>);
+
+    void patch(DataLabelPtr, void* value);
+
+    template<PtrTag tag>
+    void patch(DataLabelPtr, CodeLocationLabel<tag> value);
 
     // These methods are used to obtain handles to allow the code to be relinked / repatched later.
     

--- a/Source/JavaScriptCore/assembler/LinkBufferInternal.h
+++ b/Source/JavaScriptCore/assembler/LinkBufferInternal.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if ENABLE(ASSEMBLER)
+
+#include "AbstractMacroAssemblerInternal.h"
+#include "MacroAssemblerARM64Internal.h"
+#include <JavaScriptCore/LinkBuffer.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+
+template<PtrTag tag, typename Func, typename>
+ALWAYS_INLINE void LinkBuffer::link(Call call, Func funcName)
+{
+    CodePtr<tag> function(funcName);
+    link(call, function);
+}
+
+template<PtrTag tag>
+ALWAYS_INLINE void LinkBuffer::link(Call call, CodePtr<tag> function)
+{
+    ASSERT(call.isFlagSet(Call::Linkable));
+    call.m_label = applyOffset(call.m_label);
+    MacroAssembler::linkCall(code(), call, function);
+}
+
+template<PtrTag tag>
+ALWAYS_INLINE void LinkBuffer::link(Call call, CodeLocationLabel<tag> label)
+{
+    link(call, CodePtr<tag>(label));
+}
+
+template<PtrTag tag>
+ALWAYS_INLINE void LinkBuffer::link(Jump jump, CodeLocationLabel<tag> label)
+{
+    jump.m_label = applyOffset(jump.m_label);
+    MacroAssembler::linkJump(code(), jump, label);
+}
+
+template<PtrTag tag>
+ALWAYS_INLINE void LinkBuffer::link(const JumpList& list, CodeLocationLabel<tag> label)
+{
+    for (const Jump& jump : list.jumps())
+        link(jump, label);
+}
+
+ALWAYS_INLINE void LinkBuffer::patch(DataLabelPtr label, void* value)
+{
+    AssemblerLabel target = applyOffset(label.m_label);
+    MacroAssembler::linkPointer(code(), target, value);
+}
+
+template<PtrTag tag>
+ALWAYS_INLINE void LinkBuffer::patch(DataLabelPtr label, CodeLocationLabel<tag> value)
+{
+    AssemblerLabel target = applyOffset(label.m_label);
+    MacroAssembler::linkPointer(code(), target, value);
+}
+
+
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(ASSEMBLER)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -6441,22 +6441,13 @@ public:
     }
 
     template<PtrTag tag>
-    static void replaceWithVMHalt(CodeLocationLabel<tag> instructionStart)
-    {
-        Assembler::replaceWithVMHalt(instructionStart.dataLocation());
-    }
+    static void replaceWithVMHalt(CodeLocationLabel<tag> instructionStart);
 
     template<PtrTag startTag, PtrTag destTag>
-    static void replaceWithJump(CodeLocationLabel<startTag> instructionStart, CodeLocationLabel<destTag> destination)
-    {
-        Assembler::replaceWithJump(instructionStart.dataLocation(), destination.dataLocation());
-    }
+    static void replaceWithJump(CodeLocationLabel<startTag> instructionStart, CodeLocationLabel<destTag> destination);
 
     template<PtrTag startTag>
-    static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
-    {
-        Assembler::replaceWithNops(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
-    }
+    static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes);
 
     static ptrdiff_t maxJumpReplacementSize()
     {
@@ -6517,16 +6508,10 @@ public:
     }
 
     template<PtrTag callTag, PtrTag destTag>
-    static void repatchCall(CodeLocationCall<callTag> call, CodeLocationLabel<destTag> destination)
-    {
-        Assembler::repatchPointer(call.dataLabelPtrAtOffset(REPATCH_OFFSET_CALL_TO_POINTER).dataLocation(), destination.taggedPtr());
-    }
+    static void repatchCall(CodeLocationCall<callTag>, CodeLocationLabel<destTag> destination);
 
     template<PtrTag callTag, PtrTag destTag>
-    static void repatchCall(CodeLocationCall<callTag> call, CodePtr<destTag> destination)
-    {
-        Assembler::repatchPointer(call.dataLabelPtrAtOffset(REPATCH_OFFSET_CALL_TO_POINTER).dataLocation(), destination.taggedPtr());
-    }
+    static void repatchCall(CodeLocationCall<callTag>, CodePtr<destTag> destination);
 
     JSC_OPERATION_VALIDATION_MACROASSEMBLER_ARM64_SUPPORT();
 
@@ -7245,15 +7230,7 @@ protected:
     friend class LinkBuffer;
 
     template<PtrTag tag>
-    static void linkCall(void* code, Call call, CodePtr<tag> function)
-    {
-        if (!call.isFlagSet(Call::Near))
-            Assembler::linkPointer(code, call.m_label.labelAtOffset(REPATCH_OFFSET_CALL_TO_POINTER), function.taggedPtr());
-        else if (call.isFlagSet(Call::Tail))
-            Assembler::linkJump(code, call.m_label, function.untaggedPtr());
-        else
-            Assembler::linkCall(code, call.m_label, function.untaggedPtr());
-    }
+    static void linkCall(void* code, Call, CodePtr<tag> function);
 
     JS_EXPORT_PRIVATE static void collectCPUFeatures();
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64Internal.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64Internal.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if ENABLE(ASSEMBLER) && CPU(ARM64)
+
+#include "ARM64AssemblerInternal.h"
+#include <JavaScriptCore/MacroAssemblerARM64.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+
+template<PtrTag tag>
+ALWAYS_INLINE void MacroAssemblerARM64::linkCall(void* code, Call call, CodePtr<tag> function)
+{
+    if (!call.isFlagSet(Call::Near))
+        Assembler::linkPointer(code, call.m_label.labelAtOffset(REPATCH_OFFSET_CALL_TO_POINTER), function.taggedPtr());
+    else if (call.isFlagSet(Call::Tail))
+        Assembler::linkJump(code, call.m_label, function.untaggedPtr());
+    else
+        Assembler::linkCall(code, call.m_label, function.untaggedPtr());
+}
+
+template<PtrTag callTag, PtrTag destTag>
+ALWAYS_INLINE void MacroAssemblerARM64::repatchCall(CodeLocationCall<callTag> call, CodeLocationLabel<destTag> destination)
+{
+    Assembler::repatchPointer(call.dataLabelPtrAtOffset(REPATCH_OFFSET_CALL_TO_POINTER).dataLocation(), destination.taggedPtr());
+}
+
+template<PtrTag callTag, PtrTag destTag>
+ALWAYS_INLINE void MacroAssemblerARM64::repatchCall(CodeLocationCall<callTag> call, CodePtr<destTag> destination)
+{
+    Assembler::repatchPointer(call.dataLabelPtrAtOffset(REPATCH_OFFSET_CALL_TO_POINTER).dataLocation(), destination.taggedPtr());
+}
+
+template<PtrTag tag>
+ALWAYS_INLINE void MacroAssemblerARM64::replaceWithVMHalt(CodeLocationLabel<tag> instructionStart)
+{
+    Assembler::replaceWithVMHalt(instructionStart.dataLocation());
+}
+
+template<PtrTag startTag, PtrTag destTag>
+ALWAYS_INLINE void MacroAssemblerARM64::replaceWithJump(CodeLocationLabel<startTag> instructionStart, CodeLocationLabel<destTag> destination)
+{
+    Assembler::replaceWithJump(instructionStart.dataLocation(), destination.dataLocation());
+}
+
+template<PtrTag startTag>
+ALWAYS_INLINE void MacroAssemblerARM64::replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
+{
+    Assembler::replaceWithNops(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
+}
+
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(ASSEMBLER) && CPU(ARM64)

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CallLinkInfo.h"
 
+#include "AbstractMacroAssemblerInternal.h"
 #include "CCallHelpers.h"
 #include "CallFrameShuffleData.h"
 #include "DFGJITCode.h"
@@ -36,6 +37,7 @@
 #include "JSWebAssemblyModule.h"
 #include "LLIntEntrypoint.h"
 #include "LinkBuffer.h"
+#include "MacroAssemblerARM64Internal.h"
 #include "Opcode.h"
 #include "Repatch.h"
 #include "ThunkGenerators.h"

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -57,6 +57,7 @@
 #include "JSWebAssemblyModule.h"
 #include "LLIntData.h"
 #include "LinkBuffer.h"
+#include "MacroAssemblerARM64Internal.h"
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "ModuleNamespaceAccessCase.h"
 #include "ScopedArguments.h"

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
@@ -30,6 +30,7 @@
 #include "CacheableIdentifierInlines.h"
 #include "DFGJITCode.h"
 #include "InlineCacheCompiler.h"
+#include "MacroAssemblerARM64Internal.h"
 #include "Repatch.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -38,7 +38,7 @@
 #include "DFGSpeculativeJIT.h"
 #include "DFGThunks.h"
 #include "JSCJSValueInlines.h"
-#include "LinkBuffer.h"
+#include "LinkBufferInternal.h"
 #include "ProbeContext.h"
 #include "ThunkGenerators.h"
 #include "VM.h"

--- a/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
@@ -28,10 +28,11 @@
 
 #if ENABLE(DFG_JIT)
 
+#include "AbstractMacroAssemblerInternal.h"
 #include "CCallHelpers.h"
 #include "DFGGraph.h"
 #include "JSCJSValueInlines.h"
-#include "LinkBuffer.h"
+#include "LinkBufferInternal.h"
 
 namespace JSC { namespace DFG {
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -41,6 +41,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "HasOwnPropertyCache.h"
 #include "JSMap.h"
 #include "JSSet.h"
+#include "LinkBufferInternal.h"
+#include "MacroAssemblerARM64Internal.h"
 #include "MegamorphicCache.h"
 #include "SetupVarargsFrame.h"
 #include "SpillRegistersMode.h"

--- a/Source/JavaScriptCore/ftl/FTLExceptionTarget.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExceptionTarget.cpp
@@ -28,7 +28,7 @@
 
 #if ENABLE(FTL_JIT)
 
-#include "LinkBuffer.h"
+#include "LinkBufferInternal.h"
 
 namespace JSC { namespace FTL {
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -95,6 +95,7 @@
 #include "JSWebAssemblyInstance.h"
 #include "JSWrapForValidIterator.h"
 #include "LLIntThunks.h"
+#include "LinkBufferInternal.h"
 #include "MegamorphicCache.h"
 #include "OperandsInlines.h"
 #include "PCToCodeOriginMap.h"

--- a/Source/JavaScriptCore/ftl/FTLSlowPathCall.cpp
+++ b/Source/JavaScriptCore/ftl/FTLSlowPathCall.cpp
@@ -32,6 +32,7 @@
 #include "FTLState.h"
 #include "FTLThunks.h"
 #include "GPRInfo.h"
+#include "LinkBufferInternal.h"
 
 namespace JSC { namespace FTL {
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -24,10 +24,11 @@
  */
 
 #include "config.h"
-#include "ExecutableAllocator.h"
+#include "ExecutableAllocatorInternal.h"
 
 #if ENABLE(JIT)
 
+#include "ARM64AssemblerInternal.h"
 #include "ExecutableAllocationFuzz.h"
 #include "JITOperationValidation.h"
 #include "LinkBuffer.h"

--- a/Source/JavaScriptCore/jit/ExecutableAllocatorInternal.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocatorInternal.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FastJITPermissions.h"
+#include <JavaScriptCore/ExecutableAllocator.h>
+
+namespace JSC {
+
+#if ENABLE(JIT)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+template<RepatchingInfo repatch>
+ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
+{
+    static_assert(!(*repatch).contains(RepatchingFlag::Memcpy));
+    static_assert(!(*repatch).contains(RepatchingFlag::Flush));
+    jitMemcpyChecks(dst, src, n);
+    if (isJITPC(dst)) {
+#if ENABLE(MPROTECT_RX_TO_RWX)
+        auto ret = performJITMemcpyWithMProtect(dst, src, n);
+        jitMemcpyCheckForZeros(dst, src, n);
+        return ret;
+#endif
+
+        if (g_jscConfig.useFastJITPermissions) {
+            threadSelfRestrict<MemoryRestriction::kRwxToRw>();
+            if constexpr ((*repatch).contains(RepatchingFlag::Atomic))
+                memcpyAtomic(dst, src, n);
+            else
+                memcpyAtomicIfPossible(dst, src, n);
+            threadSelfRestrict<MemoryRestriction::kRwxToRx>();
+            jitMemcpyCheckForZeros(dst, src, n);
+            return dst;
+        }
+
+#if ENABLE(SEPARATED_WX_HEAP)
+        if (g_jscConfig.jitWriteSeparateHeaps) {
+            // Use execute-only write thunk for writes inside the JIT region. This is a variant of
+            // memcpy that takes an offset into the JIT region as its destination (first) parameter.
+            off_t offset = (off_t)((uintptr_t)dst - startOfFixedExecutableMemoryPool<uintptr_t>());
+            retagCodePtr<JITThunkPtrTag, CFunctionPtrTag>(g_jscConfig.jitWriteSeparateHeaps)(offset, src, n);
+            RELEASE_ASSERT(!Gigacage::contains(src));
+            jitMemcpyCheckForZeros(dst, src, n);
+            return dst;
+        }
+#endif
+        memcpyAtomicIfPossible(dst, src, n);
+        jitMemcpyCheckForZeros(dst, src, n);
+        return dst;
+    }
+
+    return memcpyAtomicIfPossible(dst, src, n);
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#else
+
+inline void* performJITMemcpy(void *dst, const void *src, size_t n)
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    return memcpy(dst, src, n);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
+inline bool isJITPC(void*) { return false; }
+#endif // ENABLE(JIT)
+
+} // namespace JSC

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -40,7 +40,7 @@
 #include "JITThunks.h"
 #include "LLIntEntrypoint.h"
 #include "LLIntThunks.h"
-#include "LinkBuffer.h"
+#include "LinkBufferInternal.h"
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "ModuleProgramCodeBlock.h"
 #include "PCToCodeOriginMap.h"

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -38,7 +38,7 @@
 #include "JSCast.h"
 #include "JSFunction.h"
 #include "JSPropertyNameEnumerator.h"
-#include "LinkBuffer.h"
+#include "LinkBufferInternal.h"
 #include "SuperSampler.h"
 #include "ThunkGenerators.h"
 #include "TypeLocation.h"

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -31,6 +31,7 @@
 #include "JSBoundFunction.h"
 #include "JSRemoteFunction.h"
 #include "LLIntThunks.h"
+#include "LinkBufferInternal.h"
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "SpecializedThunkJIT.h"
 #include "ThunkGenerator.h"

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -30,6 +30,7 @@
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
+#include "AbstractMacroAssemblerInternal.h"
 #include "B3Common.h"
 #include "B3ValueRep.h"
 #include "BinarySwitch.h"

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -33,7 +33,7 @@
 #include "JSCJSValue.h"
 #include "JSInterfaceJIT.h"
 #include "JSWebAssemblyInstance.h"
-#include "LinkBuffer.h"
+#include "LinkBufferInternal.h"
 #include "ProbeContext.h"
 #include "ScratchRegisterAllocator.h"
 #include "WasmExceptionType.h"

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -29,7 +29,7 @@
 
 #include "AllowMacroScratchRegisterUsage.h"
 #include "CCallHelpers.h"
-#include "LinkBuffer.h"
+#include "LinkBufferInternal.h"
 #include "Options.h"
 #if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
 #include "JITThunks.h"


### PR DESCRIPTION
#### 6e648d0b918a9e673b0ca0c5d587811313f9e48f
<pre>
[Swift in WebKit] Work towards modularizing JSC private headers (Part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298495">https://bugs.webkit.org/show_bug.cgi?id=298495</a>
<a href="https://rdar.apple.com/159990396">rdar://159990396</a>

Reviewed by NOBODY (OOPS!).

The private interface of JSC should not expose the interface or implementation of FastJITPermissions.h.
Moreover, doing so fails module verification due to some malformed system headers the file depends on.

To fix, make FastJITPermissions.h project-level instead of private-level. Because JSC has a lot of inline
functions, this requires some changes in the dependencies of the header; specifically:

1. For each private header in JSC that directly or transitively depends on FastJITPermissions.h,
    (a) Create an associated &quot;*Internal.h&quot; header file at project-level
    (b) Identify all inline functions in the dependent header that depend on a function in FastJITPermissions.h
        (i) For each of these functions, move the function definition to the &quot;*.Internal.h&quot; file, and explicitly mark it as inline.
2. For each private header that depends on any of the functions that were moved to &quot;*.Internal.h&quot;,
    (a) repeat the steps in (1)
3. For each implementation (cpp) file, and each project-level header file, that depends on any of those functions, include the &quot;*.Internal.h&quot; file.

The end result of this operation is the addition of several new *.Internal.h files, which better separates
the project interface of JSC with the private interface. All previous inlined functions remain inlined.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/ARM64AssemblerInternal.h: Added.
(JSC::ARM64Assembler::linkPointer):
(JSC::ARM64Assembler::replaceWithVMHalt):
(JSC::ARM64Assembler::replaceWithJump):
(JSC::ARM64Assembler::replaceWithNops):
(JSC::ARM64Assembler::fillNops):
(JSC::ARM64Assembler::fillNearTailCall):
(JSC::ARM64Assembler::repatchPointer):
(JSC::ARM64Assembler::setPointer):
(JSC::ARM64Assembler::linkCompareAndBranch):
(JSC::ARM64Assembler::linkConditionalBranch):
(JSC::ARM64Assembler::linkTestAndBranch):
(JSC::ARM64Assembler::linkJumpOrCall):
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::linkPointer): Deleted.
(JSC::AbstractMacroAssembler::repatchPointer): Deleted.
* Source/JavaScriptCore/assembler/AbstractMacroAssemblerInternal.h: Copied from Source/JavaScriptCore/dfg/DFGJumpReplacement.cpp.
(JSC::AbstractMacroAssembler&lt;AssemblerType&gt;::repatchPointer):
(JSC::AbstractMacroAssembler&lt;AssemblerType&gt;::linkPointer):
* Source/JavaScriptCore/assembler/AssemblerCommon.h:
(JSC::machineCodeCopy): Deleted.
* Source/JavaScriptCore/assembler/AssemblerCommonInternal.h: Copied from Source/JavaScriptCore/dfg/DFGJumpReplacement.cpp.
(JSC::machineCodeCopy):
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
* Source/JavaScriptCore/assembler/LinkBuffer.h:
(JSC::LinkBuffer::link): Deleted.
(JSC::LinkBuffer::patch): Deleted.
* Source/JavaScriptCore/assembler/LinkBufferInternal.h: Added.
(JSC::LinkBuffer::link):
(JSC::LinkBuffer::patch):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::replaceWithVMHalt): Deleted.
(JSC::MacroAssemblerARM64::replaceWithJump): Deleted.
(JSC::MacroAssemblerARM64::replaceWithNops): Deleted.
(JSC::MacroAssemblerARM64::repatchCall): Deleted.
(JSC::MacroAssemblerARM64::linkCall): Deleted.
* Source/JavaScriptCore/assembler/MacroAssemblerARM64Internal.h: Added.
(JSC::MacroAssemblerARM64::linkCall):
(JSC::MacroAssemblerARM64::repatchCall):
(JSC::MacroAssemblerARM64::replaceWithVMHalt):
(JSC::MacroAssemblerARM64::replaceWithJump):
(JSC::MacroAssemblerARM64::replaceWithNops):
* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
* Source/JavaScriptCore/dfg/DFGJumpReplacement.cpp:
* Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
* Source/JavaScriptCore/ftl/FTLExceptionTarget.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
* Source/JavaScriptCore/ftl/FTLSlowPathCall.cpp:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::performJITMemcpy): Deleted.
* Source/JavaScriptCore/jit/ExecutableAllocatorInternal.h: Added.
(JSC::performJITMemcpy):
(JSC::isJITPC):
* Source/JavaScriptCore/jit/JIT.cpp:
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e648d0b918a9e673b0ca0c5d587811313f9e48f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119764 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39458 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30108 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126064 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71836 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4e4513b5-c117-4a66-8326-fefa09fa68cf) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40152 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48034 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/126064 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/71836 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b710b12b-ba7f-4ac2-a5ef-70074c3cfc2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122716 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/40152 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/30108 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/126064 "Hash 6e648d0b for PR 50409 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9ceb641-2364-42ad-a976-31b01ddb3e5c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/40152 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/30108 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69707 "Hash 6e648d0b for PR 50409 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111889 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/40152 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/30108 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129010 "Hash 6e648d0b for PR 50409 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118280 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46684 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/48034 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/129010 "Hash 6e648d0b for PR 50409 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47050 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/30108 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/129010 "Hash 6e648d0b for PR 50409 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/30108 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43250 "Hash 6e648d0b for PR 50409 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46546 "Hash 6e648d0b for PR 50409 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52252 "Failed to build and analyze WebKit") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146978 "Hash 6e648d0b for PR 50409 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46012 "Hash 6e648d0b for PR 50409 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/146978 "Hash 6e648d0b for PR 50409 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49361 "Hash 6e648d0b for PR 50409 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47698 "Hash 6e648d0b for PR 50409 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->