### PR TITLE
Address Safer CPP unexpected failures on the bot

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -48,7 +48,6 @@ platform/mock/DeviceOrientationClientMock.h
 rendering/BackgroundPainter.h
 rendering/GlyphDisplayListCache.cpp
 rendering/GridTrackSizingAlgorithm.h
-rendering/ImageQualityController.h
 rendering/InlineBoxPainter.h
 rendering/LayerOverlapMap.cpp
 rendering/LayerOverlapMap.h

--- a/Source/WebCore/rendering/LayoutScope.cpp
+++ b/Source/WebCore/rendering/LayoutScope.cpp
@@ -37,7 +37,7 @@ LayoutScope::LayoutScope(RenderElement& renderer)
 
 LayoutScope::~LayoutScope()
 {
-    if (auto* block = dynamicDowncast<RenderBlock>(m_renderer.get())) {
+    if (CheckedPtr block = dynamicDowncast<RenderBlock>(m_renderer.get())) {
         block->updateLayerTransform();
         block->updateScrollInfoAfterLayout();
     }

--- a/Source/WebCore/rendering/LayoutScope.h
+++ b/Source/WebCore/rendering/LayoutScope.h
@@ -36,7 +36,7 @@ public:
     ~LayoutScope();
 
 private:
-    CheckedPtr<RenderElement> m_renderer;
+    const CheckedRef<RenderElement> m_renderer;
 };
 
 }

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -84,6 +84,7 @@ public:
     }
 
     RenderObject* currentObject() { return m_current.renderer(); }
+    CheckedPtr<RenderObject> checkedCurrentObject() { return currentObject(); }
     LegacyInlineIterator lineBreak() { return m_lineBreak; }
     LineWidth& lineWidth() { return m_width; }
     bool atEnd() { return m_atEnd; }

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -68,7 +68,7 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
                 return context.lineBreak();
             }
         } else if (context.currentObject()->isLineBreakOpportunity())
-            context.commitLineBreakAtCurrentWidth(*context.currentObject());
+            context.commitLineBreakAtCurrentWidth(*context.checkedCurrentObject());
         else
             ASSERT_NOT_REACHED();
 


### PR DESCRIPTION
#### 9667aa121c4e5d7b59d5c6760afad13401e155a5
<pre>
Address Safer CPP unexpected failures on the bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=298517">https://bugs.webkit.org/show_bug.cgi?id=298517</a>

Unreviewed.

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/rendering/LayoutScope.cpp:
(WebCore::LayoutScope::~LayoutScope):
* Source/WebCore/rendering/LayoutScope.h:
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::checkedCurrentObject):
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::nextLineBreak):

Canonical link: <a href="https://commits.webkit.org/299683@main">https://commits.webkit.org/299683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/900b90329308d76684985d5a9b945a2debbec7b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71937 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc6755e2-0cb9-4bdc-a74d-f258c064eeee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48134 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60324 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b862e124-cbf6-4f93-8e8f-518d70bc72de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107475 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/71580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe5dacd9-4697-4f8c-b3b2-5da7b15a53e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25580 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69824 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129110 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99640 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99485 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43401 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52352 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46112 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47798 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->