### PR TITLE
GPUTexture should be supported for depth-stencil and resolve attachments as well

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pass/resolve-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pass/resolve-expected.txt
@@ -1,10 +1,6 @@
 
 PASS :resolve_attachment:
-FAIL :resolve_attachment:bindTextureResource=true assert_unreached:
-  - EXCEPTION: TypeError: Type error
-    beginRenderPass@[native code]
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/render_pass/resolve.spec.js:188:41
- Reached unreachable code
+PASS :resolve_attachment:bindTextureResource=true
 PASS :resolve_attachment:colorAttachmentSamples=1
 PASS :resolve_attachment:resolveTargetSamples=4
 PASS :resolve_attachment:resolveTargetUsage=1

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.idl
@@ -35,7 +35,7 @@ typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 dictionary GPURenderPassColorAttachment {
     required (GPUTexture or GPUTextureView) view;
     GPUIntegerCoordinate depthSlice;
-    GPUTextureView resolveTarget;
+    (GPUTexture or GPUTextureView) resolveTarget;
 
     GPUColor clearValue;
     required GPULoadOp loadOp;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.idl
@@ -32,7 +32,7 @@ typedef [EnforceRange] unsigned long GPUStencilValue;
     EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderPassDepthStencilAttachment {
-    required GPUTextureView view;
+    required (GPUTexture or GPUTextureView) view;
 
     float depthClearValue;
     GPULoadOp depthLoadOp;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -61,12 +61,15 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
         if (colorAttachment) {
             RefPtr texture = colorAttachment->protectedTexture().get();
             RefPtr textureView = colorAttachment->protectedView().get();
+            RefPtr resolveTexture = colorAttachment->protectedResolveTexture().get();
+            RefPtr resolveTarget = colorAttachment->protectedResolveTarget().get();
             colorAttachments.append(WGPURenderPassColorAttachment {
                 .nextInChain = nullptr,
                 .texture = texture ? convertToBackingContext->convertToBacking(*texture) : nullptr,
                 .view = textureView ? convertToBackingContext->convertToBacking(*textureView) : nullptr,
                 .depthSlice = colorAttachment->depthSlice,
-                .resolveTarget = colorAttachment->resolveTarget ? convertToBackingContext->convertToBacking(*colorAttachment->protectedResolveTarget()) : nullptr,
+                .resolveTexture = resolveTexture ? convertToBackingContext->convertToBacking(*resolveTexture) : nullptr,
+                .resolveTarget = resolveTarget ? convertToBackingContext->convertToBacking(*resolveTarget) : nullptr,
                 .loadOp = convertToBackingContext->convertToBacking(colorAttachment->loadOp),
                 .storeOp = convertToBackingContext->convertToBacking(colorAttachment->storeOp),
                 .clearValue = colorAttachment->clearValue ? convertToBackingContext->convertToBacking(*colorAttachment->clearValue) : WGPUColor { 0, 0, 0, 0 },
@@ -77,6 +80,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
                 .texture = nullptr,
                 .view = nullptr,
                 .depthSlice = std::nullopt,
+                .resolveTexture = nullptr,
                 .resolveTarget = nullptr,
                 .loadOp = WGPULoadOp_Clear,
                 .storeOp = WGPUStoreOp_Discard,
@@ -86,8 +90,12 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
 
     std::optional<WGPURenderPassDepthStencilAttachment> depthStencilAttachment;
     if (descriptor.depthStencilAttachment) {
+        RefPtr texture = descriptor.depthStencilAttachment->protectedTexture().get();
+        RefPtr textureView = descriptor.depthStencilAttachment->protectedView().get();
+
         depthStencilAttachment = WGPURenderPassDepthStencilAttachment {
-            .view = convertToBackingContext->convertToBacking(descriptor.depthStencilAttachment->protectedView().get()),
+            .texture = texture ? convertToBackingContext->convertToBacking(*texture) : nullptr,
+            .view = textureView ? convertToBackingContext->convertToBacking(*textureView) : nullptr,
             .depthLoadOp = descriptor.depthStencilAttachment->depthLoadOp ? convertToBackingContext->convertToBacking(*descriptor.depthStencilAttachment->depthLoadOp) : WGPULoadOp_Undefined,
             .depthStoreOp = descriptor.depthStencilAttachment->depthStoreOp ? convertToBackingContext->convertToBacking(*descriptor.depthStencilAttachment->depthStoreOp) : WGPUStoreOp_Undefined,
             .depthClearValue = descriptor.depthStencilAttachment->depthClearValue,

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
@@ -36,8 +36,10 @@ namespace WebCore::WebGPU {
 
 class TextureView;
 
+using RenderPassDepthAttachmentView = Variant<const WeakRef<Texture>, const WeakRef<TextureView>>;
+
 struct RenderPassDepthStencilAttachment {
-    WeakRef<TextureView> view;
+    RenderPassDepthAttachmentView view;
 
     float depthClearValue { 0 };
     std::optional<LoadOp> depthLoadOp;
@@ -49,7 +51,22 @@ struct RenderPassDepthStencilAttachment {
     std::optional<StoreOp> stencilStoreOp;
     bool stencilReadOnly { false };
 
-    Ref<TextureView> protectedView() const { return view.get(); }
+    RefPtr<Texture> protectedTexture() const
+    {
+        return WTF::switchOn(view, [&](const WeakRef<Texture>& texture) -> const RefPtr<Texture> {
+            return texture.ptr();
+        }, [&](const WeakRef<TextureView>&) -> const RefPtr<Texture> {
+            return nullptr;
+        });
+    }
+    RefPtr<TextureView> protectedView() const
+    {
+        return WTF::switchOn(view, [&](const WeakRef<Texture>&) -> const RefPtr<TextureView> {
+            return nullptr;
+        }, [&](const WeakRef<TextureView>& view) -> const RefPtr<TextureView> {
+            return view.ptr();
+        });
+    }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -504,11 +504,64 @@ static bool isMultisampleTexture(id<MTLTexture> texture)
     return texture.textureType == MTLTextureType2DMultisample || texture.textureType == MTLTextureType2DMultisampleArray;
 }
 
-static bool isRenderableTextureView(const TextureView& texture)
-{
-    auto textureDimension = texture.dimension();
+class TextureOrTextureView {
+public:
+    TextureOrTextureView(Texture& texture)
+        : m_texture(&texture)
+    {
+    }
+    TextureOrTextureView(TextureView& view)
+        : m_view(&view)
+    {
+    }
 
-    return (texture.usage() & WGPUTextureUsage_RenderAttachment) && (textureDimension == WGPUTextureViewDimension_2D || textureDimension == WGPUTextureViewDimension_2DArray || textureDimension == WGPUTextureViewDimension_3D) && texture.mipLevelCount() == 1 && texture.arrayLayerCount() <= 1;
+#define TEXTURE_OR_VIEW_INVOKE(x) return m_view ? RefPtr { m_view }->x() : RefPtr { m_texture }->x()
+#define TEXTURE_OR_VIEW_HELPER(x) auto x() const { TEXTURE_OR_VIEW_INVOKE(x); }
+#define TEXTURE_OR_VIEW_HELPER_NONCONST(x) auto x() { TEXTURE_OR_VIEW_INVOKE(x); }
+#define TEXTURE_OR_VIEW_HELPER_REF(x) const auto& x() const { TEXTURE_OR_VIEW_INVOKE(x); }
+
+    TEXTURE_OR_VIEW_HELPER(width)
+    TEXTURE_OR_VIEW_HELPER(height)
+    TEXTURE_OR_VIEW_HELPER(is2DTexture)
+    TEXTURE_OR_VIEW_HELPER(is2DArrayTexture)
+    TEXTURE_OR_VIEW_HELPER(is3DTexture)
+    TEXTURE_OR_VIEW_HELPER(sampleCount)
+    TEXTURE_OR_VIEW_HELPER(format)
+    TEXTURE_OR_VIEW_HELPER(isDestroyed)
+    TEXTURE_OR_VIEW_HELPER(depthOrArrayLayers)
+    TEXTURE_OR_VIEW_HELPER(baseArrayLayer)
+    TEXTURE_OR_VIEW_HELPER(baseMipLevel)
+    TEXTURE_OR_VIEW_HELPER(parentTexture)
+    TEXTURE_OR_VIEW_HELPER(parentRelativeSlice)
+    TEXTURE_OR_VIEW_HELPER(previouslyCleared)
+    TEXTURE_OR_VIEW_HELPER_NONCONST(setPreviouslyCleared)
+    TEXTURE_OR_VIEW_HELPER(texture)
+    TEXTURE_OR_VIEW_HELPER(isValid)
+    TEXTURE_OR_VIEW_HELPER(usage)
+    TEXTURE_OR_VIEW_HELPER(mipLevelCount)
+    TEXTURE_OR_VIEW_HELPER(arrayLayerCount)
+
+    TEXTURE_OR_VIEW_HELPER_REF(apiParentTexture)
+    TEXTURE_OR_VIEW_HELPER_REF(device)
+
+    void setCommandEncoder(CommandEncoder& encoder)
+    {
+        m_view ? RefPtr { m_view }->setCommandEncoder(encoder) : RefPtr { m_texture }->setCommandEncoder(encoder);
+    }
+
+#undef TEXTURE_OR_VIEW_INVOKE
+#undef TEXTURE_OR_VIEW_HELPER
+#undef TEXTURE_OR_VIEW_HELPER_REF
+#undef TEXTURE_OR_VIEW_HELPER_NONCONST
+
+private:
+    RefPtr<Texture> m_texture;
+    RefPtr<TextureView> m_view;
+};
+
+static bool isRenderableTextureView(const auto& texture)
+{
+    return (texture.usage() & WGPUTextureUsage_RenderAttachment) && (texture.is2DTexture() || texture.is2DArrayTexture() || texture.is3DTexture()) && texture.mipLevelCount() == 1 && texture.arrayLayerCount() <= 1;
 }
 
 Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescriptor& descriptor)
@@ -569,7 +622,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
     HashMap<void*, SliceSet> depthSlices;
     NSUInteger compositorTextureSlice = 0;
     for (auto [ i, attachment ] : indexedRange(descriptor.colorAttachmentsSpan())) {
-        if (!attachment.view)
+        if (!attachment.view && !attachment.texture)
             continue;
 
         // MTLRenderPassColorAttachmentDescriptorArray is bounds-checked internally.
@@ -580,31 +633,32 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
             attachment.clearValue.b,
             attachment.clearValue.a);
 
-        Ref texture = fromAPI(attachment.view);
+        auto texture = attachment.view ? TextureOrTextureView(fromAPI(attachment.view)) : TextureOrTextureView(fromAPI(attachment.texture));
+
         if (!isValidToUseWith(texture, *this))
             return RenderPassEncoder::createInvalid(*this, m_device, @"device mismatch");
-        if (textureWidth && (texture->width() != textureWidth || texture->height() != textureHeight || sampleCount != texture->sampleCount()))
+        if (textureWidth && (texture.width() != textureWidth || texture.height() != textureHeight || sampleCount != texture.sampleCount()))
             return RenderPassEncoder::createInvalid(*this, m_device, @"texture size does not match");
-        textureWidth = texture->width();
-        textureHeight = texture->height();
-        sampleCount = texture->sampleCount();
-        auto textureFormat = texture->format();
+        textureWidth = texture.width();
+        textureHeight = texture.height();
+        sampleCount = texture.sampleCount();
+        auto textureFormat = texture.format();
         bytesPerSample = roundUpToMultipleOfNonPowerOfTwo(Texture::renderTargetPixelByteAlignment(textureFormat), bytesPerSample);
         bytesPerSample += Texture::renderTargetPixelByteCost(textureFormat);
         if (bytesPerSample > maxColorAttachmentBytesPerSample)
             return RenderPassEncoder::createInvalid(*this, m_device, @"total bytes per sample exceeds limit");
 
-        bool textureIsDestroyed = texture->isDestroyed();
+        bool textureIsDestroyed = texture.isDestroyed();
         if (!textureIsDestroyed) {
-            if (!(texture->usage() & WGPUTextureUsage_RenderAttachment) || !Texture::isColorRenderableFormat(textureFormat, m_device))
+            if (!(texture.usage() & WGPUTextureUsage_RenderAttachment) || !Texture::isColorRenderableFormat(textureFormat, m_device))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"color attachment is not renderable");
 
             if (!isRenderableTextureView(texture))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"texture view is not renderable");
         }
-        texture->setCommandEncoder(*this);
+        texture.setCommandEncoder(*this);
 
-        id<MTLTexture> mtlTexture = texture->texture();
+        id<MTLTexture> mtlTexture = texture.texture();
         mtlAttachment.texture = mtlTexture;
         if (!mtlAttachment.texture) {
             if (!textureIsDestroyed)
@@ -614,22 +668,21 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
         mtlAttachment.level = 0;
         mtlAttachment.slice = 0;
         uint64_t depthSliceOrArrayLayer = 0;
-        auto textureDimension = texture->dimension();
         if (attachment.depthSlice) {
-            if (textureDimension != WGPUTextureViewDimension_3D)
+            if (!texture.is3DTexture())
                 return RenderPassEncoder::createInvalid(*this, m_device, @"depthSlice specified on 2D texture");
             depthSliceOrArrayLayer = textureIsDestroyed ? 0 : *attachment.depthSlice;
-            if (depthSliceOrArrayLayer >= texture->depthOrArrayLayers())
+            if (depthSliceOrArrayLayer >= texture.depthOrArrayLayers())
                 return RenderPassEncoder::createInvalid(*this, m_device, @"depthSlice is greater than texture's depth or array layers");
 
         } else {
-            if (textureDimension == WGPUTextureViewDimension_3D)
+            if (texture.is3DTexture())
                 return RenderPassEncoder::createInvalid(*this, m_device, @"textureDimension is 3D and no depth slice is specified");
-            depthSliceOrArrayLayer = textureIsDestroyed ? 0 : texture->baseArrayLayer();
+            depthSliceOrArrayLayer = textureIsDestroyed ? 0 : texture.baseArrayLayer();
         }
 
-        auto* bridgedTexture = (__bridge void*)texture->parentTexture();
-        auto baseMipLevel = textureIsDestroyed ? 0 : texture->baseMipLevel();
+        auto* bridgedTexture = (__bridge void*)texture.parentTexture();
+        auto baseMipLevel = textureIsDestroyed ? 0 : texture.baseMipLevel();
         uint64_t depthAndMipLevel = depthSliceOrArrayLayer | (static_cast<uint64_t>(baseMipLevel) << 32);
         if (auto it = depthSlices.find(bridgedTexture); it != depthSlices.end()) {
             auto addResult = it->value.add(depthAndMipLevel);
@@ -638,46 +691,46 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
         } else
             depthSlices.set(bridgedTexture, SliceSet { depthAndMipLevel });
 
-        mtlAttachment.depthPlane = textureDimension == WGPUTextureViewDimension_3D ? depthSliceOrArrayLayer : 0;
+        mtlAttachment.depthPlane = texture.is3DTexture() ? depthSliceOrArrayLayer : 0;
         mtlAttachment.slice = 0;
         mtlAttachment.loadAction = loadAction(attachment.loadOp);
         mtlAttachment.storeAction = storeAction(attachment.storeOp, !!attachment.resolveTarget);
 
         zeroColorTargets = false;
         id<MTLTexture> textureToClear = nil;
-        if (mtlAttachment.loadAction == MTLLoadActionLoad && !texture->previouslyCleared())
+        if (mtlAttachment.loadAction == MTLLoadActionLoad && !texture.previouslyCleared())
             textureToClear = mtlAttachment.texture;
 
         auto compositorTexture = texture;
         if (attachment.resolveTarget) {
-            Ref resolveTarget = fromAPI(attachment.resolveTarget);
+            auto resolveTarget = attachment.resolveTarget ? TextureOrTextureView(fromAPI(attachment.resolveTarget)) : TextureOrTextureView(fromAPI(attachment.resolveTexture));
             compositorTexture = resolveTarget;
 
             if (!isValidToUseWith(resolveTarget, *this))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"resolve target created from different device");
-            resolveTarget->setCommandEncoder(*this);
-            id<MTLTexture> resolveTexture = resolveTarget->texture();
-            if (mtlTexture.sampleCount == 1 || resolveTexture.sampleCount != 1 || isMultisampleTexture(resolveTexture) || !isMultisampleTexture(mtlTexture) || !isRenderableTextureView(resolveTarget) || mtlTexture.pixelFormat != resolveTexture.pixelFormat || !Texture::supportsResolve(resolveTarget->format(), m_device))
+            resolveTarget.setCommandEncoder(*this);
+            id<MTLTexture> resolveTexture = resolveTarget.texture();
+            if (mtlTexture.sampleCount == 1 || resolveTexture.sampleCount != 1 || isMultisampleTexture(resolveTexture) || !isMultisampleTexture(mtlTexture) || !isRenderableTextureView(resolveTarget) || mtlTexture.pixelFormat != resolveTexture.pixelFormat || !Texture::supportsResolve(resolveTarget.format(), m_device))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"resolve target is invalid");
 
             mtlAttachment.resolveTexture = resolveTexture;
             mtlAttachment.resolveLevel = 0;
             mtlAttachment.resolveSlice = 0;
             mtlAttachment.resolveDepthPlane = 0;
-            if (resolveTarget->width() != texture->width() || resolveTarget->height() != texture->height())
-                return RenderPassEncoder::createInvalid(*this, m_device, [NSString stringWithFormat:@"resolve target dimensions (%u x %u) don't match expected dimensions (%u x %u)", resolveTarget->width(), resolveTarget->height(), texture->width(), texture->height()]);
+            if (resolveTarget.width() != texture.width() || resolveTarget.height() != texture.height())
+                return RenderPassEncoder::createInvalid(*this, m_device, [NSString stringWithFormat:@"resolve target dimensions (%u x %u) don't match expected dimensions (%u x %u)", resolveTarget.width(), resolveTarget.height(), texture.width(), texture.height()]);
         }
 
-        if (id<MTLRasterizationRateMap> rateMap = compositorTexture->apiParentTexture().rasterizationMapForSlice(compositorTexture->parentRelativeSlice())) {
+        if (id<MTLRasterizationRateMap> rateMap = compositorTexture.apiParentTexture().rasterizationMapForSlice(compositorTexture.parentRelativeSlice())) {
             mtlDescriptor.rasterizationRateMap = rateMap;
-            compositorTextureSlice = compositorTexture->parentRelativeSlice();
+            compositorTextureSlice = compositorTexture.parentRelativeSlice();
         }
 
         if (textureToClear) {
             TextureAndClearColor *textureWithResolve = [[TextureAndClearColor alloc] initWithTexture:textureToClear];
             [attachmentsToClear setObject:textureWithResolve forKey:@(i)];
             if (textureToClear)
-                texture->setPreviouslyCleared();
+                texture.setPreviouslyCleared();
             if (attachment.resolveTarget)
                 protectedFromAPI(attachment.resolveTarget)->setPreviouslyCleared();
         }
@@ -688,28 +741,28 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
     id<MTLTexture> depthStencilAttachmentToClear = nil;
     bool depthAttachmentToClear = false;
     if (const auto* attachment = descriptor.depthStencilAttachment) {
-        Ref textureView = fromAPI(attachment->view);
+        auto textureView = attachment->view ? TextureOrTextureView(fromAPI(attachment->view)) : TextureOrTextureView(fromAPI(attachment->texture));
         if (!isValidToUseWith(textureView, *this))
             return RenderPassEncoder::createInvalid(*this, m_device, @"depth stencil texture device mismatch");
-        id<MTLTexture> metalDepthStencilTexture = textureView->texture();
-        auto textureFormat = textureView->format();
+        id<MTLTexture> metalDepthStencilTexture = textureView.texture();
+        auto textureFormat = textureView.format();
         hasStencilComponent = Texture::containsStencilAspect(textureFormat);
         bool hasDepthComponent = Texture::containsDepthAspect(textureFormat);
-        bool isDestroyed = textureView->isDestroyed();
+        bool isDestroyed = textureView.isDestroyed();
         if (!isDestroyed) {
-            if (textureWidth && (textureView->width() != textureWidth || textureView->height() != textureHeight || sampleCount != textureView->sampleCount()))
+            if (textureWidth && (textureView.width() != textureWidth || textureView.height() != textureHeight || sampleCount != textureView.sampleCount()))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"depth stencil texture dimensions mismatch");
-            if (textureView->arrayLayerCount() > 1 || textureView->mipLevelCount() > 1)
+            if (textureView.arrayLayerCount() > 1 || textureView.mipLevelCount() > 1)
                 return RenderPassEncoder::createInvalid(*this, m_device, @"depth stencil texture has more than one array layer or mip level");
 
-            if (!Texture::isDepthStencilRenderableFormat(textureView->format(), m_device) || !isRenderableTextureView(textureView))
+            if (!Texture::isDepthStencilRenderableFormat(textureView.format(), m_device) || !isRenderableTextureView(textureView))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"depth stencil texture is not renderable");
         }
 
         depthReadOnly = attachment->depthReadOnly;
         if (hasDepthComponent) {
             const auto& mtlAttachment = mtlDescriptor.depthAttachment;
-            auto clearDepth = std::clamp(RenderPassEncoder::quantizedDepthValue(attachment->depthClearValue, textureView->format()), 0., 1.);
+            auto clearDepth = std::clamp(RenderPassEncoder::quantizedDepthValue(attachment->depthClearValue, textureView.format()), 0., 1.);
             mtlAttachment.clearDepth = attachment->depthLoadOp == WGPULoadOp_Clear ? clearDepth : 1.0;
             mtlAttachment.texture = metalDepthStencilTexture;
             mtlAttachment.level = 0;
@@ -726,7 +779,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
                 }
             }
 
-            if (mtlAttachment.loadAction == MTLLoadActionLoad && mtlAttachment.storeAction == MTLStoreActionDontCare && !textureView->previouslyCleared()) {
+            if (mtlAttachment.loadAction == MTLLoadActionLoad && mtlAttachment.storeAction == MTLStoreActionDontCare && !textureView.previouslyCleared()) {
                 depthStencilAttachmentToClear = mtlAttachment.texture;
                 depthAttachmentToClear = !!mtlAttachment.texture;
             }
@@ -756,14 +809,14 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
     if (const auto* attachment = descriptor.depthStencilAttachment) {
         const auto& mtlAttachment = mtlDescriptor.stencilAttachment;
         stencilReadOnly = attachment->stencilReadOnly;
-        Ref textureView = fromAPI(attachment->view);
+        auto textureView = attachment->view ? TextureOrTextureView(fromAPI(attachment->view)) : TextureOrTextureView(fromAPI(attachment->texture));
         if (hasStencilComponent)
-            mtlAttachment.texture = textureView->texture();
+            mtlAttachment.texture = textureView.texture();
         mtlAttachment.clearStencil = attachment->stencilClearValue;
         mtlAttachment.loadAction = loadAction(attachment->stencilLoadOp);
         mtlAttachment.storeAction = storeAction(attachment->stencilStoreOp);
 
-        bool isDestroyed = textureView->isDestroyed();
+        bool isDestroyed = textureView.isDestroyed();
         if (!isDestroyed) {
             if (hasStencilComponent && !stencilReadOnly) {
                 if (attachment->stencilLoadOp == WGPULoadOp_Undefined || attachment->stencilStoreOp == WGPUStoreOp_Undefined)
@@ -772,9 +825,9 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
                 return RenderPassEncoder::createInvalid(*this, m_device, @"stencil load and store op were specified");
         }
 
-        textureView->setCommandEncoder(*this);
+        textureView.setCommandEncoder(*this);
 
-        if (hasStencilComponent && mtlAttachment.loadAction == MTLLoadActionLoad && mtlAttachment.storeAction == MTLStoreActionDontCare && !textureView->previouslyCleared()) {
+        if (hasStencilComponent && mtlAttachment.loadAction == MTLLoadActionLoad && mtlAttachment.storeAction == MTLStoreActionDontCare && !textureView.previouslyCleared()) {
             depthStencilAttachmentToClear = mtlAttachment.texture;
             stencilAttachmentToClear = !!mtlAttachment.texture;
         }

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -123,6 +123,8 @@ public:
 
     Device& device() const { return m_device; }
 
+    bool previouslyCleared() const;
+    void setPreviouslyCleared();
     bool previouslyCleared(uint32_t mipLevel, uint32_t slice) const;
     void setPreviouslyCleared(uint32_t mipLevel, uint32_t slice, bool = true);
     bool isDestroyed() const { return m_destroyed; }
@@ -142,10 +144,17 @@ public:
     id<MTLSharedEvent> sharedEvent() const;
     uint64_t sharedEventSignalValue() const;
     void setRasterizationRateMaps(std::pair<id<MTLRasterizationRateMap>, id<MTLRasterizationRateMap>>&& rateMaps) { m_leftRightRasterizationMaps = WTFMove(rateMaps); }
-    id<MTLRasterizationRateMap> rasterizationMapForSlice(uint32_t slice) { return slice ? m_leftRightRasterizationMaps.second : m_leftRightRasterizationMaps.first; }
+    id<MTLRasterizationRateMap> rasterizationMapForSlice(uint32_t slice) const { return slice ? m_leftRightRasterizationMaps.second : m_leftRightRasterizationMaps.first; }
     uint32_t arrayLayerCount() const;
     WGPUTextureAspect aspect() const { return WGPUTextureAspect_All; }
+    uint32_t baseArrayLayer() const { return 0; }
+    uint32_t baseMipLevel() const { return 0; }
+    uint32_t parentRelativeSlice() const { return 0; }
     bool is2DTexture() const { return dimension() == WGPUTextureDimension_2D; }
+    bool is2DArrayTexture() const { return is2DTexture() && arrayLayerCount() > 1; }
+    bool is3DTexture() const { return dimension() == WGPUTextureDimension_3D; }
+    id<MTLTexture> parentTexture() const { return texture(); }
+    const Texture& apiParentTexture() const { return *this; }
 
 private:
     Texture(id<MTLTexture>, const WGPUTextureDescriptor&, Vector<WGPUTextureFormat>&& viewFormats, Device&);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -4082,6 +4082,26 @@ NSString* Texture::errorValidatingLinearTextureData(const WGPUTextureDataLayout&
     return nil;
 }
 
+bool Texture::previouslyCleared() const
+{
+    for (uint32_t m = 0; m < mipLevelCount(); ++m) {
+        for (uint32_t s = 0; s < arrayLayerCount(); ++s) {
+            if (!previouslyCleared(m, s))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+void Texture::setPreviouslyCleared()
+{
+    for (uint32_t m = 0; m < mipLevelCount(); ++m) {
+        for (uint32_t s = 0; s < arrayLayerCount(); ++s)
+            setPreviouslyCleared(m, s);
+    }
+}
+
 bool Texture::previouslyCleared(uint32_t mipLevel, uint32_t slice) const
 {
     if (isDestroyed())

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -93,7 +93,9 @@ public:
     uint32_t parentRelativeSlice() const;
     uint32_t parentRelativeMipLevel() const;
     bool is2DTexture() const { return dimension() == WGPUTextureViewDimension_2D; }
-    id<MTLRasterizationRateMap> rasterizationMapForSlice(uint32_t slice);
+    bool is2DArrayTexture() const { return dimension() == WGPUTextureViewDimension_2DArray; }
+    bool is3DTexture() const { return dimension() == WGPUTextureViewDimension_3D; }
+    id<MTLRasterizationRateMap> rasterizationMapForSlice(uint32_t slice) const;
 
 private:
     TextureView(id<MTLTexture>, const WGPUTextureViewDescriptor&, const std::optional<WGPUExtent3D>&, Texture&, Device&);

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -189,7 +189,7 @@ void TextureView::setCommandEncoder(CommandEncoder& commandEncoder) const
         commandEncoder.makeSubmitInvalid();
 }
 
-id<MTLRasterizationRateMap> TextureView::rasterizationMapForSlice(uint32_t slice)
+id<MTLRasterizationRateMap> TextureView::rasterizationMapForSlice(uint32_t slice) const
 {
     return apiParentTexture().rasterizationMapForSlice(slice);
 }

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1005,6 +1005,7 @@ typedef struct WGPURenderBundleEncoderDescriptor {
 } WGPURenderBundleEncoderDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassDepthStencilAttachment {
+    WGPUTexture texture;
     WGPUTextureView view;
     WGPULoadOp depthLoadOp;
     WGPUStoreOp depthStoreOp;
@@ -1289,6 +1290,7 @@ typedef struct WGPURenderPassColorAttachment {
     WGPU_NULLABLE WGPUTexture texture;
     WGPU_NULLABLE WGPUTextureView view;
     std::optional<uint32_t> depthSlice;
+    WGPU_NULLABLE WGPUTexture resolveTexture;
     WGPU_NULLABLE WGPUTextureView resolveTarget;
     WGPULoadOp loadOp;
     WGPUStoreOp storeOp;


### PR DESCRIPTION
#### b52ce5c2b3124b335eba9f7286878d2b08b2ce58
<pre>
GPUTexture should be supported for depth-stencil and resolve attachments as well
<a href="https://bugs.webkit.org/show_bug.cgi?id=298455">https://bugs.webkit.org/show_bug.cgi?id=298455</a>
<a href="https://rdar.apple.com/159952306">rdar://159952306</a>

Reviewed by Tadeu Zagallo.

The specification says we are supposed to be able to pass a GPUTexture or a GPUTextureView
for color, resolve, and depth stencil targets.

We added support for color targets in 299475@main but failed to add resolve or depth-stencil
target support, leading to some CTS failures

* LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pass/resolve-expected.txt:
Add new passing expectation which covers this.

* Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h:
(WebCore::GPURenderPassColorAttachment::parseResolveTarget const):
(WebCore::GPURenderPassColorAttachment::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.h:
(WebCore::GPURenderPassDepthStencilAttachment::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h:
(WebCore::WebGPU::RenderPassColorAttachment::protectedResolveTexture const):
(WebCore::WebGPU::RenderPassColorAttachment::protectedResolveTarget const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h:
(WebCore::WebGPU::RenderPassDepthStencilAttachment::protectedTexture const):
(WebCore::WebGPU::RenderPassDepthStencilAttachment::protectedView const):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::TextureOrTextureView::TextureOrTextureView):
(WebGPU::TextureOrTextureView::setCommandEncoder):
(WebGPU::isRenderableTextureView):
(WebGPU::CommandEncoder::beginRenderPass):
* Source/WebGPU/WebGPU/Texture.h:
(WebGPU::Texture::rasterizationMapForSlice const):
(WebGPU::Texture::baseArrayLayer const):
(WebGPU::Texture::baseMipLevel const):
(WebGPU::Texture::parentRelativeSlice const):
(WebGPU::Texture::is2DArrayTexture const):
(WebGPU::Texture::is3DTexture const):
(WebGPU::Texture::parentTexture const):
(WebGPU::Texture::apiParentTexture const):
(WebGPU::Texture::rasterizationMapForSlice): Deleted.
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::previouslyCleared const):
(WebGPU::Texture::setPreviouslyCleared):
* Source/WebGPU/WebGPU/TextureView.h:
(WebGPU::TextureView::is2DArrayTexture const):
(WebGPU::TextureView::is3DTexture const):
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::rasterizationMapForSlice const):
(WebGPU::TextureView::rasterizationMapForSlice): Deleted.
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp:
(WebKit::WebGPU::getIdentifier):
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):

Canonical link: <a href="https://commits.webkit.org/299708@main">https://commits.webkit.org/299708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd513d410fa75fde5520a5a788718e343eaf2f18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72012 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5be3b3fa-37a5-4c3c-bf6a-7afb316b9ced) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91078 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60388 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a18b4703-63a7-4f02-9ac2-e5fe744607cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5beb61d9-f486-47c0-b0fe-545d15e4c626) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69900 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129185 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99701 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25270 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43480 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52427 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46187 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49536 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->