### PR TITLE
ASSERT fires when calling CanvasRenderingContext2D::reset() after beginning a layer with a filter

### DIFF
--- a/LayoutTests/fast/canvas/canvas-reset-layer-filter-no-end-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-reset-layer-filter-no-end-expected.txt
@@ -1,0 +1,3 @@
+This test ensures that calling reset() after starting a layer with a filter does not crash.
+
+

--- a/LayoutTests/fast/canvas/canvas-reset-layer-filter-no-end.html
+++ b/LayoutTests/fast/canvas/canvas-reset-layer-filter-no-end.html
@@ -1,0 +1,15 @@
+<body>
+    <h2>This test ensures that calling reset() after starting a layer with a filter does not crash.</h2>
+    <canvas id="canvas" width="100" height="50"></canvas>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const canvas = document.getElementById("canvas");
+        const ctx = canvas.getContext('2d');
+
+        ctx.filter = 'drop-shadow(10px 10px 0px green)';
+        ctx.beginLayer();
+        ctx.reset();
+    </script>
+</body>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -262,9 +262,14 @@ void CanvasRenderingContext2DBase::unwindStateStack()
     size_t stackSize = m_stateStack.size();
     if (stackSize <= 1)
         return;
+
     // We need to keep the last state because it is tracked by CanvasBase::m_contextStateSaver.
-    if (auto* context = existingDrawingContext())
-        context->unwindStateStack(stackSize - 1);
+    auto* context = existingDrawingContext();
+    while (m_stateStack.size() > 1) {
+        m_stateStack.removeLast();
+        if (context)
+            context->restore();
+    }
 }
 
 CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
@@ -316,7 +321,7 @@ void CanvasRenderingContext2DBase::reset()
 {
     unwindStateStack();
 
-    m_stateStack.resize(1);
+    ASSERT(m_stateStack.size() == 1);
     m_stateStack.first() = State();
 
     m_path.clear();


### PR DESCRIPTION
#### ec19ea6f19878f13a1774a48692079c05ea2e499
<pre>
ASSERT fires when calling CanvasRenderingContext2D::reset() after beginning a layer with a filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=298501">https://bugs.webkit.org/show_bug.cgi?id=298501</a>
<a href="https://rdar.apple.com/160017871">rdar://160017871</a>

Reviewed by Simon Fraser.

Unwind the CanvasRenderingContext2D state stack in the right order. A state has
to be removed from the stack first then the drawing context has to be restored.

Deleting a state calls the destructor of CanvasLayerContextSwitcher if a layer
has begun. This calls TransparencyLayerContextSwitcher::endDrawSourceImage()
which calls GraphicsContext::endTransparencyLayer(). This calls restore() whose
save() was called when the layer transparency layer was begun.

* LayoutTests/fast/canvas/canvas-reset-layer-filter-no-end-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-reset-layer-filter-no-end.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::unwindStateStack):
(WebCore::CanvasRenderingContext2DBase::reset):

Canonical link: <a href="https://commits.webkit.org/299695@main">https://commits.webkit.org/299695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08d7e8d587fe252b791d6860f2f29e62deaa22d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71862 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7347c688-4f7c-466a-a69c-32149061b8b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60263 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32c3f362-2748-41f2-a630-ea268d1b4f08) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71536 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46568eeb-4b85-4afe-a245-ef7510eba459) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69738 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129036 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99580 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99424 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43288 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46572 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52278 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->