### PR TITLE
Fix AbortController memory leak with event

### DIFF
--- a/LayoutTests/fast/dom/gc-abort-controller-expected.txt
+++ b/LayoutTests/fast/dom/gc-abort-controller-expected.txt
@@ -1,0 +1,10 @@
+Test AbortController memory leak with event listeners
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Some AbortSignals were garbage collected.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/gc-abort-controller.html
+++ b/LayoutTests/fast/dom/gc-abort-controller.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Test AbortController memory leak with event listeners");
+jsTestIsAsync = true;
+
+if (!window.testRunner || !window.internals) {
+    testFailed("Requires testRunner and internals.");
+    finishJSTest();
+}
+
+function runTest() {
+    let weakRefs = [];
+    let controllers = [];
+    
+    for (let i = 0; i < 20; i++) {
+        let controller = new AbortController();
+        controller.signal.addEventListener('abort', () => {
+            console.log('Event listener for controller ' + i);
+        });
+        controllers.push(controller);
+        weakRefs.push(new WeakRef(controller.signal));
+    }
+    
+    controllers = null;
+    
+    setTimeout(() => {
+        gc();
+        
+        let aliveCount = 0;
+        for (let weakRef of weakRefs) {
+            if (weakRef.deref())
+                aliveCount++;
+        }
+        
+        if (aliveCount < 20)
+            testPassed(`Some AbortSignals were garbage collected.`);
+        else
+            testFailed(`No AbortSignals were collected.`);
+
+        finishJSTest();
+    }, 0)
+}
+
+onload = runTest;
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
@@ -55,9 +55,10 @@ bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
                 return true;
             }
         } else {
-            if (reason) [[unlikely]]
-                *reason = "Has Abort Event Listener"_s;
-            return true;
+            bool isReachable = containsWebCoreOpaqueRoot(visitor, abortSignal);
+            if (isReachable && reason) [[unlikely]]
+                *reason = "Has Abort Event Listener And Is Referenced By Other Objects"_s;
+            return isReachable;
         }
     }
 


### PR DESCRIPTION
#### 1f6b6bea2079964f2f70dd12df7f4b7fbc335aa2
<pre>
Fix AbortController memory leak with event

<a href="https://bugs.webkit.org/show_bug.cgi?id=298499">https://bugs.webkit.org/show_bug.cgi?id=298499</a>

Reviewed by Ryosuke Niwa.

AbortSignals with event listeners were never garbage collected due to incorrect reachability check in JSAbortSignalOwner::isReachableFromOpaqueRoots().
The method unconditionally returned true for signals with event listeners, even when they had no other references.

Changed the logic to check containsWebCoreOpaqueRoot() before marking the signal as reachable, allowing proper garbage collection.

* LayoutTests/fast/dom/gc-abort-controller-expected.txt: Added.
* LayoutTests/fast/dom/gc-abort-controller.html: Added.
* Source/WebCore/bindings/js/JSAbortSignalCustom.cpp:
(WebCore::JSAbortSignalOwner::isReachableFromOpaqueRoots):

Canonical link: <a href="https://commits.webkit.org/299758@main">https://commits.webkit.org/299758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7142f1f82c6cc13e24ef04ca8d877459f0728848

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91209 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71760 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70072 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129353 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35667 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103874 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/99675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45126 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52588 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46350 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->