### PR TITLE
Adopt AudioVideoRendererAVFObjC in MediaPlayerPrivateMediaSourceAVFObjC

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-play-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-play-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Test worker MediaSource construction, attachment, buffering and basic playback Test timed out
+PASS Test worker MediaSource construction, attachment, buffering and basic playback
 

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -38,7 +38,6 @@ platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -79,8 +79,6 @@ public:
 
     bool hasSelectedVideo() const;
 
-    void willSeek();
-
     FloatSize naturalSize() const;
 
     void hasSelectedVideoChanged(SourceBufferPrivateAVFObjC&);
@@ -89,12 +87,7 @@ public:
     void videoRendererWillReconfigure(VideoMediaSampleRenderer&);
     void videoRendererDidReconfigure(VideoMediaSampleRenderer&);
 
-#if PLATFORM(IOS_FAMILY)
-    void applicationWillResignActive();
-    void applicationDidBecomeActive();
-#endif
-
-    void flushActiveSourceBuffersIfNeeded();
+    void flushAndReenqueueActiveVideoSourceBuffers();
 
 #if ENABLE(ENCRYPTED_MEDIA)
     void cdmInstanceAttached(CDMInstance&);

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -226,6 +226,7 @@ private:
     unsigned m_droppedVideoFramesOffset WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
     std::atomic<unsigned> m_corruptedVideoFrames { 0 };
     std::atomic<unsigned> m_presentedVideoFrames { 0 };
+    mutable unsigned m_sampleCount WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
     MediaTime m_totalFrameDelay { MediaTime::zeroTime() };
 
     // Protected samples

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -1045,7 +1045,9 @@ auto VideoMediaSampleRenderer::copyDisplayedPixelBuffer() -> DisplayedPixelBuffe
 
 unsigned VideoMediaSampleRenderer::totalDisplayedFrames() const
 {
-    return m_presentedVideoFrames;
+    assertIsMainThread();
+
+    return isUsingDecompressionSession() ? m_presentedVideoFrames.load() : ++m_sampleCount;
 }
 
 unsigned VideoMediaSampleRenderer::totalVideoFrames() const
@@ -1280,7 +1282,7 @@ void VideoMediaSampleRenderer::videoRendererReadyForDisplayChanged(WebSampleBuff
     if (renderer != this->renderer() || !isReadyForDisplay)
         return;
     if (!isUsingDecompressionSession() && m_hasFirstFrameAvailableCallback)
-        m_hasFirstFrameAvailableCallback({ }, { });
+        m_hasFirstFrameAvailableCallback(currentTime(), (MonotonicTime::now() - m_startupTime).seconds());
 }
 
 void VideoMediaSampleRenderer::outputObscuredDueToInsufficientExternalProtectionChanged(bool obscured)


### PR DESCRIPTION
#### 468654de4a9e634b8d76babd8720bc060ed1df60
<pre>
Adopt AudioVideoRendererAVFObjC in MediaPlayerPrivateMediaSourceAVFObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=298507">https://bugs.webkit.org/show_bug.cgi?id=298507</a>
<a href="https://rdar.apple.com/160036437">rdar://160036437</a>

Reviewed by Jer Noble.

We adopt the use of the AudioVideoRendererAVFObjC in MediaPlayerPrivateMediaSourceAVFObjC
and related objects (MediaSourcePrivateAVFObjC and SourceBufferPrivateAVFObjC).
This abstract the interaction with the video and audio layer so that the SourceBufferPrivate
no longer has to manually managed the various renderers and the switching between rendering mode
(such as on visionOS when you dock/undock the video).
This abstraction was necessary so that the MediaSourcePrivate and SourceBufferPrivate
can now be moved to the content process.

It also removes the continuous round-trips from the GPUP to CP and back whenever
the SourceBufferPrivate needed to interact with the MediaPlayer such as when data was added
or removed, a seek operation was performed etc.
The controls of stalling/resuming playback is now managed all in-process
allowing the playback to stall and resume much quicker whenever new data is added.

We can also achieve feature parity between the MSE and WebM players and will allow much
easier future maintenance as now the audio and video renderer and A/V sync is common
between the two players.

No change in observable behaviours, covered by existing tests.
Intensive manual testing was done to test protected content site such as Netflix,
Amazon Prime and HBO) which are poorly covered by our tests.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::audioVideoRenderer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::allRenderersHaveAvailableSamples const): Deleted.
(WTF::LogArgument&lt;WebCore::MediaPlayerPrivateMediaSourceAVFObjC::SeekState&gt;::toString): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isAvailable):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setResourceOwner):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::platformLayer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::playInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::paused const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVolume):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setMuted):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentTime const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::timeIsProgressing const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cancelPendingSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::completeSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seeking const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setRateDouble):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::effectiveRate const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPreservesPitch):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setLayerRequiresFlush):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::flushVideoIfNeeded):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::flush):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateLastVideoFrame):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateLastImage):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::maybePurgeLastImage):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::videoFrameForCurrentTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPresentationSize):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::videoPlaybackQualityMetrics):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldBePlaying const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceAttached):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceDetached):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::needsVideoLayerChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setReadyState):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::characteristicsChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenFrame):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::syncTextTrackBounds):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setTextTrackRepresentation):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::checkNewVideoFrameMetadata):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::stopVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setShouldDisableHDR):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPlatformDynamicRangeLimit):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::playerContentBoxRectChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setShouldMaintainAspectRatio):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoTarget):
(WebCore::MediaPlayerPrivateWebM::applicationWillResignActive):
(WebCore::MediaPlayerPrivateWebM::applicationDidBecomeActive):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChanged):
(WebCore::convertEnumerationToString): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::clampTimeToSensicalValue const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setCurrentTimeDidChangeCallback): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::maybeCompleteSeek): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayerOrVideoRenderer const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoLayerSizeFenced): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateDisplayLayer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::prepareForRendering): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoLayerIfNeeded): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureVideoRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isUsingRenderlessMediaSampleRenderer const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureRenderlessVideoMediaSampleRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyRenderlessVideoMediaSampleRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRendererWithDecompressionSession): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayerOrVideoRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::configureLayerOrVideoRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::stageVideoRenderer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::createVideoMediaSampleRendererForRendererer): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedVideoMode const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::canUseDecompressionSession const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isUsingDecompressionSession const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::willUseDecompressionSessionIfNeeded const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setSynchronizerRate): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateAllRenderersHaveAvailableSamples): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::sizeWillChangeAtTime): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::flushPendingSizeChanges): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setNeedsPlaceholderImage): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoFrameMetadataGatheringCallbackIfNeeded): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::hasVideoRenderer const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::layerOrVideoRenderer const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::applicationWillResignActive): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::applicationDidBecomeActive): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::maybeUpdateDisplayLayer): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::addSourceBuffer):
(WebCore::MediaSourcePrivateAVFObjC::flushActiveVideoSourceBuffers):
(WebCore::MediaSourcePrivateAVFObjC::cdmInstanceAttached):
(WebCore::MediaSourcePrivateAVFObjC::cdmInstanceDetached):
(WebCore::MediaSourcePrivateAVFObjC::setSourceBufferWithSelectedVideo):
(WebCore::MediaSourcePrivateAVFObjC::setVideoRenderer): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::stageVideoRenderer): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::videoRendererWillReconfigure): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::videoRendererDidReconfigure): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::flushActiveSourceBuffersIfNeeded): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::applicationWillResignActive): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::applicationDidBecomeActive): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::create):
(WebCore::SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::isMediaSampleAllowed const):
(WebCore::SourceBufferPrivateAVFObjC::updateTrackIds):
(WebCore::SourceBufferPrivateAVFObjC::destroyRendererTracks):
(WebCore::SourceBufferPrivateAVFObjC::removedFromMediaSource):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::setCDMSession):
(WebCore::SourceBufferPrivateAVFObjC::setCDMInstance):
(WebCore::SourceBufferPrivateAVFObjC::trackIdentifierFor const):
(WebCore::SourceBufferPrivateAVFObjC::setVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::flush):
(WebCore::SourceBufferPrivateAVFObjC::flushVideo):
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::canSetMinimumUpcomingPresentationTime const):
(WebCore::SourceBufferPrivateAVFObjC::setMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivateAVFObjC::destroyRenderers): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::requiresFlush const): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::flushIfNeeded): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::audioRendererWasAutomaticallyFlushed): Deleted.
(): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::setLayerRequiresFlush): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::applicationWillResignActive): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::applicationDidBecomeActive): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::enqueueSampleBuffer): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::configureVideoRenderer): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::invalidateVideoRenderer): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::stageVideoRenderer): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::videoRendererWillReconfigure): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::videoRendererDidReconfigure): Deleted.

Canonical link: <a href="https://commits.webkit.org/301011@main">https://commits.webkit.org/301011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaace7d55a3a2646a84c1a23387df4f39fe65eca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5f588e2-8266-4e0b-9b2d-6085424d9f09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94857 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62916 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e1772ab-0c15-4a6e-8f28-e334362ab471) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75427 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/028549dd-339a-49d4-9d5b-5c1a35ba2a6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29656 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75000 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134186 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103332 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103106 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26246 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48479 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48486 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57198 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54150 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->