### PR TITLE
[GTK MiniBrowser] Fix clang warnings after 299591@main

### DIFF
--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -345,18 +345,16 @@ static gchar *WebKitXRSessionFeaturesToString(WebKitXRSessionFeatures features)
 {
     unsigned count = 0;
     GString *str = g_string_new(NULL);
-    if (features & WEBKIT_XR_SESSION_FEATURES_VIEWER)
-        g_string_append(str, " viewer" + !(count++));
-    if (features & WEBKIT_XR_SESSION_FEATURES_LOCAL)
-        g_string_append(str, " local" + !(count++));
-    if (features & WEBKIT_XR_SESSION_FEATURES_LOCAL_FLOOR)
-        g_string_append(str, " local-floor" + !(count++));
-    if (features & WEBKIT_XR_SESSION_FEATURES_BOUNDED_FLOOR)
-        g_string_append(str, " bounded-floor" + !(count++));
-    if (features & WEBKIT_XR_SESSION_FEATURES_UNBOUNDED)
-        g_string_append(str, " unbounded" + !(count++));
-    if (features & WEBKIT_XR_SESSION_FEATURES_HAND_TRACKING)
-        g_string_append(str, " hand-tracking" + !(count++));
+#define APPEND_FEATURE(feature, name) \
+    if (features & feature) \
+        g_string_append(str, (" " name) + !(count++));
+    APPEND_FEATURE(WEBKIT_XR_SESSION_FEATURES_VIEWER, "viewer");
+    APPEND_FEATURE(WEBKIT_XR_SESSION_FEATURES_LOCAL, "local");
+    APPEND_FEATURE(WEBKIT_XR_SESSION_FEATURES_LOCAL_FLOOR, "local-floor");
+    APPEND_FEATURE(WEBKIT_XR_SESSION_FEATURES_BOUNDED_FLOOR, "bounded-floor");
+    APPEND_FEATURE(WEBKIT_XR_SESSION_FEATURES_UNBOUNDED, "unbounded");
+    APPEND_FEATURE(WEBKIT_XR_SESSION_FEATURES_HAND_TRACKING, "hand_tracking");
+#undef APPEND_FEATURE
     gchar *result = str->str;
     g_string_free(str, FALSE);
     return result;


### PR DESCRIPTION
#### d65a76dbf3a5120eecd6c1912b0812796ab6a25f
<pre>
[GTK MiniBrowser] Fix clang warnings after 299591@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=298178">https://bugs.webkit.org/show_bug.cgi?id=298178</a>

Unreviewed clang warning fix.

&gt; Tools/MiniBrowser/gtk/BrowserTab.c:349:40: error: adding &apos;int&apos; to a string does not append to the string [-Werror,-Wstring-plus-int]
&gt;   349 |         g_string_append(str, &quot; viewer&quot; + !(count++));
&gt;       |                              ~~~~~~~~~~^~~~~~~~~~~~

* Tools/MiniBrowser/gtk/BrowserTab.c:
(WebKitXRSessionFeaturesToString):

Canonical link: <a href="https://commits.webkit.org/299670@main">https://commits.webkit.org/299670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef605f2ca7e8172e106aba72ecd316b32e05d79d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30177 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/126143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48103 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/126143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107454 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/126143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25559 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69789 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129079 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46753 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/35434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99465 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44905 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43348 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46615 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->