### PR TITLE
[WTF] Always use our own WTF::Variant

### DIFF
--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
-
 // MPark.Variant
 //
 // Copyright Michael Park, 2015-2017
@@ -402,6 +400,7 @@ namespace mpark {
 #ifndef MPARK_LIB_HPP
 #define MPARK_LIB_HPP
 
+#include <array>
 #include <memory>
 #include <functional>
 #include <type_traits>
@@ -2937,33 +2936,5 @@ template<typename Visitor, typename... Variants> constexpr auto visit(Visitor&& 
 #if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 13)
 #include <variant>
 #endif
-
-#else // PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
-
-#include <utility>
-#include <variant>
-namespace WTF {
-template<typename... Ts> using Variant = std::variant<Ts...>;
-template<typename T> constexpr std::in_place_type_t<T> InPlaceType { };
-template<typename T> using InPlaceTypeT = std::in_place_type_t<T>;
-template<size_t I> constexpr std::in_place_index_t<I> InPlaceIndex { };
-template<size_t I> using InPlaceIndexT = std::in_place_index_t<I>;
-template <size_t I, class T> struct VariantAlternative;
-template<size_t I, typename... Types> struct VariantAlternative<I, Variant<Types...>> : std::variant_alternative<I, Variant<Types...>> { };
-template<size_t I, typename T> using VariantAlternativeT = typename VariantAlternative<I, T>::type;
-template<typename T> struct VariantSize;
-template<typename... Types> struct VariantSize<Variant<Types...>> : std::integral_constant<std::size_t, sizeof...(Types)> { };
-template<typename T> struct VariantSize<const T> : VariantSize<T> { };
-template<typename T> constexpr size_t VariantSizeV = VariantSize<T>::value;
-
-template<typename Visitor, typename... Variants> constexpr auto visit(Visitor&& v, Variants&&... values)
-    -> decltype(std::visit<Visitor, Variants...>(std::forward<Visitor>(v), std::forward<Variants>(values)...))
-{
-    return std::visit<Visitor, Variants...>(std::forward<Visitor>(v), std::forward<Variants>(values)...);
-}
-
-}
-
-#endif // PLATFORM(COCOA)
 
 using WTF::Variant;


### PR DESCRIPTION
#### 079ad9ead34e10331baf00cb60eafca91fed4f01
<pre>
[WTF] Always use our own WTF::Variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=298515">https://bugs.webkit.org/show_bug.cgi?id=298515</a>
<a href="https://rdar.apple.com/160075190">rdar://160075190</a>

Reviewed by Alex Christensen.

WTF::Variant is great for all aspects (code size, performance etc.)
compared to std::variant. Given that it is already enabled on most of
platforms (PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)), let&apos;s
just enable it by default.

* Source/WTF/wtf/Variant.h:

Canonical link: <a href="https://commits.webkit.org/299791@main">https://commits.webkit.org/299791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e9351bc980577ae824d9ddd36195a97e2cd1fbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71934 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc1c4ab3-aded-496e-83f5-ddd44c02c75c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91022 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60323 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aedc8b15-e40c-445b-9af3-75b0e29c84a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71579 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38d35223-68c8-4c04-8c09-b8f3f1fd21fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25577 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69823 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111986 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129107 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118377 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99638 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99483 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43386 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19099 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52349 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147075 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46109 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37790 "Found 1 new JSC binary failure: testapi, Found 18663 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->