### PR TITLE
Non-unified source build fix 2025-09 (part 2)

### DIFF
--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -28,6 +28,7 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXObjectCacheInlines.h"
+#include "AXUtilities.h"
 #include "AccessibilityObject.h"
 #include "Logging.h"
 #include "TextIterator.h"

--- a/Source/WebCore/accessibility/AXTableHelpers.cpp
+++ b/Source/WebCore/accessibility/AXTableHelpers.cpp
@@ -43,6 +43,7 @@
 #include "RenderObject.h"
 #include "RenderStyle.h"
 #include "RenderTable.h"
+#include "RenderTableCell.h"
 #include "RenderTableRow.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <queue>

--- a/Source/WebKit/Shared/WebEventModifier.cpp
+++ b/Source/WebKit/Shared/WebEventModifier.cpp
@@ -54,7 +54,7 @@ OptionSet<WebEventModifier> modifiersForNavigationAction(const WebCore::Navigati
 {
     OptionSet<WebEventModifier> modifiers;
     if (auto keyStateEventData = navigationAction.keyStateEventData()) {
-        RefPtr document = navigationAction.requester() ? Document::allDocumentsMap().get(navigationAction.requester()->documentIdentifier) : nullptr;
+        RefPtr document = navigationAction.requester() ? WebCore::Document::allDocumentsMap().get(navigationAction.requester()->documentIdentifier) : nullptr;
         RefPtr domWindow = document ? document->window() : nullptr;
         auto lastMouseClickEvent = domWindow ? domWindow->consumeLastUserClickEvent() : std::nullopt;
         // For security reasons, we normally only set modifiers when the navigation comes from a trusted event.


### PR DESCRIPTION
#### 14b99c0e40db17064a1e2cd77c40c3eae346e6e7
<pre>
Non-unified source build fix 2025-09 (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298385">https://bugs.webkit.org/show_bug.cgi?id=298385</a>

Unreviewed build fix.

* Source/WebCore/accessibility/AXSearchManager.cpp:
* Source/WebCore/accessibility/AXTableHelpers.cpp:
* Source/WebKit/Shared/WebEventModifier.cpp:
(WebKit::modifiersForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/299669@main">https://commits.webkit.org/299669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f6cd9b911d9873c4aa09ec0393a676ce71c1c2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60299 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107450 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/71566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69785 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35430 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99461 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43343 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19055 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52317 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->