### PR TITLE
[JSC] Clean up Wasm CalleeSave registers handling

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -352,9 +352,9 @@ unsigned Code::jsHash() const
     return result;
 }
 
-void Code::setNumEntrypoints(unsigned numEntryPoints)
+void Code::setNumEntrypoints(unsigned numEntrypoints)
 {
-    m_prologueGenerators = { numEntryPoints, m_defaultPrologueGenerator.copyRef() };
+    m_prologueGenerators = { numEntrypoints, m_defaultPrologueGenerator.copyRef() };
 }
 
 bool Code::usesSIMD() const

--- a/Source/JavaScriptCore/bytecode/BytecodeRewriter.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeRewriter.h
@@ -84,7 +84,7 @@ class BytecodeRewriter {
 WTF_MAKE_NONCOPYABLE(BytecodeRewriter);
 public:
     enum class Position : int8_t {
-        EntryPoint = -2,
+        Entrypoint = -2,
         Before = -1,
         LabelPoint = 0,
         After = 1,
@@ -218,7 +218,7 @@ public:
 
     int32_t adjustAbsoluteOffset(JSInstructionStream::Offset absoluteOffset)
     {
-        return adjustJumpTarget(InsertionPoint(0, Position::EntryPoint), InsertionPoint(absoluteOffset, Position::LabelPoint));
+        return adjustJumpTarget(InsertionPoint(0, Position::Entrypoint), InsertionPoint(absoluteOffset, Position::LabelPoint));
     }
 
     int32_t adjustJumpTarget(JSInstructionStream::Offset originalBytecodeOffset, int32_t originalJumpTarget)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1140,7 +1140,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, ModuleProgramNode* moduleProgramNod
             //        a();
             //    }
             //
-            // Module EntryPoint (executed last):
+            // Module Entrypoint (executed last):
             //    import "B";
             //    import "A";
             //

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -299,7 +299,7 @@ public:
     LinkerIR m_linkerIR;
 
 #if ENABLE(FTL_JIT)
-    // For osrEntryPoint that are in inner loop, this maps their bytecode to the bytecode
+    // For osrEntrypoint that are in inner loop, this maps their bytecode to the bytecode
     // of the outerloop entry points in order (from innermost to outermost).
     //
     // The key may not always be a target for OSR Entry but the list in the value is guaranteed

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1338,7 +1338,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
 
 #if ENABLE(WEBASSEMBLY)
     if (callData.native.isWasm)
-        return JSValue::decode(vmEntryToWasm(jsCast<WebAssemblyFunction*>(function)->jsEntrypoint(ArityCheckMode::MustCheckArity).taggedPtr(), &vm, &protoCallFrame));
+        return JSValue::decode(vmEntryToWasm(jsCast<WebAssemblyFunction*>(function)->jsToWasm(ArityCheckMode::MustCheckArity).taggedPtr(), &vm, &protoCallFrame));
 #endif
 
     return JSValue::decode(vmEntryToNative(nativeFunction.taggedPtr(), &vm, &protoCallFrame));

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -364,12 +364,11 @@ public:
     static constexpr GPRReg regT6 = X86Registers::edi;
     static constexpr GPRReg regT7 = X86Registers::r9;
 
-    static constexpr GPRReg regCS0 = X86Registers::ebx;
-
-    static constexpr GPRReg regCS1 = X86Registers::r12; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS2 = X86Registers::r13; // jitDataRegister
-    static constexpr GPRReg regCS3 = X86Registers::r14; // numberTagRegister
-    static constexpr GPRReg regCS4 = X86Registers::r15; // notCellMaskRegister
+    static constexpr GPRReg regCS0 = X86Registers::ebx; // WasmInstance
+    static constexpr GPRReg regCS1 = X86Registers::r12; // metadataTable in LLInt/Baseline / IPIntMC
+    static constexpr GPRReg regCS2 = X86Registers::r13; // jitData / IPIntPC
+    static constexpr GPRReg regCS3 = X86Registers::r14; // numberTag / WasmBaseMemory
+    static constexpr GPRReg regCS4 = X86Registers::r15; // notCellMask / WasmBoundsCheckingSize
 
     static constexpr GPRReg regWS0 = X86Registers::eax;
     static constexpr GPRReg regWS1 = X86Registers::r10;
@@ -484,8 +483,8 @@ public:
     static constexpr GPRReg regT5 = ARMRegisters::r5;
     static constexpr GPRReg regT6 = ARMRegisters::r8;
     static constexpr GPRReg regT7 = ARMRegisters::r9;
-    static constexpr GPRReg regCS0 = ARMRegisters::r10; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS1 = ARMRegisters::r11; // jitDataRegister
+    static constexpr GPRReg regCS0 = ARMRegisters::r10; // metadataTable in LLInt/Baseline / WasmInstance
+    static constexpr GPRReg regCS1 = ARMRegisters::r11; // jitData / IPIntPC
 
     // These registers match the baseline JIT.
     static constexpr GPRReg callFrameRegister = ARMRegisters::fp;
@@ -601,14 +600,14 @@ public:
     static constexpr GPRReg regT13 = ARM64Registers::x13;
     static constexpr GPRReg regT14 = ARM64Registers::x14;
     static constexpr GPRReg regT15 = ARM64Registers::x15;
-    static constexpr GPRReg regCS0 = ARM64Registers::x19; // Used by FTL only
-    static constexpr GPRReg regCS1 = ARM64Registers::x20; // Used by FTL only
-    static constexpr GPRReg regCS2 = ARM64Registers::x21; // Used by FTL only
-    static constexpr GPRReg regCS3 = ARM64Registers::x22; // Used by FTL only
-    static constexpr GPRReg regCS4 = ARM64Registers::x23; // Used by FTL only
-    static constexpr GPRReg regCS5 = ARM64Registers::x24; // Used by FTL only
-    static constexpr GPRReg regCS6 = ARM64Registers::x25; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS7 = ARM64Registers::x26; // constants
+    static constexpr GPRReg regCS0 = ARM64Registers::x19; // WasmInstance
+    static constexpr GPRReg regCS1 = ARM64Registers::x20; //
+    static constexpr GPRReg regCS2 = ARM64Registers::x21; //
+    static constexpr GPRReg regCS3 = ARM64Registers::x22; // WasmBaseMemory
+    static constexpr GPRReg regCS4 = ARM64Registers::x23; // WasmBoundsCheckingSize
+    static constexpr GPRReg regCS5 = ARM64Registers::x24; //
+    static constexpr GPRReg regCS6 = ARM64Registers::x25; // metadataTable in LLInt/Baseline / IPIntMC
+    static constexpr GPRReg regCS7 = ARM64Registers::x26; // jitData / IPIntPC
     static constexpr GPRReg regCS8 = ARM64Registers::x27; // numberTag
     static constexpr GPRReg regCS9 = ARM64Registers::x28; // notCellMask
     // These constants provide the names for the general purpose argument & return value registers.
@@ -744,14 +743,14 @@ public:
     static constexpr GPRReg regT11 = RISCV64Registers::x28;
     static constexpr GPRReg regT12 = RISCV64Registers::x29;
 
-    static constexpr GPRReg regCS0 = RISCV64Registers::x9;
+    static constexpr GPRReg regCS0 = RISCV64Registers::x9;  // WasmInstance
     static constexpr GPRReg regCS1 = RISCV64Registers::x18;
     static constexpr GPRReg regCS2 = RISCV64Registers::x19;
-    static constexpr GPRReg regCS3 = RISCV64Registers::x20;
-    static constexpr GPRReg regCS4 = RISCV64Registers::x21;
+    static constexpr GPRReg regCS3 = RISCV64Registers::x20; // WasmBaseMemory
+    static constexpr GPRReg regCS4 = RISCV64Registers::x21; // WasmBoundsCheckingSize
     static constexpr GPRReg regCS5 = RISCV64Registers::x22;
-    static constexpr GPRReg regCS6 = RISCV64Registers::x23; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS7 = RISCV64Registers::x24; // constants
+    static constexpr GPRReg regCS6 = RISCV64Registers::x23; // metadataTable in LLInt/Baseline / IPIntMC
+    static constexpr GPRReg regCS7 = RISCV64Registers::x24; // jitData / IPIntPC
     static constexpr GPRReg regCS8 = RISCV64Registers::x25; // numberTag
     static constexpr GPRReg regCS9 = RISCV64Registers::x26; // notCellMask
     static constexpr GPRReg regCS10 = RISCV64Registers::x27;

--- a/Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp
+++ b/Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp
@@ -101,6 +101,28 @@ const RegisterAtOffsetList& RegisterAtOffsetList::dfgCalleeSaveRegisters()
     return result.get();
 }
 
+#if ENABLE(WEBASSEMBLY)
+const RegisterAtOffsetList& RegisterAtOffsetList::wasmPinnedRegisters()
+{
+    static std::once_flag onceKey;
+    static LazyNeverDestroyed<RegisterAtOffsetList> result;
+    std::call_once(onceKey, [] {
+        result.construct(RegisterSetBuilder::wasmPinnedRegisters());
+    });
+    return result.get();
+}
+
+const RegisterAtOffsetList& RegisterAtOffsetList::ipintCalleeSaveRegisters()
+{
+    static std::once_flag onceKey;
+    static LazyNeverDestroyed<RegisterAtOffsetList> result;
+    std::call_once(onceKey, [] {
+        result.construct(RegisterSetBuilder::ipintCalleeSaveRegisters());
+    });
+    return result.get();
+}
+#endif
+
 } // namespace JSC
 
 #endif // ENABLE(ASSEMBLER)

--- a/Source/JavaScriptCore/jit/RegisterAtOffsetList.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffsetList.h
@@ -68,6 +68,10 @@ public:
 
     static const RegisterAtOffsetList& llintBaselineCalleeSaveRegisters(); // Registers and Offsets saved and used by the LLInt.
     static const RegisterAtOffsetList& dfgCalleeSaveRegisters(); // Registers and Offsets saved and used by DFG.
+#if ENABLE(WEBASSEMBLY)
+    static const RegisterAtOffsetList& wasmPinnedRegisters();
+    static const RegisterAtOffsetList& ipintCalleeSaveRegisters(); // Registers and Offsets saved and used by IPInt.
+#endif
 
 private:
     FixedVector<RegisterAtOffset> m_registers;

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -425,6 +425,24 @@ RegisterSet RegisterSetBuilder::wasmPinnedRegisters()
         result.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
     return result;
 }
+
+RegisterSet RegisterSetBuilder::ipintCalleeSaveRegisters()
+{
+    RegisterSet registers;
+#if CPU(X86_64)
+    registers.add(GPRInfo::regCS1, IgnoreVectors); // MC (pointer to metadata)
+    registers.add(GPRInfo::regCS2, IgnoreVectors); // PB
+#elif CPU(ARM64) || CPU(RISCV64)
+    registers.add(GPRInfo::regCS6, IgnoreVectors); // MC
+    registers.add(GPRInfo::regCS7, IgnoreVectors); // PB
+#elif CPU(ARM)
+    registers.add(GPRInfo::regCS0, IgnoreVectors); // MC
+    registers.add(GPRInfo::regCS1, IgnoreVectors); // PB
+#else
+#error Unsupported architecture.
+#endif
+    return registers;
+}
 #endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -209,6 +209,7 @@ public:
     JS_EXPORT_PRIVATE static RegisterSet argumentFPRs();
 #if ENABLE(WEBASSEMBLY)
     JS_EXPORT_PRIVATE static RegisterSet wasmPinnedRegisters();
+    JS_EXPORT_PRIVATE static RegisterSet ipintCalleeSaveRegisters(); // Registers saved and used by the IPInt.
 #endif
     JS_EXPORT_PRIVATE static RegisterSetBuilder registersToSaveForJSCall(RegisterSetBuilder live);
     JS_EXPORT_PRIVATE static RegisterSetBuilder registersToSaveForCCall(RegisterSetBuilder live);

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -82,7 +82,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
     if (!moduleProgramNode)
         return false;
 
-    PrivateName privateName(PrivateName::Description, "EntryPointModule"_s);
+    PrivateName privateName(PrivateName::Description, "EntrypointModule"_s);
     ModuleAnalyzer moduleAnalyzer(globalObject, Identifier::fromUid(privateName), source, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables(), moduleProgramNode->features());
     return !!moduleAnalyzer.analyze(*moduleProgramNode);
 }
@@ -170,10 +170,10 @@ JSValue evaluateWithScopeExtension(JSGlobalObject* globalObject, const SourceCod
     return returnValue;
 }
 
-static Symbol* createSymbolForEntryPointModule(VM& vm)
+static Symbol* createSymbolForEntrypointModule(VM& vm)
 {
     // Generate the unique key for the source-provided module.
-    PrivateName privateName(PrivateName::Description, "EntryPointModule"_s);
+    PrivateName privateName(PrivateName::Description, "EntrypointModule"_s);
     return Symbol::create(vm, privateName.uid());
 }
 
@@ -212,7 +212,7 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const Sou
     RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
-    Symbol* key = createSymbolForEntryPointModule(vm);
+    Symbol* key = createSymbolForEntrypointModule(vm);
 
     // Insert the given source code to the ModuleLoader registry as the fetched registry entry.
     globalObject->moduleLoader()->provideFetch(globalObject, key, source);
@@ -238,7 +238,7 @@ JSInternalPromise* loadModule(JSGlobalObject* globalObject, const SourceCode& so
     RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
-    Symbol* key = createSymbolForEntryPointModule(vm);
+    Symbol* key = createSymbolForEntrypointModule(vm);
 
     // Insert the given source code to the ModuleLoader registry as the fetched registry entry.
     // FIXME: Introduce JSSourceCode object to wrap around this source.

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1057,7 +1057,7 @@ static String tierName(SamplingProfiler::StackFrame& frame)
             switch (frame.wasmCompilationMode.value()) {
             case Wasm::CompilationMode::IPIntMode:
                 return Tiers::ipint;
-            case Wasm::CompilationMode::JSToWasmEntrypointMode:
+            case Wasm::CompilationMode::JSToWasmMode:
             case Wasm::CompilationMode::JSToWasmICMode:
             case Wasm::CompilationMode::WasmToJSMode:
             case Wasm::CompilationMode::WasmBuiltinMode:

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -47,7 +47,7 @@ namespace Wasm {
 class BBQCallee;
 class IPIntCallee;
 class CalleeGroup;
-class JSEntrypointCallee;
+class JSToWasmCallee;
 
 class BBQPlan final : public Plan {
 public:

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -69,7 +69,7 @@ public:
     CompilationMode compilationMode() const { return m_compilationMode; }
 
     CodePtr<WasmEntryPtrTag> entrypoint() const;
-    RegisterAtOffsetList* calleeSaveRegisters();
+    const RegisterAtOffsetList* calleeSaveRegisters();
     // Used by Wasm's fault signal handler to determine if the fault came from Wasm.
     std::tuple<void*, void*> range() const;
 
@@ -125,11 +125,11 @@ protected:
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_entrypoint.compilation->code().retagged<WasmEntryPtrTag>(); }
 
-    RegisterAtOffsetList* calleeSaveRegistersImpl() { return &m_entrypoint.calleeSaveRegisters; }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return &m_entrypoint.calleeSaveRegisters; }
 #else
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
-    RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
 #endif
 
     FixedVector<UnlinkedWasmToWasmCall> m_wasmToWasmCallsites;
@@ -138,25 +138,22 @@ protected:
 #endif
 };
 
-class JSEntrypointCallee final : public Callee {
-    WTF_MAKE_COMPACT_TZONE_ALLOCATED(JSEntrypointCallee);
+class JSToWasmCallee final : public Callee {
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(JSToWasmCallee);
 public:
     friend class Callee;
     friend class JSC::LLIntOffsetsExtractor;
 
-    static inline Ref<JSEntrypointCallee> create(TypeIndex typeIndex, bool usesSIMD)
+    static inline Ref<JSToWasmCallee> create(TypeIndex typeIndex, bool usesSIMD)
     {
-        return adoptRef(*new JSEntrypointCallee(typeIndex, usesSIMD));
+        return adoptRef(*new JSToWasmCallee(typeIndex, usesSIMD));
     }
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const;
-    static JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
+    static JS_EXPORT_PRIVATE const RegisterAtOffsetList* calleeSaveRegistersImpl();
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
-#if ASSERT_ENABLED
-    static constexpr ptrdiff_t offsetOfIdent() { return OBJECT_OFFSETOF(JSEntrypointCallee, m_ident); }
-#endif
-    static constexpr ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JSEntrypointCallee, m_wasmCallee); }
-    static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(JSEntrypointCallee, m_frameSize); }
+    static constexpr ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JSToWasmCallee, m_wasmCallee); }
+    static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(JSToWasmCallee, m_frameSize); }
 
     // Space for callee-saves; Not included in frameSize
     static constexpr unsigned SpillStackSpaceAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(3 * sizeof(UCPURegister));
@@ -164,9 +161,6 @@ public:
     static constexpr unsigned RegisterStackSpaceAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(
         FPRInfo::numberOfArgumentRegisters * bytesForWidth(Width::Width64) + GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister));
 
-#if ASSERT_ENABLED
-    unsigned ident() const { return m_ident; }
-#endif
     unsigned frameSize() const { return m_frameSize; }
     CalleeBits wasmCallee() const { return m_wasmCallee; }
     TypeIndex typeIndex() const { return m_typeIndex; }
@@ -177,11 +171,8 @@ public:
     }
 
 private:
-    JSEntrypointCallee(TypeIndex, bool);
+    JSToWasmCallee(TypeIndex, bool);
 
-#if ASSERT_ENABLED
-    const unsigned m_ident { 0xBF };
-#endif
     unsigned m_frameSize { };
     // This must be initialized after the callee is created unfortunately.
     CalleeBits m_wasmCallee;
@@ -200,7 +191,7 @@ private:
     WasmToJSCallee();
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
-    RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
 };
 
 #if ENABLE(JIT)
@@ -213,8 +204,8 @@ public:
         return adoptRef(*new JSToWasmICCallee(WTFMove(calleeSaves)));
     }
 
-    RegisterAtOffsetList* calleeSaveRegistersImpl() { return &m_calleeSaves; }
-    CodePtr<JSEntryPtrTag> jsEntrypoint() { return m_jsToWasmICEntrypoint.code(); }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return &m_calleeSaves; }
+    CodePtr<JSEntryPtrTag> jsToWasm() { return m_jsToWasmICEntrypoint.code(); }
 
     void setEntrypoint(MacroAssemblerCodeRef<JSEntryPtrTag>&&);
 
@@ -459,7 +450,7 @@ private:
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_entrypoint; }
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; };
-    JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
+    JS_EXPORT_PRIVATE const RegisterAtOffsetList* calleeSaveRegistersImpl();
 
     FunctionCodeIndex m_functionIndex;
     CodePtr<WasmEntryPtrTag> m_entrypoint;
@@ -506,7 +497,7 @@ public:
 
 protected:
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
-    RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
 
 private:
     MacroAssemblerCodeRef<WasmEntryPtrTag> m_code;

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -89,13 +89,13 @@ public:
 
     // These two callee getters are only valid once the callees have been populated.
 
-    JSEntrypointCallee& jsEntrypointCalleeFromFunctionIndexSpace(FunctionSpaceIndex functionIndexSpace)
+    JSToWasmCallee& jsToWasmCalleeFromFunctionIndexSpace(FunctionSpaceIndex functionIndexSpace)
     {
         ASSERT(runnable());
         ASSERT(functionIndexSpace >= functionImportCount());
         unsigned calleeIndex = functionIndexSpace - functionImportCount();
 
-        auto callee = m_jsEntrypointCallees.get(calleeIndex);
+        auto callee = m_jsToWasmCallees.get(calleeIndex);
         RELEASE_ASSERT(callee);
         return *callee;
     }
@@ -182,7 +182,7 @@ public:
     {
         RELEASE_ASSERT(functionIndexSpace >= functionImportCount());
         unsigned calleeIndex = functionIndexSpace - functionImportCount();
-        return &m_wasmIndirectCallEntryPoints[calleeIndex];
+        return &m_wasmIndirectCallEntrypoints[calleeIndex];
     }
 
     RefPtr<Wasm::IPIntCallee> wasmCalleeFromFunctionIndexSpace(FunctionSpaceIndex functionIndexSpace)
@@ -233,7 +233,7 @@ private:
     FixedVector<ThreadSafeWeakOrStrongPtr<BBQCallee>> m_bbqCallees WTF_GUARDED_BY_LOCK(m_lock);
 #endif
     RefPtr<IPIntCallees> m_ipintCallees WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsEntrypointCallees;
+    UncheckedKeyHashMap<uint32_t, RefPtr<JSToWasmCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmCallees;
 #if ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
     // FIXME: We should probably find some way to prune dead entries periodically.
     UncheckedKeyHashMap<uint32_t, ThreadSafeWeakPtr<OMGOSREntryCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_osrEntryCallees WTF_GUARDED_BY_LOCK(m_lock);
@@ -246,7 +246,7 @@ private:
     using SparseCallers = UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     using DenseCallers = BitVector;
     FixedVector<Variant<SparseCallers, DenseCallers>> m_callers WTF_GUARDED_BY_LOCK(m_lock);
-    FixedVector<CodePtr<WasmEntryPtrTag>> m_wasmIndirectCallEntryPoints;
+    FixedVector<CodePtr<WasmEntryPtrTag>> m_wasmIndirectCallEntrypoints;
     FixedVector<RefPtr<Wasm::IPIntCallee>> m_wasmIndirectCallWasmCallees;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToWasmExitStubs;
     RefPtr<EntryPlan> m_plan;

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -40,12 +40,8 @@
 
 namespace JSC { namespace Wasm {
 
-#if CPU(ARM)
 constexpr unsigned numberOfIPIntCalleeSaveRegisters = 2;
-#else
-constexpr unsigned numberOfIPIntCalleeSaveRegisters = 3;
-#endif
-constexpr unsigned numberOfIPIntInternalRegisters = 2;
+constexpr unsigned numberOfIPIntInternalRegisters = 1; // UnboxedWasmCalleeStackSlot
 constexpr ptrdiff_t WasmToJSScratchSpaceSize = 0x8 * 1 + 0x8; // Needs to be aligned to 0x10.
 constexpr ptrdiff_t WasmToJSCallableFunctionSlot = -0x8;
 

--- a/Source/JavaScriptCore/wasm/WasmCompilationContext.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationContext.h
@@ -62,7 +62,7 @@ class OptimizingJITCallee;
 class TierUpCount;
 
 struct CompilationContext {
-    std::unique_ptr<CCallHelpers> jsEntrypointJIT;
+    std::unique_ptr<CCallHelpers> jsToWasmJIT;
     std::unique_ptr<CCallHelpers> wasmEntrypointJIT;
     std::unique_ptr<OpaqueByproducts> wasmEntrypointByproducts;
     std::unique_ptr<B3::Procedure> procedure;

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -34,7 +34,7 @@ enum class CompilationMode : uint8_t {
     BBQMode,
     OMGMode,
     OMGForOSREntryMode,
-    JSToWasmEntrypointMode,
+    JSToWasmMode,
     JSToWasmICMode,
     WasmToJSMode,
     WasmBuiltinMode
@@ -48,7 +48,7 @@ constexpr inline bool isAnyInterpreter(CompilationMode compilationMode)
     case CompilationMode::BBQMode:
     case CompilationMode::OMGForOSREntryMode:
     case CompilationMode::OMGMode:
-    case CompilationMode::JSToWasmEntrypointMode:
+    case CompilationMode::JSToWasmMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
     case CompilationMode::WasmBuiltinMode:
@@ -65,7 +65,7 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     case CompilationMode::OMGForOSREntryMode:
     case CompilationMode::IPIntMode:
     case CompilationMode::OMGMode:
-    case CompilationMode::JSToWasmEntrypointMode:
+    case CompilationMode::JSToWasmMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
     case CompilationMode::WasmBuiltinMode:
@@ -82,7 +82,7 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
         return true;
     case CompilationMode::BBQMode:
     case CompilationMode::IPIntMode:
-    case CompilationMode::JSToWasmEntrypointMode:
+    case CompilationMode::JSToWasmMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
     case CompilationMode::WasmBuiltinMode:
@@ -100,7 +100,7 @@ constexpr inline bool isAnyWasmToJS(CompilationMode compilationMode)
     case CompilationMode::OMGForOSREntryMode:
     case CompilationMode::BBQMode:
     case CompilationMode::IPIntMode:
-    case CompilationMode::JSToWasmEntrypointMode:
+    case CompilationMode::JSToWasmMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmBuiltinMode:
         return false;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -173,7 +173,7 @@ bool IPIntPlan::ensureEntrypoint(IPIntCallee&, FunctionCodeIndex functionIndex)
     if (m_entrypoints[functionIndex])
         return true;
 
-    m_entrypoints[functionIndex] = JSEntrypointCallee::create(m_moduleInformation->internalFunctionTypeIndices[functionIndex], m_moduleInformation->usesSIMD(functionIndex));
+    m_entrypoints[functionIndex] = JSToWasmCallee::create(m_moduleInformation->internalFunctionTypeIndices[functionIndex], m_moduleInformation->usesSIMD(functionIndex));
     return true;
 }
 
@@ -202,9 +202,8 @@ void IPIntPlan::didCompleteCompilation()
             }
         }
         if (auto& callee = m_entrypoints[functionIndex]) {
-            if (callee->compilationMode() == CompilationMode::JSToWasmEntrypointMode)
-                static_cast<JSEntrypointCallee*>(callee.get())->setWasmCallee(CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get()));
-            m_jsEntrypointCallees.add(functionIndex, callee);
+            callee->setWasmCallee(CalleeBits::encodeNativeCallee(&m_callees[functionIndex].get()));
+            m_jsToWasmCallees.add(functionIndex, callee);
         }
     }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -37,7 +37,7 @@ namespace Wasm {
 
 class IPIntCallee;
 
-using JSEntrypointCalleeMap = UncheckedKeyHashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using JSToWasmCalleeMap = UncheckedKeyHashMap<uint32_t, RefPtr<JSToWasmCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
 using TailCallGraph = UncheckedKeyHashMap<uint32_t, UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
@@ -56,10 +56,10 @@ public:
         return WTFMove(m_calleesVector);
     }
 
-    JSEntrypointCalleeMap&& takeJSCallees()
+    JSToWasmCalleeMap&& takeJSToWasmCallees()
     {
         RELEASE_ASSERT(!failed() && !hasWork());
-        return WTFMove(m_jsEntrypointCallees);
+        return WTFMove(m_jsToWasmCallees);
     }
 
     bool hasWork() const final
@@ -91,8 +91,8 @@ private:
     Vector<std::unique_ptr<FunctionIPIntMetadataGenerator>> m_wasmInternalFunctions;
     const Ref<IPIntCallee>* m_callees { nullptr };
     Vector<Ref<IPIntCallee>> m_calleesVector;
-    Vector<RefPtr<JSEntrypointCallee>> m_entrypoints;
-    JSEntrypointCalleeMap m_jsEntrypointCallees;
+    Vector<RefPtr<JSToWasmCallee>> m_entrypoints;
+    JSToWasmCalleeMap m_jsToWasmCallees;
     TailCallGraph m_tailCallGraph;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -51,11 +51,11 @@ enum class UseDefaultValue : bool { No, Yes };
 enum class ArrayGetKind : unsigned { New, NewDefault, NewFixed };
 
 class TypeDefinition;
-class JSEntrypointCallee;
+class JSToWasmCallee;
 
 typedef int64_t EncodedWasmValue;
 
-JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, JSEntrypointCallee*, (void*, CallFrame*, WebAssemblyFunction*));
+JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, JSToWasmCallee*, (void*, CallFrame*, WebAssemblyFunction*));
 JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJSValue, (void*, CallFrame*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmCalleeStackSize, UCPUStrictInt32, (JSWebAssemblyInstance*, WasmCallableFunction*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmToJSExitNeedToUnpack, const TypeDefinition*, (WasmOrJSImportableFunctionCallLinkInfo*));

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -517,7 +517,7 @@ private:
     mutable RefPtr<JSToWasmICCallee> m_jsToWasmICCallee;
     // FIXME: We should have a WTF::Once that uses ParkingLot and the low bits of a pointer as a lock and use that here.
     mutable Lock m_jitCodeLock;
-    // FIXME: Support caching wasmToJSEntrypoints too.
+    // FIXME: Support caching wasmToJS too.
 #endif
     bool m_hasRecursiveReference : 1 { false };
     bool m_argumentsOrResultsIncludeI64 : 1 { false };

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.h
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.h
@@ -42,7 +42,7 @@ class CCallHelpers;
 namespace Wasm {
 
 struct CallInformation;
-class JSEntrypointCallee;
+class JSToWasmCallee;
 class Module;
 
 MacroAssemblerCodeRef<JITThunkPtrTag> createJSToWasmJITShared();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -535,7 +535,7 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
                 continue;
             }
 
-            auto& jsEntrypointCallee = calleeGroup()->jsEntrypointCalleeFromFunctionIndexSpace(functionIndex);
+            auto& jsToWasmCallee = calleeGroup()->jsToWasmCalleeFromFunctionIndexSpace(functionIndex);
             auto wasmCallee = calleeGroup()->wasmCalleeFromFunctionIndexSpace(functionIndex);
             ASSERT(wasmCallee);
             WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup()->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
@@ -551,7 +551,7 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
                 signature.argumentCount(),
                 WTF::makeString(functionIndex.rawIndex()),
                 this,
-                jsEntrypointCallee,
+                jsToWasmCallee,
                 *wasmCallee,
                 entrypointLoadLocation,
                 typeIndex,

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
@@ -87,7 +87,7 @@ namespace JSC {
 
 JSObject* WebAssemblyBuiltin::jsWrapper(JSGlobalObject* globalObject) const
 {
-    return JSFunction::create(globalObject->vm(), globalObject, 0, m_name, m_jsEntryPoint, ImplementationVisibility::Public, JSC::NoIntrinsic);
+    return JSFunction::create(globalObject->vm(), globalObject, 0, m_name, m_jsHostFunction, ImplementationVisibility::Public, JSC::NoIntrinsic);
 }
 
 const WebAssemblyBuiltin* WebAssemblyBuiltinSet::findBuiltin(const String& name) const

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.h
@@ -119,15 +119,15 @@ public:
     using WasmTrampolinePtr = EncodedJSValue (*)();
     friend class WebAssemblyBuiltinSet;
 
-    template <typename WasmEntryPoint>
-    WebAssemblyBuiltin(uint32_t id, ASCIILiteral name, WebAssemblyBuiltinSignature&& sig, WasmEntryPoint wasmEntryPoint, WasmTrampolinePtr wasmTrampoline, NativeFunction jsEntryPoint)
+    template <typename WasmEntrypoint>
+    WebAssemblyBuiltin(uint32_t id, ASCIILiteral name, WebAssemblyBuiltinSignature&& sig, WasmEntrypoint wasmEntrypoint, WasmTrampolinePtr wasmTrampoline, NativeFunction jsHostFunction)
         : m_id(id)
         , m_name(name)
         , m_signature(WTFMove(sig))
-        , m_jsEntryPoint(jsEntryPoint)
+        , m_jsHostFunction(jsHostFunction)
     {
         ASSERT(sig.numParams() <= 4); // see generateWasmBuiltinTrampoline() for why this is the limit
-        m_wasmEntryPoint = CodePtr<CFunctionPtrTag>::fromTaggedPtr(std::bit_cast<void*>(wasmEntryPoint));
+        m_wasmEntrypoint = CodePtr<CFunctionPtrTag>::fromTaggedPtr(std::bit_cast<void*>(wasmEntrypoint));
         m_wasmTrampoline = CodePtr<CFunctionPtrTag>::fromTaggedPtr(std::bit_cast<void*>(wasmTrampoline)).template retagged<WasmEntryPtrTag>();
     }
 
@@ -142,9 +142,9 @@ public:
     // The signature that a valid import of this builtin must match.
     const WebAssemblyBuiltinSignature& signature() const { return m_signature; }
 
-    CodePtr<CFunctionPtrTag> wasmEntryPoint() const { return m_wasmEntryPoint; }
+    CodePtr<CFunctionPtrTag> wasmEntrypoint() const { return m_wasmEntrypoint; }
     CodePtr<WasmEntryPtrTag> wasmTrampoline() const { return m_wasmTrampoline; }
-    // Return a JSFunction wrapping m_jsEntryPoint.
+    // Return a JSFunction wrapping m_jsHostFunction.
     JSObject* jsWrapper(JSGlobalObject*) const;
 
     Wasm::WasmBuiltinCallee* callee() const { return m_callee.get(); }
@@ -155,9 +155,9 @@ private:
     uint32_t m_id;
     ASCIILiteral m_name;
     WebAssemblyBuiltinSignature m_signature;
-    CodePtr<CFunctionPtrTag> m_wasmEntryPoint;
+    CodePtr<CFunctionPtrTag> m_wasmEntrypoint;
     CodePtr<WasmEntryPtrTag> m_wasmTrampoline;
-    NativeFunction m_jsEntryPoint;
+    NativeFunction m_jsHostFunction;
     // The following are set by WasmBuiltinSet::finalizeCreation()
     const Wasm::Name* m_wasmName;
     RefPtr<Wasm::NameSection> m_nameSection;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.cpp
@@ -68,8 +68,8 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> generateWasmBui
 
     // Add wasmInstance as the extra arg
     jit.move(GPRInfo::wasmContextInstancePointer, extraArgGPR);
-    CodePtr<OperationPtrTag> entryPointAsOperation = builtin.wasmEntryPoint().template retagged<OperationPtrTag>();
-    jit.callOperation<OperationPtrTag>(entryPointAsOperation);
+    CodePtr<OperationPtrTag> entrypointAsOperation = builtin.wasmEntrypoint().template retagged<OperationPtrTag>();
+    jit.callOperation<OperationPtrTag>(entrypointAsOperation);
 
     // Check for an exception and branch if present
     jit.loadPtr(JIT::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfVM()), scratch);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -60,11 +60,11 @@ public:
 
     DECLARE_VISIT_CHILDREN;
 
-    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::JSEntrypointCallee&, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation, Wasm::TypeIndex, Ref<const Wasm::RTT>&&);
+    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::JSToWasmCallee&, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation, Wasm::TypeIndex, Ref<const Wasm::RTT>&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    Wasm::JSEntrypointCallee* jsToWasmCallee() const { return m_boxedJSToWasmCallee.ptr(); }
-    CodePtr<WasmEntryPtrTag> jsEntrypoint(ArityCheckMode arity)
+    Wasm::JSToWasmCallee* jsToWasmCallee() const { return m_boxedJSToWasmCallee.ptr(); }
+    CodePtr<WasmEntryPtrTag> jsToWasm(ArityCheckMode arity)
     {
         ASSERT_UNUSED(arity, arity == ArityCheckMode::ArityCheckNotRequired || arity == ArityCheckMode::MustCheckArity);
         return m_boxedJSToWasmCallee->entrypoint();
@@ -92,12 +92,12 @@ public:
     static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(WebAssemblyFunction, m_frameSize); }
 
 private:
-    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::JSEntrypointCallee&, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex, Ref<const Wasm::RTT>&&);
+    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::JSToWasmCallee&, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex, Ref<const Wasm::RTT>&&);
 
     CodePtr<JSEntryPtrTag> jsCallEntrypointSlow();
 
     // This let's the JS->Wasm interpreter find its metadata
-    Ref<Wasm::JSEntrypointCallee, BoxedNativeCalleePtrTraits<Wasm::JSEntrypointCallee>> m_boxedJSToWasmCallee;
+    Ref<Wasm::JSToWasmCallee, BoxedNativeCalleePtrTraits<Wasm::JSToWasmCallee>> m_boxedJSToWasmCallee;
     uint32_t m_frameSize;
     SourceTaintedOrigin m_taintedness;
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -575,13 +575,13 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             //     a. Let func be an Exported Function Exotic Object created from c.
             //     b. Append func to funcs.
             //     c. Return func.
-            auto& jsEntrypointCallee = calleeGroup->jsEntrypointCalleeFromFunctionIndexSpace(functionIndexSpace);
+            auto& jsToWasmCallee = calleeGroup->jsToWasmCalleeFromFunctionIndexSpace(functionIndexSpace);
             auto wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(functionIndexSpace);
             ASSERT(wasmCallee);
             Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndexSpace);
             Wasm::TypeIndex typeIndex = module->typeIndexFromFunctionIndexSpace(functionIndexSpace);
             const auto& signature = Wasm::TypeInformation::getFunctionSignature(typeIndex);
-            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), makeString(functionIndexSpace.rawIndex()), m_instance.get(), jsEntrypointCallee, *wasmCallee, entrypointLoadLocation, typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));
+            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), makeString(functionIndexSpace.rawIndex()), m_instance.get(), jsToWasmCallee, *wasmCallee, entrypointLoadLocation, typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));
             wrapper = function;
         }
 
@@ -822,11 +822,11 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             JSObject* startFunction = m_instance->importFunction(startFunctionIndexSpace).get();
             m_startFunction.set(vm, this, startFunction);
         } else {
-            auto& jsEntrypointCallee = calleeGroup->jsEntrypointCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
+            auto& jsToWasmCallee = calleeGroup->jsToWasmCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
             auto wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
             ASSERT(wasmCallee);
             Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(startFunctionIndexSpace);
-            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), "start"_s, m_instance.get(), jsEntrypointCallee, *wasmCallee, entrypointLoadLocation, typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));
+            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), "start"_s, m_instance.get(), jsToWasmCallee, *wasmCallee, entrypointLoadLocation, typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));
             m_startFunction.set(vm, this, function);
         }
     }


### PR DESCRIPTION
#### 5205c9e994bbfedcb7054cd7defd14d2b696f134
<pre>
[JSC] Clean up Wasm CalleeSave registers handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=298506">https://bugs.webkit.org/show_bug.cgi?id=298506</a>
<a href="https://rdar.apple.com/160026957">rdar://160026957</a>

Reviewed by Yijia Huang.

Clean up a bit weird things in wasm callee save registers code.

1. Let&apos;s rename JSEntrypointCallee to JSToWasmCallee since we already
   have WasmToJSCallee. So this is much clear for readers. Also let&apos;s
   use Entrypoint instead of EntryPoint throughout the code for
   consistency.
2. Do not include Wasm Instance callee save register in
   IPIntCallee::calleeSaveRegistersImpl. They are part of wasm pinned
   registers. So adding it is OK, but unnecessary.
3. Move RegisterSet listing implementation to
   RegisterSetBuilder::ipintCalleeSaveRegisters. Aligned to the other
   JIT tiers.
4. numberOfIPIntInternalRegisters should be 1 since that&apos;s only
   UnboxedWasmCalleeStackSlot slot. Decrease it from 2 to 1 not to
   allocate unnecessary region.

* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::setNumEntrypoints):
* Source/JavaScriptCore/bytecode/BytecodeRewriter.h:
(JSC::BytecodeRewriter::adjustAbsoluteOffset):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeCallImpl):
* Source/JavaScriptCore/jit/GPRInfo.h:
* Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp:
(JSC::RegisterAtOffsetList::wasmPinnedRegisters):
(JSC::RegisterAtOffsetList::ipintCalleeSaveRegisters):
* Source/JavaScriptCore/jit/RegisterAtOffsetList.h:
* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSetBuilder::ipintCalleeSaveRegisters):
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::checkModuleSyntax):
(JSC::createSymbolForEntrypointModule):
(JSC::loadAndEvaluateModule):
(JSC::loadModule):
(JSC::createSymbolForEntryPointModule): Deleted.
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::tierName):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
(JSC::Wasm::Callee::calleeSaveRegisters):
(JSC::Wasm::IPIntCallee::calleeSaveRegistersImpl):
(JSC::Wasm::JSToWasmCallee::JSToWasmCallee):
(JSC::Wasm::JSToWasmCallee::entrypointImpl const):
(JSC::Wasm::JSToWasmCallee::calleeSaveRegistersImpl):
(JSC::Wasm::JSEntrypointCallee::JSEntrypointCallee): Deleted.
(JSC::Wasm::JSEntrypointCallee::entrypointImpl const): Deleted.
(JSC::Wasm::JSEntrypointCallee::calleeSaveRegistersImpl): Deleted.
* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::JITCallee::calleeSaveRegistersImpl):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
(JSC::Wasm::CalleeGroup::updateCallsitesToCallUs):
(JSC::Wasm::CalleeGroup::calleeIsReferenced const):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
* Source/JavaScriptCore/wasm/WasmCompilationContext.h:
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
(JSC::Wasm::isAnyInterpreter):
(JSC::Wasm::isAnyBBQ):
(JSC::Wasm::isAnyOMG):
(JSC::Wasm::isAnyWasmToJS):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::ensureEntrypoint):
(JSC::Wasm::IPIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmJITShared):
(JSC::Wasm::FunctionSignature::jsToWasmICEntrypoint const):
* Source/JavaScriptCore/wasm/js/JSToWasm.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::initElementSegment):
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp:
(JSC::WebAssemblyBuiltin::jsWrapper const):
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.h:
(JSC::WebAssemblyBuiltin::WebAssemblyBuiltin):
(JSC::WebAssemblyBuiltin::wasmEntrypoint const):
(JSC::WebAssemblyBuiltin::wasmEntryPoint const): Deleted.
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltinTrampoline.cpp:
(JSC::Wasm::generateWasmBuiltinTrampoline):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::WebAssemblyFunction::create):
(JSC::WebAssemblyFunction::WebAssemblyFunction):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/299680@main">https://commits.webkit.org/299680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a080c14cbc0f7fc5bf8448d892ff02990ea585

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119809 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71882 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8686dfc3-140e-4ad2-ac0a-e8717a198c77) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60282 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eac6ea4f-61e6-43c4-9679-dceb31aa3e6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71549 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/340937d8-cd95-4ff3-a1ce-1317a3fab68a) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31122 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document\|Window\|HTML.*) (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25535 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69760 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111934 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129055 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118325 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99598 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99442 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43314 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19059 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52297 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147023 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46057 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37775 "Found 1 new JSC binary failure: testapi, Found 18646 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/concat1.js.default, ChakraCore.yaml/ChakraCore/test/Array/protoLookup.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49406 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->