### PR TITLE
[list-marker] Marker gets clipped when certain padding values are applied in inline direction

### DIFF
--- a/LayoutTests/fast/dynamic/first-letter-after-list-marker-expected.txt
+++ b/LayoutTests/fast/dynamic/first-letter-after-list-marker-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x492
       RenderBlock {UL} at (0,0) size 784x100
         RenderListItem {LI} at (40,0) size 744x100
-          RenderListMarker at (-61,0) size 29x100: bullet
+          RenderListMarker at (-48,0) size 29x100: bullet
           RenderInline (generated) at (0,0) size 100x100 [color=#008000]
             RenderText at (0,0) size 100x100
               text run at (0,0) width 100: "a"

--- a/LayoutTests/fast/lists/list-marker-before-content-table-expected.txt
+++ b/LayoutTests/fast/lists/list-marker-before-content-table-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x160
       RenderBlock {UL} at (0,0) size 784x96
         RenderListItem {LI} at (40,0) size 744x96 [color=#008000]
           RenderBlock (anonymous) at (0,0) size 744x32
-            RenderListMarker at (-25,0) size 11x32: bullet
+            RenderListMarker at (-21,0) size 11x32: bullet
           RenderTable at (0,32) size 128x32
             RenderTableSection (anonymous) at (0,0) size 128x32
               RenderTableRow (anonymous) at (0,0) size 128x32 [color=#0000FF]

--- a/LayoutTests/fast/lists/list-marker-padding-expected.html
+++ b/LayoutTests/fast/lists/list-marker-padding-expected.html
@@ -1,0 +1,13 @@
+<style>
+body {
+  padding: 10px;
+}
+div {
+  font-size: 14px;
+  font-family: Ahem;
+}
+span {
+  margin-right: 1px;
+}
+</style> 
+<div><span>1.</span> PASS if marker is fully visible</div>

--- a/LayoutTests/fast/lists/list-marker-padding.html
+++ b/LayoutTests/fast/lists/list-marker-padding.html
@@ -1,0 +1,13 @@
+<style>
+body {
+  padding: 10px;
+}
+ol {
+  overflow: hidden;
+  padding-left: 43px;
+  font-size: 14px;
+  font-family: Ahem;
+}
+</style> 
+<ol>
+<li>PASS if marker is fully visible</li>

--- a/LayoutTests/fast/repaint/list-marker-expected.txt
+++ b/LayoutTests/fast/repaint/list-marker-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,52) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 22x18
               text run at (0,0) width 22: "foo"
           RenderBlock {DIV} at (10,28) size 724x0
@@ -33,7 +33,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,120) size 784x18
         RenderListItem {LI} at (0,0) size 744x18
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (754,0) size 7x18: bullet
+            RenderListMarker at (752,0) size 7x18: bullet
             RenderText {#text} at (722,0) size 22x18
               text run at (722,0) width 22: "foo"
           RenderBlock {DIV} at (10,28) size 724x0

--- a/LayoutTests/platform/ios-18/editing/pasteboard/input-field-1-expected.txt
+++ b/LayoutTests/platform/ios-18/editing/pasteboard/input-field-1-expected.txt
@@ -24,7 +24,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (158,1) size 156x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
       RenderBlock {UL} at (0,74) size 784x21
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 44x19
             text run at (0,0) width 44: "Passed"
 layer at (15,48) size 141x14

--- a/LayoutTests/platform/ios-18/fast/forms/plaintext-mode-2-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/forms/plaintext-mode-2-expected.txt
@@ -26,11 +26,11 @@ layer at (0,0) size 800x600
           text run at (371,0) width 203: "All richness should be stripped."
       RenderBlock {OL} at (0,57) size 784x41
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 332x19
             text run at (0,0) width 332: "Success: document.execCommand(\"Copy\") == true"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 331x19
             text run at (0,0) width 331: "Success: document.execCommand(\"Paste\") == true"
 layer at (15,11) size 587x14

--- a/LayoutTests/platform/ios-18/fast/lists/dynamic-marker-crash-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/lists/dynamic-marker-crash-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x90
         RenderListItem {LI} at (40,0) size 744x59
           RenderBlock {FORM} at (0,0) size 744x23
             RenderBlock {P} at (0,0) size 744x23
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
               RenderTextControl {INPUT} at (0,1) size 295x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
               RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,38) size 744x21

--- a/LayoutTests/platform/ios/css1/basic/containment-expected.txt
+++ b/LayoutTests/platform/ios/css1/basic/containment-expected.txt
@@ -52,7 +52,7 @@ layer at (0,0) size 800x1009
           text run at (0,20) width 330: "\"Alternate SS\" has been selected via the user agent."
       RenderBlock {UL} at (0,299) size 784x60 [color=#FF0000]
         RenderListItem {LI} at (40,0) size 744x20 [color=#008000]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 398x19
             text run at (0,0) width 398: "This sentence should be green due to an imported style sheet ["
           RenderInline {CODE} at (397,5) size 204x14
@@ -61,7 +61,7 @@ layer at (0,0) size 800x1009
           RenderText {#text} at (600,0) size 10x19
             text run at (600,0) width 10: "]."
         RenderListItem {LI} at (40,20) size 744x20 [color=#800080]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 404x19
             text run at (0,0) width 404: "This sentence should be purple due to an imported style sheet ["
           RenderInline {CODE} at (403,5) size 180x14
@@ -70,7 +70,7 @@ layer at (0,0) size 800x1009
           RenderText {#text} at (582,0) size 10x19
             text run at (582,0) width 10: "]."
         RenderListItem {LI} at (40,40) size 744x20 [color=#008000]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 400x19
             text run at (0,0) width 400: "This sentence should be green thanks to the STYLE attribute ["
           RenderInline {CODE} at (399,5) size 164x14
@@ -83,15 +83,15 @@ layer at (0,0) size 800x1009
           text run at (0,0) width 510: "This sentence should be purple, and it doesn't have a terminating paragraph tag."
       RenderBlock {OL} at (0,411) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 204x19
             text run at (0,0) width 204: "This list should NOT be purple."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 176x19
             text run at (0,0) width 176: "It should, instead, be black."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 512x19
             text run at (0,0) width 512: "If it IS purple, then the browser hasn't correctly parsed the preceding paragraph."
       RenderBlock {P} at (0,487) size 784x40
@@ -148,7 +148,7 @@ layer at (0,0) size 800x1009
                   text run at (0,20) width 330: "\"Alternate SS\" has been selected via the user agent."
               RenderBlock {UL} at (4,116) size 762x60 [color=#FF0000]
                 RenderListItem {LI} at (40,0) size 722x20 [color=#008000]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 398x19
                     text run at (0,0) width 398: "This sentence should be green due to an imported style sheet ["
                   RenderInline {CODE} at (397,5) size 204x14
@@ -157,7 +157,7 @@ layer at (0,0) size 800x1009
                   RenderText {#text} at (600,0) size 10x19
                     text run at (600,0) width 10: "]."
                 RenderListItem {LI} at (40,20) size 722x20 [color=#800080]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 404x19
                     text run at (0,0) width 404: "This sentence should be purple due to an imported style sheet ["
                   RenderInline {CODE} at (403,5) size 180x14
@@ -166,7 +166,7 @@ layer at (0,0) size 800x1009
                   RenderText {#text} at (582,0) size 10x19
                     text run at (582,0) width 10: "]."
                 RenderListItem {LI} at (40,40) size 722x20 [color=#008000]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 400x19
                     text run at (0,0) width 400: "This sentence should be green thanks to the STYLE attribute ["
                   RenderInline {CODE} at (399,5) size 164x14
@@ -179,15 +179,15 @@ layer at (0,0) size 800x1009
                   text run at (0,0) width 510: "This sentence should be purple, and it doesn't have a terminating paragraph tag."
               RenderBlock {OL} at (4,228) size 762x60
                 RenderListItem {LI} at (40,0) size 722x20
-                  RenderListMarker at (-21,0) size 16x19: "1"
+                  RenderListMarker at (-17,0) size 16x19: "1"
                   RenderText {#text} at (0,0) size 204x19
                     text run at (0,0) width 204: "This list should NOT be purple."
                 RenderListItem {LI} at (40,20) size 722x20
-                  RenderListMarker at (-21,0) size 16x19: "2"
+                  RenderListMarker at (-17,0) size 16x19: "2"
                   RenderText {#text} at (0,0) size 176x19
                     text run at (0,0) width 176: "It should, instead, be black."
                 RenderListItem {LI} at (40,40) size 722x20
-                  RenderListMarker at (-21,0) size 16x19: "3"
+                  RenderListMarker at (-17,0) size 16x19: "3"
                   RenderText {#text} at (0,0) size 512x19
                     text run at (0,0) width 512: "If it IS purple, then the browser hasn't correctly parsed the preceding paragraph."
               RenderBlock {P} at (4,304) size 762x40

--- a/LayoutTests/platform/ios/css1/basic/contextual_selectors-expected.txt
+++ b/LayoutTests/platform/ios/css1/basic/contextual_selectors-expected.txt
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,195) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderInline {EM} at (0,0) size 40x19 [color=#008000]
               RenderText {#text} at (0,0) size 40x19
                 text run at (0,0) width 40: "Hello."
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
               text run at (43,0) width 403: "The first \"hello\" should be green, but this part should be black."
           RenderBlock {UL} at (0,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20 [color=#008000]
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 138x19
                 text run at (0,0) width 138: "This should be green."
       RenderTable {TABLE} at (0,251) size 730x166 [border: (1px outset #000000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
               RenderBlock {UL} at (4,76) size 708x40
                 RenderListItem {LI} at (40,0) size 668x40
                   RenderBlock (anonymous) at (0,0) size 668x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderInline {EM} at (0,0) size 40x19 [color=#008000]
                       RenderText {#text} at (0,0) size 40x19
                         text run at (0,0) width 40: "Hello."
@@ -76,7 +76,7 @@ layer at (0,0) size 800x600
                       text run at (43,0) width 403: "The first \"hello\" should be green, but this part should be black."
                   RenderBlock {UL} at (0,20) size 668x20
                     RenderListItem {LI} at (40,0) size 628x20 [color=#008000]
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 138x19
                         text run at (0,0) width 138: "This should be green."
 layer at (8,113) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/ios/css1/basic/id_as_selector-expected.txt
+++ b/LayoutTests/platform/ios/css1/basic/id_as_selector-expected.txt
@@ -47,7 +47,7 @@ layer at (0,0) size 800x635
           text run at (460,0) width 1: " "
       RenderBlock {UL} at (0,344) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 239x19
             text run at (0,0) width 239: "This sentence should NOT be purple."
       RenderTable {TABLE} at (0,380) size 413x239 [border: (1px outset #000000)]
@@ -86,7 +86,7 @@ layer at (0,0) size 800x635
                   text run at (351,0) width 1: " "
               RenderBlock {UL} at (4,169) size 391x20
                 RenderListItem {LI} at (40,0) size 351x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 239x19
                     text run at (0,0) width 239: "This sentence should NOT be purple."
 layer at (8,169) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/ios/css1/box_properties/border_bottom-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/border_bottom-expected.txt
@@ -52,28 +52,28 @@ layer at (0,0) size 800x1055
       RenderBlock {UL} at (0,396) size 784x149
         RenderListItem {LI} at (40,0) size 744x83 [border: none (3px solid #000000) none]
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (0,20) size 744x60
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 75x19
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,20) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 118x19
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,40) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 182x19
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,83) size 744x23 [border: none (3px solid #000000) none]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 163x19
             text run at (0,0) width 163: "This is a second list item."
         RenderListItem {LI} at (40,106) size 744x43 [border: none (3px solid #000000) none]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 743x39
             text run at (0,0) width 743: "Each list item in this list should have a medium-width black border at its bottom, which for the first item means that"
             text run at (0,20) width 107: "it should appear "
@@ -130,28 +130,28 @@ layer at (0,0) size 800x1055
               RenderBlock {UL} at (4,277) size 762x149
                 RenderListItem {LI} at (40,0) size 722x83 [border: none (3px solid #000000) none]
                   RenderBlock (anonymous) at (0,0) size 722x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 123x19
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (0,20) size 722x60
                     RenderListItem {LI} at (40,0) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 75x19
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,20) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 118x19
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,40) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 182x19
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,83) size 722x23 [border: none (3px solid #000000) none]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 163x19
                     text run at (0,0) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,106) size 722x43 [border: none (3px solid #000000) none]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 715x39
                     text run at (0,0) width 715: "Each list item in this list should have a medium-width black border at its bottom, which for the first item means"
                     text run at (0,20) width 135: "that it should appear "

--- a/LayoutTests/platform/ios/css1/box_properties/border_left-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/border_left-expected.txt
@@ -58,28 +58,28 @@ layer at (0,0) size 800x1089
       RenderBlock {UL} at (0,424) size 784x160
         RenderListItem {LI} at (40,0) size 744x80 [border: none (3px solid #000000)]
           RenderBlock (anonymous) at (3,0) size 741x20
-            RenderListMarker at (-21,0) size 7x19: bullet
+            RenderListMarker at (-18,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (3,20) size 741x60
             RenderListItem {LI} at (40,0) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 75x19
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,20) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 118x19
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,40) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 182x19
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,80) size 744x20 [border: none (3px solid #800080)]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (3,0) size 163x19
             text run at (3,0) width 163: "This is a second list item."
         RenderListItem {LI} at (40,100) size 744x60 [border: none (3px solid #0000FF)]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (3,0) size 738x59
             text run at (3,0) width 713: "Each list item in this 'parent' list should have a medium-width border along its left side, in each of three colors. "
             text run at (715,0) width 26: "The"
@@ -133,28 +133,28 @@ layer at (0,0) size 800x1089
               RenderBlock {UL} at (5,263) size 760x160
                 RenderListItem {LI} at (40,0) size 720x80 [border: none (3px solid #000000)]
                   RenderBlock (anonymous) at (3,0) size 717x20
-                    RenderListMarker at (-21,0) size 7x19: bullet
+                    RenderListMarker at (-18,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 123x19
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (3,20) size 717x60
                     RenderListItem {LI} at (40,0) size 677x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 75x19
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,20) size 677x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 118x19
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,40) size 677x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 182x19
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,80) size 720x20 [border: none (3px solid #800080)]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (3,0) size 163x19
                     text run at (3,0) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,100) size 720x60 [border: none (3px solid #0000FF)]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (3,0) size 709x59
                     text run at (3,0) width 709: "Each list item in this 'parent' list should have a medium-width border along its left side, in each of three colors."
                     text run at (3,20) width 659: "The first item's border should travel the entire height the nested list (to end near the baseline of the line"

--- a/LayoutTests/platform/ios/css1/box_properties/border_right_inline-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/border_right_inline-expected.txt
@@ -58,28 +58,28 @@ layer at (0,0) size 800x1149
       RenderBlock {UL} at (0,424) size 784x180
         RenderListItem {LI} at (40,0) size 744x80 [border: none (3px solid #000000) none]
           RenderBlock (anonymous) at (0,0) size 741x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (0,20) size 741x60
             RenderListItem {LI} at (40,0) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 75x19
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,20) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 118x19
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,40) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 182x19
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,80) size 744x20 [border: none (3px solid #800080) none]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 163x19
             text run at (0,0) width 163: "This is a second list item."
         RenderListItem {LI} at (40,100) size 744x80 [border: none (3px solid #0000FF) none]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 722x79
             text run at (0,0) width 718: "Each list item in this 'parent' list should have a medium-width border along its right side, in each of three colors."
             text run at (0,20) width 722: "The first item's border should travel the entire height the nested list (to end near the baseline of the line \"...nested"
@@ -134,28 +134,28 @@ layer at (0,0) size 800x1149
               RenderBlock {UL} at (4,263) size 760x200
                 RenderListItem {LI} at (40,0) size 720x80 [border: none (3px solid #000000) none]
                   RenderBlock (anonymous) at (0,0) size 717x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 123x19
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (0,20) size 717x60
                     RenderListItem {LI} at (40,0) size 677x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 75x19
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,20) size 677x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 118x19
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,40) size 677x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 182x19
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,80) size 720x20 [border: none (3px solid #800080) none]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 163x19
                     text run at (0,0) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,100) size 720x100 [border: none (3px solid #0000FF) none]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 706x99
                     text run at (0,0) width 671: "Each list item in this 'parent' list should have a medium-width border along its right side, in each of three"
                     text run at (0,20) width 48: "colors. "

--- a/LayoutTests/platform/ios/css1/box_properties/border_top-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/border_top-expected.txt
@@ -52,28 +52,28 @@ layer at (0,0) size 800x1015
       RenderBlock {UL} at (0,396) size 784x129
         RenderListItem {LI} at (40,0) size 744x83 [border: (3px solid #000000) none]
           RenderBlock (anonymous) at (0,3) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (0,23) size 744x60
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 75x19
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,20) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 118x19
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,40) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 182x19
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,83) size 744x23 [border: (3px solid #000000) none]
-          RenderListMarker at (-18,3) size 7x19: bullet
+          RenderListMarker at (-15,3) size 7x19: bullet
           RenderText {#text} at (0,3) size 163x19
             text run at (0,3) width 163: "This is a second list item."
         RenderListItem {LI} at (40,106) size 744x23 [border: (3px solid #000000) none]
-          RenderListMarker at (-18,3) size 7x19: bullet
+          RenderListMarker at (-15,3) size 7x19: bullet
           RenderText {#text} at (0,3) size 493x19
             text run at (0,3) width 493: "Each list item in this list should have a medium-width black border at its top."
       RenderTable {TABLE} at (0,541) size 784x458 [border: (1px outset #000000)]
@@ -124,28 +124,28 @@ layer at (0,0) size 800x1015
               RenderBlock {UL} at (4,278) size 762x129
                 RenderListItem {LI} at (40,0) size 722x83 [border: (3px solid #000000) none]
                   RenderBlock (anonymous) at (0,3) size 722x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 123x19
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (0,23) size 722x60
                     RenderListItem {LI} at (40,0) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 75x19
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,20) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 118x19
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,40) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 182x19
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,83) size 722x23 [border: (3px solid #000000) none]
-                  RenderListMarker at (-18,3) size 7x19: bullet
+                  RenderListMarker at (-15,3) size 7x19: bullet
                   RenderText {#text} at (0,3) size 163x19
                     text run at (0,3) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,106) size 722x23 [border: (3px solid #000000) none]
-                  RenderListMarker at (-18,3) size 7x19: bullet
+                  RenderListMarker at (-15,3) size 7x19: bullet
                   RenderText {#text} at (0,3) size 493x19
                     text run at (0,3) width 493: "Each list item in this list should have a medium-width black border at its top."
 layer at (8,113) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/ios/css1/box_properties/clear_float-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/clear_float-expected.txt
@@ -30,19 +30,19 @@ layer at (0,0) size 800x810
             text run at (0,0) width 82: "Top menu"
         RenderBlock {UL} at (24,35) size 156x81
           RenderListItem {LI} at (0,0) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 36x19
               text run at (0,0) width 36: "green"
           RenderListItem {LI} at (0,20) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 64x19
               text run at (0,0) width 64: "white text"
           RenderListItem {LI} at (0,40) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 96x19
               text run at (0,0) width 96: "0.5em padding"
           RenderListItem {LI} at (0,60) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 89x19
               text run at (0,0) width 89: "0.5em margin"
       RenderBlock (floating) {DIV} at (0,318) size 192x127 [color=#FFFFFF] [bgcolor=#0000FF]
@@ -51,19 +51,19 @@ layer at (0,0) size 800x810
             text run at (0,0) width 112: "Bottom menu"
         RenderBlock {UL} at (24,35) size 156x81
           RenderListItem {LI} at (0,0) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 108x19
               text run at (0,0) width 108: "blue background"
           RenderListItem {LI} at (0,20) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 64x19
               text run at (0,0) width 64: "white text"
           RenderListItem {LI} at (0,40) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 96x19
               text run at (0,0) width 96: "0.5em padding"
           RenderListItem {LI} at (0,60) size 156x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 89x19
               text run at (0,0) width 89: "0.5em margin"
       RenderBlock {DIV} at (224,182) size 528x237 [bgcolor=#FFFF00]
@@ -100,19 +100,19 @@ layer at (0,0) size 800x810
                     text run at (0,0) width 82: "Top menu"
                 RenderBlock {UL} at (24,35) size 156x81
                   RenderListItem {LI} at (0,0) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 36x19
                       text run at (0,0) width 36: "green"
                   RenderListItem {LI} at (0,20) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 64x19
                       text run at (0,0) width 64: "white text"
                   RenderListItem {LI} at (0,40) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 96x19
                       text run at (0,0) width 96: "0.5em padding"
                   RenderListItem {LI} at (0,60) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 89x19
                       text run at (0,0) width 89: "0.5em margin"
               RenderBlock (floating) {DIV} at (4,140) size 192x127 [color=#FFFFFF] [bgcolor=#0000FF]
@@ -121,19 +121,19 @@ layer at (0,0) size 800x810
                     text run at (0,0) width 112: "Bottom menu"
                 RenderBlock {UL} at (24,35) size 156x81
                   RenderListItem {LI} at (0,0) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 108x19
                       text run at (0,0) width 108: "blue background"
                   RenderListItem {LI} at (0,20) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 64x19
                       text run at (0,0) width 64: "white text"
                   RenderListItem {LI} at (0,40) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 96x19
                       text run at (0,0) width 96: "0.5em padding"
                   RenderListItem {LI} at (0,60) size 156x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 89x19
                       text run at (0,0) width 89: "0.5em margin"
               RenderBlock {DIV} at (228,4) size 314x337 [bgcolor=#FFFF00]

--- a/LayoutTests/platform/ios/css1/box_properties/margin-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/margin-expected.txt
@@ -58,19 +58,19 @@ layer at (0,0) size 800x2736
           text run at (0,0) width 208: "This element has a class of zero."
       RenderBlock {UL} at (25,1184) size 734x130 [bgcolor=#00FFFF]
         RenderListItem {LI} at (40,0) size 694x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 382x19
             text run at (0,0) width 382: "This list has a margin of 25px, and a light blue background."
         RenderListItem {LI} at (40,20) size 694x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 269x19
             text run at (0,0) width 269: "Therefore, it ought to have such a margin."
         RenderListItem {LI} at (65,65) size 644x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 555x19
             text run at (0,0) width 555: "This list item has a margin of 25px, which should cause it to be offset in some fashion."
         RenderListItem {LI} at (40,110) size 694x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 304x19
             text run at (0,0) width 304: "This list item has no special styles applied to it."
       RenderBlock {P} at (0,1339) size 784x20 [bgcolor=#C0C0C0]
@@ -136,19 +136,19 @@ layer at (0,0) size 800x2736
                   text run at (0,0) width 208: "This element has a class of zero."
               RenderBlock {UL} at (29,1032) size 712x130 [bgcolor=#00FFFF]
                 RenderListItem {LI} at (40,0) size 672x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 382x19
                     text run at (0,0) width 382: "This list has a margin of 25px, and a light blue background."
                 RenderListItem {LI} at (40,20) size 672x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 269x19
                     text run at (0,0) width 269: "Therefore, it ought to have such a margin."
                 RenderListItem {LI} at (65,65) size 622x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 555x19
                     text run at (0,0) width 555: "This list item has a margin of 25px, which should cause it to be offset in some fashion."
                 RenderListItem {LI} at (40,110) size 672x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 304x19
                     text run at (0,0) width 304: "This list item has no special styles applied to it."
               RenderBlock {P} at (4,1187) size 762x20 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/ios/css1/box_properties/margin_bottom-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/margin_bottom-expected.txt
@@ -52,19 +52,19 @@ layer at (0,0) size 800x1812
           text run at (0,0) width 238: "This element also has a class of zero."
       RenderBlock {UL} at (0,754) size 784x105 [bgcolor=#00FFFF]
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 433x19
             text run at (0,0) width 433: "This list has a margin-bottom of 25px, and a light blue background."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 269x19
             text run at (0,0) width 269: "Therefore, it ought to have such a margin."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 604x19
             text run at (0,0) width 604: "This list item has a bottom margin of 25px, which should cause it to be offset in some fashion."
         RenderListItem {LI} at (40,85) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 304x19
             text run at (0,0) width 304: "This list item has no special styles applied to it."
       RenderBlock {P} at (0,884) size 784x60 [bgcolor=#00FFFF]
@@ -119,19 +119,19 @@ layer at (0,0) size 800x1812
                   text run at (0,0) width 238: "This element also has a class of zero."
               RenderBlock {UL} at (4,567) size 762x106 [bgcolor=#00FFFF]
                 RenderListItem {LI} at (40,0) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 433x19
                     text run at (0,0) width 433: "This list has a margin-bottom of 25px, and a light blue background."
                 RenderListItem {LI} at (40,20) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 269x19
                     text run at (0,0) width 269: "Therefore, it ought to have such a margin."
                 RenderListItem {LI} at (40,40) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 604x19
                     text run at (0,0) width 604: "This list item has a bottom margin of 25px, which should cause it to be offset in some fashion."
                 RenderListItem {LI} at (40,85) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 304x19
                     text run at (0,0) width 304: "This list item has no special styles applied to it."
               RenderBlock {P} at (4,697) size 762x61 [bgcolor=#00FFFF]

--- a/LayoutTests/platform/ios/css1/box_properties/margin_left-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/margin_left-expected.txt
@@ -38,18 +38,18 @@ layer at (0,0) size 800x1065
           text run at (0,20) width 180: "width of the parent element."
       RenderBlock {UL} at (25,351) size 759x100 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 719x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 699x19
             text run at (0,0) width 699: "The left margin on this unordered list has been set to 25 pixels, and its background color has been set to gray."
         RenderListItem {LI} at (65,20) size 694x60 [bgcolor=#FFFFFF]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 685x59
             text run at (0,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (0,20) width 61: "checked. "
             text run at (60,20) width 625: "This list item has its left margin also set to 25 pixels, which should combine with the list's margin"
             text run at (0,40) width 488: "to make 50 pixels of margin, and its background color has been set to white."
         RenderListItem {LI} at (40,80) size 719x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 185x19
             text run at (0,0) width 185: "This is an unclassed list item"
       RenderBlock {P} at (0,467) size 784x20 [bgcolor=#C0C0C0]
@@ -92,19 +92,19 @@ layer at (0,0) size 800x1065
                   text run at (0,20) width 180: "width of the parent element."
               RenderBlock {UL} at (29,204) size 737x120 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 697x40
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 664x39
                     text run at (0,0) width 664: "The left margin on this unordered list has been set to 25 pixels, and its background color has been set to"
                     text run at (0,20) width 32: "gray."
                 RenderListItem {LI} at (65,40) size 672x60 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 669x59
                     text run at (0,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
                     text run at (0,20) width 61: "checked. "
                     text run at (60,20) width 576: "This list item has its left margin also set to 25 pixels, which should combine with the list's"
                     text run at (0,40) width 537: "margin to make 50 pixels of margin, and its background color has been set to white."
                 RenderListItem {LI} at (40,100) size 697x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 185x19
                     text run at (0,0) width 185: "This is an unclassed list item"
               RenderBlock {P} at (4,340) size 762x20 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/ios/css1/box_properties/margin_right-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/margin_right-expected.txt
@@ -38,18 +38,18 @@ layer at (0,0) size 800x1065
           text run at (408,20) width 180: "width of the parent element."
       RenderBlock {UL} at (0,351) size 759x100 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 719x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (7,0) size 712x19
             text run at (7,0) width 712: "The right margin on this unordered list has been set to 25 pixels, and the background color has been set to gray."
         RenderListItem {LI} at (40,20) size 694x60 [bgcolor=#FFFFFF]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 694x59
             text run at (25,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (0,20) width 62: "checked. "
             text run at (61,20) width 633: "This list item has its right margin also set to 25 pixels, which should combine with the list's margin"
             text run at (205,40) width 489: "to make 50 pixels of margin, and its background-color has been set to white."
         RenderListItem {LI} at (40,80) size 719x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (534,0) size 185x19
             text run at (534,0) width 185: "This is an unclassed list item"
       RenderBlock {P} at (0,467) size 784x20 [bgcolor=#C0C0C0]
@@ -92,19 +92,19 @@ layer at (0,0) size 800x1065
                   text run at (391,20) width 181: "width of the parent element."
               RenderBlock {UL} at (4,204) size 737x120 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 697x40
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (20,0) size 677x39
                     text run at (20,0) width 677: "The right margin on this unordered list has been set to 25 pixels, and the background color has been set to"
                     text run at (665,20) width 32: "gray."
                 RenderListItem {LI} at (40,40) size 672x60 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (3,0) size 669x59
                     text run at (3,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
                     text run at (27,20) width 62: "checked. "
                     text run at (88,20) width 584: "This list item has its right margin also set to 25 pixels, which should combine with the list's"
                     text run at (134,40) width 538: "margin to make 50 pixels of margin, and its background-color has been set to white."
                 RenderListItem {LI} at (40,100) size 697x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (512,0) size 185x19
                     text run at (512,0) width 185: "This is an unclassed list item"
               RenderBlock {P} at (4,340) size 762x20 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/ios/css1/box_properties/margin_top-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/margin_top-expected.txt
@@ -49,19 +49,19 @@ layer at (0,0) size 800x1715
           text run at (0,20) width 240: "will require extra text in order to test."
       RenderBlock {UL} at (0,742) size 784x105 [bgcolor=#00FFFF]
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 408x19
             text run at (0,0) width 408: "This list has a margin-top of 25px, and a light blue background."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 269x19
             text run at (0,0) width 269: "Therefore, it ought to have such a margin."
         RenderListItem {LI} at (40,65) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 579x19
             text run at (0,0) width 579: "This list item has a top margin of 25px, which should cause it to be offset in some fashion."
         RenderListItem {LI} at (40,85) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 304x19
             text run at (0,0) width 304: "This list item has no special styles applied to it."
       RenderBlock {P} at (0,847) size 784x20 [bgcolor=#C0C0C0]
@@ -109,19 +109,19 @@ layer at (0,0) size 800x1715
                   text run at (0,20) width 272: "This will require extra text in order to test."
               RenderBlock {UL} at (4,572) size 762x106 [bgcolor=#00FFFF]
                 RenderListItem {LI} at (40,0) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 408x19
                     text run at (0,0) width 408: "This list has a margin-top of 25px, and a light blue background."
                 RenderListItem {LI} at (40,20) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 269x19
                     text run at (0,0) width 269: "Therefore, it ought to have such a margin."
                 RenderListItem {LI} at (40,65) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 579x19
                     text run at (0,0) width 579: "This list item has a top margin of 25px, which should cause it to be offset in some fashion."
                 RenderListItem {LI} at (40,85) size 722x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 304x19
                     text run at (0,0) width 304: "This list item has no special styles applied to it."
               RenderBlock {P} at (4,677) size 762x21 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/ios/css1/box_properties/padding_left-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/padding_left-expected.txt
@@ -46,11 +46,11 @@ layer at (0,0) size 800x1053
           text run at (196,40) width 76: "(light blue)."
       RenderBlock {UL} at (0,431) size 784x80 [bgcolor=#808080]
         RenderListItem {LI} at (25,0) size 759x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 732x19
             text run at (0,0) width 732: "The left padding on this unordered list has been set to 25 pixels, which will require some extra test in order to test."
         RenderListItem {LI} at (25,20) size 759x60 [bgcolor=#FFFFFF]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (25,0) size 726x59
             text run at (25,0) width 726: "Another list item might not be such a bad idea, either, considering that such things do need to be double-checked."
             text run at (25,20) width 713: "This list item has its left padding also set to 25 pixels, which should combine with the list's padding to make 50"
@@ -98,11 +98,11 @@ layer at (0,0) size 800x1053
                   text run at (190,40) width 111: "aqua (light blue)."
               RenderBlock {UL} at (4,284) size 762x80 [bgcolor=#808080]
                 RenderListItem {LI} at (25,0) size 737x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 732x19
                     text run at (0,0) width 732: "The left padding on this unordered list has been set to 25 pixels, which will require some extra test in order to test."
                 RenderListItem {LI} at (25,20) size 737x60 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (25,0) size 698x59
                     text run at (25,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
                     text run at (25,20) width 61: "checked. "

--- a/LayoutTests/platform/ios/css1/box_properties/padding_right-expected.txt
+++ b/LayoutTests/platform/ios/css1/box_properties/padding_right-expected.txt
@@ -53,12 +53,12 @@ layer at (0,0) size 800x1233
           text run at (80,40) width 508: "The text has been right-aligned in order to make the right padding easier to see."
       RenderBlock {UL} at (0,491) size 784x80 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 719x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (7,0) size 712x39
             text run at (7,0) width 712: "The right padding on this unordered list has been set to 25 pixels, which will require some extra text in order to"
             text run at (692,20) width 27: "test."
         RenderListItem {LI} at (40,40) size 719x40 [bgcolor=#FFFFFF]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (21,0) size 673x39
             text run at (21,0) width 673: "This list item has a right padding of 25 pixels, which will appear to the left of the gray padding of the UL"
             text run at (639,20) width 55: "element."
@@ -115,12 +115,12 @@ layer at (0,0) size 800x1233
                   text run at (489,60) width 83: "easier to see."
               RenderBlock {UL} at (4,364) size 762x80 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 697x40
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (1,0) size 696x39
                     text run at (1,0) width 696: "The right padding on this unordered list has been set to 25 pixels, which will require some extra text in order"
                     text run at (654,20) width 43: "to test."
                 RenderListItem {LI} at (40,40) size 697x40 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (24,0) size 648x39
                     text run at (24,0) width 648: "This list item has a right padding of 25 pixels, which will appear to the left of the gray padding of the"
                     text run at (592,20) width 80: "UL element."

--- a/LayoutTests/platform/ios/css1/cascade/cascade_order-expected.txt
+++ b/LayoutTests/platform/ios/css1/cascade/cascade_order-expected.txt
@@ -31,37 +31,37 @@ layer at (0,0) size 800x827
           text run at (0,140) width 0: " "
       RenderBlock {UL} at (0,221) size 784x160
         RenderListItem {LI} at (40,0) size 744x20 [color=#0000FF]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 194x19
             text run at (0,0) width 194: "This list item should be blue..."
         RenderListItem {LI} at (40,20) size 744x80 [color=#0000FF]
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 295x19
               text run at (0,0) width 295: "...and so should this; neither should be purple."
           RenderBlock {UL} at (0,20) size 744x60
             RenderListItem {LI} at (40,0) size 704x20 [color=#808080]
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 194x19
                 text run at (0,0) width 194: "This list item should be gray..."
             RenderListItem {LI} at (40,20) size 704x20 [color=#808080]
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 116x19
                 text run at (0,0) width 116: "...as should this...."
             RenderListItem {LI} at (40,40) size 704x20 [color=#008000]
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 196x19
                 text run at (0,0) width 196: "...but this one should be green."
         RenderListItem {LI} at (40,100) size 744x20 [color=#660000]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 174x19
             text run at (0,0) width 174: "This ought to be dark red..."
         RenderListItem {LI} at (40,120) size 744x20 [color=#008000]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 87x19
             text run at (0,0) width 87: "...this green..."
         RenderListItem {LI} at (40,140) size 744x20 [color=#0000FF]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 98x19
             text run at (0,0) width 98: "...and this blue."
       RenderBlock {P} at (0,397) size 784x20 [color=#0000FF]
@@ -92,37 +92,37 @@ layer at (0,0) size 800x827
             RenderTableCell {TD} at (12,28) size 705x276 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 697x160
                 RenderListItem {LI} at (40,0) size 657x20 [color=#0000FF]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 194x19
                     text run at (0,0) width 194: "This list item should be blue..."
                 RenderListItem {LI} at (40,20) size 657x80 [color=#0000FF]
                   RenderBlock (anonymous) at (0,0) size 657x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 295x19
                       text run at (0,0) width 295: "...and so should this; neither should be purple."
                   RenderBlock {UL} at (0,20) size 657x60
                     RenderListItem {LI} at (40,0) size 617x20 [color=#808080]
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 194x19
                         text run at (0,0) width 194: "This list item should be gray..."
                     RenderListItem {LI} at (40,20) size 617x20 [color=#808080]
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 116x19
                         text run at (0,0) width 116: "...as should this...."
                     RenderListItem {LI} at (40,40) size 617x20 [color=#008000]
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderText {#text} at (0,0) size 196x19
                         text run at (0,0) width 196: "...but this one should be green."
                 RenderListItem {LI} at (40,100) size 657x20 [color=#660000]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 174x19
                     text run at (0,0) width 174: "This ought to be dark red..."
                 RenderListItem {LI} at (40,120) size 657x20 [color=#008000]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 87x19
                     text run at (0,0) width 87: "...this green..."
                 RenderListItem {LI} at (40,140) size 657x20 [color=#0000FF]
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 98x19
                     text run at (0,0) width 98: "...and this blue."
               RenderBlock {P} at (4,180) size 697x20 [color=#0000FF]

--- a/LayoutTests/platform/ios/css1/classification/display-expected.txt
+++ b/LayoutTests/platform/ios/css1/classification/display-expected.txt
@@ -39,7 +39,7 @@ layer at (0,0) size 800x863
             text run at (403,40) width 112: " is being ignored."
         RenderText {#text} at (0,0) size 0x0
       RenderListItem {P} at (48,249) size 736x60
-        RenderListMarker at (-18,0) size 7x19: black square
+        RenderListMarker at (-15,0) size 7x19: black square
         RenderText {#text} at (0,0) size 733x39
           text run at (0,0) width 733: "This sentence should be treated as a list-item, and therefore be rendered however this user agent displays list items"
           text run at (0,20) width 20: "(if "
@@ -100,7 +100,7 @@ layer at (0,0) size 800x863
                     text run at (434,40) width 112: " is being ignored."
                 RenderText {#text} at (0,0) size 0x0
               RenderListItem {P} at (52,116) size 714x60
-                RenderListMarker at (-18,0) size 7x19: black square
+                RenderListMarker at (-15,0) size 7x19: black square
                 RenderText {#text} at (0,0) size 694x39
                   text run at (0,0) width 694: "This sentence should be treated as a list-item, and therefore be rendered however this user agent displays list"
                   text run at (0,20) width 58: "items (if "

--- a/LayoutTests/platform/ios/css1/classification/list_style_image-expected.txt
+++ b/LayoutTests/platform/ios/css1/classification/list_style_image-expected.txt
@@ -28,15 +28,15 @@ layer at (0,0) size 800x600
             text run at (0,0) width 150: "...images for each item."
       RenderBlock {UL} at (0,185) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 238x19
             text run at (0,0) width 238: "...standard list markers for each item."
       RenderTable {TABLE} at (0,261) size 300x190 [border: (1px outset #000000)]
@@ -66,15 +66,15 @@ layer at (0,0) size 800x600
                     text run at (0,0) width 150: "...images for each item."
               RenderBlock {UL} at (4,80) size 278x60
                 RenderListItem {LI} at (40,0) size 238x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 238x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 238x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 238x19
                     text run at (0,0) width 238: "...standard list markers for each item."
 layer at (8,99) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/ios/css1/classification/list_style_position-expected.txt
+++ b/LayoutTests/platform/ios/css1/classification/list_style_position-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
           text run at (0,28) width 0: " "
       RenderBlock {UL} at (0,109) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 743x39
             text run at (0,0) width 743: "The text in this item should behave as expected; that is, it should line up with itself on the left margin, leaving blank"
             text run at (0,20) width 158: "space beneath the bullet."
@@ -39,7 +39,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (12,28) size 770x120 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 762x40
                 RenderListItem {LI} at (40,0) size 722x40
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 704x39
                     text run at (0,0) width 704: "The text in this item should behave as expected; that is, it should line up with itself on the left margin, leaving"
                     text run at (0,20) width 197: "blank space beneath the bullet."

--- a/LayoutTests/platform/ios/css1/classification/list_style_type-expected.txt
+++ b/LayoutTests/platform/ios/css1/classification/list_style_type-expected.txt
@@ -29,106 +29,106 @@ layer at (0,0) size 800x1629
           text run at (0,126) width 0: " "
       RenderBlock {UL} at (0,207) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 137x19
             text run at (0,0) width 137: "...discs for each item."
       RenderBlock {UL} at (0,283) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: white bullet
+          RenderListMarker at (-15,0) size 7x19: white bullet
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: white bullet
+          RenderListMarker at (-15,0) size 7x19: white bullet
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: white bullet
+          RenderListMarker at (-15,0) size 7x19: white bullet
           RenderText {#text} at (0,0) size 147x19
             text run at (0,0) width 147: "...circles for each item."
       RenderBlock {UL} at (0,359) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: black square
+          RenderListMarker at (-15,0) size 7x19: black square
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: black square
+          RenderListMarker at (-15,0) size 7x19: black square
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: black square
+          RenderListMarker at (-15,0) size 7x19: black square
           RenderText {#text} at (0,0) size 153x19
             text run at (0,0) width 153: "...squares for each item."
       RenderBlock {OL} at (0,435) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 13x19: "i"
+          RenderListMarker at (-14,0) size 13x19: "i"
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-22,0) size 17x19: "ii"
+          RenderListMarker at (-18,0) size 17x19: "ii"
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-27,0) size 22x19: "iii"
+          RenderListMarker at (-23,0) size 22x19: "iii"
           RenderText {#text} at (0,0) size 282x19
             text run at (0,0) width 282: "...lowercase Roman numerals for each item."
       RenderBlock {OL} at (0,511) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-19,0) size 14x19: "I"
+          RenderListMarker at (-15,0) size 14x19: "I"
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "II"
+          RenderListMarker at (-20,0) size 19x19: "II"
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-29,0) size 24x19: "III"
+          RenderListMarker at (-25,0) size 24x19: "III"
           RenderText {#text} at (0,0) size 282x19
             text run at (0,0) width 282: "...uppercase Roman numerals for each item."
       RenderBlock {OL} at (0,587) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "a"
+          RenderListMarker at (-17,0) size 16x19: "a"
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "b"
+          RenderListMarker at (-17,0) size 16x19: "b"
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "c"
+          RenderListMarker at (-17,0) size 16x19: "c"
           RenderText {#text} at (0,0) size 212x19
             text run at (0,0) width 212: "...lowercase letters for each item."
       RenderBlock {OL} at (0,663) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-25,0) size 20x19: "A"
+          RenderListMarker at (-21,0) size 20x19: "A"
           RenderText {#text} at (0,0) size 65x19
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "B"
+          RenderListMarker at (-20,0) size 19x19: "B"
           RenderText {#text} at (0,0) size 116x19
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "C"
+          RenderListMarker at (-20,0) size 19x19: "C"
           RenderText {#text} at (0,0) size 212x19
             text run at (0,0) width 212: "...uppercase letters for each item."
       RenderBlock {OL} at (0,739) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-25,0) size 20x19: "A"
+          RenderListMarker at (-21,0) size 20x19: "A"
           RenderText {#text} at (0,0) size 160x19
             text run at (0,0) width 160: "This list should feature..."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "B"
+          RenderListMarker at (-20,0) size 19x19: "B"
           RenderText {#text} at (0,0) size 152x19
             text run at (0,0) width 152: "...letters for each item..."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 112x19
             text run at (0,0) width 112: "...except this one."
       RenderBlock {UL} at (0,815) size 784x60
@@ -155,106 +155,106 @@ layer at (0,0) size 800x1629
             RenderTableCell {TD} at (12,28) size 330x692 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 137x19
                     text run at (0,0) width 137: "...discs for each item."
               RenderBlock {UL} at (4,80) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: white bullet
+                  RenderListMarker at (-15,0) size 7x19: white bullet
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: white bullet
+                  RenderListMarker at (-15,0) size 7x19: white bullet
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: white bullet
+                  RenderListMarker at (-15,0) size 7x19: white bullet
                   RenderText {#text} at (0,0) size 147x19
                     text run at (0,0) width 147: "...circles for each item."
               RenderBlock {UL} at (4,156) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: black square
+                  RenderListMarker at (-15,0) size 7x19: black square
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: black square
+                  RenderListMarker at (-15,0) size 7x19: black square
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-18,0) size 7x19: black square
+                  RenderListMarker at (-15,0) size 7x19: black square
                   RenderText {#text} at (0,0) size 153x19
                     text run at (0,0) width 153: "...squares for each item."
               RenderBlock {OL} at (4,232) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-18,0) size 13x19: "i"
+                  RenderListMarker at (-14,0) size 13x19: "i"
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-22,0) size 17x19: "ii"
+                  RenderListMarker at (-18,0) size 17x19: "ii"
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-27,0) size 22x19: "iii"
+                  RenderListMarker at (-23,0) size 22x19: "iii"
                   RenderText {#text} at (0,0) size 282x19
                     text run at (0,0) width 282: "...lowercase Roman numerals for each item."
               RenderBlock {OL} at (4,308) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-19,0) size 14x19: "I"
+                  RenderListMarker at (-15,0) size 14x19: "I"
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-24,0) size 19x19: "II"
+                  RenderListMarker at (-20,0) size 19x19: "II"
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-29,0) size 24x19: "III"
+                  RenderListMarker at (-25,0) size 24x19: "III"
                   RenderText {#text} at (0,0) size 282x19
                     text run at (0,0) width 282: "...uppercase Roman numerals for each item."
               RenderBlock {OL} at (4,384) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-21,0) size 16x19: "a"
+                  RenderListMarker at (-17,0) size 16x19: "a"
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-21,0) size 16x19: "b"
+                  RenderListMarker at (-17,0) size 16x19: "b"
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-21,0) size 16x19: "c"
+                  RenderListMarker at (-17,0) size 16x19: "c"
                   RenderText {#text} at (0,0) size 212x19
                     text run at (0,0) width 212: "...lowercase letters for each item."
               RenderBlock {OL} at (4,460) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-25,0) size 20x19: "A"
+                  RenderListMarker at (-21,0) size 20x19: "A"
                   RenderText {#text} at (0,0) size 65x19
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-24,0) size 19x19: "B"
+                  RenderListMarker at (-20,0) size 19x19: "B"
                   RenderText {#text} at (0,0) size 116x19
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-24,0) size 19x19: "C"
+                  RenderListMarker at (-20,0) size 19x19: "C"
                   RenderText {#text} at (0,0) size 212x19
                     text run at (0,0) width 212: "...uppercase letters for each item."
               RenderBlock {OL} at (4,536) size 322x60
                 RenderListItem {LI} at (40,0) size 282x20
-                  RenderListMarker at (-25,0) size 20x19: "A"
+                  RenderListMarker at (-21,0) size 20x19: "A"
                   RenderText {#text} at (0,0) size 160x19
                     text run at (0,0) width 160: "This list should feature..."
                 RenderListItem {LI} at (40,20) size 282x20
-                  RenderListMarker at (-24,0) size 19x19: "B"
+                  RenderListMarker at (-20,0) size 19x19: "B"
                   RenderText {#text} at (0,0) size 152x19
                     text run at (0,0) width 152: "...letters for each item..."
                 RenderListItem {LI} at (40,40) size 282x20
-                  RenderListMarker at (-21,0) size 16x19: "3"
+                  RenderListMarker at (-17,0) size 16x19: "3"
                   RenderText {#text} at (0,0) size 112x19
                     text run at (0,0) width 112: "...except this one."
               RenderBlock {UL} at (4,612) size 322x60

--- a/LayoutTests/platform/ios/css1/conformance/forward_compatible_parsing-expected.txt
+++ b/LayoutTests/platform/ios/css1/conformance/forward_compatible_parsing-expected.txt
@@ -169,7 +169,7 @@ layer at (0,0) size 800x4213
           text run at (0,20) width 241: "standards (e.g., font names or URLs.)"
       RenderBlock {OL} at (0,1439) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 635x19
             text run at (0,0) width 635: "This ordered list item should be black, because the declaration has an invalid pseudo-class selector."
       RenderBlock {P} at (0,1475) size 784x40
@@ -178,7 +178,7 @@ layer at (0,0) size 800x4213
           text run at (0,20) width 114: "not the first child."
       RenderBlock {UL} at (0,1531) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 704x39
             text run at (0,0) width 704: "This unordered list item should be black, because, according to CSS1, the selector is invalid, and according to"
             text run at (0,20) width 232: "CSS2, the selector should not apply."
@@ -389,7 +389,7 @@ layer at (0,0) size 800x4213
                   text run at (0,20) width 278: "other standards (e.g., font names or URLs.)"
               RenderBlock {OL} at (4,620) size 762x20
                 RenderListItem {LI} at (40,0) size 722x20
-                  RenderListMarker at (-21,0) size 16x19: "1"
+                  RenderListMarker at (-17,0) size 16x19: "1"
                   RenderText {#text} at (0,0) size 635x19
                     text run at (0,0) width 635: "This ordered list item should be black, because the declaration has an invalid pseudo-class selector."
               RenderBlock {P} at (4,656) size 762x40
@@ -398,7 +398,7 @@ layer at (0,0) size 800x4213
                   text run at (0,20) width 129: "is not the first child."
               RenderBlock {UL} at (4,712) size 762x40
                 RenderListItem {LI} at (40,0) size 722x40
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 704x39
                     text run at (0,0) width 704: "This unordered list item should be black, because, according to CSS1, the selector is invalid, and according to"
                     text run at (0,20) width 232: "CSS2, the selector should not apply."

--- a/LayoutTests/platform/ios/css1/pseudo/anchor-expected.txt
+++ b/LayoutTests/platform/ios/css1/pseudo/anchor-expected.txt
@@ -25,36 +25,36 @@ layer at (0,0) size 800x725
       RenderBlock {UL} at (0,187) size 784x160
         RenderListItem {LI} at (40,0) size 744x120
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 583x19
               text run at (0,0) width 583: "Purple unvisited, lime (light green) visited, maroon (dark red) while active (being clicked):"
           RenderBlock {UL} at (0,20) size 744x100
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderInline {A} at (0,0) size 110x19 [color=#800080]
                 RenderText {#text} at (0,0) size 110x19
                   text run at (0,0) width 110: "W3C Web server"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,20) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderInline {A} at (0,0) size 112x19 [color=#800080]
                 RenderText {#text} at (0,0) size 112x19
                   text run at (0,0) width 112: "NIST Web server"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,40) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderInline {A} at (0,0) size 125x19 [color=#800080]
                 RenderText {#text} at (0,0) size 125x19
                   text run at (0,0) width 125: "CWRU Web server"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,60) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderInline {A} at (0,0) size 47x19 [color=#800080]
                 RenderText {#text} at (0,0) size 47x19
                   text run at (0,0) width 47: "Yahoo!"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,80) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderInline {A} at (0,0) size 58x19 [color=#800080]
                 RenderText {#text} at (0,0) size 58x19
                   text run at (0,0) width 58: "Erewhon"
@@ -62,12 +62,12 @@ layer at (0,0) size 800x725
                 text run at (57,0) width 225: " (don't click on it, it goes nowhere)"
         RenderListItem {LI} at (40,120) size 744x40
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 208x19
               text run at (0,0) width 208: "Dark green in any circumstance:"
           RenderBlock {UL} at (0,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderInline {A} at (0,0) size 125x19 [color=#006600]
                 RenderText {#text} at (0,0) size 125x19
                   text run at (0,0) width 125: "CWRU Web server"
@@ -101,36 +101,36 @@ layer at (0,0) size 800x725
               RenderBlock {UL} at (4,40) size 762x160
                 RenderListItem {LI} at (40,0) size 722x120
                   RenderBlock (anonymous) at (0,0) size 722x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 583x19
                       text run at (0,0) width 583: "Purple unvisited, lime (light green) visited, maroon (dark red) while active (being clicked):"
                   RenderBlock {UL} at (0,20) size 722x100
                     RenderListItem {LI} at (40,0) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderInline {A} at (0,0) size 110x19 [color=#800080]
                         RenderText {#text} at (0,0) size 110x19
                           text run at (0,0) width 110: "W3C Web server"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,20) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderInline {A} at (0,0) size 112x19 [color=#800080]
                         RenderText {#text} at (0,0) size 112x19
                           text run at (0,0) width 112: "NIST Web server"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,40) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderInline {A} at (0,0) size 125x19 [color=#800080]
                         RenderText {#text} at (0,0) size 125x19
                           text run at (0,0) width 125: "CWRU Web server"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,60) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderInline {A} at (0,0) size 47x19 [color=#800080]
                         RenderText {#text} at (0,0) size 47x19
                           text run at (0,0) width 47: "Yahoo!"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,80) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderInline {A} at (0,0) size 58x19 [color=#800080]
                         RenderText {#text} at (0,0) size 58x19
                           text run at (0,0) width 58: "Erewhon"
@@ -138,12 +138,12 @@ layer at (0,0) size 800x725
                         text run at (57,0) width 225: " (don't click on it, it goes nowhere)"
                 RenderListItem {LI} at (40,120) size 722x40
                   RenderBlock (anonymous) at (0,0) size 722x20
-                    RenderListMarker at (-18,0) size 7x19: bullet
+                    RenderListMarker at (-15,0) size 7x19: bullet
                     RenderText {#text} at (0,0) size 208x19
                       text run at (0,0) width 208: "Dark green in any circumstance:"
                   RenderBlock {UL} at (0,20) size 722x20
                     RenderListItem {LI} at (40,0) size 682x20
-                      RenderListMarker at (-18,0) size 7x19: white bullet
+                      RenderListMarker at (-15,0) size 7x19: white bullet
                       RenderInline {A} at (0,0) size 125x19 [color=#006600]
                         RenderText {#text} at (0,0) size 125x19
                           text run at (0,0) width 125: "CWRU Web server"

--- a/LayoutTests/platform/ios/css2.1/20110323/margin-applies-to-010-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/20110323/margin-applies-to-010-expected.txt
@@ -10,4 +10,4 @@ layer at (0,0) size 800x72
 layer at (8,72) size 340x340
   RenderBlock (positioned) {DIV} at (8,72) size 340x340 [border: (10px solid #0000FF)]
     RenderListItem {DIV} at (60,60) size 220x220 [border: (10px solid #FFA500)]
-      RenderListMarker at (-18,10) size 7x19: bullet
+      RenderListMarker at (-15,10) size 7x19: bullet

--- a/LayoutTests/platform/ios/css2.1/t0402-c71-fwd-parsing-02-f-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t0402-c71-fwd-parsing-02-f-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x592
           text run at (0,0) width 166: "This line should be green."
       RenderBlock {OL} at (0,144) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 166x19
             text run at (0,0) width 166: "This line should be green."
       RenderBlock {P} at (0,180) size 784x20
@@ -25,7 +25,7 @@ layer at (0,0) size 800x592
           text run at (0,0) width 166: "This line should be green."
       RenderBlock {UL} at (0,216) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 166x19
             text run at (0,0) width 166: "This line should be green."
       RenderBlock {BLOCKQUOTE} at (40,252) size 704x20

--- a/LayoutTests/platform/ios/css2.1/t0505-c16-descendant-01-e-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t0505-c16-descendant-01-e-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x88
             text run at (0,0) width 166: "This line should be green."
       RenderBlock {UL} at (0,36) size 784x20 [color=#008000]
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {SPAN} at (0,0) size 0x19 [color=#FF0000]
             RenderText {#text} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 166x19

--- a/LayoutTests/platform/ios/css2.1/t050803-c14-classes-00-e-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t050803-c14-classes-00-e-expected.txt
@@ -23,6 +23,6 @@ layer at (0,0) size 800x226
       RenderBlock {DIV} at (0,174) size 784x20 [color=#008000]
         RenderBlock {UL} at (0,0) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 197x19
               text run at (0,0) width 197: "This sentence should be green."

--- a/LayoutTests/platform/ios/css2.1/t0509-c15-ids-01-e-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t0509-c15-ids-01-e-expected.txt
@@ -13,6 +13,6 @@ layer at (0,0) size 800x118
           text run at (0,0) width 219: " This line should be green. "
       RenderBlock {UL} at (0,66) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 166x19
             text run at (0,0) width 166: "This line should be green."

--- a/LayoutTests/platform/ios/css2.1/t0805-c5518-brdr-t-01-e-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t0805-c5518-brdr-t-01-e-expected.txt
@@ -35,27 +35,27 @@ layer at (0,0) size 800x347
       RenderBlock {UL} at (0,174) size 784x141
         RenderListItem {LI} at (40,0) size 744x87 [border: (2px solid #0000FF) none]
           RenderBlock (anonymous) at (0,2) size 744x25
-            RenderListMarker at (-18,4) size 7x19: bullet
+            RenderListMarker at (-15,4) size 7x19: bullet
             RenderText {#text} at (0,4) size 62x19
               text run at (0,4) width 62: "HERE \x{21E7}"
           RenderBlock {UL} at (0,27) size 744x60
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 77x19
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,20) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 77x19
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,40) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 77x19
                 text run at (0,0) width 77: "dummy text"
         RenderListItem {LI} at (40,87) size 744x27 [border: (2px solid #0000FF) none]
-          RenderListMarker at (-18,6) size 7x19: bullet
+          RenderListMarker at (-15,6) size 7x19: bullet
           RenderText {#text} at (0,6) size 62x19
             text run at (0,6) width 62: "HERE \x{21E7}"
         RenderListItem {LI} at (40,114) size 744x27 [border: (2px solid #0000FF) none]
-          RenderListMarker at (-18,6) size 7x19: bullet
+          RenderListMarker at (-15,6) size 7x19: bullet
           RenderText {#text} at (0,6) size 62x19
             text run at (0,6) width 62: "HERE \x{21E7}"

--- a/LayoutTests/platform/ios/css2.1/t0805-c5519-brdr-r-02-e-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t0805-c5519-brdr-r-02-e-expected.txt
@@ -10,28 +10,28 @@ layer at (0,0) size 800x368
       RenderBlock {UL} at (0,36) size 588x300
         RenderListItem {LI} at (40,0) size 548x80 [border: none (3px solid #FFA500) none]
           RenderBlock (anonymous) at (0,0) size 545x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 107x19
               text run at (0,0) width 107: "Orange orange..."
           RenderBlock {UL} at (0,20) size 409x60
             RenderListItem {LI} at (40,0) size 369x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 116x19
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,20) size 369x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 116x19
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,40) size 369x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 108x19
                 text run at (0,0) width 108: "...orange orange."
         RenderListItem {LI} at (40,80) size 548x20 [border: none (3px solid #00FF00) none]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 38x19
             text run at (0,0) width 38: "Lime."
         RenderListItem {LI} at (40,100) size 548x200 [border: none (3px solid #FFFF00) none]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 521x199
             text run at (0,0) width 335: "Yellow yellow yellow yellow yellow yellow yellow "
             text run at (334,0) width 187: "yellow yellow yellow yellow"

--- a/LayoutTests/platform/ios/css2.1/t0805-c5520-brdr-b-01-e-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t0805-c5520-brdr-b-01-e-expected.txt
@@ -36,26 +36,26 @@ layer at (0,0) size 800x347
         RenderListItem {LI} at (40,0) size 744x87 [border: none (2px solid #0000FF) none]
           RenderBlock {UL} at (0,0) size 744x60
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
-              RenderListMarker at (-58,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
+              RenderListMarker at (-55,0) size 7x19: bullet
               RenderText {#text} at (0,0) size 77x19
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,20) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 77x19
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,40) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 77x19
                 text run at (0,0) width 77: "dummy text"
           RenderBlock (anonymous) at (0,60) size 744x25
             RenderText {#text} at (0,4) size 62x19
               text run at (0,4) width 62: "HERE \x{21E9}"
         RenderListItem {LI} at (40,87) size 744x27 [border: none (2px solid #0000FF) none]
-          RenderListMarker at (-18,4) size 7x19: bullet
+          RenderListMarker at (-15,4) size 7x19: bullet
           RenderText {#text} at (0,4) size 62x19
             text run at (0,4) width 62: "HERE \x{21E9}"
         RenderListItem {LI} at (40,114) size 744x27 [border: none (2px solid #0000FF) none]
-          RenderListMarker at (-18,4) size 7x19: bullet
+          RenderListMarker at (-15,4) size 7x19: bullet
           RenderText {#text} at (0,4) size 62x19
             text run at (0,4) width 62: "HERE \x{21E9}"

--- a/LayoutTests/platform/ios/css2.1/t0805-c5521-brdr-l-02-e-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t0805-c5521-brdr-l-02-e-expected.txt
@@ -10,28 +10,28 @@ layer at (0,0) size 800x308
       RenderBlock {UL} at (0,36) size 784x240
         RenderListItem {LI} at (40,0) size 744x80 [border: none (3px solid #FFA500)]
           RenderBlock (anonymous) at (3,0) size 741x20
-            RenderListMarker at (-21,0) size 7x19: bullet
+            RenderListMarker at (-18,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 107x19
               text run at (0,0) width 107: "Orange orange..."
           RenderBlock {UL} at (3,20) size 741x60
             RenderListItem {LI} at (40,0) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 116x19
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,20) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 116x19
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,40) size 701x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 108x19
                 text run at (0,0) width 108: "...orange orange."
         RenderListItem {LI} at (40,80) size 744x20 [border: none (3px solid #00FF00)]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (3,0) size 38x19
             text run at (3,0) width 38: "Lime."
         RenderListItem {LI} at (40,100) size 744x140 [border: none (3px solid #FFFF00)]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (3,0) size 713x139
             text run at (3,0) width 335: "Yellow yellow yellow yellow yellow yellow yellow "
             text run at (337,0) width 378: "yellow yellow yellow yellow yellow yellow yellow yellow"

--- a/LayoutTests/platform/ios/css2.1/t1205-c563-list-type-00-b-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t1205-c563-list-type-00-b-expected.txt
@@ -8,41 +8,41 @@ layer at (0,0) size 800x356
           text run at (0,0) width 466: "Each bullet should look as described, and there should be no red present."
       RenderBlock {UL} at (0,36) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 26x19
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 26x19
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 26x19
             text run at (0,0) width 26: "disc"
       RenderBlock {UL} at (0,112) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: white bullet
+          RenderListMarker at (-15,0) size 7x19: white bullet
           RenderText {#text} at (0,0) size 36x19
             text run at (0,0) width 36: "circle"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: white bullet
+          RenderListMarker at (-15,0) size 7x19: white bullet
           RenderText {#text} at (0,0) size 36x19
             text run at (0,0) width 36: "circle"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: white bullet
+          RenderListMarker at (-15,0) size 7x19: white bullet
           RenderText {#text} at (0,0) size 36x19
             text run at (0,0) width 36: "circle"
       RenderBlock {UL} at (0,188) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: black square
+          RenderListMarker at (-15,0) size 7x19: black square
           RenderText {#text} at (0,0) size 42x19
             text run at (0,0) width 42: "square"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: black square
+          RenderListMarker at (-15,0) size 7x19: black square
           RenderText {#text} at (0,0) size 42x19
             text run at (0,0) width 42: "square"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: black square
+          RenderListMarker at (-15,0) size 7x19: black square
           RenderText {#text} at (0,0) size 42x19
             text run at (0,0) width 42: "square"
       RenderBlock {UL} at (0,264) size 784x60 [color=#FF0000]

--- a/LayoutTests/platform/ios/css2.1/t1205-c563-list-type-01-b-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t1205-c563-list-type-01-b-expected.txt
@@ -8,66 +8,66 @@ layer at (0,0) size 800x432
           text run at (0,0) width 396: "The two columns should look the same, except for alignment."
       RenderBlock {OL} at (0,36) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 13x19: "i"
+          RenderListMarker at (-14,0) size 13x19: "i"
           RenderText {#text} at (0,0) size 9x19
             text run at (0,0) width 9: "i."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-22,0) size 17x19: "ii"
+          RenderListMarker at (-18,0) size 17x19: "ii"
           RenderText {#text} at (0,0) size 13x19
             text run at (0,0) width 13: "ii."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-27,0) size 22x19: "iii"
+          RenderListMarker at (-23,0) size 22x19: "iii"
           RenderText {#text} at (0,0) size 18x19
             text run at (0,0) width 18: "iii."
       RenderBlock {OL} at (0,112) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-19,0) size 14x19: "I"
+          RenderListMarker at (-15,0) size 14x19: "I"
           RenderText {#text} at (0,0) size 10x19
             text run at (0,0) width 10: "I."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "II"
+          RenderListMarker at (-20,0) size 19x19: "II"
           RenderText {#text} at (0,0) size 15x19
             text run at (0,0) width 15: "II."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-29,0) size 24x19: "III"
+          RenderListMarker at (-25,0) size 24x19: "III"
           RenderText {#text} at (0,0) size 20x19
             text run at (0,0) width 20: "III."
       RenderBlock {OL} at (0,188) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "a"
+          RenderListMarker at (-17,0) size 16x19: "a"
           RenderText {#text} at (0,0) size 12x19
             text run at (0,0) width 12: "a."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "b"
+          RenderListMarker at (-17,0) size 16x19: "b"
           RenderText {#text} at (0,0) size 12x19
             text run at (0,0) width 12: "b."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "c"
+          RenderListMarker at (-17,0) size 16x19: "c"
           RenderText {#text} at (0,0) size 12x19
             text run at (0,0) width 12: "c."
       RenderBlock {OL} at (0,264) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-25,0) size 20x19: "A"
+          RenderListMarker at (-21,0) size 20x19: "A"
           RenderText {#text} at (0,0) size 16x19
             text run at (0,0) width 16: "A."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "B"
+          RenderListMarker at (-20,0) size 19x19: "B"
           RenderText {#text} at (0,0) size 15x19
             text run at (0,0) width 15: "B."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "C"
+          RenderListMarker at (-20,0) size 19x19: "C"
           RenderText {#text} at (0,0) size 15x19
             text run at (0,0) width 15: "C."
       RenderBlock {OL} at (0,340) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-25,0) size 20x19: "A"
+          RenderListMarker at (-21,0) size 20x19: "A"
           RenderText {#text} at (0,0) size 16x19
             text run at (0,0) width 16: "A."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-24,0) size 19x19: "B"
+          RenderListMarker at (-20,0) size 19x19: "B"
           RenderText {#text} at (0,0) size 15x19
             text run at (0,0) width 15: "B."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 12x19
             text run at (0,0) width 12: "3."

--- a/LayoutTests/platform/ios/css2.1/t1205-c564-list-img-00-b-g-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t1205-c564-list-img-00-b-g-expected.txt
@@ -21,14 +21,14 @@ layer at (0,0) size 800x210
             text run at (0,2) width 87: "purple square"
       RenderBlock {UL} at (0,118) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 26x19
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 26x19
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 26x19
             text run at (0,0) width 26: "disc"

--- a/LayoutTests/platform/ios/css2.1/t1205-c565-list-pos-00-b-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t1205-c565-list-pos-00-b-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x102
           text run at (0,0) width 370: "The following two boxes should be identical, to the pixel."
       RenderBlock {OL} at (80,36) size 160x20 [color=#FFFFFF] [bgcolor=#000080]
         RenderListItem {LI} at (0,0) size 160x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderInline {SPAN} at (0,0) size 12x19 [color=#000080]
             RenderText {#text} at (0,0) size 12x19
               text run at (0,0) width 12: "1."

--- a/LayoutTests/platform/ios/css3/blending/blend-mode-overflow-expected.txt
+++ b/LayoutTests/platform/ios/css3/blending/blend-mode-overflow-expected.txt
@@ -6,29 +6,29 @@ layer at (0,0) size 800x594 isolatesBlending
       RenderBlock {UL} at (0,0) size 784x562
         RenderBlock {OL} at (40,0) size 744x160
           RenderListItem {LI} at (40,0) size 704x20
-            RenderListMarker at (-21,0) size 16x19: "1"
+            RenderListMarker at (-17,0) size 16x19: "1"
             RenderText {#text} at (0,0) size 319x19
               text run at (0,0) width 319: "No blending. Duck should be yellow everywhere."
           RenderListItem {LI} at (40,20) size 704x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 540x19
               text run at (0,0) width 540: "Simple blending. Duck should be a horizontal rainbow inside, and blue on overflow."
           RenderListItem {LI} at (40,40) size 704x40
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 701x39
               text run at (0,0) width 701: "Parent is a stacking context. Duck should be a horizontal rainbow inside, and yellow on overflow (since there"
               text run at (0,20) width 244: "is no background there to blend with)."
           RenderListItem {LI} at (40,80) size 704x20
-            RenderListMarker at (-21,0) size 16x19: "4"
+            RenderListMarker at (-17,0) size 16x19: "4"
             RenderText {#text} at (0,0) size 681x19
               text run at (0,0) width 681: "Intermediate parent - no stacking context. Duck should be a vertical gradient inside, and blue on overflow."
           RenderListItem {LI} at (40,100) size 704x40
-            RenderListMarker at (-21,0) size 16x19: "5"
+            RenderListMarker at (-17,0) size 16x19: "5"
             RenderText {#text} at (0,0) size 695x39
               text run at (0,0) width 695: "Intermediate parent with grandparent stacking context. Duck should be a vertical gradient inside, and yellow"
               text run at (0,20) width 81: "on overflow."
           RenderListItem {LI} at (40,140) size 704x20
-            RenderListMarker at (-21,0) size 16x19: "6"
+            RenderListMarker at (-17,0) size 16x19: "6"
             RenderText {#text} at (0,0) size 641x19
               text run at (0,0) width 641: "Intermediate parent has overflow. Duck should be a vertical gradient inside, and overflow is hidden."
         RenderBlock (anonymous) at (40,192) size 744x370

--- a/LayoutTests/platform/ios/editing/deleting/delete-first-list-item-expected.txt
+++ b/LayoutTests/platform/ios/editing/deleting/delete-first-list-item-expected.txt
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
               text run at (0,0) width 22: "foo"
         RenderBlock {UL} at (0,36) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 21x19
               text run at (0,0) width 21: "bar"
 caret: position 3 of child 0 {#text} of child 0 {B} of child 0 {DIV} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/deleting/delete-listitem-002-expected.txt
+++ b/LayoutTests/platform/ios/editing/deleting/delete-listitem-002-expected.txt
@@ -37,22 +37,22 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x226 [border: (2px solid #FF0000)]
         RenderBlock {UL} at (14,38) size 756x150
           RenderListItem {LI} at (40,0) size 716x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderText {#text} at (0,1) size 35x28
               text run at (0,1) width 35: "one"
           RenderListItem {LI} at (40,30) size 716x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderText {#text} at (0,1) size 36x28
               text run at (0,1) width 36: "two"
           RenderListItem {LI} at (40,60) size 716x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderBR {BR} at (0,1) size 0x28
           RenderListItem {LI} at (40,90) size 716x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderText {#text} at (0,1) size 40x28
               text run at (0,1) width 40: "four"
           RenderListItem {LI} at (40,120) size 716x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderText {#text} at (0,1) size 38x28
               text run at (0,1) width 38: "five"
 caret: position 0 of child 0 {BR} of child 5 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/LayoutTests/platform/ios/editing/deleting/list-item-1-expected.txt
+++ b/LayoutTests/platform/ios/editing/deleting/list-item-1-expected.txt
@@ -22,9 +22,9 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,36) size 784x40
         RenderBlock {UL} at (0,0) size 784x40
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderBR {BR} at (0,0) size 0x19
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderBR {BR} at (0,0) size 0x19
 caret: position 0 of child 0 {BR} of child 0 {LI} of child 0 {UL} of child 3 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/4580583-1-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/4580583-1-expected.txt
@@ -12,11 +12,11 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,0) size 742x40 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x40
             RenderListItem {LI} at (40,0) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "1"
+              RenderListMarker at (-17,0) size 16x19: "1"
               RenderText {#text} at (0,0) size 27x19
                 text run at (0,0) width 27: "One"
             RenderListItem {LI} at (40,20) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "2"
+              RenderListMarker at (-17,0) size 16x19: "2"
               RenderText {#text} at (0,0) size 29x19
                 text run at (0,0) width 29: "Two"
         RenderBlock (anonymous) at (0,56) size 784x20
@@ -24,11 +24,11 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,92) size 742x40 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x40
             RenderListItem {LI} at (40,0) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "3"
+              RenderListMarker at (-17,0) size 16x19: "3"
               RenderText {#text} at (0,0) size 38x19
                 text run at (0,0) width 38: "Three"
             RenderListItem {LI} at (40,20) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "4"
+              RenderListMarker at (-17,0) size 16x19: "4"
               RenderText {#text} at (0,0) size 31x19
                 text run at (0,0) width 31: "Four"
 caret: position 0 of child 2 {BR} of child 3 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/4580583-2-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/4580583-2-expected.txt
@@ -12,11 +12,11 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,0) size 742x40 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x40
             RenderListItem {LI} at (40,0) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "1"
+              RenderListMarker at (-17,0) size 16x19: "1"
               RenderText {#text} at (0,0) size 27x19
                 text run at (0,0) width 27: "One"
             RenderListItem {LI} at (40,20) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "2"
+              RenderListMarker at (-17,0) size 16x19: "2"
               RenderText {#text} at (0,0) size 29x19
                 text run at (0,0) width 29: "Two"
         RenderBlock (anonymous) at (0,56) size 784x20
@@ -24,15 +24,15 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,92) size 742x60 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x60
             RenderListItem {LI} at (40,0) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "2"
+              RenderListMarker at (-17,0) size 16x19: "2"
               RenderText {#text} at (0,0) size 29x19
                 text run at (0,0) width 29: "Two"
             RenderListItem {LI} at (40,20) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "3"
+              RenderListMarker at (-17,0) size 16x19: "3"
               RenderText {#text} at (0,0) size 38x19
                 text run at (0,0) width 38: "Three"
             RenderListItem {LI} at (40,40) size 700x20
-              RenderListMarker at (-21,0) size 16x19: "4"
+              RenderListMarker at (-17,0) size 16x19: "4"
               RenderText {#text} at (0,0) size 31x19
                 text run at (0,0) width 31: "Four"
 caret: position 0 of child 2 {BR} of child 3 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/4641880-1-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/4641880-1-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,56) size 784x56
         RenderBlock {UL} at (0,0) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 218x19
               text run at (0,0) width 218: "This paragraph should be in a list."
         RenderBlock (anonymous) at (0,36) size 784x20

--- a/LayoutTests/platform/ios/editing/execCommand/4747450-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/4747450-expected.txt
@@ -20,6 +20,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,36) size 784x20
           RenderBlock {UL} at (0,0) size 784x20
             RenderListItem {LI} at (40,0) size 744x20
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
               RenderBR {BR} at (0,0) size 0x19
 caret: position 0 of child 0 {BR} of child 0 {LI} of child 0 {UL} of child 1 {DIV} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/4916402-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/4916402-expected.txt
@@ -10,12 +10,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,56) size 784x56
         RenderBlock {UL} at (0,0) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 22x19
               text run at (0,0) width 22: "foo"
         RenderBlock {OL} at (0,36) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "1"
+            RenderListMarker at (-17,0) size 16x19: "1"
             RenderText {#text} at (0,0) size 21x19
               text run at (0,0) width 21: "bar"
 caret: position 0 of child 0 {#text} of child 0 {LI} of child 1 {OL} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/4924441-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/4924441-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
         RenderBlock {UL} at (0,0) size 784x20
           RenderBlock {OL} at (40,0) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-21,0) size 16x19: "1"
+              RenderListMarker at (-17,0) size 16x19: "1"
               RenderText {#text} at (0,0) size 22x19
                 text run at (0,0) width 22: "foo"
 caret: position 3 of child 0 {#text} of child 0 {LI} of child 0 {OL} of child 0 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/5136770-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/5136770-expected.txt
@@ -13,13 +13,13 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,36) size 784x60
           RenderBlock {UL} at (0,0) size 784x60
             RenderListItem {LI} at (40,0) size 744x20
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
               RenderBR {BR} at (0,0) size 0x19
             RenderListItem {LI} at (40,20) size 744x20
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
               RenderBR {BR} at (0,0) size 0x19
             RenderListItem {LI} at (40,40) size 744x20
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
               RenderText {#text} at (0,0) size 243x19
                 text run at (0,0) width 243: "This should be an unordered list item."
 selection start: position 0 of child 0 {BR} of child 0 {LI} of child 0 {UL} of child 3 {DIV} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/5142012-2-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/5142012-2-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 721x39 [color=#0000EE]
             RenderText {#text} at (0,0) size 721x39
               text run at (0,0) width 345: "This tests for a crash when creating a list from a link. "

--- a/LayoutTests/platform/ios/editing/execCommand/5190926-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/5190926-expected.txt
@@ -5,17 +5,17 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {OL} at (0,0) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderInline {U} at (0,0) size 508x19
             RenderText {#text} at (0,0) size 508x19
               text run at (0,0) width 508: "This tests for a crash when making and removing lists from underlined content."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderInline {U} at (0,0) size 280x19
             RenderText {#text} at (0,0) size 280x19
               text run at (0,0) width 280: "All three paragraphs should be in list items."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderInline {U} at (0,0) size 226x19
             RenderText {#text} at (0,0) size 226x19
               text run at (0,0) width 226: "And all three should be underlined."

--- a/LayoutTests/platform/ios/editing/execCommand/5569741-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/5569741-expected.txt
@@ -9,12 +9,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,36) size 784x60
         RenderBlock {UL} at (0,0) size 784x60
           RenderListItem {LI} at (40,0) size 744x40
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 22x19
               text run at (0,0) width 22: "foo"
             RenderBR {BR} at (21,0) size 1x19
             RenderBR {BR} at (0,20) size 0x19
           RenderListItem {LI} at (40,40) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderBR {BR} at (0,0) size 0x19
 caret: position 0 of child 0 {BR} of child 1 {LI} of child 1 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/create-list-with-hr-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/create-list-with-hr-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
         RenderBlock {UL} at (0,0) size 784x30
           RenderListItem {LI} at (40,0) size 744x30
             RenderBlock (anonymous) at (0,10) size 744x20
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
 layer at (48,64) size 744x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 744x2 [color=#808080] [border: (1px inset #808080)]
 caret: position 0 of child 0 {HR} of child 0 {LI} of child 0 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/indent-list-item-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/indent-list-item-expected.txt
@@ -17,16 +17,16 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,56) size 784x60
         RenderBlock {UL} at (0,0) size 784x60
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 25x19
               text run at (0,0) width 25: "Foo"
           RenderBlock {UL} at (40,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 24x19
                 text run at (0,0) width 24: "Bar"
           RenderListItem {LI} at (40,40) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 25x19
               text run at (0,0) width 25: "Baz"
 caret: position 0 of child 0 {#text} of child 0 {LI} of child 3 {UL} of child 1 {UL} of child 4 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/indent-selection-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/indent-selection-expected.txt
@@ -31,15 +31,15 @@ layer at (0,0) size 800x600
           RenderBlock {UL} at (0,0) size 744x60
             RenderBlock {UL} at (40,0) size 704x60
               RenderListItem {LI} at (40,0) size 664x20
-                RenderListMarker at (-18,0) size 7x19: white bullet
+                RenderListMarker at (-15,0) size 7x19: white bullet
                 RenderText {#text} at (0,0) size 25x19
                   text run at (0,0) width 25: "Foo"
               RenderListItem {LI} at (40,20) size 664x20
-                RenderListMarker at (-18,0) size 7x19: white bullet
+                RenderListMarker at (-15,0) size 7x19: white bullet
                 RenderText {#text} at (0,0) size 24x19
                   text run at (0,0) width 24: "Bar"
               RenderListItem {LI} at (40,40) size 664x20
-                RenderListMarker at (-18,0) size 7x19: white bullet
+                RenderListMarker at (-15,0) size 7x19: white bullet
                 RenderText {#text} at (0,0) size 25x19
                   text run at (0,0) width 25: "Baz"
         RenderBlock {BLOCKQUOTE} at (40,152) size 744x60

--- a/LayoutTests/platform/ios/editing/execCommand/insert-list-and-stitch-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/insert-list-and-stitch-expected.txt
@@ -24,15 +24,15 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 784x60
           RenderBlock {OL} at (0,0) size 784x60
             RenderListItem {LI} at (40,0) size 744x20
-              RenderListMarker at (-21,0) size 16x19: "1"
+              RenderListMarker at (-17,0) size 16x19: "1"
               RenderText {#text} at (0,0) size 22x19
                 text run at (0,0) width 22: "foo"
             RenderListItem {LI} at (40,20) size 744x20
-              RenderListMarker at (-21,0) size 16x19: "2"
+              RenderListMarker at (-17,0) size 16x19: "2"
               RenderText {#text} at (0,0) size 21x19
                 text run at (0,0) width 21: "bar"
             RenderListItem {LI} at (40,40) size 744x20
-              RenderListMarker at (-21,0) size 16x19: "3"
+              RenderListMarker at (-17,0) size 16x19: "3"
               RenderText {#text} at (0,0) size 23x19
                 text run at (0,0) width 23: "baz"
 caret: position 0 of child 0 {#text} of child 2 {LI} of child 0 {OL} of child 1 {DIV} of child 1 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/remove-list-from-range-selection-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/remove-list-from-range-selection-expected.txt
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
           RenderBR {BR} at (51,60) size 1x19
         RenderBlock {OL} at (0,96) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "1"
+            RenderListMarker at (-17,0) size 16x19: "1"
             RenderText {#text} at (0,0) size 323x19
               text run at (0,0) width 323: "This should be in a list and should not be selected."
 selection start: position 2 of child 0 {#text} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/execCommand/remove-list-item-1-expected.txt
+++ b/LayoutTests/platform/ios/editing/execCommand/remove-list-item-1-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,36) size 784x20
         RenderBlock {UL} at (0,0) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 22x19
               text run at (0,0) width 22: "foo"
 caret: position 0 of child 0 {#text} of child 0 {LI} of child 0 {UL} of child 3 {DIV} of body

--- a/LayoutTests/platform/ios/editing/inserting/4875189-1-expected.txt
+++ b/LayoutTests/platform/ios/editing/inserting/4875189-1-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,36) size 784x20
         RenderBlock {UL} at (0,0) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 182x19
               text run at (0,0) width 182: "This should be in a list item."
 caret: position 30 of child 0 {#text} of child 0 {LI} of child 0 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/inserting/4959067-expected.txt
+++ b/LayoutTests/platform/ios/editing/inserting/4959067-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,36) size 784x20
         RenderBlock {UL} at (0,0) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderInline {A} at (0,0) size 22x19 [color=#0000EE]
               RenderText {#text} at (0,0) size 22x19
                 text run at (0,0) width 22: "foo"

--- a/LayoutTests/platform/ios/editing/pasteboard/innerText-inline-table-expected.txt
+++ b/LayoutTests/platform/ios/editing/pasteboard/innerText-inline-table-expected.txt
@@ -31,6 +31,6 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,92) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
           RenderBlock {PRE} at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,5) size 63x14
               text run at (0,5) width 63: "Success!"

--- a/LayoutTests/platform/ios/editing/pasteboard/input-field-1-expected.txt
+++ b/LayoutTests/platform/ios/editing/pasteboard/input-field-1-expected.txt
@@ -17,18 +17,18 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 241x19
           text run at (0,0) width 241: "This tests Copy/Paste of a input field."
-      RenderBlock {DIV} at (0,36) size 784x21
-        RenderTextControl {INPUT} at (0,1) size 154x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-        RenderText {#text} at (153,0) size 5x19
-          text run at (153,0) width 5: " "
-        RenderTextControl {INPUT} at (157,1) size 155x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-      RenderBlock {UL} at (0,73) size 784x20
+      RenderBlock {DIV} at (0,36) size 784x23
+        RenderTextControl {INPUT} at (0,1) size 155x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+        RenderText {#text} at (154,0) size 5x19
+          text run at (154,0) width 5: " "
+        RenderTextControl {INPUT} at (158,1) size 156x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+      RenderBlock {UL} at (0,74) size 784x21
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 44x19
             text run at (0,0) width 44: "Passed"
-layer at (14,48) size 142x14
-  RenderBlock {DIV} at (6,3) size 142x14
-layer at (172,48) size 142x14
-  RenderBlock {DIV} at (6,3) size 142x14
+layer at (15,48) size 141x14
+  RenderBlock {DIV} at (6,3) size 143x15
+layer at (173,48) size 141x14
+  RenderBlock {DIV} at (6,3) size 143x15
 caret: position 1 of child 2 {INPUT} of child 2 {DIV} of body

--- a/LayoutTests/platform/ios/editing/pasteboard/merge-start-list-expected.txt
+++ b/LayoutTests/platform/ios/editing/pasteboard/merge-start-list-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,72) size 784x20
         RenderBlock {UL} at (0,0) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 21x19
               text run at (0,0) width 21: "bar"
 caret: position 3 of child 0 {#text} of child 0 {LI} of child 0 {UL} of child 4 {DIV} of body

--- a/LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 148x174 [border: (2px solid #FF0000)]
         RenderBlock {UL} at (14,14) size 120x146
           RenderListItem {LI} at (0,0) size 120x22
-            RenderListMarker at (-15,5) size 6x14: bullet
+            RenderListMarker at (-13,5) size 6x14: bullet
             RenderInline (generated) at (5,-5) size 15x26
               RenderText at (5,-5) size 15x26
                 text run at (5,-5) width 15: "\x{B7} "
@@ -24,7 +24,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,5) size 53x14
                 text run at (19,5) width 53: "Appetizers"
           RenderListItem {LI} at (0,22) size 120x22
-            RenderListMarker at (-15,5) size 6x14: bullet
+            RenderListMarker at (-13,5) size 6x14: bullet
             RenderInline (generated) at (5,-5) size 15x26
               RenderText at (5,-5) size 15x26
                 text run at (5,-5) width 15: "\x{B7} "
@@ -33,7 +33,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,5) size 79x14
                 text run at (19,5) width 79: "Soups & Salads"
           RenderListItem {LI} at (0,44) size 120x36
-            RenderListMarker at (-15,5) size 6x14: bullet
+            RenderListMarker at (-13,5) size 6x14: bullet
             RenderInline (generated) at (5,-5) size 15x26
               RenderText at (5,-5) size 15x26
                 text run at (5,-5) width 15: "\x{B7} "
@@ -43,7 +43,7 @@ layer at (0,0) size 800x600
                 text run at (19,5) width 74: "Sandwiches & "
                 text run at (16,19) width 40: "Burgers"
           RenderListItem {LI} at (0,80) size 120x22
-            RenderListMarker at (-15,5) size 6x14: bullet
+            RenderListMarker at (-13,5) size 6x14: bullet
             RenderInline (generated) at (5,-5) size 15x26
               RenderText at (5,-5) size 15x26
                 text run at (5,-5) width 15: "\x{B7} "
@@ -52,7 +52,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,5) size 65x14
                 text run at (19,5) width 65: "Steak & Ribs"
           RenderListItem {LI} at (0,102) size 120x22
-            RenderListMarker at (-15,5) size 6x14: bullet
+            RenderListMarker at (-13,5) size 6x14: bullet
             RenderInline (generated) at (5,-5) size 15x26
               RenderText at (5,-5) size 15x26
                 text run at (5,-5) width 15: "\x{B7} "
@@ -61,7 +61,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,5) size 41x14
                 text run at (19,5) width 41: "Seafood"
           RenderListItem {LI} at (0,124) size 120x22
-            RenderListMarker at (-15,5) size 6x14: bullet
+            RenderListMarker at (-13,5) size 6x14: bullet
             RenderInline (generated) at (5,-5) size 15x26
               RenderText at (5,-5) size 15x26
                 text run at (5,-5) width 15: "\x{B7} "

--- a/LayoutTests/platform/ios/editing/selection/move-by-line-002-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/move-by-line-002-expected.txt
@@ -12,22 +12,22 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (14,38) size 756x150
           RenderBlock {OL} at (0,0) size 756x150
             RenderListItem {LI} at (40,0) size 716x30
-              RenderListMarker at (-31,1) size 24x28: "1"
+              RenderListMarker at (-26,1) size 24x28: "1"
               RenderText {#text} at (0,1) size 35x28
                 text run at (0,1) width 35: "one"
             RenderListItem {LI} at (40,30) size 716x30
-              RenderListMarker at (-31,1) size 24x28: "2"
+              RenderListMarker at (-26,1) size 24x28: "2"
               RenderText {#text} at (0,1) size 36x28
                 text run at (0,1) width 36: "two"
             RenderListItem {LI} at (40,60) size 716x30
-              RenderListMarker at (-31,1) size 24x28: "3"
+              RenderListMarker at (-26,1) size 24x28: "3"
               RenderBR {BR} at (0,1) size 0x28
             RenderListItem {LI} at (40,90) size 716x30
-              RenderListMarker at (-31,1) size 24x28: "4"
+              RenderListMarker at (-26,1) size 24x28: "4"
               RenderText {#text} at (0,1) size 40x28
                 text run at (0,1) width 40: "four"
             RenderListItem {LI} at (40,120) size 716x30
-              RenderListMarker at (-31,1) size 24x28: "5"
+              RenderListMarker at (-26,1) size 24x28: "5"
               RenderText {#text} at (0,1) size 38x28
                 text run at (0,1) width 38: "five"
 caret: position 0 of child 0 {BR} of child 2 {LI} of child 1 {OL} of child 1 {DIV} of child 1 {DIV} of body

--- a/LayoutTests/platform/ios/editing/selection/select-all-iframe-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/select-all-iframe-expected.txt
@@ -41,12 +41,12 @@ layer at (0,0) size 800x600
           text run at (130,40) width 173: "Two things should happen:"
       RenderBlock {UL} at (0,322) size 784x60
         RenderListItem {LI} at (40,0) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 689x39
             text run at (0,0) width 462: "The Select All operation should not select the iframe, only it's contents. "
             text run at (461,0) width 228: "The results of the Select All will be"
             text run at (0,20) width 517: "apparent from the delegate messages that DumpRenderTree receives and dumps."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 344x19
             text run at (0,0) width 344: "The contents of the editable iframe should be deleted."

--- a/LayoutTests/platform/ios/editing/selection/selectNode-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/selectNode-expected.txt
@@ -20,6 +20,6 @@ layer at (0,0) size 800x600
           text run at (0,0) width 27: "four"
       RenderBlock {UL} at (0,132) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 55x19
             text run at (0,0) width 55: "Success."

--- a/LayoutTests/platform/ios/editing/selection/selectNodeContents-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/selectNodeContents-expected.txt
@@ -20,6 +20,6 @@ layer at (0,0) size 800x600
           text run at (0,0) width 27: "four"
       RenderBlock {UL} at (0,132) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 55x19
             text run at (0,0) width 55: "Success."

--- a/LayoutTests/platform/ios/editing/unsupported-content/list-type-after-expected.txt
+++ b/LayoutTests/platform/ios/editing/unsupported-content/list-type-after-expected.txt
@@ -49,30 +49,30 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,242) size 784x142 [border: (2px solid #008000)]
         RenderBlock {UL} at (2,26) size 780x90
           RenderListItem {LI} at (40,0) size 740x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderText {#text} at (0,1) size 77x28
               text run at (0,1) width 77: "line one"
           RenderListItem {LI} at (40,30) size 740x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderText {#text} at (0,1) size 78x28
               text run at (0,1) width 78: "line two"
           RenderListItem {LI} at (40,60) size 740x30
-            RenderListMarker at (-22,1) size 9x28: bullet
+            RenderListMarker at (-19,1) size 9x28: bullet
             RenderText {#text} at (0,1) size 126x28
               text run at (0,1) width 126: "line threexxx"
       RenderBlock {DIV} at (0,394) size 784x142
         RenderBlock {DIV} at (0,0) size 784x142 [border: (2px solid #FF0000)]
           RenderBlock {UL} at (2,26) size 780x90
             RenderListItem {LI} at (40,0) size 740x30
-              RenderListMarker at (-22,1) size 9x28: bullet
+              RenderListMarker at (-19,1) size 9x28: bullet
               RenderText {#text} at (0,1) size 77x28
                 text run at (0,1) width 77: "line one"
             RenderListItem {LI} at (40,30) size 740x30
-              RenderListMarker at (-22,1) size 9x28: bullet
+              RenderListMarker at (-19,1) size 9x28: bullet
               RenderText {#text} at (0,1) size 78x28
                 text run at (0,1) width 78: "line two"
             RenderListItem {LI} at (40,60) size 740x30
-              RenderListMarker at (-22,1) size 9x28: bullet
+              RenderListMarker at (-19,1) size 9x28: bullet
               RenderText {#text} at (0,1) size 126x28
                 text run at (0,1) width 126: "line threexxx"
 caret: position 13 of child 0 {#text} of child 5 {LI} of child 1 {UL} of child 1 {DIV} of child 5 {DIV} of body

--- a/LayoutTests/platform/ios/fast/backgrounds/background-inherit-color-bug-expected.txt
+++ b/LayoutTests/platform/ios/fast/backgrounds/background-inherit-color-bug-expected.txt
@@ -35,7 +35,7 @@ layer at (0,0) size 800x1142
             text run at (0,0) width 410: "This is in contradiction with the CSS2 specification which says:"
         RenderBlock {UL} at (4,388) size 628x40
           RenderListItem {LI} at (40,0) size 588x40
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 29x19
               text run at (0,0) width 29: "The "
             RenderInline {A} at (28,0) size 83x19 [color=#0000EE]

--- a/LayoutTests/platform/ios/fast/backgrounds/repeat/noRepeatCorrectClip-expected.txt
+++ b/LayoutTests/platform/ios/fast/backgrounds/repeat/noRepeatCorrectClip-expected.txt
@@ -5,4 +5,4 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet

--- a/LayoutTests/platform/ios/fast/backgrounds/selection-background-color-of-list-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/backgrounds/selection-background-color-of-list-style-expected.txt
@@ -9,20 +9,20 @@ layer at (0,0) size 800x156
             text run at (0,0) width 497: "Test passes if backgrounds of list style in ul and ol are each green and yellow."
         RenderBlock {UL} at (0,36) size 784x40
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 27x19
               text run at (0,0) width 27: "One"
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 29x19
               text run at (0,0) width 29: "Two"
         RenderBlock {OL} at (0,92) size 784x40
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "1"
+            RenderListMarker at (-17,0) size 16x19: "1"
             RenderText {#text} at (0,0) size 27x19
               text run at (0,0) width 27: "One"
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 29x19
               text run at (0,0) width 29: "Two"
 selection start: position 86 of child 0 {#text} of child 0 {DIV} of body

--- a/LayoutTests/platform/ios/fast/block/float/014-expected.txt
+++ b/LayoutTests/platform/ios/fast/block/float/014-expected.txt
@@ -9,10 +9,10 @@ layer at (0,0) size 800x152
           RenderImage {IMG} at (0,0) size 60x45
         RenderBlock {UL} at (15,47) size 769x81 [bgcolor=#FF0000]
           RenderListItem {LI} at (0,8) size 769x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 127x19
               text run at (0,0) width 127: "Classroom Training"
           RenderListItem {LI} at (0,44) size 769x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 80x19
               text run at (0,0) width 80: "Find a Class"

--- a/LayoutTests/platform/ios/fast/block/positioning/padding-percent-expected.txt
+++ b/LayoutTests/platform/ios/fast/block/positioning/padding-percent-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {OL} at (0,0) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 161x19
             text run at (0,0) width 161: "Make text bigger/smaller"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 219x19
             text run at (0,0) width 219: "Make the window narrower/wider"
 layer at (8,64) size 132x26

--- a/LayoutTests/platform/ios/fast/css-generated-content/009-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/009-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
           text run at (158,0) width 45: " green."
       RenderBlock {UL} at (0,36) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 380x19
             text run at (0,0) width 380: "All of this text should be green. The bullet should be black."
       RenderBlock {DIV} at (0,72) size 784x57 [color=#FF0000]

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-to-inline-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-to-inline-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (653,0) size 1x19
       RenderBlock {UL} at (0,36) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline (generated) at (0,0) size 32x19
             RenderText at (0,0) size 32x19
               text run at (0,0) width 32: "hello"

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,36) size 784x60
         RenderListItem {LI} at (40,0) size 744x60
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderTable at (0,20) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,36) size 784x60
         RenderListItem {LI} at (40,0) size 744x60
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderTable at (0,20) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,36) size 784x60
         RenderListItem {LI} at (40,0) size 744x60
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderTable at (0,20) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20

--- a/LayoutTests/platform/ios/fast/css/background-shorthand-invalid-url-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/background-shorthand-invalid-url-expected.txt
@@ -10,6 +10,6 @@ layer at (0,0) size 800x188
         RenderBlock {UL} at (0,0) size 784x91
           RenderListItem {LI} at (40,0) size 744x91 [border: (1px solid #FF0000)]
             RenderBlock {SPAN} at (1,1) size 304x89 [border: (2px solid #008000)]
-              RenderListMarker at (-19,2) size 7x19: bullet
+              RenderListMarker at (-16,2) size 7x19: bullet
               RenderText {#text} at (2,2) size 4x19
                 text run at (2,2) width 4: " "

--- a/LayoutTests/platform/ios/fast/css/compare-content-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/compare-content-style-expected.txt
@@ -35,14 +35,14 @@ layer at (0,0) size 800x256
               text run at (0,0) width 683: "Bug 23741: StyleRareNonInheritedData::operator==() should not compare ContentData objects by pointer"
         RenderBlock {OL} at (0,36) size 784x60
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "1"
+            RenderListMarker at (-17,0) size 16x19: "1"
             RenderText {#text} at (0,0) size 348x19
               text run at (0,0) width 348: "All lines above should be \"PASS\" on initial page load."
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 142x19
               text run at (0,0) width 142: "Reload the page once."
           RenderListItem {LI} at (40,40) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 249x19
               text run at (0,0) width 249: "All lines above should still be \"PASS\"."

--- a/LayoutTests/platform/ios/fast/css/empty-pseudo-class-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/empty-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 800x1620
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x75 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "1"
+            RenderListMarker at (-35,6) size 18x20: "1"
             RenderText {#text} at (6,11) size 87x58
               text run at (6,11) width 63: ":empty {"
               text run at (68,11) width 1: " "
@@ -42,7 +42,7 @@ layer at (0,0) size 800x1620
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x75 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "2"
+            RenderListMarker at (-35,6) size 18x20: "2"
             RenderText {#text} at (6,11) size 266x58
               text run at (6,11) width 63: ":empty {"
               text run at (68,11) width 1: " "
@@ -57,7 +57,7 @@ layer at (0,0) size 800x1620
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x75 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "3"
+            RenderListMarker at (-35,6) size 18x20: "3"
             RenderText {#text} at (6,11) size 95x58
               text run at (6,11) width 63: ":empty {"
               text run at (68,11) width 1: " "
@@ -71,7 +71,7 @@ layer at (0,0) size 800x1620
         RenderListItem {LI} at (40,732) size 628x238 [bgcolor=#AAAAAA]
           RenderBlock {DIV} at (16,16) size 596x44 [bgcolor=#009900]
             RenderBlock {DIV} at (0,0) size 596x44
-              RenderListMarker at (-39,12) size 18x19: "4"
+              RenderListMarker at (-35,12) size 18x19: "4"
               RenderText {#text} at (12,12) size 5x19
                 text run at (12,12) width 5: "."
           RenderBlock {PRE} at (16,73) size 596x97 [bgcolor=#FFFFFF]
@@ -94,7 +94,7 @@ layer at (0,0) size 800x1620
             RenderBlock {DIV} at (0,0) size 596x24
               RenderBlock {BLOCKQUOTE} at (12,12) size 572x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 596x75 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "5"
+            RenderListMarker at (-35,6) size 18x20: "5"
             RenderText {#text} at (6,11) size 282x58
               text run at (6,11) width 63: ":empty {"
               text run at (68,11) width 1: " "
@@ -110,7 +110,7 @@ layer at (0,0) size 800x1620
             RenderBlock {DIV} at (0,0) size 596x24
               RenderBlock {DIV} at (12,12) size 572x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "6"
+            RenderListMarker at (-35,6) size 18x20: "6"
             RenderText {#text} at (6,11) size 375x100
               text run at (6,11) width 63: ":empty {"
               text run at (68,11) width 1: " "

--- a/LayoutTests/platform/ios/fast/css/first-child-pseudo-class-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/first-child-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 800x2270
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x103 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "1"
+            RenderListMarker at (-35,6) size 18x20: "1"
             RenderText {#text} at (6,11) size 141x86
               text run at (6,11) width 141: "div :first-child {"
               text run at (146,11) width 1: " "
@@ -48,7 +48,7 @@ layer at (0,0) size 800x2270
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock {BLOCKQUOTE} at (0,24) size 596x0
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "2"
+            RenderListMarker at (-35,6) size 18x20: "2"
             RenderText {#text} at (6,11) size 219x100
               text run at (6,11) width 141: "div :first-child {"
               text run at (146,11) width 1: " "
@@ -70,7 +70,7 @@ layer at (0,0) size 800x2270
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "3"
+            RenderListMarker at (-35,6) size 18x20: "3"
             RenderText {#text} at (6,11) size 204x100
               text run at (6,11) width 141: "div :first-child {"
               text run at (146,11) width 1: " "
@@ -93,7 +93,7 @@ layer at (0,0) size 800x2270
         RenderListItem {LI} at (40,924) size 628x292 [bgcolor=#AAAAAA]
           RenderBlock {DIV} at (16,16) size 596x44 [bgcolor=#990000]
             RenderBlock (anonymous) at (0,0) size 596x20
-              RenderListMarker at (-39,0) size 18x19: "4"
+              RenderListMarker at (-35,0) size 18x19: "4"
               RenderText {#text} at (0,0) size 5x19
                 text run at (0,0) width 5: "."
             RenderBlock {DIV} at (0,20) size 596x24 [bgcolor=#009900]
@@ -122,7 +122,7 @@ layer at (0,0) size 800x2270
             RenderBlock {BLOCKQUOTE} at (0,0) size 596x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "5"
+            RenderListMarker at (-35,6) size 18x20: "5"
             RenderText {#text} at (6,11) size 219x100
               text run at (6,11) width 141: "div :first-child {"
               text run at (146,11) width 1: " "
@@ -145,7 +145,7 @@ layer at (0,0) size 800x2270
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,24) size 596x0
           RenderBlock {PRE} at (16,53) size 596x145 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "6"
+            RenderListMarker at (-35,6) size 18x20: "6"
             RenderText {#text} at (6,11) size 508x128
               text run at (6,11) width 141: "div :first-child {"
               text run at (146,11) width 1: " "
@@ -171,7 +171,7 @@ layer at (0,0) size 800x2270
             RenderBlock {DIV} at (0,0) size 596x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x145 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "7"
+            RenderListMarker at (-35,6) size 18x20: "7"
             RenderText {#text} at (6,11) size 508x128
               text run at (6,11) width 141: "div :first-child {"
               text run at (146,11) width 1: " "

--- a/LayoutTests/platform/ios/fast/css/first-of-type-pseudo-class-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/first-of-type-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 800x2924
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x75 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "1"
+            RenderListMarker at (-35,6) size 18x20: "1"
             RenderText {#text} at (6,11) size 274x58
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -44,7 +44,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,24) size 596x0
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "2"
+            RenderListMarker at (-35,6) size 18x20: "2"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -63,7 +63,7 @@ layer at (0,0) size 800x2924
             RenderBlock {BLOCKQUOTE} at (0,0) size 596x0 [bgcolor=#009900]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "3"
+            RenderListMarker at (-35,6) size 18x20: "3"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -83,7 +83,7 @@ layer at (0,0) size 800x2924
             RenderBlock {BLOCKQUOTE} at (0,0) size 596x24 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "4"
+            RenderListMarker at (-35,6) size 18x20: "4"
             RenderText {#text} at (6,11) size 297x100
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -106,7 +106,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x103 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "5"
+            RenderListMarker at (-35,6) size 18x20: "5"
             RenderText {#text} at (6,11) size 297x86
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -128,7 +128,7 @@ layer at (0,0) size 800x2924
               RenderBlock {DIV} at (0,0) size 596x0
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "6"
+            RenderListMarker at (-35,6) size 18x20: "6"
             RenderText {#text} at (6,11) size 274x100
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -151,7 +151,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "7"
+            RenderListMarker at (-35,6) size 18x20: "7"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -170,7 +170,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "8"
+            RenderListMarker at (-35,6) size 18x20: "8"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -189,7 +189,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,24) size 596x0
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "9"
+            RenderListMarker at (-35,6) size 18x20: "9"
             RenderText {#text} at (6,11) size 508x100
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "
@@ -211,7 +211,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-48,6) size 27x20: "10"
+            RenderListMarker at (-44,6) size 27x20: "10"
             RenderText {#text} at (6,11) size 508x100
               text run at (6,11) width 149: "div:first-of-type {"
               text run at (154,11) width 1: " "

--- a/LayoutTests/platform/ios/fast/css/last-child-pseudo-class-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/last-child-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 800x2270
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x103 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "1"
+            RenderListMarker at (-35,6) size 18x20: "1"
             RenderText {#text} at (6,11) size 134x86
               text run at (6,11) width 134: "div :last-child {"
               text run at (139,11) width 1: " "
@@ -48,7 +48,7 @@ layer at (0,0) size 800x2270
             RenderBlock {BLOCKQUOTE} at (0,0) size 596x0
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "2"
+            RenderListMarker at (-35,6) size 18x20: "2"
             RenderText {#text} at (6,11) size 219x100
               text run at (6,11) width 134: "div :last-child {"
               text run at (139,11) width 1: " "
@@ -70,7 +70,7 @@ layer at (0,0) size 800x2270
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "3"
+            RenderListMarker at (-35,6) size 18x20: "3"
             RenderText {#text} at (6,11) size 204x100
               text run at (6,11) width 134: "div :last-child {"
               text run at (139,11) width 1: " "
@@ -94,7 +94,7 @@ layer at (0,0) size 800x2270
           RenderBlock {DIV} at (16,16) size 596x44 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock (anonymous) at (0,24) size 596x20
-              RenderListMarker at (-39,0) size 18x19: "4"
+              RenderListMarker at (-35,0) size 18x19: "4"
               RenderText {#text} at (0,0) size 5x19
                 text run at (0,0) width 5: "."
           RenderBlock {PRE} at (16,73) size 596x111 [bgcolor=#FFFFFF]
@@ -122,7 +122,7 @@ layer at (0,0) size 800x2270
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {BLOCKQUOTE} at (0,24) size 596x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "5"
+            RenderListMarker at (-35,6) size 18x20: "5"
             RenderText {#text} at (6,11) size 219x100
               text run at (6,11) width 134: "div :last-child {"
               text run at (139,11) width 1: " "
@@ -145,7 +145,7 @@ layer at (0,0) size 800x2270
             RenderBlock {DIV} at (0,0) size 596x0
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x145 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "6"
+            RenderListMarker at (-35,6) size 18x20: "6"
             RenderText {#text} at (6,11) size 469x128
               text run at (6,11) width 134: "div :last-child {"
               text run at (139,11) width 1: " "
@@ -171,7 +171,7 @@ layer at (0,0) size 800x2270
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 596x145 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "7"
+            RenderListMarker at (-35,6) size 18x20: "7"
             RenderText {#text} at (6,11) size 469x128
               text run at (6,11) width 134: "div :last-child {"
               text run at (139,11) width 1: " "

--- a/LayoutTests/platform/ios/fast/css/last-of-type-pseudo-class-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/last-of-type-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 800x2924
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x75 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "1"
+            RenderListMarker at (-35,6) size 18x20: "1"
             RenderText {#text} at (6,11) size 274x58
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -44,7 +44,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x0
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "2"
+            RenderListMarker at (-35,6) size 18x20: "2"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -63,7 +63,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock {BLOCKQUOTE} at (0,24) size 596x0 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "3"
+            RenderListMarker at (-35,6) size 18x20: "3"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -83,7 +83,7 @@ layer at (0,0) size 800x2924
               RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "4"
+            RenderListMarker at (-35,6) size 18x20: "4"
             RenderText {#text} at (6,11) size 297x100
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -106,7 +106,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 596x24
           RenderBlock {PRE} at (16,53) size 596x103 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "5"
+            RenderListMarker at (-35,6) size 18x20: "5"
             RenderText {#text} at (6,11) size 297x86
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -128,7 +128,7 @@ layer at (0,0) size 800x2924
             RenderBlock {BLOCKQUOTE} at (0,24) size 596x0 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 596x0
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "6"
+            RenderListMarker at (-35,6) size 18x20: "6"
             RenderText {#text} at (6,11) size 274x100
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -151,7 +151,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "7"
+            RenderListMarker at (-35,6) size 18x20: "7"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -170,7 +170,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "8"
+            RenderListMarker at (-35,6) size 18x20: "8"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -189,7 +189,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x0
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "9"
+            RenderListMarker at (-35,6) size 18x20: "9"
             RenderText {#text} at (6,11) size 469x100
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "
@@ -211,7 +211,7 @@ layer at (0,0) size 800x2924
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-48,6) size 27x20: "10"
+            RenderListMarker at (-44,6) size 27x20: "10"
             RenderText {#text} at (6,11) size 469x100
               text run at (6,11) width 141: "div:last-of-type {"
               text run at (146,11) width 1: " "

--- a/LayoutTests/platform/ios/fast/css/list-outline-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/list-outline-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x84
     RenderBody {BODY} at (8,16) size 784x52
       RenderBlock {OL} at (0,0) size 784x52
         RenderListItem {LI} at (40,0) size 744x52
-          RenderListMarker at (-21,16) size 16x19: "1"
+          RenderListMarker at (-17,16) size 16x19: "1"
           RenderText {#text} at (16,16) size 595x19
             text run at (16,16) width 595: "A single outline should only appear over the list element, and not over internal text elements."

--- a/LayoutTests/platform/ios/fast/css/only-child-pseudo-class-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/only-child-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 800x1613
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x103 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "1"
+            RenderListMarker at (-35,6) size 18x20: "1"
             RenderText {#text} at (6,11) size 134x86
               text run at (6,11) width 134: "div :only-child {"
               text run at (139,11) width 1: " "
@@ -47,7 +47,7 @@ layer at (0,0) size 800x1613
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "2"
+            RenderListMarker at (-35,6) size 18x20: "2"
             RenderText {#text} at (6,11) size 204x100
               text run at (6,11) width 134: "div :only-child {"
               text run at (139,11) width 1: " "
@@ -69,7 +69,7 @@ layer at (0,0) size 800x1613
           RenderBlock {DIV} at (16,16) size 596x44 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock (anonymous) at (0,24) size 596x20
-              RenderListMarker at (-39,0) size 18x19: "3"
+              RenderListMarker at (-35,0) size 18x19: "3"
               RenderText {#text} at (0,0) size 5x19
                 text run at (0,0) width 5: "."
           RenderBlock {PRE} at (16,73) size 596x111 [bgcolor=#FFFFFF]
@@ -95,7 +95,7 @@ layer at (0,0) size 800x1613
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {BLOCKQUOTE} at (40,40) size 516x0
           RenderBlock {PRE} at (16,56) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "4"
+            RenderListMarker at (-35,6) size 18x20: "4"
             RenderText {#text} at (6,11) size 219x100
               text run at (6,11) width 134: "div :only-child {"
               text run at (139,11) width 1: " "
@@ -118,7 +118,7 @@ layer at (0,0) size 800x1613
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0
           RenderBlock {PRE} at (16,53) size 596x145 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "5"
+            RenderListMarker at (-35,6) size 18x20: "5"
             RenderText {#text} at (6,11) size 469x128
               text run at (6,11) width 134: "div :only-child {"
               text run at (139,11) width 1: " "

--- a/LayoutTests/platform/ios/fast/css/only-of-type-pseudo-class-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/only-of-type-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 800x1504
           RenderBlock {DIV} at (16,16) size 596x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x75 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "1"
+            RenderListMarker at (-35,6) size 18x20: "1"
             RenderText {#text} at (6,11) size 274x58
               text run at (6,11) width 141: "div:only-of-type {"
               text run at (146,11) width 1: " "
@@ -44,7 +44,7 @@ layer at (0,0) size 800x1504
             RenderBlock {DIV} at (0,0) size 596x24 [bgcolor=#009900]
             RenderBlock {BLOCKQUOTE} at (0,24) size 596x0 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "2"
+            RenderListMarker at (-35,6) size 18x20: "2"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 141: "div:only-of-type {"
               text run at (146,11) width 1: " "
@@ -64,7 +64,7 @@ layer at (0,0) size 800x1504
             RenderBlock {BLOCKQUOTE} at (0,24) size 596x0 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 596x0
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "3"
+            RenderListMarker at (-35,6) size 18x20: "3"
             RenderText {#text} at (6,11) size 274x100
               text run at (6,11) width 141: "div:only-of-type {"
               text run at (146,11) width 1: " "
@@ -87,7 +87,7 @@ layer at (0,0) size 800x1504
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0
           RenderBlock {PRE} at (16,53) size 596x89 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "4"
+            RenderListMarker at (-35,6) size 18x20: "4"
             RenderText {#text} at (6,11) size 274x72
               text run at (6,11) width 141: "div:only-of-type {"
               text run at (146,11) width 1: " "
@@ -106,7 +106,7 @@ layer at (0,0) size 800x1504
             RenderBlock {DIV} at (0,0) size 596x24
             RenderBlock {DIV} at (0,24) size 596x0
           RenderBlock {PRE} at (16,53) size 596x117 [bgcolor=#FFFFFF]
-            RenderListMarker at (-39,6) size 18x20: "5"
+            RenderListMarker at (-35,6) size 18x20: "5"
             RenderText {#text} at (6,11) size 469x100
               text run at (6,11) width 141: "div:only-of-type {"
               text run at (146,11) width 1: " "

--- a/LayoutTests/platform/ios/fast/doctypes/001-expected.txt
+++ b/LayoutTests/platform/ios/fast/doctypes/001-expected.txt
@@ -11,10 +11,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,136) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderBlock {UL} at (0,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 244x19
                 text run at (0,0) width 244: "I should be underneath the first bullet."
 layer at (10,10) size 80x80

--- a/LayoutTests/platform/ios/fast/doctypes/002-expected.txt
+++ b/LayoutTests/platform/ios/fast/doctypes/002-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 800x180
         RenderListItem {LI} at (40,0) size 744x20
           RenderBlock {UL} at (0,0) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
-              RenderListMarker at (-58,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
+              RenderListMarker at (-55,0) size 7x19: bullet
               RenderText {#text} at (0,0) size 256x19
                 text run at (0,0) width 256: "Both bullets should be on the same line."
 layer at (8,8) size 80x80

--- a/LayoutTests/platform/ios/fast/doctypes/003-expected.txt
+++ b/LayoutTests/platform/ios/fast/doctypes/003-expected.txt
@@ -11,10 +11,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,136) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderBlock {UL} at (0,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 259x19
                 text run at (0,0) width 259: "Both bullets should be on separate lines."
 layer at (10,10) size 80x80

--- a/LayoutTests/platform/ios/fast/doctypes/004-expected.txt
+++ b/LayoutTests/platform/ios/fast/doctypes/004-expected.txt
@@ -11,10 +11,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,136) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderBlock {UL} at (0,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 244x19
                 text run at (0,0) width 244: "I should be underneath the first bullet."
 layer at (10,10) size 80x80

--- a/LayoutTests/platform/ios/fast/dom/34176-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/34176-expected.txt
@@ -273,107 +273,107 @@ layer at (0,0) size 800x1574
               RenderInline {EM} at (0,0) size 0x0
         RenderBlock {UL} at (0,236) size 784x520
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 0: : Success"
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 1: : Success"
           RenderListItem {LI} at (40,40) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 2: : Success"
           RenderListItem {LI} at (40,60) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 3: : Success"
           RenderListItem {LI} at (40,80) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 4: : Success"
           RenderListItem {LI} at (40,100) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 5: : Success"
           RenderListItem {LI} at (40,120) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 6: : Success"
           RenderListItem {LI} at (40,140) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 7: : Success"
           RenderListItem {LI} at (40,160) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 8: : Success"
           RenderListItem {LI} at (40,180) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 111x19
               text run at (0,0) width 111: "Test 9: : Success"
           RenderListItem {LI} at (40,200) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 10: : Success"
           RenderListItem {LI} at (40,220) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 118x19
               text run at (0,0) width 118: "Test 11: : Success"
           RenderListItem {LI} at (40,240) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 12: : Success"
           RenderListItem {LI} at (40,260) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 13: : Success"
           RenderListItem {LI} at (40,280) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 14: : Success"
           RenderListItem {LI} at (40,300) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 15: : Success"
           RenderListItem {LI} at (40,320) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 16: : Success"
           RenderListItem {LI} at (40,340) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 17: : Success"
           RenderListItem {LI} at (40,360) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 18: : Success"
           RenderListItem {LI} at (40,380) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 19: : Success"
           RenderListItem {LI} at (40,400) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 20: : Success"
           RenderListItem {LI} at (40,420) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 21: : Success"
           RenderListItem {LI} at (40,440) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 22: : Success"
           RenderListItem {LI} at (40,460) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 23: : Success"
           RenderListItem {LI} at (40,480) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 24: : Success"
           RenderListItem {LI} at (40,500) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 119x19
               text run at (0,0) width 119: "Test 25: : Success"
       RenderBlock (anonymous) at (0,1558) size 784x0

--- a/LayoutTests/platform/ios/fast/dom/52776-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/52776-expected.txt
@@ -237,7 +237,7 @@ layer at (0,0) size 800x1828
             text run at (14,0) width 1: "\x{202C}\x{202A}"
       RenderBlock {UL} at (0,1776) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 717x19
             text run at (0,0) width 717: "test id=test: the right-most character of rendering result of <PDF>abc<PDF> in RTL block should be c: Success"
 selection start: position 3 of child 0 {#text} of child 20 {DIV} of child 1 {DIV} of body

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 800x600
           text run at (0,1) width 360: "Meters with border values"
       RenderBlock {UL} at (0,59) size 784x301
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 169x19
             text run at (0,0) width 169: "min,low,optimal,high,max"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {B} at (0,0) size 8x19
             RenderText {#text} at (0,0) size 8x19
               text run at (0,0) width 8: "9"
@@ -20,7 +20,7 @@ layer at (0,0) size 800x600
             text run at (8,0) width 108: "|10,20,30,40,50: "
           RenderMeter {METER} at (115,2) size 81x17
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {B} at (0,0) size 16x19
             RenderText {#text} at (0,0) size 16x19
               text run at (0,0) width 16: "10"
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
             text run at (16,0) width 89: ",20,30,40,50: "
           RenderMeter {METER} at (104,2) size 81x17
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 20x19
             text run at (0,0) width 20: "10,"
           RenderInline {B} at (20,0) size 16x19
@@ -40,7 +40,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (184,0) size 113x19
             text run at (184,0) width 113: "(should be green)"
         RenderListItem {LI} at (40,80) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 40x19
             text run at (0,0) width 40: "10,20,"
           RenderInline {B} at (40,0) size 16x19
@@ -52,7 +52,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (184,0) size 113x19
             text run at (184,0) width 113: "(should be green)"
         RenderListItem {LI} at (40,100) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 60x19
             text run at (0,0) width 60: "10,20,30,"
           RenderInline {B} at (60,0) size 16x19
@@ -64,7 +64,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (184,0) size 113x19
             text run at (184,0) width 113: "(should be green)"
         RenderListItem {LI} at (40,120) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 80x19
             text run at (0,0) width 80: "10,20,30,40,"
           RenderInline {B} at (80,0) size 16x19
@@ -76,7 +76,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (184,0) size 121x19
             text run at (184,0) width 121: "(should be yellow)"
         RenderListItem {LI} at (40,140) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 100x19
             text run at (0,0) width 100: "10,20,30,40,50|"
           RenderInline {B} at (99,0) size 17x19
@@ -88,7 +88,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (203,0) size 121x19
             text run at (203,0) width 121: "(should be yellow)"
         RenderListItem {LI} at (40,160) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 20x19
             text run at (0,0) width 20: "10,"
           RenderInline {B} at (20,0) size 16x19
@@ -98,7 +98,7 @@ layer at (0,0) size 800x600
             text run at (36,0) width 69: ",30,40,50: "
           RenderMeter {METER} at (104,2) size 81x17
         RenderListItem {LI} at (40,180) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 60x19
             text run at (0,0) width 60: "10,20,30,"
           RenderInline {B} at (60,0) size 16x19
@@ -110,7 +110,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (184,0) size 113x19
             text run at (184,0) width 113: "(should be green)"
         RenderListItem {LI} at (40,200) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {B} at (0,0) size 8x19
             RenderText {#text} at (0,0) size 8x19
               text run at (0,0) width 8: "9"
@@ -118,7 +118,7 @@ layer at (0,0) size 800x600
             text run at (8,0) width 108: "|10,10,10,20,30: "
           RenderMeter {METER} at (115,2) size 81x17
         RenderListItem {LI} at (40,220) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 40x19
             text run at (0,0) width 40: "10,10,"
           RenderInline {B} at (40,0) size 16x19
@@ -128,7 +128,7 @@ layer at (0,0) size 800x600
             text run at (56,0) width 49: ",20,30: "
           RenderMeter {METER} at (104,2) size 81x17
         RenderListItem {LI} at (40,240) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 40x19
             text run at (0,0) width 40: "10,20,"
           RenderInline {B} at (40,0) size 16x19
@@ -140,7 +140,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (184,0) size 113x19
             text run at (184,0) width 113: "(should be green)"
         RenderListItem {LI} at (40,260) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 100x19
             text run at (0,0) width 100: "10,20,30,30,30|"
           RenderInline {B} at (99,0) size 17x19
@@ -152,7 +152,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (203,0) size 113x19
             text run at (203,0) width 113: "(should be green)"
         RenderListItem {LI} at (40,280) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 40x19
             text run at (0,0) width 40: "10,20,"
           RenderInline {B} at (40,0) size 16x19

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-optimums-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-optimums-expected.txt
@@ -14,27 +14,27 @@ layer at (0,0) size 800x613
           text run at (0,1) width 144: "optimum=450"
       RenderBlock {UL} at (0,149) size 784x101
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=150: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=450: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=750: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 61x19
             text run at (0,0) width 61: "value=0: "
           RenderMeter {METER} at (60,2) size 81x17
         RenderListItem {LI} at (40,80) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "value=1000: "
           RenderMeter {METER} at (84,2) size 81x17
@@ -43,27 +43,27 @@ layer at (0,0) size 800x613
           text run at (0,1) width 144: "optimum=150"
       RenderBlock {UL} at (0,319) size 784x101
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=150: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=450: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=750: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 61x19
             text run at (0,0) width 61: "value=0: "
           RenderMeter {METER} at (60,2) size 81x17
         RenderListItem {LI} at (40,80) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "value=1000: "
           RenderMeter {METER} at (84,2) size 81x17
@@ -72,27 +72,27 @@ layer at (0,0) size 800x613
           text run at (0,1) width 144: "optimum=750"
       RenderBlock {UL} at (0,488) size 784x101
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=150: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=450: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "value=750: "
           RenderMeter {METER} at (76,2) size 81x17
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 61x19
             text run at (0,0) width 61: "value=0: "
           RenderMeter {METER} at (60,2) size 81x17
         RenderListItem {LI} at (40,80) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "value=1000: "
           RenderMeter {METER} at (84,2) size 81x17

--- a/LayoutTests/platform/ios/fast/dom/HTMLProgressElement/progress-bar-value-pseudo-element-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLProgressElement/progress-bar-value-pseudo-element-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x184
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 91x19
             text run at (0,0) width 91: "Default style: "
           RenderBlock {PROGRESS} at (90,2) size 161x17
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 16x16 [bgcolor=#008000]
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 98x19
             text run at (0,0) width 98: "Progress style: "
           RenderBlock {PROGRESS} at (97,2) size 161x17 [bgcolor=#0000FF] [border: (3px solid #000066)]
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 154x10
                 RenderBlock {DIV} at (0,0) size 31x10 [bgcolor=#008000]
         RenderListItem {LI} at (40,40) size 744x32
-          RenderListMarker at (-18,11) size 7x20: bullet
+          RenderListMarker at (-15,11) size 7x20: bullet
           RenderText {#text} at (0,11) size 138x20
             text run at (0,11) width 138: "Progress style (size): "
           RenderBlock {PROGRESS} at (137,0) size 301x30
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 300x30 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 90x30 [bgcolor=#008000]
         RenderListItem {LI} at (40,71) size 744x21
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 66x19
             text run at (0,0) width 66: "Bar style: "
           RenderBlock {PROGRESS} at (65,2) size 161x17
@@ -37,7 +37,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#FF0000] [border: (3px solid #990000)]
                 RenderBlock {DIV} at (3,3) size 62x10 [bgcolor=#008000]
         RenderListItem {LI} at (40,91) size 744x21
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 80x19
             text run at (0,0) width 80: "Value style: "
           RenderBlock {PROGRESS} at (79,2) size 161x17
@@ -45,7 +45,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#FFFF00] [border: (3px solid #999900)]
         RenderListItem {LI} at (40,111) size 744x33
-          RenderListMarker at (-18,11) size 7x20: bullet
+          RenderListMarker at (-15,11) size 7x20: bullet
           RenderText {#text} at (0,11) size 195x20
             text run at (0,11) width 195: "Styling for all three elements: "
           RenderBlock {PROGRESS} at (194,0) size 161x30 [bgcolor=#0000FF] [border: (3px solid #000066)]
@@ -53,7 +53,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 154x24 [bgcolor=#FF0000] [border: (3px solid #990000)]
                 RenderBlock {DIV} at (3,3) size 89x18 [bgcolor=#FFFF00] [border: (3px solid #999900)]
         RenderListItem {LI} at (40,143) size 744x21
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 235x19
             text run at (0,0) width 235: "Removing appearance dynamically: "
           RenderBlock {PROGRESS} at (234,2) size 161x17
@@ -61,7 +61,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 112x16 [bgcolor=#008000]
         RenderListItem {LI} at (40,163) size 744x21
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 278x19
             text run at (0,0) width 278: "Giving progress style change dynamically: "
           RenderBlock {PROGRESS} at (277,2) size 161x17 [bgcolor=#ADD8E6]

--- a/LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt
@@ -39,7 +39,7 @@ layer at (0,0) size 800x694
       RenderBlock {DIV} at (0,156) size 784x46
         RenderListItem {DIV} at (0,0) size 784x46
           RenderBlock (anonymous) at (0,0) size 784x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderBlock {FORM} at (0,20) size 784x26
             RenderTable {TABLE} at (0,0) size 114x26
               RenderTableSection {TBODY} at (0,0) size 114x26

--- a/LayoutTests/platform/ios/fast/forms/plaintext-mode-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/plaintext-mode-2-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock (anonymous) at (0,0) size 784x20
-        RenderTextControl {INPUT} at (0,0) size 600x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+      RenderBlock (anonymous) at (0,0) size 784x22
+        RenderTextControl {INPUT} at (0,0) size 600x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (600,-1) size 0x19
-      RenderBlock {DIV} at (0,20) size 784x20
+      RenderBlock {DIV} at (0,21) size 784x21
         RenderText {#text} at (0,0) size 33x19
           text run at (0,0) width 33: "This "
         RenderInline {B} at (32,0) size 69x19
@@ -24,17 +24,17 @@ layer at (0,0) size 800x600
         RenderText {#text} at (160,0) size 414x19
           text run at (160,0) width 212: " will be pasted into the textfield. "
           text run at (371,0) width 203: "All richness should be stripped."
-      RenderBlock {OL} at (0,56) size 784x40
+      RenderBlock {OL} at (0,57) size 784x41
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 332x19
             text run at (0,0) width 332: "Success: document.execCommand(\"Copy\") == true"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 331x19
             text run at (0,0) width 331: "Success: document.execCommand(\"Paste\") == true"
-layer at (14,11) size 588x14
-  RenderBlock {DIV} at (6,3) size 588x14
+layer at (15,11) size 587x14
+  RenderBlock {DIV} at (6,3) size 588x15
     RenderText {#text} at (0,0) size 464x14
       text run at (0,0) width 464: "This styled text, and link will be pasted into the textfield. All richness should be stripped."
 caret: position 94 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 0 {INPUT} of body

--- a/LayoutTests/platform/ios/fast/inline/emptyInlinesWithinLists-expected.txt
+++ b/LayoutTests/platform/ios/fast/inline/emptyInlinesWithinLists-expected.txt
@@ -8,21 +8,21 @@ layer at (0,0) size 800x600
           text run at (0,0) width 468: "This test demonstrates our behavior regarding empty inlines in list items."
       RenderBlock {UL} at (0,36) size 784x100
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {SPAN} at (0,-2) size 4x23 [border: (2px solid #FF0000)]
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {SPAN} at (0,-4) size 8x27 [border: (2px solid #FF0000)]
           RenderText {#text} at (8,0) size 29x19
             text run at (8,0) width 29: "Text"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "TextTextText"
           RenderInline {SPAN} at (84,-4) size 9x27 [border: (2px solid #FF0000)]
         RenderBlock (anonymous) at (40,60) size 744x20
           RenderInline {SPAN} at (0,-4) size 8x27 [border: (2px solid #FF0000)]
         RenderListItem {LI} at (40,80) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 29x19
             text run at (0,0) width 29: "Text"

--- a/LayoutTests/platform/ios/fast/lists/001-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/001-expected.txt
@@ -1,21 +1,21 @@
-layer at (0,0) size 810x600
+layer at (0,0) size 807x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {DIV} at (0,0) size 784x108 [border: (3px solid #FFA500)]
         RenderListItem {DIV} at (11,11) size 122x122 [bgcolor=#FFA500] [border: (3px solid #FFA500)]
-          RenderListMarker at (-18,11) size 7x19: bullet
+          RenderListMarker at (-15,11) size 7x19: bullet
         RenderListItem {DIV} at (11,11) size 762x86 [border: (3px solid #FFA500)]
           RenderListItem {DIV} at (11,11) size 740x64 [border: (3px solid #FFA500)]
             RenderListItem {DIV} at (11,11) size 718x42 [border: (3px solid #FFA500)]
-              RenderListMarker at (103,11) size 7x19: bullet
-              RenderListMarker at (103,11) size 7x19: bullet
-              RenderListMarker at (103,11) size 7x19: bullet
+              RenderListMarker at (106,11) size 7x19: bullet
+              RenderListMarker at (106,11) size 7x19: bullet
+              RenderListMarker at (106,11) size 7x19: bullet
               RenderText {#text} at (132,11) size 90x19
                 text run at (132,11) width 90: "List item text."
       RenderBlock {UL} at (0,124) size 784x124
         RenderListItem {LI} at (40,0) size 744x124 [border: (2px solid #FF0000)]
-          RenderListMarker at (754,52) size 8x19: bullet
+          RenderListMarker at (751,52) size 8x19: bullet
           RenderText {#text} at (52,52) size 504x19
             text run at (52,52) width 504: "Foo fofodfosjlkdf dslkdjlk asdlksjald djklsd klasjdkas sdajd lsadjkl asjdlksajdk"

--- a/LayoutTests/platform/ios/fast/lists/001-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/001-vertical-expected.txt
@@ -1,22 +1,22 @@
-layer at (0,0) size 800x610
+layer at (0,0) size 800x607
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 776x584
       RenderBlock {DIV} at (0,0) size 108x584 [border: (3px solid #FFA500)]
         RenderListItem {DIV} at (11,11) size 122x122 [bgcolor=#FFA500] [border: (3px solid #FFA500)]
-          RenderListMarker at (12,-18) size 19x7: bullet
+          RenderListMarker at (12,-15) size 19x7: bullet
         RenderListItem {DIV} at (11,11) size 86x562 [border: (3px solid #FFA500)]
           RenderListItem {DIV} at (11,11) size 64x540 [border: (3px solid #FFA500)]
             RenderListItem {DIV} at (11,11) size 42x518 [border: (3px solid #FFA500)]
-              RenderListMarker at (12,103) size 19x7: bullet
-              RenderListMarker at (12,103) size 19x7: bullet
-              RenderListMarker at (12,103) size 19x7: bullet
+              RenderListMarker at (12,106) size 19x7: bullet
+              RenderListMarker at (12,106) size 19x7: bullet
+              RenderListMarker at (12,106) size 19x7: bullet
               RenderText {#text} at (12,132) size 19x90
                 text run at (12,132) width 90: "List item text."
       RenderBlock {UL} at (124,0) size 144x584
         RenderListItem {LI} at (0,40) size 144x544 [border: (2px solid #FF0000)]
-          RenderListMarker at (53,555) size 19x7: bullet
+          RenderListMarker at (53,552) size 19x7: bullet
           RenderText {#text} at (53,52) size 39x428
             text run at (53,52) width 428: "Foo fofodfosjlkdf dslkdjlk asdlksjald djklsd klasjdkas sdajd lsadjkl"
             text run at (73,52) width 72: "asjdlksajdk"

--- a/LayoutTests/platform/ios/fast/lists/002-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/002-expected.txt
@@ -6,12 +6,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x40
         RenderBlock {UL} at (0,0) size 784x40
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderInline {A} at (704,0) size 40x19 [color=#0000EE]
               RenderText {#text} at (704,0) size 40x19
                 text run at (704,0) width 40: "Home"
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderInline {A} at (686,0) size 58x19 [color=#0000EE]
               RenderText {#text} at (686,0) size 58x19
                 text run at (686,0) width 58: "Archives"

--- a/LayoutTests/platform/ios/fast/lists/002-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/002-vertical-expected.txt
@@ -6,12 +6,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 40x584
         RenderBlock {UL} at (0,0) size 40x584
           RenderListItem {LI} at (0,40) size 20x544
-            RenderListMarker at (0,-18) size 19x7: bullet
+            RenderListMarker at (0,-15) size 19x7: bullet
             RenderInline {A} at (0,504) size 19x40 [color=#0000EE]
               RenderText {#text} at (0,504) size 19x40
                 text run at (0,504) width 40: "Home"
           RenderListItem {LI} at (20,40) size 20x544
-            RenderListMarker at (0,-18) size 19x7: bullet
+            RenderListMarker at (0,-15) size 19x7: bullet
             RenderInline {A} at (0,486) size 19x58 [color=#0000EE]
               RenderText {#text} at (0,486) size 19x58
                 text run at (0,486) width 58: "Archives"

--- a/LayoutTests/platform/ios/fast/lists/003-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/003-expected.txt
@@ -39,18 +39,18 @@ layer at (0,0) size 800x400
             text run at (260,20) width 5: "."
         RenderBlock {OL} at (0,148) size 471x220
           RenderListItem {LI} at (40,0) size 431x40
-            RenderListMarker at (-21,0) size 16x19: "1"
+            RenderListMarker at (-17,0) size 16x19: "1"
             RenderText {#text} at (0,0) size 406x39
               text run at (0,0) width 159: "New larger PowerBook. "
               text run at (158,0) width 248: "Still 1 GHz, but with a 17-inch screen."
               text run at (0,20) width 44: "$3299."
           RenderListItem {LI} at (40,40) size 431x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 359x19
               text run at (0,0) width 315: "New smaller PowerBook, with a 12-inch screen. "
               text run at (314,0) width 45: "$1799."
           RenderListItem {LI} at (40,60) size 431x60
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 95x19
               text run at (0,0) width 95: "New browser: "
             RenderInline {A} at (94,0) size 39x19 [color=#0000EE]
@@ -78,13 +78,13 @@ layer at (0,0) size 800x400
               text run at (85,40) width 124: "Only runs on 10.2. "
               text run at (208,40) width 158: "Currently in public beta."
           RenderListItem {LI} at (40,120) size 431x40
-            RenderListMarker at (-21,0) size 16x19: "4"
+            RenderListMarker at (-17,0) size 16x19: "4"
             RenderText {#text} at (0,0) size 399x39
               text run at (0,0) width 243: "New presentation software: Keynote. "
               text run at (242,0) width 157: "The software Steve Jobs"
               text run at (0,20) width 32: "uses."
           RenderListItem {LI} at (40,160) size 431x40
-            RenderListMarker at (-21,0) size 16x19: "5"
+            RenderListMarker at (-17,0) size 16x19: "5"
             RenderText {#text} at (0,0) size 109x19
               text run at (0,0) width 109: "New versions of "
             RenderInline {A} at (108,0) size 48x19 [color=#0000EE]
@@ -109,7 +109,7 @@ layer at (0,0) size 800x400
             RenderText {#text} at (31,20) size 59x19
               text run at (31,20) width 59: ", for $49."
           RenderListItem {LI} at (40,200) size 431x20
-            RenderListMarker at (-21,0) size 16x19: "6"
+            RenderListMarker at (-17,0) size 16x19: "6"
             RenderInline {A} at (0,0) size 115x19 [color=#0000EE]
               RenderText {#text} at (0,0) size 115x19
                 text run at (0,0) width 115: "Final Cut Express"
@@ -119,42 +119,42 @@ layer at (0,0) size 800x400
       RenderBlock {DIV} at (0,0) size 784x332
         RenderBlock {UL} at (0,0) size 784x160
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (704,0) size 40x19 [color=#0000EE]
               RenderText {#text} at (704,0) size 40x19
                 text run at (704,0) width 40: "About"
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (687,0) size 57x19 [color=#0000EE]
               RenderText {#text} at (687,0) size 57x19
                 text run at (687,0) width 57: "Site map"
           RenderListItem {LI} at (40,40) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (686,0) size 58x19 [color=#0000EE]
               RenderText {#text} at (686,0) size 58x19
                 text run at (686,0) width 58: "Archives"
           RenderListItem {LI} at (40,60) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (692,0) size 52x19 [color=#0000EE]
               RenderText {#text} at (692,0) size 52x19
                 text run at (692,0) width 52: "Projects"
           RenderListItem {LI} at (40,80) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (700,0) size 44x19 [color=#0000EE]
               RenderText {#text} at (700,0) size 44x19
                 text run at (700,0) width 44: "Photos"
           RenderListItem {LI} at (40,100) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (686,0) size 58x19 [color=#0000EE]
               RenderText {#text} at (686,0) size 58x19
                 text run at (686,0) width 58: "Statistics"
           RenderListItem {LI} at (40,120) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (595,0) size 149x19 [color=#0000EE]
               RenderText {#text} at (595,0) size 149x19
                 text run at (595,0) width 149: "Accessibility statement"
           RenderListItem {LI} at (40,140) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (630,0) size 29x19 [color=#0000EE]
               RenderText {#text} at (630,0) size 29x19
                 text run at (630,0) width 29: "RSS"
@@ -167,38 +167,38 @@ layer at (0,0) size 800x400
               text run at (738,0) width 6: ")"
         RenderBlock {UL} at (0,176) size 784x20
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (655,0) size 89x19 [color=#0000EE]
               RenderText {#text} at (655,0) size 89x19
                 text run at (655,0) width 89: "What is RSS?"
         RenderBlock {UL} at (0,212) size 784x120
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (652,0) size 92x19 [color=#0000EE]
               RenderText {#text} at (652,0) size 92x19
                 text run at (652,0) width 92: "RSS Validator"
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (595,0) size 149x19 [color=#0000EE]
               RenderText {#text} at (595,0) size 149x19
                 text run at (595,0) width 149: "Dive Into Accessibility"
           RenderListItem {LI} at (40,40) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (643,0) size 101x19 [color=#0000EE]
               RenderText {#text} at (643,0) size 101x19
                 text run at (643,0) width 101: "Dive Into OS X"
           RenderListItem {LI} at (40,60) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (645,0) size 99x19 [color=#0000EE]
               RenderText {#text} at (645,0) size 99x19
                 text run at (645,0) width 99: "Dive Into J2EE"
           RenderListItem {LI} at (40,80) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (633,0) size 111x19 [color=#0000EE]
               RenderText {#text} at (633,0) size 111x19
                 text run at (633,0) width 111: "Dive Into Python"
           RenderListItem {LI} at (40,100) size 744x20
-            RenderListMarker at (412,0) size 8x19: bullet
+            RenderListMarker at (415,0) size 8x19: bullet
             RenderInline {A} at (697,0) size 47x19 [color=#0000EE]
               RenderText {#text} at (697,0) size 47x19
                 text run at (697,0) width 47: "r\x{E9}sum\x{E9}"

--- a/LayoutTests/platform/ios/fast/lists/003-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/003-vertical-expected.txt
@@ -42,18 +42,18 @@ layer at (0,0) size 500x600
             text run at (41,73) width 4: "."
         RenderBlock {OL} at (188,0) size 280x351
           RenderListItem {LI} at (0,40) size 40x311
-            RenderListMarker at (1,-21) size 19x16: "1"
+            RenderListMarker at (1,-17) size 19x16: "1"
             RenderText {#text} at (1,0) size 39x304
               text run at (1,0) width 159: "New larger PowerBook. "
               text run at (1,158) width 145: "Still 1 GHz, but with a"
               text run at (21,0) width 146: "17-inch screen. $3299."
           RenderListItem {LI} at (40,40) size 40x311
-            RenderListMarker at (1,-21) size 19x16: "2"
+            RenderListMarker at (1,-17) size 19x16: "2"
             RenderText {#text} at (1,0) size 39x311
               text run at (1,0) width 311: "New smaller PowerBook, with a 12-inch screen."
               text run at (21,0) width 44: "$1799."
           RenderListItem {LI} at (80,40) size 100x311
-            RenderListMarker at (1,-21) size 19x16: "3"
+            RenderListMarker at (1,-17) size 19x16: "3"
             RenderText {#text} at (1,0) size 19x95
               text run at (1,0) width 95: "New browser: "
             RenderInline {A} at (0,94) size 19x39 [color=#0000EE]
@@ -83,13 +83,13 @@ layer at (0,0) size 500x600
               text run at (61,180) width 122: "Currently in public"
               text run at (81,0) width 31: "beta."
           RenderListItem {LI} at (180,40) size 40x311
-            RenderListMarker at (1,-21) size 19x16: "4"
+            RenderListMarker at (1,-17) size 19x16: "4"
             RenderText {#text} at (1,0) size 39x268
               text run at (1,0) width 243: "New presentation software: Keynote. "
               text run at (1,242) width 25: "The"
               text run at (21,0) width 163: "software Steve Jobs uses."
           RenderListItem {LI} at (220,40) size 40x311
-            RenderListMarker at (1,-21) size 19x16: "5"
+            RenderListMarker at (1,-17) size 19x16: "5"
             RenderText {#text} at (1,0) size 19x109
               text run at (1,0) width 109: "New versions of "
             RenderInline {A} at (0,108) size 19x48 [color=#0000EE]
@@ -114,7 +114,7 @@ layer at (0,0) size 500x600
             RenderText {#text} at (21,199) size 19x60
               text run at (21,199) width 59: ", for $49."
           RenderListItem {LI} at (260,40) size 20x311
-            RenderListMarker at (1,-21) size 19x16: "6"
+            RenderListMarker at (1,-17) size 19x16: "6"
             RenderInline {A} at (0,0) size 19x115 [color=#0000EE]
               RenderText {#text} at (1,0) size 19x115
                 text run at (1,0) width 115: "Final Cut Express"
@@ -124,42 +124,42 @@ layer at (0,0) size 500x600
       RenderBlock {DIV} at (0,0) size 332x584
         RenderBlock {UL} at (0,0) size 160x584
           RenderListItem {LI} at (0,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,504) size 19x40 [color=#0000EE]
               RenderText {#text} at (1,504) size 19x40
                 text run at (1,504) width 40: "About"
           RenderListItem {LI} at (20,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,487) size 19x57 [color=#0000EE]
               RenderText {#text} at (1,487) size 19x57
                 text run at (1,487) width 57: "Site map"
           RenderListItem {LI} at (40,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,486) size 19x58 [color=#0000EE]
               RenderText {#text} at (1,486) size 19x58
                 text run at (1,486) width 58: "Archives"
           RenderListItem {LI} at (60,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,492) size 19x52 [color=#0000EE]
               RenderText {#text} at (1,492) size 19x52
                 text run at (1,492) width 52: "Projects"
           RenderListItem {LI} at (80,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,500) size 19x44 [color=#0000EE]
               RenderText {#text} at (1,500) size 19x44
                 text run at (1,500) width 44: "Photos"
           RenderListItem {LI} at (100,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,486) size 19x58 [color=#0000EE]
               RenderText {#text} at (1,486) size 19x58
                 text run at (1,486) width 58: "Statistics"
           RenderListItem {LI} at (120,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,395) size 19x149 [color=#0000EE]
               RenderText {#text} at (1,395) size 19x149
                 text run at (1,395) width 149: "Accessibility statement"
           RenderListItem {LI} at (140,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,430) size 19x29 [color=#0000EE]
               RenderText {#text} at (1,430) size 19x29
                 text run at (1,430) width 29: "RSS"
@@ -172,38 +172,38 @@ layer at (0,0) size 500x600
               text run at (1,538) width 6: ")"
         RenderBlock {UL} at (176,0) size 20x584
           RenderListItem {LI} at (0,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,455) size 19x89 [color=#0000EE]
               RenderText {#text} at (1,455) size 19x89
                 text run at (1,455) width 89: "What is RSS?"
         RenderBlock {UL} at (212,0) size 120x584
           RenderListItem {LI} at (0,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,452) size 19x92 [color=#0000EE]
               RenderText {#text} at (1,452) size 19x92
                 text run at (1,452) width 92: "RSS Validator"
           RenderListItem {LI} at (20,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,395) size 19x149 [color=#0000EE]
               RenderText {#text} at (1,395) size 19x149
                 text run at (1,395) width 149: "Dive Into Accessibility"
           RenderListItem {LI} at (40,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,443) size 19x101 [color=#0000EE]
               RenderText {#text} at (1,443) size 19x101
                 text run at (1,443) width 101: "Dive Into OS X"
           RenderListItem {LI} at (60,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,445) size 19x99 [color=#0000EE]
               RenderText {#text} at (1,445) size 19x99
                 text run at (1,445) width 99: "Dive Into J2EE"
           RenderListItem {LI} at (80,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,433) size 19x111 [color=#0000EE]
               RenderText {#text} at (1,433) size 19x111
                 text run at (1,433) width 111: "Dive Into Python"
           RenderListItem {LI} at (100,40) size 20x544
-            RenderListMarker at (1,292) size 19x7: bullet
+            RenderListMarker at (1,295) size 19x7: bullet
             RenderInline {A} at (0,497) size 19x47 [color=#0000EE]
               RenderText {#text} at (1,497) size 19x47
                 text run at (1,497) width 47: "r\x{E9}sum\x{E9}"

--- a/LayoutTests/platform/ios/fast/lists/005-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/005-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x60
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 328x19
             text run at (0,0) width 328: "There should be two bullets with no text above me."

--- a/LayoutTests/platform/ios/fast/lists/005-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/005-vertical-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 776x584
       RenderBlock {UL} at (0,0) size 60x584
         RenderListItem {LI} at (0,40) size 20x544
-          RenderListMarker at (0,-18) size 19x7: bullet
+          RenderListMarker at (0,-15) size 19x7: bullet
         RenderListItem {LI} at (20,40) size 20x544
-          RenderListMarker at (0,-18) size 19x7: bullet
+          RenderListMarker at (0,-15) size 19x7: bullet
         RenderListItem {LI} at (40,40) size 20x544
-          RenderListMarker at (0,-18) size 19x7: bullet
+          RenderListMarker at (0,-15) size 19x7: bullet
           RenderText {#text} at (0,0) size 19x328
             text run at (0,0) width 328: "There should be two bullets with no text above me."

--- a/LayoutTests/platform/ios/fast/lists/006-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/006-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {OL} at (0,0) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "1"
+            RenderListMarker at (-17,0) size 16x19: "1"
             RenderInline {I} at (0,0) size 77x19
               RenderInline {U} at (0,0) size 77x19
                 RenderText {#text} at (0,0) size 77x19
@@ -14,6 +14,6 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {OL} at (0,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-21,0) size 16x19: "1"
+              RenderListMarker at (-17,0) size 16x19: "1"
               RenderText {#text} at (0,0) size 59x19
                 text run at (0,0) width 59: "Goodbye"

--- a/LayoutTests/platform/ios/fast/lists/006-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/006-vertical-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {OL} at (0,0) size 40x584
         RenderListItem {LI} at (0,40) size 40x544
           RenderBlock (anonymous) at (0,0) size 20x544
-            RenderListMarker at (0,-21) size 19x16: "1"
+            RenderListMarker at (0,-17) size 19x16: "1"
             RenderInline {I} at (0,0) size 19x77
               RenderInline {U} at (0,0) size 19x77
                 RenderText {#text} at (0,0) size 19x77
@@ -14,6 +14,6 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {OL} at (20,0) size 20x544
             RenderListItem {LI} at (0,40) size 20x504
-              RenderListMarker at (0,-21) size 19x16: "1"
+              RenderListMarker at (0,-17) size 19x16: "1"
               RenderText {#text} at (0,0) size 19x59
                 text run at (0,0) width 59: "Goodbye"

--- a/LayoutTests/platform/ios/fast/lists/007-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/007-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x80 [bgcolor=#808080] [border: none (25px solid #008000)]
         RenderListItem {LI} at (50,0) size 734x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 732x19
             text run at (0,0) width 732: "The left padding on this unordered list has been set to 25 pixels, which will require some extra test in order to test."
         RenderListItem {LI} at (50,20) size 734x60 [bgcolor=#FFFFFF] [border: none (25px solid #008000)]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (50,0) size 669x59
             text run at (50,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (50,20) width 61: "checked. "

--- a/LayoutTests/platform/ios/fast/lists/007-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/007-vertical-expected.txt
@@ -5,12 +5,12 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 776x584
       RenderBlock {UL} at (0,0) size 120x584 [bgcolor=#808080] [border: (25px solid #008000) none]
         RenderListItem {LI} at (0,50) size 40x534
-          RenderListMarker at (0,-18) size 19x7: bullet
+          RenderListMarker at (0,-15) size 19x7: bullet
           RenderText {#text} at (0,0) size 39x530
             text run at (0,0) width 530: "The top padding on this unordered list has been set to 25 pixels, which will require"
             text run at (20,0) width 197: "some extra test in order to test."
         RenderListItem {LI} at (40,50) size 80x534 [bgcolor=#FFFFFF] [border: (25px solid #008000) none]
-          RenderListMarker at (0,-18) size 19x7: bullet
+          RenderListMarker at (0,-15) size 19x7: bullet
           RenderText {#text} at (0,50) size 79x484
             text run at (0,50) width 484: "Another list item might not be such a bad idea, either, considering that such"
             text run at (20,50) width 243: "things do need to be double-checked. "

--- a/LayoutTests/platform/ios/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-expected.txt
@@ -5,30 +5,30 @@ layer at (0,0) size 800x1944
     RenderBody {BODY} at (8,8) size 784x1920
       RenderBlock {UL} at (0,0) size 186x142 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (-18,10) size 7x19: bullet
+          RenderListMarker at (-15,10) size 7x19: bullet
           RenderText {#text} at (10,10) size 62x19
             text run at (10,10) width 62: "First item"
         RenderListItem {LI} at (41,41) size 144x60 [border: (5px solid #FFA500)]
-          RenderListMarker at (-18,10) size 7x19: bullet
+          RenderListMarker at (-15,10) size 7x19: bullet
           RenderText {#text} at (10,10) size 107x39
             text run at (10,10) width 107: "Second and very"
             text run at (10,30) width 94: "very long item"
         RenderListItem {LI} at (41,101) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (-18,10) size 7x19: bullet
+          RenderListMarker at (-15,10) size 7x19: bullet
           RenderText {#text} at (10,10) size 68x19
             text run at (10,10) width 68: "Third item"
       RenderBlock {UL} at (0,158) size 186x142 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (154,10) size 8x19: bullet
+          RenderListMarker at (151,10) size 8x19: bullet
           RenderText {#text} at (71,10) size 63x19
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,41) size 144x60 [border: (5px solid #FFA500)]
-          RenderListMarker at (154,10) size 8x19: bullet
+          RenderListMarker at (151,10) size 8x19: bullet
           RenderText {#text} at (26,10) size 108x39
             text run at (26,10) width 108: "Second and very"
             text run at (39,30) width 95: "very long item"
         RenderListItem {LI} at (1,101) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (154,10) size 8x19: bullet
+          RenderListMarker at (151,10) size 8x19: bullet
           RenderText {#text} at (65,10) size 69x19
             text run at (65,10) width 69: "Third item"
       RenderBlock {UL} at (0,316) size 186x142 [border: (1px solid #0000FF)]
@@ -119,30 +119,30 @@ layer at (0,0) size 800x1944
             text run at (48,10) width 69: "Third item"
       RenderBlock {OL} at (0,1304) size 186x142 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (-21,10) size 16x19: "1"
+          RenderListMarker at (-17,10) size 16x19: "1"
           RenderText {#text} at (10,10) size 62x19
             text run at (10,10) width 62: "First item"
         RenderListItem {LI} at (41,41) size 144x60 [border: (5px solid #FFA500)]
-          RenderListMarker at (-21,10) size 16x19: "2"
+          RenderListMarker at (-17,10) size 16x19: "2"
           RenderText {#text} at (10,10) size 107x39
             text run at (10,10) width 107: "Second and very"
             text run at (10,30) width 94: "very long item"
         RenderListItem {LI} at (41,101) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (-21,10) size 16x19: "3"
+          RenderListMarker at (-17,10) size 16x19: "3"
           RenderText {#text} at (10,10) size 68x19
             text run at (10,10) width 68: "Third item"
       RenderBlock {OL} at (0,1462) size 186x142 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (148,10) size 17x19: "1"
+          RenderListMarker at (144,10) size 17x19: "1"
           RenderText {#text} at (71,10) size 63x19
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,41) size 144x60 [border: (5px solid #FFA500)]
-          RenderListMarker at (148,10) size 17x19: "2"
+          RenderListMarker at (144,10) size 17x19: "2"
           RenderText {#text} at (26,10) size 108x39
             text run at (26,10) width 108: "Second and very"
             text run at (39,30) width 95: "very long item"
         RenderListItem {LI} at (1,101) size 144x40 [border: (5px solid #FFA500)]
-          RenderListMarker at (148,10) size 17x19: "3"
+          RenderListMarker at (144,10) size 17x19: "3"
           RenderText {#text} at (65,10) size 69x19
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1620) size 186x142 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
@@ -5,30 +5,30 @@ layer at (0,0) size 1944x600
     RenderBody {BODY} at (8,8) size 1920x584
       RenderBlock {UL} at (0,0) size 142x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,-18) size 19x7: bullet
+          RenderListMarker at (11,-15) size 19x7: bullet
           RenderText {#text} at (11,10) size 19x62
             text run at (11,10) width 62: "First item"
         RenderListItem {LI} at (41,41) size 60x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,-18) size 19x7: bullet
+          RenderListMarker at (11,-15) size 19x7: bullet
           RenderText {#text} at (11,10) size 39x107
             text run at (11,10) width 107: "Second and very"
             text run at (31,10) width 94: "very long item"
         RenderListItem {LI} at (101,41) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,-18) size 19x7: bullet
+          RenderListMarker at (11,-15) size 19x7: bullet
           RenderText {#text} at (11,10) size 19x68
             text run at (11,10) width 68: "Third item"
       RenderBlock {UL} at (158,0) size 142x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,154) size 19x8: bullet
+          RenderListMarker at (11,151) size 19x8: bullet
           RenderText {#text} at (11,71) size 19x63
             text run at (11,71) width 62: "First item"
         RenderListItem {LI} at (41,1) size 60x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,154) size 19x8: bullet
+          RenderListMarker at (11,151) size 19x8: bullet
           RenderText {#text} at (11,26) size 39x108
             text run at (11,26) width 107: "Second and very"
             text run at (31,39) width 94: "very long item"
         RenderListItem {LI} at (101,1) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,154) size 19x8: bullet
+          RenderListMarker at (11,151) size 19x8: bullet
           RenderText {#text} at (11,65) size 19x69
             text run at (11,65) width 68: "Third item"
       RenderBlock {UL} at (316,0) size 142x186 [border: (1px solid #0000FF)]
@@ -119,30 +119,30 @@ layer at (0,0) size 1944x600
             text run at (11,48) width 68: "Third item"
       RenderBlock {OL} at (1304,0) size 142x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,-21) size 19x16: "1"
+          RenderListMarker at (11,-17) size 19x16: "1"
           RenderText {#text} at (11,10) size 19x62
             text run at (11,10) width 62: "First item"
         RenderListItem {LI} at (41,41) size 60x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,-21) size 19x16: "2"
+          RenderListMarker at (11,-17) size 19x16: "2"
           RenderText {#text} at (11,10) size 39x107
             text run at (11,10) width 107: "Second and very"
             text run at (31,10) width 94: "very long item"
         RenderListItem {LI} at (101,41) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,-21) size 19x16: "3"
+          RenderListMarker at (11,-17) size 19x16: "3"
           RenderText {#text} at (11,10) size 19x68
             text run at (11,10) width 68: "Third item"
       RenderBlock {OL} at (1462,0) size 142x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,148) size 19x17: "1"
+          RenderListMarker at (11,144) size 19x17: "1"
           RenderText {#text} at (11,71) size 19x63
             text run at (11,71) width 62: "First item"
         RenderListItem {LI} at (41,1) size 60x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,148) size 19x17: "2"
+          RenderListMarker at (11,144) size 19x17: "2"
           RenderText {#text} at (11,26) size 39x108
             text run at (11,26) width 107: "Second and very"
             text run at (31,39) width 94: "very long item"
         RenderListItem {LI} at (101,1) size 40x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (11,148) size 19x17: "3"
+          RenderListMarker at (11,144) size 19x17: "3"
           RenderText {#text} at (11,65) size 19x69
             text run at (11,65) width 68: "Third item"
       RenderBlock {OL} at (1620,0) size 142x186 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/lists/anonymous-items-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/anonymous-items-expected.txt
@@ -8,35 +8,35 @@ layer at (0,0) size 800x600
           text run at (0,0) width 405: "Tests list item numbering when there are anonymous list items."
       RenderBlock {OL} at (0,36) size 784x20
         RenderListItem at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText at (0,0) size 33x19
             text run at (0,0) width 33: "ONE"
       RenderBlock {OL} at (0,72) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 24x19
             text run at (0,0) width 24: "one"
         RenderListItem at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText at (0,0) size 37x19
             text run at (0,0) width 37: "TWO"
       RenderBlock {OL} at (0,128) size 784x20
         RenderListItem at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText at (0,0) size 33x19
             text run at (0,0) width 33: "ONE"
       RenderBlock {OL} at (0,164) size 784x40
         RenderListItem at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText at (0,0) size 33x19
             text run at (0,0) width 33: "ONE"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 24x19
             text run at (0,0) width 24: "two"
       RenderBlock {OL} at (0,220) size 784x80
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 24x19
             text run at (0,0) width 24: "one"
         RenderBlock {DIV} at (40,20) size 744x40
@@ -44,27 +44,27 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 21x19
               text run at (0,0) width 21: "div"
           RenderListItem at (0,20) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText at (0,0) size 37x19
               text run at (0,0) width 37: "TWO"
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 32x19
             text run at (0,0) width 32: "three"
       RenderBlock {OL} at (0,316) size 784x80
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 24x19
             text run at (0,0) width 24: "one"
         RenderBlock {DIV} at (40,20) size 744x40
           RenderListItem at (0,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText at (0,0) size 37x19
               text run at (0,0) width 37: "TWO"
           RenderBlock (anonymous) at (0,20) size 744x20
             RenderText {#text} at (0,0) size 21x19
               text run at (0,0) width 21: "div"
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 32x19
             text run at (0,0) width 32: "three"

--- a/LayoutTests/platform/ios/fast/lists/big-list-marker-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/big-list-marker-expected.txt
@@ -9,6 +9,6 @@ layer at (0,0) size 800x600
           text run at (527,0) width 103: "See bug #11957"
       RenderBlock {UL} at (0,36) size 784x40 [border: (10px dashed #000000)]
         RenderListItem {LI} at (50,10) size 724x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 271x19
             text run at (0,0) width 271: "The list-marker should be the normal size."

--- a/LayoutTests/platform/ios/fast/lists/drag-into-marker-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/drag-into-marker-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,16) size 784x568
       RenderBlock {UL} at (16,0) size 752x59 [border: (1px solid #000000)]
         RenderListItem {LI} at (41,1) size 710x57
-          RenderListMarker at (-36,1) size 16x54: black square
+          RenderListMarker at (-29,1) size 16x54: black square
           RenderText {#text} at (0,1) size 108x54
             text run at (0,1) width 108: "hello "
           RenderInline {SPAN} at (107,1) size 113x54

--- a/LayoutTests/platform/ios/fast/lists/dynamic-marker-crash-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/dynamic-marker-crash-expected.txt
@@ -1,19 +1,19 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x89
-  RenderBlock {HTML} at (0,0) size 800x89
-    RenderBody {BODY} at (8,16) size 784x57
-      RenderBlock {UL} at (0,0) size 784x57
-        RenderListItem {LI} at (40,0) size 744x57
-          RenderBlock {FORM} at (0,0) size 744x21
-            RenderBlock {P} at (0,0) size 744x21
-              RenderListMarker at (-18,0) size 7x19: bullet
-              RenderTextControl {INPUT} at (0,1) size 294x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+layer at (0,0) size 800x90
+  RenderBlock {HTML} at (0,0) size 800x91
+    RenderBody {BODY} at (8,16) size 784x59
+      RenderBlock {UL} at (0,0) size 784x59
+        RenderListItem {LI} at (40,0) size 744x59
+          RenderBlock {FORM} at (0,0) size 744x23
+            RenderBlock {P} at (0,0) size 744x23
+              RenderListMarker at (-15,0) size 7x19: bullet
+              RenderTextControl {INPUT} at (0,1) size 295x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
               RenderText {#text} at (0,0) size 0x0
-          RenderBlock {P} at (0,37) size 744x20
+          RenderBlock {P} at (0,38) size 744x21
             RenderText {#text} at (0,0) size 340x19
               text run at (0,0) width 340: "There should be an input field above this line of text."
-layer at (54,20) size 282x14
-  RenderBlock {DIV} at (6,3) size 282x14
+layer at (55,20) size 281x14
+  RenderBlock {DIV} at (6,3) size 283x15
     RenderText {#text} at (0,0) size 56x14
       text run at (0,0) width 56: "blah blubb"

--- a/LayoutTests/platform/ios/fast/lists/inlineBoxWrapperNullCheck-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/inlineBoxWrapperNullCheck-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 190x28
         RenderBlock {UL} at (0,0) size 190x28
           RenderListItem {LI} at (40,0) size 150x28
-            RenderListMarker at (-18,8) size 7x19: bullet
+            RenderListMarker at (-15,8) size 7x19: bullet
             RenderInline {A} at (0,8) size 207x19
               RenderText {#text} at (0,0) size 0x0
               RenderImage {IMG} at (0,0) size 207x23

--- a/LayoutTests/platform/ios/fast/lists/li-br-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/li-br-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {OL} at (0,0) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 1492x19
             text run at (0,0) width 1492: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       RenderBlock {OL} at (0,36) size 784x40

--- a/LayoutTests/platform/ios/fast/lists/li-style-alpha-huge-value-crash-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/li-style-alpha-huge-value-crash-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (40,0) size 624x60
           RenderBlock {OL} at (0,0) size 624x60
             RenderListItem {LI} at (40,0) size 584x60
-              RenderListMarker at (-92,0) size 87x19: "CYWOQVJ"
+              RenderListMarker at (-88,0) size 87x19: "CYWOQVJ"
               RenderBR {BR} at (0,0) size 0x19
               RenderText {#text} at (0,20) size 492x39
                 text run at (0,20) width 190: "SUCCESS (you didn't crash) "

--- a/LayoutTests/platform/ios/fast/lists/list-marker-with-line-height-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/list-marker-with-line-height-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {OL} at (0,0) size 784x24
         RenderListItem {LI} at (40,0) size 744x24
-          RenderListMarker at (-21,2) size 16x19: "1"
+          RenderListMarker at (-17,2) size 16x19: "1"
           RenderText {#text} at (0,2) size 419x19
             text run at (0,2) width 419: "This test passes if the list item and list marker are evenly aligned."

--- a/LayoutTests/platform/ios/fast/lists/marker-before-empty-inline-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/marker-before-empty-inline-expected.txt
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (0,0) size 0x0
           RenderBlock (anonymous) at (0,0) size 744x20
             RenderBlock {DIV} at (0,0) size 744x20
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
               RenderText {#text} at (0,0) size 29x19
                 text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,20) size 744x0
@@ -37,7 +37,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (0,0) size 0x0
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {DIV} at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderText {#text} at (0,0) size 29x19
               text run at (0,0) width 29: "item"
       RenderBlock {UL} at (0,144) size 784x20
@@ -49,7 +49,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (0,0) size 0x0
           RenderBlock (anonymous) at (0,0) size 744x20
             RenderBlock {DIV} at (0,0) size 744x20
-              RenderListMarker at (-18,0) size 7x19: bullet
+              RenderListMarker at (-15,0) size 7x19: bullet
               RenderText {#text} at (0,0) size 28x19
                 text run at (0,0) width 28: "item"
           RenderBlock (anonymous) at (0,20) size 744x0
@@ -60,7 +60,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,180) size 784x40
         RenderListItem {LI} at (40,0) size 744x40
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
             RenderInline {SPAN} at (0,0) size 41x19
               RenderInline (generated) at (0,0) size 41x19
                 RenderText at (0,0) size 41x19
@@ -79,8 +79,8 @@ layer at (0,0) size 800x600
           RenderBlock (anonymous) at (0,0) size 744x20
             RenderBlock {UL} at (0,0) size 744x20
               RenderListItem {LI} at (40,0) size 704x20
-                RenderListMarker at (-18,0) size 7x19: white bullet
-                RenderListMarker at (-58,0) size 7x19: bullet
+                RenderListMarker at (-15,0) size 7x19: white bullet
+                RenderListMarker at (-55,0) size 7x19: bullet
                 RenderText {#text} at (0,0) size 29x19
                   text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,20) size 744x20
@@ -91,8 +91,8 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 744x20
             RenderBlock {UL} at (0,0) size 744x20
               RenderListItem {LI} at (40,0) size 704x20
-                RenderListMarker at (-18,0) size 7x19: white bullet
-                RenderListMarker at (-58,0) size 7x19: bullet
+                RenderListMarker at (-15,0) size 7x19: white bullet
+                RenderListMarker at (-55,0) size 7x19: bullet
                 RenderText {#text} at (0,0) size 29x19
                   text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,20) size 744x20
@@ -103,10 +103,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,384) size 784x60
         RenderListItem {LI} at (40,0) size 744x60
           RenderBlock (anonymous) at (0,0) size 744x20
-            RenderListMarker at (-18,0) size 7x19: bullet
+            RenderListMarker at (-15,0) size 7x19: bullet
           RenderBlock {UL} at (0,20) size 744x20
             RenderListItem {LI} at (40,0) size 704x20
-              RenderListMarker at (-18,0) size 7x19: white bullet
+              RenderListMarker at (-15,0) size 7x19: white bullet
               RenderText {#text} at (0,0) size 29x19
                 text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,40) size 744x20

--- a/LayoutTests/platform/ios/fast/lists/marker-image-error-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/marker-image-error-expected.txt
@@ -21,22 +21,22 @@ layer at (0,0) size 800x600
           text run at (0,0) width 407: "There should be a bullet next to each item on the following list:"
       RenderBlock {UL} at (0,92) size 784x100
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 162x19
             text run at (0,0) width 162: "Prospectuses and courses"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 170x19
             text run at (0,0) width 170: "Undergraduate admissions"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 134x19
             text run at (0,0) width 134: "Graduate admissions"
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 139x19
             text run at (0,0) width 139: "Continuing education"
         RenderListItem {LI} at (40,80) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 96x19
             text run at (0,0) width 96: "Online courses"

--- a/LayoutTests/platform/ios/fast/lists/markers-in-selection-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/markers-in-selection-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {UL} at (0,90) size 784x20
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 162x19
             text run at (0,0) width 162: "Item with outside marker"
       RenderBlock {UL} at (0,126) size 784x20
@@ -43,11 +43,11 @@ layer at (0,0) size 800x600
             text run at (17,0) width 197: "Item with inside image marker"
       RenderBlock {OL} at (0,234) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 162x19
             text run at (0,0) width 162: "Item with outside ordinal"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 103x19
             text run at (0,0) width 103: "and another one"
       RenderBlock {OL} at (0,290) size 784x40

--- a/LayoutTests/platform/ios/fast/lists/numeric-markers-outside-list-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/numeric-markers-outside-list-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DIV} at (0,0) size 784x40
         RenderListItem {DIV} at (30,0) size 754x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 153x19
             text run at (0,0) width 153: "should have a label of 1"
         RenderListItem {DIV} at (30,20) size 754x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 153x19
             text run at (0,0) width 153: "should have a label of 2"

--- a/LayoutTests/platform/ios/fast/lists/ol-display-types-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/ol-display-types-expected.txt
@@ -9,18 +9,18 @@ layer at (0,0) size 800x600
           text run at (0,20) width 317: "number. This is generally going to be LI element."
       RenderBlock {OL} at (0,56) size 784x340
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 3"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "4"
+          RenderListMarker at (-17,0) size 16x19: "4"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 4"
         RenderBlock {LI} at (40,40) size 744x20
           RenderText {#text} at (0,0) size 168x19
             text run at (0,0) width 168: "Should not have a number"
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "5"
+          RenderListMarker at (-17,0) size 16x19: "5"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 5"
         RenderBlock (anonymous) at (40,80) size 744x20
@@ -29,48 +29,48 @@ layer at (0,0) size 800x600
               text run at (0,0) width 168: "Should not have a number"
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,100) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "6"
+          RenderListMarker at (-17,0) size 16x19: "6"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 6"
         RenderBlock {DIV} at (40,120) size 744x20
           RenderText {#text} at (0,0) size 168x19
             text run at (0,0) width 168: "Should not have a number"
         RenderListItem {DIV} at (40,140) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "7"
+          RenderListMarker at (-17,0) size 16x19: "7"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 7"
         RenderListItem {LI} at (40,160) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "8"
+          RenderListMarker at (-17,0) size 16x19: "8"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 8"
         RenderListItem {LI} at (40,180) size 744x20
           RenderText {#text} at (0,0) size 168x19
             text run at (0,0) width 168: "Should not have a number"
         RenderListItem {LI} at (40,200) size 744x20
-          RenderListMarker at (-29,0) size 24x19: "10"
+          RenderListMarker at (-25,0) size 24x19: "10"
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "Should be 10"
         RenderListItem {LI} at (40,220) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 121x19
             text run at (0,0) width 121: "Should have a disc"
         RenderListItem {LI} at (40,240) size 744x20
-          RenderListMarker at (-29,0) size 24x19: "12"
+          RenderListMarker at (-25,0) size 24x19: "12"
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "Should be 12"
         RenderListItem {LI} at (40,260) size 744x20
-          RenderListMarker at (-18,0) size 7x19: black square
+          RenderListMarker at (-15,0) size 7x19: black square
           RenderText {#text} at (0,0) size 137x19
             text run at (0,0) width 137: "Should have a square"
         RenderListItem {LI} at (40,280) size 744x20
-          RenderListMarker at (-29,0) size 24x19: "14"
+          RenderListMarker at (-25,0) size 24x19: "14"
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "Should be 14"
         RenderListItem {LI} at (40,300) size 744x20
-          RenderListMarker at (-18,0) size 7x19: white bullet
+          RenderListMarker at (-15,0) size 7x19: white bullet
           RenderText {#text} at (0,0) size 131x19
             text run at (0,0) width 131: "Should have a circle"
         RenderListItem {LI} at (40,320) size 744x20
-          RenderListMarker at (-29,0) size 24x19: "16"
+          RenderListMarker at (-25,0) size 24x19: "16"
           RenderText {#text} at (0,0) size 85x19
             text run at (0,0) width 85: "Should be 16"

--- a/LayoutTests/platform/ios/fast/lists/ol-start-dynamic-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/ol-start-dynamic-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x40
         RenderBlock {OL} at (0,0) size 784x40
           RenderListItem {LI} at (40,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 22x19
               text run at (0,0) width 22: "foo"
           RenderListItem {LI} at (40,20) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 21x19
               text run at (0,0) width 21: "bar"

--- a/LayoutTests/platform/ios/fast/lists/ol-start-parsing-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/ol-start-parsing-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 113: "No start attribute."
       RenderBlock {OL} at (0,36) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,102) size 784x20
@@ -20,11 +20,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 28: "start"
       RenderBlock {OL} at (0,138) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,204) size 784x20
@@ -32,11 +32,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 50: "start=\"\""
       RenderBlock {OL} at (0,240) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,306) size 784x20
@@ -44,11 +44,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 66: "start=\" 2 \""
       RenderBlock {OL} at (0,342) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,408) size 784x20
@@ -56,11 +56,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 67: "start=\"+2\""
       RenderBlock {OL} at (0,444) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,510) size 784x20
@@ -68,11 +68,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 70: "start=\"A2\""
       RenderBlock {OL} at (0,546) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,612) size 784x20
@@ -80,11 +80,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 62: "start=\".2\""
       RenderBlock {OL} at (0,648) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,714) size 784x20
@@ -92,11 +92,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 66: "start=\"#2\""
       RenderBlock {OL} at (0,750) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,806) size 784x20
@@ -104,11 +104,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 58: "start=\"0\""
       RenderBlock {OL} at (0,842) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "0"
+          RenderListMarker at (-17,0) size 16x19: "0"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 0"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
       RenderBlock (anonymous) at (0,908) size 784x20
@@ -116,11 +116,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 66: "start=\" 0 \""
       RenderBlock {OL} at (0,944) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "0"
+          RenderListMarker at (-17,0) size 16x19: "0"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 0"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
       RenderBlock (anonymous) at (0,1010) size 784x20
@@ -128,11 +128,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 58: "start=\"2\""
       RenderBlock {OL} at (0,1046) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,1112) size 784x20
@@ -140,11 +140,11 @@ layer at (0,0) size 800x1222
           text run at (0,0) width 63: "start=\"-2\""
       RenderBlock {OL} at (0,1148) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-27,0) size 22x19: "-2"
+          RenderListMarker at (-23,0) size 22x19: "-2"
           RenderText {#text} at (0,0) size 82x19
             text run at (0,0) width 82: "Should be -2"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-27,0) size 22x19: "-1"
+          RenderListMarker at (-23,0) size 22x19: "-1"
           RenderText {#text} at (0,0) size 82x19
             text run at (0,0) width 82: "Should be -1"
 layer at (8,100) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/lists/olstart-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/olstart-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 800x830
           text run at (0,0) width 132: "1. Basic inheritance:"
       RenderBlock {OL} at (0,36) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 3"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "4"
+          RenderListMarker at (-17,0) size 16x19: "4"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 4"
       RenderBlock (anonymous) at (0,102) size 784x20
@@ -20,12 +20,12 @@ layer at (0,0) size 800x830
           text run at (0,0) width 297: "2. Test that the inner start value gets inherited:"
       RenderBlock {OL} at (0,138) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "5"
+          RenderListMarker at (-17,0) size 16x19: "5"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 5"
         RenderBlock {OL} at (40,20) size 744x20
           RenderListItem {LI} at (40,0) size 704x20
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 77x19
               text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,204) size 784x20
@@ -36,7 +36,7 @@ layer at (0,0) size 800x830
           RenderText {#text} at (0,0) size 29x19
             text run at (0,0) width 29: "Text"
         RenderListItem {LI} at (40,36) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,322) size 784x20
@@ -47,7 +47,7 @@ layer at (0,0) size 800x830
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,0) size 744x20
           RenderListItem {LI} at (0,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 155x19
               text run at (0,0) width 155: "Should be 3 (and bold)"
         RenderBlock (anonymous) at (40,20) size 744x0
@@ -61,18 +61,18 @@ layer at (0,0) size 800x830
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,0) size 744x20
           RenderListItem {LI} at (0,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 155x19
               text run at (0,0) width 155: "Should be 3 (and bold)"
         RenderBlock (anonymous) at (40,20) size 744x0
           RenderInline {B} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "4"
+          RenderListMarker at (-17,0) size 16x19: "4"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 4"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "5"
+          RenderListMarker at (-17,0) size 16x19: "5"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 5"
       RenderBlock (anonymous) at (0,526) size 784x20
@@ -80,14 +80,14 @@ layer at (0,0) size 800x830
           text run at (0,0) width 461: "6. Test for properly chaining from the previous li when current is nested"
       RenderBlock {OL} at (0,562) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 1"
         RenderBlock (anonymous) at (40,20) size 744x0
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,20) size 744x20
           RenderListItem {LI} at (0,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 155x19
               text run at (0,0) width 155: "Should be 2 (and bold)"
         RenderBlock (anonymous) at (40,40) size 744x0
@@ -101,7 +101,7 @@ layer at (0,0) size 800x830
           RenderInline {I} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,0) size 744x20
           RenderListItem {LI} at (0,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 152x19
               text run at (0,0) width 152: "Should be 2 (and italic)"
         RenderBlock (anonymous) at (40,20) size 744x0
@@ -110,7 +110,7 @@ layer at (0,0) size 800x830
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,20) size 744x20
           RenderListItem {LI} at (0,0) size 744x20
-            RenderListMarker at (-21,0) size 16x19: "3"
+            RenderListMarker at (-17,0) size 16x19: "3"
             RenderText {#text} at (0,0) size 155x19
               text run at (0,0) width 155: "Should be 3 (and bold)"
         RenderBlock (anonymous) at (40,40) size 744x0
@@ -122,11 +122,11 @@ layer at (0,0) size 800x830
       RenderBlock {OL} at (0,766) size 784x40
         RenderBlock {OL} at (40,0) size 744x20
           RenderListItem {LI} at (40,0) size 704x20
-            RenderListMarker at (-21,0) size 16x19: "2"
+            RenderListMarker at (-17,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 77x19
               text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "5"
+          RenderListMarker at (-17,0) size 16x19: "5"
           RenderText {#text} at (0,0) size 77x19
             text run at (0,0) width 77: "Should be 5"
 layer at (8,100) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -11,38 +11,38 @@ layer at (0,0) size 800x586
           text run at (0,0) width 566: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
       RenderBlock {DIV} at (24,85) size 760x473 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x22 [border: (1px solid #000000)]
-          RenderListMarker at (-21,1) size 16x19: "1"
+          RenderListMarker at (-17,1) size 16x19: "1"
           RenderText {#text} at (33,1) size 42x19
             text run at (33,1) width 42: "Item 1"
         RenderListItem {DIV} at (33,23) size 726x152 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x20
-            RenderListMarker at (-54,0) size 16x19: "2"
+            RenderListMarker at (-50,0) size 16x19: "2"
             RenderText {#text} at (0,0) size 42x19
               text run at (0,0) width 42: "Item 2"
           RenderListItem {DIV} at (33,21) size 692x42 [border: (1px solid #000000)]
-            RenderListMarker at (-21,1) size 16x19: "a"
+            RenderListMarker at (-17,1) size 16x19: "a"
             RenderText {#text} at (33,1) size 41x19
               text run at (33,1) width 41: "Item a"
             RenderBR {BR} at (73,1) size 1x19
             RenderText {#text} at (33,21) size 90x19
               text run at (33,21) width 90: "Item a, Line 2"
           RenderListItem {DIV} at (33,63) size 692x22 [border: (1px solid #000000)]
-            RenderListMarker at (-21,1) size 16x19: "b"
+            RenderListMarker at (-17,1) size 16x19: "b"
             RenderText {#text} at (33,1) size 42x19
               text run at (33,1) width 42: "Item b"
           RenderListItem {DIV} at (33,85) size 692x22 [border: (1px solid #000000)]
-            RenderListMarker at (-21,1) size 16x19: "c"
+            RenderListMarker at (-17,1) size 16x19: "c"
             RenderText {#text} at (33,1) size 41x19
               text run at (33,1) width 41: "Item c"
           RenderBlock {DIV} at (33,107) size 692x22 [border: (1px solid #000000)]
             RenderText {#text} at (33,1) size 92x19
               text run at (33,1) width 92: "Not a list item"
           RenderListItem {DIV} at (33,129) size 692x22 [border: (1px solid #000000)]
-            RenderListMarker at (-21,1) size 16x19: "d"
+            RenderListMarker at (-17,1) size 16x19: "d"
             RenderText {#text} at (33,1) size 42x19
               text run at (33,1) width 42: "Item d"
         RenderListItem {DIV} at (33,175) size 726x22 [border: (1px solid #000000)]
-          RenderListMarker at (-21,1) size 16x19: "3"
+          RenderListMarker at (-17,1) size 16x19: "3"
           RenderText {#text} at (33,1) size 42x19
             text run at (33,1) width 42: "Item 3"
         RenderBlock {DIV} at (33,197) size 726x108 [border: (1px solid #000000)]
@@ -50,7 +50,7 @@ layer at (0,0) size 800x586
             RenderText {#text} at (0,0) size 92x19
               text run at (0,0) width 92: "Not a list item"
           RenderListItem {DIV} at (33,21) size 692x42 [border: (1px solid #000000)]
-            RenderListMarker at (-21,1) size 16x19: "a"
+            RenderListMarker at (-17,1) size 16x19: "a"
             RenderText {#text} at (33,1) size 41x19
               text run at (33,1) width 41: "Item a"
             RenderBR {BR} at (73,1) size 1x19
@@ -60,21 +60,21 @@ layer at (0,0) size 800x586
             RenderText {#text} at (33,1) size 92x19
               text run at (33,1) width 92: "Not a list item"
           RenderListItem {DIV} at (33,85) size 692x22 [border: (1px solid #000000)]
-            RenderListMarker at (-21,1) size 16x19: "b"
+            RenderListMarker at (-17,1) size 16x19: "b"
             RenderText {#text} at (33,1) size 42x19
               text run at (33,1) width 42: "Item b"
         RenderListItem {DIV} at (33,305) size 726x22 [border: (1px solid #000000)]
-          RenderListMarker at (-21,1) size 16x19: "4"
+          RenderListMarker at (-17,1) size 16x19: "4"
           RenderText {#text} at (33,1) size 42x19
             text run at (33,1) width 42: "Item 4"
         RenderListItem {DIV} at (33,327) size 726x122 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x20
-            RenderListMarker at (-54,0) size 16x19: "5"
+            RenderListMarker at (-50,0) size 16x19: "5"
             RenderText {#text} at (0,0) size 42x19
               text run at (0,0) width 42: "Item 5"
           RenderListItem {TABLE} at (33,21) size 692x50 [border: (1px dashed #000000)]
             RenderBlock (anonymous) at (1,1) size 690x20
-              RenderListMarker at (-22,0) size 16x19: "a"
+              RenderListMarker at (-18,0) size 16x19: "a"
             RenderTable at (1,21) size 193x28
               RenderTableSection {TBODY} at (0,0) size 193x28
                 RenderTableRow {TR} at (0,2) size 193x24
@@ -86,7 +86,7 @@ layer at (0,0) size 800x586
                       text run at (2,2) width 89: "Table Cell B1"
           RenderListItem {TABLE} at (33,71) size 692x50 [border: (1px dashed #000000)]
             RenderBlock (anonymous) at (1,1) size 690x20
-              RenderListMarker at (-22,0) size 16x19: "b"
+              RenderListMarker at (-18,0) size 16x19: "b"
             RenderTable at (1,21) size 217x28
               RenderTableSection {TBODY} at (0,0) size 217x28
                 RenderTableRow {TR} at (0,2) size 217x24
@@ -97,6 +97,6 @@ layer at (0,0) size 800x586
                     RenderText {#text} at (2,2) size 101x19
                       text run at (2,2) width 101: "Table 2 Cell B1"
         RenderListItem {DIV} at (33,449) size 726x22 [border: (1px solid #000000)]
-          RenderListMarker at (-21,1) size 16x19: "6"
+          RenderListMarker at (-17,1) size 16x19: "6"
           RenderText {#text} at (33,1) size 42x19
             text run at (33,1) width 42: "Item 6"

--- a/LayoutTests/platform/ios/fast/lists/scrolled-marker-paint-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/scrolled-marker-paint-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
 layer at (8,-4) size 409x20 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock (positioned) {UL} at (8,-4) size 409x20
     RenderListItem {LI} at (40,0) size 369x20
-      RenderListMarker at (-18,0) size 7x19: bullet
+      RenderListMarker at (-15,0) size 7x19: bullet
       RenderText {#text} at (0,0) size 369x19
         text run at (0,0) width 119: "This is a list item. "
         text run at (118,0) width 251: "You should see a list marker to the left."

--- a/LayoutTests/platform/ios/fast/overflow/overflow-rtl-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/overflow-rtl-expected.txt
@@ -17,19 +17,19 @@ layer at (0,0) size 800x457
           text run at (0,0) width 469: "The right column should be a mirror-image of the left column in terms of"
       RenderBlock {UL} at (0,92) size 784x80
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 168x19
             text run at (0,0) width 168: "the presence of a scrollbar"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 242x19
             text run at (0,0) width 242: "the initial position of the scroll thumb"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 462x19
             text run at (0,0) width 462: "which letters are visible initially and when you scroll (in the top 3 rows)"
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 591x19
             text run at (0,0) width 591: "the position of the blue and olive boxes, initially and when you scroll (in the bottom 2 rows)"
       RenderTable {TABLE} at (0,188) size 256x245

--- a/LayoutTests/platform/ios/fast/overflow/overflow-rtl-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/overflow-rtl-vertical-expected.txt
@@ -17,15 +17,15 @@ layer at (0,0) size 343x600
           text run at (1,0) width 469: "The right column should be a mirror-image of the left column in terms of"
       RenderBlock {UL} at (92,0) size 60x584
         RenderListItem {LI} at (0,40) size 20x544
-          RenderListMarker at (1,-18) size 19x7: bullet
+          RenderListMarker at (1,-15) size 19x7: bullet
           RenderText {#text} at (1,0) size 19x168
             text run at (1,0) width 168: "the presence of a scrollbar"
         RenderListItem {LI} at (20,40) size 20x544
-          RenderListMarker at (1,-18) size 19x7: bullet
+          RenderListMarker at (1,-15) size 19x7: bullet
           RenderText {#text} at (1,0) size 19x242
             text run at (1,0) width 242: "the initial position of the scroll thumb"
         RenderListItem {LI} at (40,40) size 20x544
-          RenderListMarker at (1,-18) size 19x7: bullet
+          RenderListMarker at (1,-15) size 19x7: bullet
           RenderText {#text} at (1,0) size 19x340
             text run at (1,0) width 340: "which letters are visible initially and when you scroll"
       RenderTable {TABLE} at (168,0) size 151x256

--- a/LayoutTests/platform/ios/fast/overflow/overflow-with-local-background-attachment-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/overflow-with-local-background-attachment-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x298
     RenderBody {BODY} at (8,16) size 784x274
       RenderBlock {UL} at (0,0) size 784x60 [color=#000080]
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 338x19
             text run at (0,0) width 338: "You should not see the background under the border."
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 350x19
             text run at (0,0) width 350: "As you scroll the element below the cats should move."
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 300x19
             text run at (0,0) width 300: "The cats should be on a light grey background."
 layer at (8,92) size 390x198 clip at (38,122) size 315x138 scrollHeight 400

--- a/LayoutTests/platform/ios/fast/selectors/001-expected.txt
+++ b/LayoutTests/platform/ios/fast/selectors/001-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x108
     RenderBody {BODY} at (8,16) size 784x76
       RenderBlock {UL} at (0,0) size 784x40
         RenderListItem {LI} at (40,0) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 311x19
             text run at (0,0) width 311: "The background of this list item should be green"
         RenderListItem {LI} at (40,20) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 389x19
             text run at (0,0) width 389: "The background of this second list item should be also green"
       RenderBlock {P} at (0,56) size 784x20 [bgcolor=#00FF00]

--- a/LayoutTests/platform/ios/fast/selectors/013-expected.txt
+++ b/LayoutTests/platform/ios/fast/selectors/013-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x92
     RenderBody {BODY} at (8,16) size 784x60
       RenderBlock {UL} at (0,0) size 784x60
         RenderListItem {LI} at (40,0) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 438x19
             text run at (0,0) width 438: "This list item should have green background because its class is \"t1\""
         RenderListItem {LI} at (40,20) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 438x19
             text run at (0,0) width 438: "This list item should have green background because its class is \"t2\""
         RenderListItem {LI} at (40,40) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {SPAN} at (0,0) size 604x19
             RenderText {#text} at (0,0) size 604x19
               text run at (0,0) width 344: "This list item should have green background because "

--- a/LayoutTests/platform/ios/fast/selectors/015-expected.txt
+++ b/LayoutTests/platform/ios/fast/selectors/015-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x92
     RenderBody {BODY} at (8,16) size 784x60
       RenderBlock {UL} at (0,0) size 784x60
         RenderListItem {LI} at (40,0) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 439x19
             text run at (0,0) width 439: "This list item should have a green background. because its ID is \"t1\""
         RenderListItem {LI} at (40,20) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 439x19
             text run at (0,0) width 439: "This list item should have a green background. because its ID is \"t2\""
         RenderListItem {LI} at (40,40) size 744x20 [bgcolor=#00FF00]
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {SPAN} at (0,0) size 597x19
             RenderText {#text} at (0,0) size 597x19
               text run at (0,0) width 597: "This list item should have a green background. because the inner SPAN does not match \"#t4\""

--- a/LayoutTests/platform/ios/fast/selectors/166-expected.txt
+++ b/LayoutTests/platform/ios/fast/selectors/166-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 800x3669
           text run at (0,20) width 724: "markup is contained within it, for example the Xlink embed case uses an XLink with the show axis set to embed."
       RenderBlock {UL} at (0,205) size 784x201
         RenderListItem {LI} at (40,0) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 23x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 23x19
               text run at (0,0) width 23: "full"
@@ -68,7 +68,7 @@ layer at (0,0) size 800x3669
             RenderText {#text} at (208,20) size 84x19
               text run at (208,20) width 84: "TNG Format"
         RenderListItem {LI} at (40,40) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 34x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 34x19
               text run at (0,0) width 34: "static"
@@ -119,7 +119,7 @@ layer at (0,0) size 800x3669
             RenderText {#text} at (273,20) size 84x19
               text run at (273,20) width 84: "TNG Format"
         RenderListItem {LI} at (40,80) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 94x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 94x19
               text run at (0,0) width 94: "history-related"
@@ -170,7 +170,7 @@ layer at (0,0) size 800x3669
             RenderText {#text} at (273,20) size 84x19
               text run at (273,20) width 84: "TNG Format"
         RenderListItem {LI} at (40,120) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 68x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 68x19
               text run at (0,0) width 68: "interactive"
@@ -221,7 +221,7 @@ layer at (0,0) size 800x3669
             RenderText {#text} at (273,20) size 84x19
               text run at (273,20) width 84: "TNG Format"
         RenderListItem {LI} at (40,160) size 744x40
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 56x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 56x19
               text run at (0,0) width 56: "dynamic"
@@ -276,1092 +276,1092 @@ layer at (0,0) size 800x3669
           text run at (0,1) width 174: "Unadorned Tests"
       RenderBlock {UL} at (0,475) size 784x3121
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 125x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 125x19
               text run at (0,0) width 125: "Groups of selectors"
           RenderText {#text} at (124,0) size 32x19
             text run at (124,0) width 32: " (#1)"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 147x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 147x19
               text run at (0,0) width 147: "Type element selectors"
           RenderText {#text} at (146,0) size 32x19
             text run at (146,0) width 32: " (#2)"
         RenderListItem {LI} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 169x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 169x19
               text run at (0,0) width 169: "Omitted universal selector"
           RenderText {#text} at (168,0) size 32x19
             text run at (168,0) width 32: " (#4)"
         RenderListItem {LI} at (40,60) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 176x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 176x19
               text run at (0,0) width 176: "Attribute existence selector"
           RenderText {#text} at (175,0) size 31x19
             text run at (175,0) width 31: " (#5)"
         RenderListItem {LI} at (40,80) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 151x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 151x19
               text run at (0,0) width 151: "Attribute value selector"
           RenderText {#text} at (150,0) size 31x19
             text run at (150,0) width 31: " (#6)"
         RenderListItem {LI} at (40,100) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 184x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x19
               text run at (0,0) width 184: "Attribute multivalue selector"
           RenderText {#text} at (183,0) size 32x19
             text run at (183,0) width 32: " (#7)"
         RenderListItem {LI} at (40,120) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 184x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x19
               text run at (0,0) width 184: "Attribute multivalue selector"
           RenderText {#text} at (183,0) size 40x19
             text run at (183,0) width 40: " (#7b)"
         RenderListItem {LI} at (40,140) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 348x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 348x19
               text run at (0,0) width 348: "Attribute value selectors (hyphen-separated attributes)"
           RenderText {#text} at (347,0) size 32x19
             text run at (347,0) width 32: " (#8)"
         RenderListItem {LI} at (40,160) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 315x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 315x19
               text run at (0,0) width 315: "Substring matching attribute selector (beginning)"
           RenderText {#text} at (314,0) size 32x19
             text run at (314,0) width 32: " (#9)"
         RenderListItem {LI} at (40,180) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 274x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 274x19
               text run at (0,0) width 274: "Substring matching attribute selector (end)"
           RenderText {#text} at (273,0) size 40x19
             text run at (273,0) width 40: " (#10)"
         RenderListItem {LI} at (40,200) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 304x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 304x19
               text run at (0,0) width 304: "Substring matching attribute selector (contains)"
           RenderText {#text} at (303,0) size 39x19
             text run at (303,0) width 39: " (#11)"
         RenderListItem {LI} at (40,220) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 144x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x19
               text run at (0,0) width 144: "Default attribute value"
           RenderText {#text} at (143,0) size 40x19
             text run at (143,0) width 40: " (#12)"
         RenderListItem {LI} at (40,240) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 95x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 95x19
               text run at (0,0) width 95: "Class selectors"
           RenderText {#text} at (94,0) size 40x19
             text run at (94,0) width 40: " (#13)"
         RenderListItem {LI} at (40,260) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 183x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 183x19
               text run at (0,0) width 183: "More than one class selector"
           RenderText {#text} at (182,0) size 39x19
             text run at (182,0) width 39: " (#14)"
         RenderListItem {LI} at (40,280) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 77x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 77x19
               text run at (0,0) width 77: "ID selectors"
           RenderText {#text} at (76,0) size 40x19
             text run at (76,0) width 40: " (#15)"
         RenderListItem {LI} at (40,300) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 116x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 116x19
               text run at (0,0) width 116: ":link pseudo-class"
           RenderText {#text} at (115,0) size 39x19
             text run at (115,0) width 39: " (#16)"
         RenderListItem {LI} at (40,320) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 133x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 133x19
               text run at (0,0) width 133: ":visited pseudo-class"
           RenderText {#text} at (132,0) size 40x19
             text run at (132,0) width 40: " (#17)"
         RenderListItem {LI} at (40,340) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 127x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x19
               text run at (0,0) width 127: ":hover pseudo-class"
           RenderText {#text} at (126,0) size 40x19
             text run at (126,0) width 40: " (#18)"
         RenderListItem {LI} at (40,360) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 127x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x19
               text run at (0,0) width 127: ":hover pseudo-class"
           RenderText {#text} at (126,0) size 48x19
             text run at (126,0) width 48: " (#18b)"
         RenderListItem {LI} at (40,380) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 129x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 129x19
               text run at (0,0) width 129: ":active pseudo-class"
           RenderText {#text} at (128,0) size 40x19
             text run at (128,0) width 40: " (#19)"
         RenderListItem {LI} at (40,400) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 125x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 125x19
               text run at (0,0) width 125: ":focus pseudo-class"
           RenderText {#text} at (124,0) size 40x19
             text run at (124,0) width 40: " (#20)"
         RenderListItem {LI} at (40,420) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 127x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x19
               text run at (0,0) width 127: ":target pseudo-class"
           RenderText {#text} at (126,0) size 39x19
             text run at (126,0) width 39: " (#21)"
         RenderListItem {LI} at (40,440) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 127x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x19
               text run at (0,0) width 127: ":target pseudo-class"
           RenderText {#text} at (126,0) size 47x19
             text run at (126,0) width 47: " (#21b)"
         RenderListItem {LI} at (40,460) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 127x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x19
               text run at (0,0) width 127: ":target pseudo-class"
           RenderText {#text} at (126,0) size 47x19
             text run at (126,0) width 47: " (#21c)"
         RenderListItem {LI} at (40,480) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 129x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 129x19
               text run at (0,0) width 129: ":lang() pseudo-class"
           RenderText {#text} at (128,0) size 40x19
             text run at (128,0) width 40: " (#22)"
         RenderListItem {LI} at (40,500) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 140x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 140x19
               text run at (0,0) width 140: ":enabled pseudo-class"
           RenderText {#text} at (139,0) size 40x19
             text run at (139,0) width 40: " (#23)"
         RenderListItem {LI} at (40,520) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 144x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x19
               text run at (0,0) width 144: ":disabled pseudo-class"
           RenderText {#text} at (143,0) size 40x19
             text run at (143,0) width 40: " (#24)"
         RenderListItem {LI} at (40,540) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 143x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 143x19
               text run at (0,0) width 143: ":checked pseudo-class"
           RenderText {#text} at (142,0) size 40x19
             text run at (142,0) width 40: " (#25)"
         RenderListItem {LI} at (40,560) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 116x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 116x19
               text run at (0,0) width 116: ":root pseudo-class"
           RenderText {#text} at (115,0) size 40x19
             text run at (115,0) width 40: " (#27)"
         RenderListItem {LI} at (40,580) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 159x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 159x19
               text run at (0,0) width 159: ":nth-child() pseudo-class"
           RenderText {#text} at (158,0) size 40x19
             text run at (158,0) width 40: " (#28)"
         RenderListItem {LI} at (40,600) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 159x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 159x19
               text run at (0,0) width 159: ":nth-child() pseudo-class"
           RenderText {#text} at (158,0) size 48x19
             text run at (158,0) width 48: " (#28b)"
         RenderListItem {LI} at (40,620) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 187x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 187x19
               text run at (0,0) width 187: ":nth-last-child() pseudo-class"
           RenderText {#text} at (186,0) size 39x19
             text run at (186,0) width 39: " (#29)"
         RenderListItem {LI} at (40,640) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 187x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 187x19
               text run at (0,0) width 187: ":nth-last-child() pseudo-class"
           RenderText {#text} at (186,0) size 47x19
             text run at (186,0) width 47: " (#29b)"
         RenderListItem {LI} at (40,660) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 173x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 173x19
               text run at (0,0) width 173: ":nth-of-type() pseudo-class"
           RenderText {#text} at (172,0) size 40x19
             text run at (172,0) width 40: " (#30)"
         RenderListItem {LI} at (40,680) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 201x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 201x19
               text run at (0,0) width 201: ":nth-last-of-type() pseudo-class"
           RenderText {#text} at (200,0) size 40x19
             text run at (200,0) width 40: " (#31)"
         RenderListItem {LI} at (40,700) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 154x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 154x19
               text run at (0,0) width 154: ":first-child pseudo-class"
           RenderText {#text} at (153,0) size 39x19
             text run at (153,0) width 39: " (#32)"
         RenderListItem {LI} at (40,720) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 150x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 150x19
               text run at (0,0) width 150: ":last-child pseudo-class"
           RenderText {#text} at (149,0) size 40x19
             text run at (149,0) width 40: " (#33)"
         RenderListItem {LI} at (40,740) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 168x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 168x19
               text run at (0,0) width 168: ":first-of-type pseudo-class"
           RenderText {#text} at (167,0) size 40x19
             text run at (167,0) width 40: " (#34)"
         RenderListItem {LI} at (40,760) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 164x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 164x19
               text run at (0,0) width 164: ":last-of-type pseudo-class"
           RenderText {#text} at (163,0) size 40x19
             text run at (163,0) width 40: " (#35)"
         RenderListItem {LI} at (40,780) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 156x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x19
               text run at (0,0) width 156: ":only-child pseudo-class"
           RenderText {#text} at (155,0) size 40x19
             text run at (155,0) width 40: " (#36)"
         RenderListItem {LI} at (40,800) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 171x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 171x19
               text run at (0,0) width 171: ":only-of-type pseudo-class"
           RenderText {#text} at (170,0) size 39x19
             text run at (170,0) width 39: " (#37)"
         RenderListItem {LI} at (40,820) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 170x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 170x19
               text run at (0,0) width 170: "::first-line pseudo-element"
           RenderText {#text} at (169,0) size 39x19
             text run at (169,0) width 39: " (#38)"
         RenderListItem {LI} at (40,840) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 179x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 179x19
               text run at (0,0) width 179: "::first-letter pseudo-element"
           RenderText {#text} at (178,0) size 39x19
             text run at (178,0) width 39: " (#39)"
         RenderListItem {LI} at (40,860) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 370x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 370x19
               text run at (0,0) width 370: "::first-letter pseudo-element with ::before pseudo-element"
           RenderText {#text} at (369,0) size 47x19
             text run at (369,0) width 47: " (#39a)"
         RenderListItem {LI} at (40,880) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 370x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 370x19
               text run at (0,0) width 370: "::first-letter pseudo-element with ::before pseudo-element"
           RenderText {#text} at (369,0) size 47x19
             text run at (369,0) width 47: " (#39a)"
         RenderListItem {LI} at (40,900) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 179x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 179x19
               text run at (0,0) width 179: "::first-letter pseudo-element"
           RenderText {#text} at (178,0) size 47x19
             text run at (178,0) width 47: " (#39b)"
         RenderListItem {LI} at (40,920) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 172x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 172x19
               text run at (0,0) width 172: "::selection pseudo-element"
           RenderText {#text} at (171,0) size 39x19
             text run at (171,0) width 39: " (#40)"
         RenderListItem {LI} at (40,940) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 156x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x19
               text run at (0,0) width 156: "::before pseudo-element"
           RenderText {#text} at (155,0) size 39x19
             text run at (155,0) width 39: " (#41)"
         RenderListItem {LI} at (40,960) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 144x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x19
               text run at (0,0) width 144: "::after pseudo-element"
           RenderText {#text} at (143,0) size 40x19
             text run at (143,0) width 40: " (#42)"
         RenderListItem {LI} at (40,980) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 152x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 152x19
               text run at (0,0) width 152: "Descendant combinator"
           RenderText {#text} at (151,0) size 40x19
             text run at (151,0) width 40: " (#43)"
         RenderListItem {LI} at (40,1000) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 152x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 152x19
               text run at (0,0) width 152: "Descendant combinator"
           RenderText {#text} at (151,0) size 48x19
             text run at (151,0) width 48: " (#43b)"
         RenderListItem {LI} at (40,1020) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 113x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 113x19
               text run at (0,0) width 113: "Child combinator"
           RenderText {#text} at (112,0) size 40x19
             text run at (112,0) width 40: " (#44)"
         RenderListItem {LI} at (40,1040) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 113x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 113x19
               text run at (0,0) width 113: "Child combinator"
           RenderText {#text} at (112,0) size 48x19
             text run at (112,0) width 48: " (#44b)"
         RenderListItem {LI} at (40,1060) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 188x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 188x19
               text run at (0,0) width 188: "Child combinator and classes"
           RenderText {#text} at (187,0) size 47x19
             text run at (187,0) width 47: " (#44c)"
         RenderListItem {LI} at (40,1080) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 172x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 172x19
               text run at (0,0) width 172: "Child combinatior and IDs"
           RenderText {#text} at (171,0) size 47x19
             text run at (171,0) width 47: " (#44d)"
         RenderListItem {LI} at (40,1100) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 175x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 175x19
               text run at (0,0) width 175: "Direct adjacent combinator"
           RenderText {#text} at (174,0) size 39x19
             text run at (174,0) width 39: " (#45)"
         RenderListItem {LI} at (40,1120) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 175x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 175x19
               text run at (0,0) width 175: "Direct adjacent combinator"
           RenderText {#text} at (174,0) size 47x19
             text run at (174,0) width 47: " (#45b)"
         RenderListItem {LI} at (40,1140) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 250x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 250x19
               text run at (0,0) width 250: "Direct adjacent combinator and classes"
           RenderText {#text} at (249,0) size 47x19
             text run at (249,0) width 47: " (#45c)"
         RenderListItem {LI} at (40,1160) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 184x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x19
               text run at (0,0) width 184: "Indirect adjacent combinator"
           RenderText {#text} at (183,0) size 40x19
             text run at (183,0) width 40: " (#46)"
         RenderListItem {LI} at (40,1180) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 184x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x19
               text run at (0,0) width 184: "Indirect adjacent combinator"
           RenderText {#text} at (183,0) size 48x19
             text run at (183,0) width 48: " (#46b)"
         RenderListItem {LI} at (40,1200) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 400x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 400x19
               text run at (0,0) width 400: "NEGATED substring matching attribute selector on beginning"
           RenderText {#text} at (399,0) size 39x19
             text run at (399,0) width 39: " (#54)"
         RenderListItem {LI} at (40,1220) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 359x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 359x19
               text run at (0,0) width 359: "NEGATED substring matching attribute selector on end"
           RenderText {#text} at (358,0) size 39x19
             text run at (358,0) width 39: " (#55)"
         RenderListItem {LI} at (40,1240) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 380x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 380x19
               text run at (0,0) width 380: "NEGATED substring matching attribute selector on middle"
           RenderText {#text} at (379,0) size 40x19
             text run at (379,0) width 40: " (#56)"
         RenderListItem {LI} at (40,1260) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 316x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 316x19
               text run at (0,0) width 316: "Default attribute value and negation pseudo-class"
           RenderText {#text} at (315,0) size 40x19
             text run at (315,0) width 40: " (#58)"
         RenderListItem {LI} at (40,1280) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 163x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 163x19
               text run at (0,0) width 163: "NEGATED class selector"
           RenderText {#text} at (162,0) size 40x19
             text run at (162,0) width 40: " (#59)"
         RenderListItem {LI} at (40,1300) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 149x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 149x19
               text run at (0,0) width 149: "NEGATED ID selector"
           RenderText {#text} at (148,0) size 40x19
             text run at (148,0) width 40: " (#60)"
         RenderListItem {LI} at (40,1320) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 193x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 193x19
               text run at (0,0) width 193: "NEGATED :link pseudo-class"
           RenderText {#text} at (192,0) size 40x19
             text run at (192,0) width 40: " (#61)"
         RenderListItem {LI} at (40,1340) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 211x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 211x19
               text run at (0,0) width 211: "NEGATED :visited pseudo-class"
           RenderText {#text} at (210,0) size 40x19
             text run at (210,0) width 40: " (#62)"
         RenderListItem {LI} at (40,1360) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 205x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 205x19
               text run at (0,0) width 205: "NEGATED :hover pseudo-class"
           RenderText {#text} at (204,0) size 40x19
             text run at (204,0) width 40: " (#63)"
         RenderListItem {LI} at (40,1380) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 207x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 207x19
               text run at (0,0) width 207: "NEGATED :active pseudo-class"
           RenderText {#text} at (206,0) size 39x19
             text run at (206,0) width 39: " (#64)"
         RenderListItem {LI} at (40,1400) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 203x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 203x19
               text run at (0,0) width 203: "NEGATED :focus pseudo-class"
           RenderText {#text} at (202,0) size 40x19
             text run at (202,0) width 40: " (#65)"
         RenderListItem {LI} at (40,1420) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 205x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 205x19
               text run at (0,0) width 205: "NEGATED :target pseudo-class"
           RenderText {#text} at (204,0) size 39x19
             text run at (204,0) width 39: " (#66)"
         RenderListItem {LI} at (40,1440) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 205x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 205x19
               text run at (0,0) width 205: "NEGATED :target pseudo-class"
           RenderText {#text} at (204,0) size 47x19
             text run at (204,0) width 47: " (#66b)"
         RenderListItem {LI} at (40,1460) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 207x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 207x19
               text run at (0,0) width 207: "NEGATED :lang() pseudo-class"
           RenderText {#text} at (206,0) size 39x19
             text run at (206,0) width 39: " (#67)"
         RenderListItem {LI} at (40,1480) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 221x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 221x19
               text run at (0,0) width 221: "NEGATED :checked pseudo-class"
           RenderText {#text} at (220,0) size 40x19
             text run at (220,0) width 40: " (#70)"
         RenderListItem {LI} at (40,1500) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 194x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 194x19
               text run at (0,0) width 194: "NEGATED :root pseudo-class"
           RenderText {#text} at (193,0) size 40x19
             text run at (193,0) width 40: " (#72)"
         RenderListItem {LI} at (40,1520) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 194x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 194x19
               text run at (0,0) width 194: "NEGATED :root pseudo-class"
           RenderText {#text} at (193,0) size 48x19
             text run at (193,0) width 48: " (#72b)"
         RenderListItem {LI} at (40,1540) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 237x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 237x19
               text run at (0,0) width 237: "NEGATED :nth-child() pseudo-class"
           RenderText {#text} at (236,0) size 40x19
             text run at (236,0) width 40: " (#73)"
         RenderListItem {LI} at (40,1560) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 237x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 237x19
               text run at (0,0) width 237: "NEGATED :nth-child() pseudo-class"
           RenderText {#text} at (236,0) size 48x19
             text run at (236,0) width 48: " (#73b)"
         RenderListItem {LI} at (40,1580) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 264x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 264x19
               text run at (0,0) width 264: "NEGATED :nth-last-child() pseudo-class"
           RenderText {#text} at (263,0) size 40x19
             text run at (263,0) width 40: " (#74)"
         RenderListItem {LI} at (40,1600) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 264x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 264x19
               text run at (0,0) width 264: "NEGATED :nth-last-child() pseudo-class"
           RenderText {#text} at (263,0) size 48x19
             text run at (263,0) width 48: " (#74b)"
         RenderListItem {LI} at (40,1620) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 251x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 251x19
               text run at (0,0) width 251: "NEGATED :nth-of-type() pseudo-class"
           RenderText {#text} at (250,0) size 40x19
             text run at (250,0) width 40: " (#75)"
         RenderListItem {LI} at (40,1640) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 251x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 251x19
               text run at (0,0) width 251: "NEGATED :nth-of-type() pseudo-class"
           RenderText {#text} at (250,0) size 48x19
             text run at (250,0) width 48: " (#75b)"
         RenderListItem {LI} at (40,1660) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 279x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 279x19
               text run at (0,0) width 279: "NEGATED :nth-last-of-type() pseudo-class"
           RenderText {#text} at (278,0) size 39x19
             text run at (278,0) width 39: " (#76)"
         RenderListItem {LI} at (40,1680) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 279x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 279x19
               text run at (0,0) width 279: "NEGATED :nth-last-of-type() pseudo-class"
           RenderText {#text} at (278,0) size 47x19
             text run at (278,0) width 47: " (#76b)"
         RenderListItem {LI} at (40,1700) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 232x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 232x19
               text run at (0,0) width 232: "NEGATED :first-child pseudo-class"
           RenderText {#text} at (231,0) size 39x19
             text run at (231,0) width 39: " (#77)"
         RenderListItem {LI} at (40,1720) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 232x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 232x19
               text run at (0,0) width 232: "NEGATED :first-child pseudo-class"
           RenderText {#text} at (231,0) size 47x19
             text run at (231,0) width 47: " (#77b)"
         RenderListItem {LI} at (40,1740) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 228x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 228x19
               text run at (0,0) width 228: "NEGATED :last-child pseudo-class"
           RenderText {#text} at (227,0) size 40x19
             text run at (227,0) width 40: " (#78)"
         RenderListItem {LI} at (40,1760) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 228x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 228x19
               text run at (0,0) width 228: "NEGATED :last-child pseudo-class"
           RenderText {#text} at (227,0) size 48x19
             text run at (227,0) width 48: " (#78b)"
         RenderListItem {LI} at (40,1780) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 246x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 246x19
               text run at (0,0) width 246: "NEGATED :first-of-type pseudo-class"
           RenderText {#text} at (245,0) size 39x19
             text run at (245,0) width 39: " (#79)"
         RenderListItem {LI} at (40,1800) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 242x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 242x19
               text run at (0,0) width 242: "NEGATED :last-of-type pseudo-class"
           RenderText {#text} at (241,0) size 40x19
             text run at (241,0) width 40: " (#80)"
         RenderListItem {LI} at (40,1820) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 234x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 234x19
               text run at (0,0) width 234: "NEGATED :only-child pseudo-class"
           RenderText {#text} at (233,0) size 40x19
             text run at (233,0) width 40: " (#81)"
         RenderListItem {LI} at (40,1840) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 234x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 234x19
               text run at (0,0) width 234: "NEGATED :only-child pseudo-class"
           RenderText {#text} at (233,0) size 48x19
             text run at (233,0) width 48: " (#81b)"
         RenderListItem {LI} at (40,1860) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 248x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 248x19
               text run at (0,0) width 248: "NEGATED :only-of-type pseudo-class"
           RenderText {#text} at (247,0) size 40x19
             text run at (247,0) width 40: " (#82)"
         RenderListItem {LI} at (40,1880) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 248x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 248x19
               text run at (0,0) width 248: "NEGATED :only-of-type pseudo-class"
           RenderText {#text} at (247,0) size 48x19
             text run at (247,0) width 48: " (#82b)"
         RenderListItem {LI} at (40,1900) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 347x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 347x19
               text run at (0,0) width 347: "Negation pseudo-class cannot be an argument of itself"
           RenderText {#text} at (346,0) size 40x19
             text run at (346,0) width 40: " (#83)"
         RenderListItem {LI} at (40,1920) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 155x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 155x19
               text run at (0,0) width 155: ":contains() pseudo-class"
           RenderText {#text} at (154,0) size 39x19
             text run at (154,0) width 39: " (#84)"
         RenderListItem {LI} at (40,1940) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 155x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 155x19
               text run at (0,0) width 155: ":contains() pseudo-class"
           RenderText {#text} at (154,0) size 47x19
             text run at (154,0) width 47: " (#84b)"
         RenderListItem {LI} at (40,1960) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 232x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 232x19
               text run at (0,0) width 232: "NEGATED :contains() pseudo-class"
           RenderText {#text} at (231,0) size 40x19
             text run at (231,0) width 40: " (#85)"
         RenderListItem {LI} at (40,1980) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 453x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 453x19
               text run at (0,0) width 453: "Nondeterministic matching of direct and indirect adjacent combinators"
           RenderText {#text} at (452,0) size 40x19
             text run at (452,0) width 40: " (#87)"
         RenderListItem {LI} at (40,2000) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 453x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 453x19
               text run at (0,0) width 453: "Nondeterministic matching of direct and indirect adjacent combinators"
           RenderText {#text} at (452,0) size 48x19
             text run at (452,0) width 48: " (#87b)"
         RenderListItem {LI} at (40,2020) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 475x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 475x19
               text run at (0,0) width 475: "Nondeterministic matching of descendant and direct adjacent combinators"
           RenderText {#text} at (474,0) size 40x19
             text run at (474,0) width 40: " (#88)"
         RenderListItem {LI} at (40,2040) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 475x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 475x19
               text run at (0,0) width 475: "Nondeterministic matching of descendant and direct adjacent combinators"
           RenderText {#text} at (474,0) size 48x19
             text run at (474,0) width 48: " (#88b)"
         RenderListItem {LI} at (40,2060) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 368x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 368x19
               text run at (0,0) width 368: "Simple combination of descendant and child combinators"
           RenderText {#text} at (367,0) size 40x19
             text run at (367,0) width 40: " (#89)"
         RenderListItem {LI} at (40,2080) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 408x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 408x19
               text run at (0,0) width 408: "Simple combination of direct and indirect adjacent combinators"
           RenderText {#text} at (407,0) size 40x19
             text run at (407,0) width 40: " (#90)"
         RenderListItem {LI} at (40,2100) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 408x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 408x19
               text run at (0,0) width 408: "Simple combination of direct and indirect adjacent combinators"
           RenderText {#text} at (407,0) size 48x19
             text run at (407,0) width 48: " (#90b)"
         RenderListItem {LI} at (40,2120) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 289x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 289x19
               text run at (0,0) width 289: "NEGATED :enabled:disabled pseudo-classes"
           RenderText {#text} at (288,0) size 48x19
             text run at (288,0) width 48: " (#144)"
         RenderListItem {LI} at (40,2140) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 186x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 186x19
               text run at (0,0) width 186: ":empty pseudo-class and text"
           RenderText {#text} at (185,0) size 47x19
             text run at (185,0) width 47: " (#148)"
         RenderListItem {LI} at (40,2160) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 263x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x19
               text run at (0,0) width 263: ":empty pseudo-class and empty elements"
           RenderText {#text} at (262,0) size 47x19
             text run at (262,0) width 47: " (#149)"
         RenderListItem {LI} at (40,2180) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 263x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x19
               text run at (0,0) width 263: ":empty pseudo-class and empty elements"
           RenderText {#text} at (262,0) size 55x19
             text run at (262,0) width 55: " (#149b)"
         RenderListItem {LI} at (40,2200) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 233x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 233x19
               text run at (0,0) width 233: ":empty pseudo-class and whitespace"
           RenderText {#text} at (232,0) size 48x19
             text run at (232,0) width 48: " (#151)"
         RenderListItem {LI} at (40,2220) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 219x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 219x19
               text run at (0,0) width 219: ":empty pseudo-class and elements"
           RenderText {#text} at (218,0) size 47x19
             text run at (218,0) width 47: " (#152)"
         RenderListItem {LI} at (40,2240) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x19
             text run at (122,0) width 48: " (#154)"
         RenderListItem {LI} at (40,2260) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x19
             text run at (122,0) width 48: " (#155)"
         RenderListItem {LI} at (40,2280) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 55x19
             text run at (122,0) width 55: " (#155a)"
         RenderListItem {LI} at (40,2300) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 56x19
             text run at (122,0) width 56: " (#155b)"
         RenderListItem {LI} at (40,2320) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 55x19
             text run at (122,0) width 55: " (#155c)"
         RenderListItem {LI} at (40,2340) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 56x19
             text run at (122,0) width 56: " (#155d)"
         RenderListItem {LI} at (40,2360) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x19
             text run at (122,0) width 48: " (#156)"
         RenderListItem {LI} at (40,2380) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 56x19
             text run at (122,0) width 56: " (#156b)"
         RenderListItem {LI} at (40,2400) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 55x19
             text run at (122,0) width 55: " (#156c)"
         RenderListItem {LI} at (40,2420) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x19
             text run at (122,0) width 48: " (#157)"
         RenderListItem {LI} at (40,2440) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 123x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x19
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x19
             text run at (122,0) width 48: " (#158)"
         RenderListItem {LI} at (40,2460) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 283x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 283x19
               text run at (0,0) width 283: "Syntax and parsing of new pseudo-elements"
           RenderText {#text} at (282,0) size 47x19
             text run at (282,0) width 47: " (#159)"
         RenderListItem {LI} at (40,2480) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 303x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 303x19
               text run at (0,0) width 303: "Syntax and parsing of unknown pseudo-classes"
           RenderText {#text} at (302,0) size 48x19
             text run at (302,0) width 48: " (#160)"
         RenderListItem {LI} at (40,2500) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 442x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 442x19
               text run at (0,0) width 442: "Syntax and parsing of unknown pseudo-classes and pseudo-elements"
           RenderText {#text} at (441,0) size 47x19
             text run at (441,0) width 47: " (#161)"
         RenderListItem {LI} at (40,2520) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 140x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 140x19
               text run at (0,0) width 140: "Contextual ::selection"
           RenderText {#text} at (139,0) size 48x19
             text run at (139,0) width 48: " (#162)"
         RenderListItem {LI} at (40,2540) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 132x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 132x19
               text run at (0,0) width 132: "Contextual :contains"
           RenderText {#text} at (131,0) size 48x19
             text run at (131,0) width 48: " (#163)"
         RenderListItem {LI} at (40,2560) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 142x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 142x19
               text run at (0,0) width 142: ":focus with ::selection"
           RenderText {#text} at (141,0) size 47x19
             text run at (141,0) width 47: " (#164)"
         RenderListItem {LI} at (40,2580) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 144x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x19
               text run at (0,0) width 144: ":hover with ::selection"
           RenderText {#text} at (143,0) size 47x19
             text run at (143,0) width 47: " (#165)"
         RenderListItem {LI} at (40,2600) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 178x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 178x19
               text run at (0,0) width 178: ":first-letter with ::first-letter"
           RenderText {#text} at (177,0) size 48x19
             text run at (177,0) width 48: " (#166)"
         RenderListItem {LI} at (40,2620) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 178x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 178x19
               text run at (0,0) width 178: ":first-letter with ::first-letter"
           RenderText {#text} at (177,0) size 55x19
             text run at (177,0) width 55: " (#166a)"
         RenderListItem {LI} at (40,2640) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 160x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 160x19
               text run at (0,0) width 160: ":first-line with ::first-line"
           RenderText {#text} at (159,0) size 48x19
             text run at (159,0) width 48: " (#167)"
         RenderListItem {LI} at (40,2660) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 160x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 160x19
               text run at (0,0) width 160: ":first-line with ::first-line"
           RenderText {#text} at (159,0) size 55x19
             text run at (159,0) width 55: " (#167a)"
         RenderListItem {LI} at (40,2680) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 132x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 132x19
               text run at (0,0) width 132: ":before with ::before"
           RenderText {#text} at (131,0) size 48x19
             text run at (131,0) width 48: " (#168)"
         RenderListItem {LI} at (40,2700) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 132x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 132x19
               text run at (0,0) width 132: ":before with ::before"
           RenderText {#text} at (131,0) size 55x19
             text run at (131,0) width 55: " (#168a)"
         RenderListItem {LI} at (40,2720) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 109x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 109x19
               text run at (0,0) width 109: ":after with ::after"
           RenderText {#text} at (108,0) size 48x19
             text run at (108,0) width 48: " (#169)"
         RenderListItem {LI} at (40,2740) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 109x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 109x19
               text run at (0,0) width 109: ":after with ::after"
           RenderText {#text} at (108,0) size 55x19
             text run at (108,0) width 55: " (#169a)"
         RenderListItem {LI} at (40,2760) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 156x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x19
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 48x19
             text run at (155,0) width 48: " (#170)"
         RenderListItem {LI} at (40,2780) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 156x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x19
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 55x19
             text run at (155,0) width 55: " (#170a)"
         RenderListItem {LI} at (40,2800) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 156x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x19
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 56x19
             text run at (155,0) width 56: " (#170b)"
         RenderListItem {LI} at (40,2820) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 156x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x19
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 55x19
             text run at (155,0) width 55: " (#170c)"
         RenderListItem {LI} at (40,2840) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 156x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x19
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 56x19
             text run at (155,0) width 56: " (#170d)"
         RenderListItem {LI} at (40,2860) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 180x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 180x19
               text run at (0,0) width 180: "Parsing: Numbers in classes"
           RenderText {#text} at (179,0) size 55x19
             text run at (179,0) width 55: " (#175a)"
         RenderListItem {LI} at (40,2880) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 180x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 180x19
               text run at (0,0) width 180: "Parsing: Numbers in classes"
           RenderText {#text} at (179,0) size 56x19
             text run at (179,0) width 56: " (#175b)"
         RenderListItem {LI} at (40,2900) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 180x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 180x19
               text run at (0,0) width 180: "Parsing: Numbers in classes"
           RenderText {#text} at (179,0) size 55x19
             text run at (179,0) width 55: " (#175c)"
         RenderListItem {LI} at (40,2920) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 263x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x19
               text run at (0,0) width 263: "NEGATED Dynamic handling of :empty"
           RenderText {#text} at (262,0) size 39x19
             text run at (262,0) width 39: " (#d1)"
         RenderListItem {LI} at (40,2940) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 263x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x19
               text run at (0,0) width 263: "NEGATED Dynamic handling of :empty"
           RenderText {#text} at (262,0) size 47x19
             text run at (262,0) width 47: " (#d1b)"
         RenderListItem {LI} at (40,2960) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 220x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 220x19
               text run at (0,0) width 220: "Dynamic handling of combinators"
           RenderText {#text} at (219,0) size 39x19
             text run at (219,0) width 39: " (#d2)"
         RenderListItem {LI} at (40,2980) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 303x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 303x19
               text run at (0,0) width 303: "Dynamic updating of :first-child and :last-child"
           RenderText {#text} at (302,0) size 40x19
             text run at (302,0) width 40: " (#d4)"
         RenderListItem {LI} at (40,3000) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 93x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 93x19
               text run at (0,0) width 93: ":indeterminate"
           RenderText {#text} at (92,0) size 40x19
             text run at (92,0) width 40: " (#d5)"
         RenderListItem {LI} at (40,3020) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 181x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 181x19
               text run at (0,0) width 181: ":indeterminate and :checked"
           RenderText {#text} at (180,0) size 47x19
             text run at (180,0) width 47: " (#d5a)"
         RenderListItem {LI} at (40,3040) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 259x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 259x19
               text run at (0,0) width 259: "NEGATED :indeterminate and :checked"
           RenderText {#text} at (258,0) size 47x19
             text run at (258,0) width 47: " (#d5b)"
         RenderListItem {LI} at (40,3060) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 181x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 181x19
               text run at (0,0) width 181: ":indeterminate and :checked"
           RenderText {#text} at (180,0) size 47x19
             text run at (180,0) width 47: " (#d5c)"
         RenderListItem {LI} at (40,3080) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 186x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 186x19
               text run at (0,0) width 186: ":indeterminate with :checked"
           RenderText {#text} at (185,0) size 48x19
             text run at (185,0) width 48: " (#d5d)"
         RenderListItem {LI} at (40,3100) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderInline {A} at (0,0) size 264x19 [color=#0000EE]
             RenderText {#text} at (0,0) size 264x19
               text run at (0,0) width 264: "NEGATED :indeterminate with :checked"

--- a/LayoutTests/platform/ios/fast/table/018-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/018-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 446: "This is a test for bug 3166276. Set the following preferences to see it:"
       RenderBlock {UL} at (0,36) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 225x19
             text run at (0,0) width 225: "Proportional font -- Times 15 point"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 235x19
             text run at (0,0) width 235: "Fixed width font -- Monaco 11 point"
       RenderBlock {P} at (0,92) size 784x70

--- a/LayoutTests/platform/ios/fast/text-autosizing/ios/lists-expected.txt
+++ b/LayoutTests/platform/ios/fast/text-autosizing/ios/lists-expected.txt
@@ -9,11 +9,11 @@ layer at (0,0) size 800x600
       RenderBlock {OL} at (0,43) size 784x54
         RenderListItem {LI} at (40,0) size 744x54
           RenderBlock (anonymous) at (0,0) size 744x27
-            RenderListMarker at (-30,0) size 23x26: "1"
+            RenderListMarker at (-25,0) size 23x26: "1"
             RenderText {#text} at (0,0) size 38x26
               text run at (0,0) width 38: "first"
           RenderBlock {OL} at (0,27) size 744x27
             RenderListItem {LI} at (40,0) size 704x27
-              RenderListMarker at (-30,0) size 23x26: "1"
+              RenderListMarker at (-25,0) size 23x26: "1"
               RenderText {#text} at (0,0) size 64x26
                 text run at (0,0) width 64: "second"

--- a/LayoutTests/platform/ios/ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-003-expected.txt
+++ b/LayoutTests/platform/ios/ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-003-expected.txt
@@ -7,4 +7,4 @@ layer at (0,0) size 800x162
         RenderText {#text} at (0,0) size 361x19
           text run at (0,0) width 361: "Test passes if there is a box with rounded corners below."
       RenderListItem {DIV} at (0,36) size 102x102 [border: (3px solid #008000)]
-        RenderListMarker at (-18,3) size 7x19: bullet
+        RenderListMarker at (-15,3) size 7x19: bullet

--- a/LayoutTests/platform/ios/svg/custom/object-sizing-expected.txt
+++ b/LayoutTests/platform/ios/svg/custom/object-sizing-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x403
           text run at (0,1) width 169: "Expected results"
       RenderBlock {ul} at (0,318) size 784x61
         RenderListItem {li} at (40,0) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 29x19
             text run at (0,0) width 29: "The "
           RenderInline {code} at (28,2) size 25x17
@@ -28,7 +28,7 @@ layer at (0,0) size 800x403
           RenderText {#text} at (52,0) size 248x19
             text run at (52,0) width 248: " containing the object appears in green"
         RenderListItem {li} at (40,20) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 29x19
             text run at (0,0) width 29: "The "
           RenderInline {code} at (28,2) size 48x17
@@ -37,6 +37,6 @@ layer at (0,0) size 800x403
           RenderText {#text} at (75,0) size 278x19
             text run at (75,0) width 278: " appears in orange. Its height is set at 13em"
         RenderListItem {li} at (40,40) size 744x20
-          RenderListMarker at (-18,0) size 7x19: bullet
+          RenderListMarker at (-15,0) size 7x19: bullet
           RenderText {#text} at (0,0) size 174x19
             text run at (0,0) width 174: "The blue line is 13em wide"

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug23235-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug23235-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,0) size 510x103 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {UL} at (1,1) size 508x85
                 RenderListItem {LI} at (40,0) size 468x85
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 198x19
                     text run at (0,0) width 198: "The XML Files Resources List"
                   RenderText {#text} at (0,0) size 0x0
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,0) size 510x103 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {UL} at (1,1) size 508x85
                 RenderListItem {LI} at (40,0) size 468x85
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 198x19
                     text run at (0,0) width 198: "The XML Files Resources List"
                   RenderImage {IMG} at (0,20) size 468x60

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug3191-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug3191-expected.txt
@@ -9,6 +9,6 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,2) size 261x40 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {UL} at (2,2) size 257x20
                 RenderListItem {LI} at (40,0) size 217x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderText {#text} at (0,0) size 217x19
                     text run at (0,0) width 217: "blah blah blah blah blah blah blah"

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug32205-2-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug32205-2-expected.txt
@@ -16,16 +16,16 @@ layer at (0,0) size 800x1347
           text run at (0,40) width 112: "a number of bugs"
       RenderBlock {OL} at (0,112) size 784x80
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 467x19
             text run at (0,0) width 467: "If a height is specified for only one row (not both) then it will be ignored"
         RenderListItem {LI} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 686x19
             text run at (0,0) width 442: "If specified heights are insufficient (because the content is too large) "
             text run at (441,0) width 245: "then the entire table will be expanded."
         RenderListItem {LI} at (40,40) size 744x40
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 738x39
             text run at (0,0) width 471: "Percentage heights appear to simply be translated into pixel heights prior "
             text run at (470,0) width 268: "to other processing, so offer no additional"

--- a/LayoutTests/platform/ios/tables/mozilla/marvin/backgr_index-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/marvin/backgr_index-expected.txt
@@ -30,15 +30,15 @@ layer at (0,0) size 800x1651
           text run at (0,0) width 383: "The images used as backgrounds are the following:"
       RenderBlock {UL} at (0,231) size 784x734
         RenderListItem {LI} at (40,0) size 744x34
-          RenderListMarker at (-14,20) size 5x14: bullet
+          RenderListMarker at (-13,20) size 5x14: bullet
           RenderImage {IMG} at (0,0) size 80x30
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,34) size 744x84
-          RenderListMarker at (-14,70) size 5x14: bullet
+          RenderListMarker at (-13,70) size 5x14: bullet
           RenderImage {IMG} at (0,0) size 30x80
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,118) size 744x615
-          RenderListMarker at (-14,601) size 5x14: bullet
+          RenderListMarker at (-13,601) size 5x14: bullet
           RenderImage {IMG} at (0,0) size 779x611
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,977) size 784x15
@@ -80,162 +80,162 @@ layer at (0,0) size 800x1651
       RenderBlock {OL} at (0,1193) size 784x428
         RenderListItem {LI} at (40,0) size 744x98
           RenderBlock (anonymous) at (0,0) size 744x14
-            RenderListMarker at (-27,0) size 24x14: "A"
+            RenderListMarker at (-25,0) size 24x14: "A"
             RenderText {#text} at (0,0) size 118x14
               text run at (0,0) width 118: "Background Area"
           RenderBlock {OL} at (0,14) size 744x84
             RenderListItem {LI} at (40,0) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "1"
+              RenderListMarker at (-25,0) size 24x14: "1"
               RenderInline {A} at (0,0) size 164x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 164x14
                   text run at (0,0) width 164: "Background on 'table'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,14) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "2"
+              RenderListMarker at (-25,0) size 24x14: "2"
               RenderInline {A} at (0,0) size 242x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 242x14
                   text run at (0,0) width 242: "Background on 'table-row-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,28) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "3"
+              RenderListMarker at (-25,0) size 24x14: "3"
               RenderInline {A} at (0,0) size 266x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 266x14
                   text run at (0,0) width 266: "Background on 'table-column-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,42) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "4"
+              RenderListMarker at (-25,0) size 24x14: "4"
               RenderInline {A} at (0,0) size 196x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 196x14
                   text run at (0,0) width 196: "Background on 'table-row'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,56) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "5"
+              RenderListMarker at (-25,0) size 24x14: "5"
               RenderInline {A} at (0,0) size 219x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 219x14
                   text run at (0,0) width 219: "Background on 'table-column'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,70) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "6"
+              RenderListMarker at (-25,0) size 24x14: "6"
               RenderInline {A} at (0,0) size 203x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 203x14
                   text run at (0,0) width 203: "Background on 'table-cell'"
               RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,98) size 744x98
           RenderBlock (anonymous) at (0,0) size 744x14
-            RenderListMarker at (-27,0) size 24x14: "B"
+            RenderListMarker at (-25,0) size 24x14: "B"
             RenderText {#text} at (0,0) size 149x14
               text run at (0,0) width 149: "Background Position"
           RenderBlock {OL} at (0,14) size 744x84
             RenderListItem {LI} at (40,0) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "1"
+              RenderListMarker at (-25,0) size 24x14: "1"
               RenderInline {A} at (0,0) size 164x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 164x14
                   text run at (0,0) width 164: "Background on 'table'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,14) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "2"
+              RenderListMarker at (-25,0) size 24x14: "2"
               RenderInline {A} at (0,0) size 242x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 242x14
                   text run at (0,0) width 242: "Background on 'table-row-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,28) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "3"
+              RenderListMarker at (-25,0) size 24x14: "3"
               RenderInline {A} at (0,0) size 266x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 266x14
                   text run at (0,0) width 266: "Background on 'table-column-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,42) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "4"
+              RenderListMarker at (-25,0) size 24x14: "4"
               RenderInline {A} at (0,0) size 196x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 196x14
                   text run at (0,0) width 196: "Background on 'table-row'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,56) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "5"
+              RenderListMarker at (-25,0) size 24x14: "5"
               RenderInline {A} at (0,0) size 219x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 219x14
                   text run at (0,0) width 219: "Background on 'table-column'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,70) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "6"
+              RenderListMarker at (-25,0) size 24x14: "6"
               RenderInline {A} at (0,0) size 203x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 203x14
                   text run at (0,0) width 203: "Background on 'table-cell'"
               RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,196) size 744x42
           RenderBlock (anonymous) at (0,0) size 744x14
-            RenderListMarker at (-27,0) size 24x14: "C"
+            RenderListMarker at (-25,0) size 24x14: "C"
             RenderText {#text} at (0,0) size 133x14
               text run at (0,0) width 133: "Background Layers"
           RenderBlock {OL} at (0,14) size 744x28
             RenderListItem {LI} at (40,0) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "1"
+              RenderListMarker at (-25,0) size 24x14: "1"
               RenderInline {A} at (0,0) size 133x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 133x14
                   text run at (0,0) width 133: "empty-cells: show"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,14) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "2"
+              RenderListMarker at (-25,0) size 24x14: "2"
               RenderInline {A} at (0,0) size 133x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 133x14
                   text run at (0,0) width 133: "empty-cells: hide"
               RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,238) size 744x189
           RenderBlock (anonymous) at (0,0) size 744x14
-            RenderListMarker at (-27,0) size 24x14: "D"
+            RenderListMarker at (-25,0) size 24x14: "D"
             RenderText {#text} at (0,0) size 180x14
               text run at (0,0) width 180: "Background with Borders"
           RenderBlock {OL} at (0,14) size 744x126
             RenderListItem {LI} at (40,0) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "1"
+              RenderListMarker at (-25,0) size 24x14: "1"
               RenderInline {A} at (0,0) size 164x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 164x14
                   text run at (0,0) width 164: "Background on 'table'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,14) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "2"
+              RenderListMarker at (-25,0) size 24x14: "2"
               RenderInline {A} at (0,0) size 242x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 242x14
                   text run at (0,0) width 242: "Background on 'table-row-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,28) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "3"
+              RenderListMarker at (-25,0) size 24x14: "3"
               RenderInline {A} at (0,0) size 266x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 266x14
                   text run at (0,0) width 266: "Background on 'table-column-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,42) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "4"
+              RenderListMarker at (-25,0) size 24x14: "4"
               RenderInline {A} at (0,0) size 196x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 196x14
                   text run at (0,0) width 196: "Background on 'table-row'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,56) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "5"
+              RenderListMarker at (-25,0) size 24x14: "5"
               RenderInline {A} at (0,0) size 219x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 219x14
                   text run at (0,0) width 219: "Background on 'table-column'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,70) size 704x14
-              RenderListMarker at (-27,0) size 24x14: "6"
+              RenderListMarker at (-25,0) size 24x14: "6"
               RenderInline {A} at (0,0) size 203x14 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 203x14
                   text run at (0,0) width 203: "Background on 'table-cell'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,84) size 704x42
               RenderBlock (anonymous) at (0,0) size 704x14
-                RenderListMarker at (-27,0) size 24x14: "7"
+                RenderListMarker at (-25,0) size 24x14: "7"
                 RenderText {#text} at (0,0) size 102x14
                   text run at (0,0) width 102: "Special Tests"
               RenderBlock {OL} at (0,14) size 704x28
                 RenderListItem {LI} at (40,0) size 664x14
-                  RenderListMarker at (-27,0) size 24x14: "1"
+                  RenderListMarker at (-25,0) size 24x14: "1"
                   RenderInline {A} at (0,0) size 55x14 [color=#FFFF00]
                     RenderText {#text} at (0,0) size 55x14
                       text run at (0,0) width 55: "Opacity"
                   RenderText {#text} at (0,0) size 0x0
                 RenderListItem {LI} at (40,14) size 664x14
-                  RenderListMarker at (-27,0) size 24x14: "2"
+                  RenderListMarker at (-25,0) size 24x14: "2"
                   RenderInline {A} at (0,0) size 133x14 [color=#FFFF00]
                     RenderText {#text} at (0,0) size 133x14
                       text run at (0,0) width 133: "Fixed Backgrounds"

--- a/LayoutTests/platform/ios/tables/mozilla/marvin/backgr_layers-opacity-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/marvin/backgr_layers-opacity-expected.txt
@@ -14,15 +14,15 @@ layer at (0,0) size 800x1252
           text run at (0,0) width 110: "opacity: 0.5"
       RenderBlock {UL} at (0,111) size 784x57
         RenderListItem {LI} at (40,0) size 744x14
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 274x14
             text run at (0,0) width 274: "The first three rows should be red."
         RenderListItem {LI} at (40,14) size 744x14
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 235x14
             text run at (0,0) width 235: "The last row should be orange."
         RenderListItem {LI} at (40,28) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 679x28
             text run at (0,0) width 679: "Cell A should be purple. Cell P should also be purple, but of a shade that reflects the"
             text run at (0,14) width 297: "underlying orange rather than the red."

--- a/LayoutTests/platform/ios/tables/mozilla/marvin/x_table-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/marvin/x_table-expected.txt
@@ -8,27 +8,27 @@ layer at (0,0) size 800x354
           text run at (0,0) width 279: "The table below should have the following:"
       RenderBlock {ol} at (0,36) size 784x120
         RenderListItem {li} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 119x19
             text run at (0,0) width 119: "a caption 'TABLE'"
         RenderListItem {li} at (40,20) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 62x19
             text run at (0,0) width 62: "no border"
         RenderListItem {li} at (40,40) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 224x19
             text run at (0,0) width 224: "3 colgroups, each with one column"
         RenderListItem {li} at (40,60) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "4"
+          RenderListMarker at (-17,0) size 16x19: "4"
           RenderText {#text} at (0,0) size 154x19
             text run at (0,0) width 154: "a THEAD with one row"
         RenderListItem {li} at (40,80) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "5"
+          RenderListMarker at (-17,0) size 16x19: "5"
           RenderText {#text} at (0,0) size 162x19
             text run at (0,0) width 162: "a TBODY with two rows"
         RenderListItem {li} at (40,100) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "6"
+          RenderListMarker at (-17,0) size 16x19: "6"
           RenderText {#text} at (0,0) size 151x19
             text run at (0,0) width 151: "a TFOOT with one row"
       RenderBlock (anonymous) at (0,172) size 784x40

--- a/LayoutTests/platform/ios/tables/mozilla/other/wa_table_thtd_rowspan-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/other/wa_table_thtd_rowspan-expected.txt
@@ -49,7 +49,7 @@ layer at (0,0) size 800x2467
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {OL} at (0,265) size 784x263
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 510x19
             text run at (0,0) width 510: "Verify that the sample text displays as stated in each of the following test cases:"
         RenderBlock {P} at (40,36) size 744x110
@@ -87,7 +87,7 @@ layer at (0,0) size 800x2467
                         text run at (7,7) width 415: "table with nested header & data cells spanning multiple rows"
         RenderBlock {P} at (40,162) size 744x0
         RenderListItem {LI} at (40,162) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 288x19
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 134x19
@@ -96,7 +96,7 @@ layer at (0,0) size 800x2467
           RenderText {#text} at (420,0) size 73x19
             text run at (420,0) width 73: " the screen."
         RenderListItem {LI} at (40,182) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 288x19
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 126x19
@@ -105,7 +105,7 @@ layer at (0,0) size 800x2467
           RenderText {#text} at (412,0) size 73x19
             text run at (412,0) width 73: " the screen."
         RenderListItem {LI} at (40,202) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "4"
+          RenderListMarker at (-17,0) size 16x19: "4"
           RenderText {#text} at (0,0) size 288x19
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 141x19
@@ -114,11 +114,11 @@ layer at (0,0) size 800x2467
           RenderText {#text} at (427,0) size 73x19
             text run at (427,0) width 73: " the screen."
         RenderListItem {LI} at (40,222) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "5"
+          RenderListMarker at (-17,0) size 16x19: "5"
           RenderText {#text} at (0,0) size 416x19
             text run at (0,0) width 416: "Verify re-draw takes place correctly after maximizing the screen."
         RenderListItem {LI} at (40,242) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "6"
+          RenderListMarker at (-17,0) size 16x19: "6"
           RenderText {#text} at (0,0) size 132x19
             text run at (0,0) width 132: "Verify reload works."
       RenderBlock {P} at (0,561) size 784x65

--- a/LayoutTests/platform/ios/tables/mozilla/other/wa_table_tr_align-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/other/wa_table_tr_align-expected.txt
@@ -65,7 +65,7 @@ layer at (0,0) size 800x1387
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {OL} at (0,326) size 784x227
         RenderListItem {LI} at (40,0) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "1"
+          RenderListMarker at (-17,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 510x19
             text run at (0,0) width 510: "Verify that the sample text displays as stated in each of the following test cases:"
         RenderBlock {P} at (40,36) size 744x74
@@ -93,7 +93,7 @@ layer at (0,0) size 800x1387
                         text run at (7,7) width 595: "Tables displaying Header & Data \"LEFT|CENTER|RIGHT\" horizontal row alignment"
         RenderBlock {P} at (40,126) size 744x0
         RenderListItem {LI} at (40,126) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "2"
+          RenderListMarker at (-17,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 288x19
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 134x19
@@ -102,7 +102,7 @@ layer at (0,0) size 800x1387
           RenderText {#text} at (420,0) size 73x19
             text run at (420,0) width 73: " the screen."
         RenderListItem {LI} at (40,146) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "3"
+          RenderListMarker at (-17,0) size 16x19: "3"
           RenderText {#text} at (0,0) size 288x19
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 126x19
@@ -111,7 +111,7 @@ layer at (0,0) size 800x1387
           RenderText {#text} at (412,0) size 73x19
             text run at (412,0) width 73: " the screen."
         RenderListItem {LI} at (40,166) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "4"
+          RenderListMarker at (-17,0) size 16x19: "4"
           RenderText {#text} at (0,0) size 288x19
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 141x19
@@ -120,11 +120,11 @@ layer at (0,0) size 800x1387
           RenderText {#text} at (427,0) size 73x19
             text run at (427,0) width 73: " the screen."
         RenderListItem {LI} at (40,186) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "5"
+          RenderListMarker at (-17,0) size 16x19: "5"
           RenderText {#text} at (0,0) size 416x19
             text run at (0,0) width 416: "Verify re-draw takes place correctly after maximizing the screen."
         RenderListItem {LI} at (40,206) size 744x20
-          RenderListMarker at (-21,0) size 16x19: "6"
+          RenderListMarker at (-17,0) size 16x19: "6"
           RenderText {#text} at (0,0) size 132x19
             text run at (0,0) width 132: "Verify reload works."
       RenderBlock {P} at (0,586) size 784x65

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1010-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1010-expected.txt
@@ -9,71 +9,71 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,2) size 669x280 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderBlock {UL} at (2,2) size 665x260
                 RenderListItem {LI} at (40,0) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 182x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 182x19
                       text run at (0,0) width 182: "500 list items in a single UL"
                 RenderListItem {LI} at (40,20) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 216x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 216x19
                       text run at (0,0) width 216: "500 list items in 25 top-level ULs"
                 RenderListItem {LI} at (40,40) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 241x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 241x19
                       text run at (0,0) width 220: "500 list items in a 25-level nested "
                       text run at (219,0) width 22: "UL"
                 RenderListItem {LI} at (40,60) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 164x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 164x19
                       text run at (0,0) width 164: "300 text input form fields"
                 RenderListItem {LI} at (40,80) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 152x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 152x19
                       text run at (0,0) width 152: "Massively nested tables"
                 RenderListItem {LI} at (40,100) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 317x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 317x19
                       text run at (0,0) width 269: "Massively nested DIVs with padding and "
                       text run at (268,0) width 49: "borders"
                 RenderListItem {LI} at (40,120) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 323x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 323x19
                       text run at (0,0) width 323: "1000 OPTIONs in a single SELECT form element"
                 RenderListItem {LI} at (40,140) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 244x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 244x19
                       text run at (0,0) width 244: "10,000 cell table with text in each cell"
                 RenderListItem {LI} at (40,160) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 308x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 308x19
                       text run at (0,0) width 285: "10,000 cell table with text and color in each "
                       text run at (284,0) width 24: "cell"
                 RenderListItem {LI} at (40,180) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 291x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 291x19
                       text run at (0,0) width 291: "A 713k HTML document packed full of links"
                 RenderListItem {LI} at (40,200) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 311x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 311x19
                       text run at (0,0) width 276: "Extraordinarily long HTML doc (approx 1 "
                       text run at (275,0) width 36: "Meg)"
                 RenderListItem {LI} at (40,220) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 281x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 281x19
                       text run at (0,0) width 281: "Another large HTML doc, with colored text"
                 RenderListItem {LI} at (40,240) size 625x20
-                  RenderListMarker at (-18,0) size 7x19: bullet
+                  RenderListMarker at (-15,0) size 7x19: bullet
                   RenderInline {A} at (0,0) size 477x19 [color=#0000EE]
                     RenderText {#text} at (0,0) size 477x19
                       text run at (0,0) width 334: "A relatively large (150k) document with an average "

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/backgr_fixed-bg-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/backgr_fixed-bg-expected.txt
@@ -14,13 +14,13 @@ layer at (0,0) size 800x1620
           text run at (0,0) width 156: "Fixed Backgrounds"
       RenderBlock {UL} at (0,111) size 784x57
         RenderListItem {LI} at (40,0) size 744x42
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 742x42
             text run at (0,0) width 742: "If you scroll the table over the top left corner of the viewport, the first, second, and fourth"
             text run at (0,14) width 718: "rows as well as cell L should reveal a purple and aqua band forming a 90-degree angle in the"
             text run at (0,28) width 125: "top left corner."
         RenderListItem {LI} at (40,42) size 744x14
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 648x14
             text run at (0,0) width 648: "Cells A and P should have a rainbow background that seems attached to the viewport."
       RenderBlock {DL} at (0,180) size 784x57

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/backgr_layers-show-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/backgr_layers-show-expected.txt
@@ -20,26 +20,26 @@ layer at (0,0) size 800x1692
           text run at (0,0) width 484: "In table cell C (third cell in the first row), which is empty:"
       RenderBlock {UL} at (0,165) size 784x113
         RenderListItem {LI} at (40,0) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 742x28
             text run at (0,0) width 742: "Four sets of horizontal double violet stripes surrounded by aqua should run just inside the top"
             text run at (0,14) width 94: "border edge."
         RenderListItem {LI} at (40,28) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 742x28
             text run at (0,0) width 742: "One set of aqua-backed double violet stripes should run just inside the left, right, and bottom"
             text run at (0,14) width 102: "border edges."
         RenderListItem {LI} at (40,56) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 726x28
             text run at (0,0) width 726: "The third set along the top should turn down at the right edge and go under the fourth set to"
             text run at (0,14) width 188: "form the right-edge set."
         RenderListItem {LI} at (40,84) size 744x14
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 547x14
             text run at (0,0) width 547: "The fourth set should turn down at the left edge to form the left set."
         RenderListItem {LI} at (40,98) size 744x14
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 406x14
             text run at (0,0) width 406: "The bottom stripe should be straight and cut across "
           RenderInline {EM} at (405,0) size 32x14
@@ -52,16 +52,16 @@ layer at (0,0) size 800x1692
           text run at (0,0) width 367: "In table cell A, (first cell in the first row):"
       RenderBlock {UL} at (0,317) size 784x71
         RenderListItem {LI} at (40,0) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 695x28
             text run at (0,0) width 695: "Three sets of horizontal aqua-backed double violet stripes should run just inside the top"
             text run at (0,14) width 94: "border edge."
         RenderListItem {LI} at (40,28) size 744x14
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 250x14
             text run at (0,0) width 250: "The first set should run across."
         RenderListItem {LI} at (40,42) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 734x28
             text run at (0,0) width 734: "The second set should turn down at the left edge, going over the third set to form another set"
             text run at (0,14) width 336: "that runs just inside the left border edge."
@@ -70,12 +70,12 @@ layer at (0,0) size 800x1692
           text run at (0,0) width 359: "In table cell D, (last cell in the first row):"
       RenderBlock {UL} at (0,427) size 784x57
         RenderListItem {LI} at (40,0) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 726x28
             text run at (0,0) width 726: "Two sets of horizontal aqua-backed double violet strips should run just inside the top border"
             text run at (0,14) width 40: "edge."
         RenderListItem {LI} at (40,28) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 734x28
             text run at (0,0) width 734: "The first set should turn down at the right edge, going under the second horizontal set to run"
             text run at (0,14) width 352: "vertically just inside the right border edge."
@@ -84,17 +84,17 @@ layer at (0,0) size 800x1692
           text run at (0,0) width 375: "In table cell G, (third cell in the second row):"
       RenderBlock {UL} at (0,523) size 784x85
         RenderListItem {LI} at (40,0) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 734x28
             text run at (0,0) width 734: "Two sets of horizontal aqua-backed double violet stripes should run just inside the top border"
             text run at (0,14) width 40: "edge."
         RenderListItem {LI} at (40,28) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 718x28
             text run at (0,0) width 718: "A set of vertical stripes should run down just inside the left border edge, going under both"
             text run at (0,14) width 149: "horizontal stripes."
         RenderListItem {LI} at (40,56) size 744x28
-          RenderListMarker at (-14,0) size 5x14: bullet
+          RenderListMarker at (-13,0) size 5x14: bullet
           RenderText {#text} at (0,0) size 726x28
             text run at (0,0) width 726: "Another set of vertical stripes should run down just inside the right border edge, also going"
             text run at (0,14) width 235: "under both horizontal stripes."

--- a/LayoutTests/platform/mac-sonoma-wk1/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk1/fast/css/continuationCrash-expected.txt
@@ -15,35 +15,35 @@ layer at (0,0) size 800x600
           text run at (0,0) width 180: "Click the following buttons."
       RenderBlock {OL} at (0,73) size 784x164
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 199x18
             text run at (0,0) width 199: "Start with the outmost left one."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 138x18
             text run at (0,0) width 138: "Click the middle one."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 271x18
             text run at (0,0) width 271: "(The ouline will not be updated correctly.)"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 142x18
             text run at (0,0) width 142: "Click the right button."
         RenderListItem {LI} at (40,72) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 473x18
             text run at (0,0) width 473: "This will crash Safari 1.3 (v176 and v170, no other configurations tested)."
         RenderListItem {LI} at (40,90) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "6"
+          RenderListMarker at (-17,0) size 16x18: "6"
           RenderText {#text} at (0,0) size 300x18
             text run at (0,0) width 300: "The combination 2. 1. 3. will also crash Safari."
         RenderListItem {LI} at (40,108) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "7"
+          RenderListMarker at (-17,0) size 16x18: "7"
           RenderText {#text} at (0,0) size 457x18
             text run at (0,0) width 457: "1. 3. will not crash Safari. (But the outline should vanish. Shouldn't it?)"
         RenderListItem {LI} at (40,126) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "8"
+          RenderListMarker at (-17,0) size 16x18: "8"
           RenderText {#text} at (0,0) size 205x18
             text run at (0,0) width 205: "2. 3. will not crash Safari either."
         RenderBlock (anonymous) at (40,144) size 744x19

--- a/LayoutTests/platform/mac-sonoma-wk1/fast/forms/plaintext-mode-2-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk1/fast/forms/plaintext-mode-2-expected.txt
@@ -26,11 +26,11 @@ layer at (0,0) size 800x600
           text run at (370,0) width 203: "All richness should be stripped."
       RenderBlock {OL} at (0,53) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 332x18
             text run at (0,0) width 332: "Success: document.execCommand(\"Copy\") == true"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 331x18
             text run at (0,0) width 331: "Success: document.execCommand(\"Paste\") == true"
 layer at (11,11) size 594x13

--- a/LayoutTests/platform/mac-sonoma-wk1/fast/lists/drag-into-marker-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk1/fast/lists/drag-into-marker-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,16) size 784x568
       RenderBlock {UL} at (16,0) size 752x60 [border: (1px solid #000000)]
         RenderListItem {LI} at (41,1) size 710x58
-          RenderListMarker at (-36,3) size 16x55: black square
+          RenderListMarker at (-29,3) size 16x55: black square
           RenderText {#text} at (0,3) size 220x55
             text run at (0,3) width 220: "world hello"
       RenderBlock {P} at (0,76) size 784x72

--- a/LayoutTests/platform/mac-sonoma-wk1/fast/lists/dynamic-marker-crash-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk1/fast/lists/dynamic-marker-crash-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x85
         RenderListItem {LI} at (40,0) size 744x53
           RenderBlock {FORM} at (0,0) size 744x19
             RenderBlock {P} at (0,0) size 744x19
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderTextControl {INPUT} at (0,0) size 288x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
               RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,35) size 744x18

--- a/LayoutTests/platform/mac-sonoma/fast/dom/34176-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/fast/dom/34176-expected.txt
@@ -273,107 +273,107 @@ layer at (0,0) size 785x1458
               RenderInline {EM} at (0,0) size 0x0
         RenderBlock {UL} at (0,223) size 769x468
           RenderListItem {LI} at (40,0) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 0: : Success"
           RenderListItem {LI} at (40,18) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 1: : Success"
           RenderListItem {LI} at (40,36) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 2: : Success"
           RenderListItem {LI} at (40,54) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 3: : Success"
           RenderListItem {LI} at (40,72) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 4: : Success"
           RenderListItem {LI} at (40,90) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 5: : Success"
           RenderListItem {LI} at (40,108) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 6: : Success"
           RenderListItem {LI} at (40,126) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 7: : Success"
           RenderListItem {LI} at (40,144) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 8: : Success"
           RenderListItem {LI} at (40,162) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 9: : Success"
           RenderListItem {LI} at (40,180) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 10: : Success"
           RenderListItem {LI} at (40,198) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 118x18
               text run at (0,0) width 118: "Test 11: : Success"
           RenderListItem {LI} at (40,216) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 12: : Success"
           RenderListItem {LI} at (40,234) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 13: : Success"
           RenderListItem {LI} at (40,252) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 14: : Success"
           RenderListItem {LI} at (40,270) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 15: : Success"
           RenderListItem {LI} at (40,288) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 16: : Success"
           RenderListItem {LI} at (40,306) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 17: : Success"
           RenderListItem {LI} at (40,324) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 18: : Success"
           RenderListItem {LI} at (40,342) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 19: : Success"
           RenderListItem {LI} at (40,360) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 20: : Success"
           RenderListItem {LI} at (40,378) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 21: : Success"
           RenderListItem {LI} at (40,396) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 22: : Success"
           RenderListItem {LI} at (40,414) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 23: : Success"
           RenderListItem {LI} at (40,432) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 24: : Success"
           RenderListItem {LI} at (40,450) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 25: : Success"
       RenderBlock (anonymous) at (0,1442) size 769x0

--- a/LayoutTests/platform/mac-sonoma/fast/dom/52776-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/fast/dom/52776-expected.txt
@@ -237,7 +237,7 @@ layer at (0,0) size 785x1696
             text run at (19,1) width 1: "\x{202C}\x{202A}"
       RenderBlock {UL} at (0,1646) size 769x18
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 717x18
             text run at (0,0) width 717: "test id=test: the right-most character of rendering result of <PDF>abc<PDF> in RTL block should be c: Success"
 selection start: position 3 of child 0 {#text} of child 20 {DIV} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac-wk1/editing/pasteboard/input-field-1-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/pasteboard/input-field-1-expected.txt
@@ -17,16 +17,16 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 240x18
           text run at (0,0) width 240: "This tests Copy/Paste of a input field."
-      RenderBlock {DIV} at (0,34) size 784x21
-        RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-        RenderTextControl {INPUT} at (155,0) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-      RenderBlock {UL} at (0,71) size 784x18
+      RenderBlock {DIV} at (0,34) size 784x19
+        RenderTextControl {INPUT} at (0,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (147,0) size 149x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderBlock {UL} at (0,69) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 44x18
             text run at (0,0) width 44: "Passed"
-layer at (15,46) size 142x13
-  RenderBlock {DIV} at (7,4) size 142x13
-layer at (171,46) size 142x13
-  RenderBlock {DIV} at (7,4) size 142x13
+layer at (11,45) size 142x13
+  RenderBlock {DIV} at (3,3) size 142x13
+layer at (159,45) size 142x13
+  RenderBlock {DIV} at (3,3) size 142x13
 caret: position 1 of child 1 {INPUT} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/css1/basic/containment-expected.txt
+++ b/LayoutTests/platform/mac/css1/basic/containment-expected.txt
@@ -52,7 +52,7 @@ layer at (0,0) size 785x961
           text run at (0,18) width 330: "\"Alternate SS\" has been selected via the user agent."
       RenderBlock {UL} at (0,301) size 769x54 [color=#FF0000]
         RenderListItem {LI} at (40,0) size 729x18 [color=#008000]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 398x18
             text run at (0,0) width 398: "This sentence should be green due to an imported style sheet ["
           RenderInline {CODE} at (397,2) size 204x15
@@ -61,7 +61,7 @@ layer at (0,0) size 785x961
           RenderText {#text} at (600,0) size 10x18
             text run at (600,0) width 10: "]."
         RenderListItem {LI} at (40,18) size 729x18 [color=#800080]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 404x18
             text run at (0,0) width 404: "This sentence should be purple due to an imported style sheet ["
           RenderInline {CODE} at (403,2) size 180x15
@@ -70,7 +70,7 @@ layer at (0,0) size 785x961
           RenderText {#text} at (582,0) size 10x18
             text run at (582,0) width 10: "]."
         RenderListItem {LI} at (40,36) size 729x18 [color=#008000]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 400x18
             text run at (0,0) width 400: "This sentence should be green thanks to the STYLE attribute ["
           RenderInline {CODE} at (399,2) size 164x15
@@ -83,15 +83,15 @@ layer at (0,0) size 785x961
           text run at (0,0) width 510: "This sentence should be purple, and it doesn't have a terminating paragraph tag."
       RenderBlock {OL} at (0,405) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 204x18
             text run at (0,0) width 204: "This list should NOT be purple."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 176x18
             text run at (0,0) width 176: "It should, instead, be black."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 512x18
             text run at (0,0) width 512: "If it IS purple, then the browser hasn't correctly parsed the preceding paragraph."
       RenderBlock {P} at (0,475) size 769x36
@@ -148,7 +148,7 @@ layer at (0,0) size 785x961
                   text run at (0,18) width 367: "sheet \"Alternate SS\" has been selected via the user agent."
               RenderBlock {UL} at (4,108) size 747x54 [color=#FF0000]
                 RenderListItem {LI} at (40,0) size 707x18 [color=#008000]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 398x18
                     text run at (0,0) width 398: "This sentence should be green due to an imported style sheet ["
                   RenderInline {CODE} at (397,2) size 204x15
@@ -157,7 +157,7 @@ layer at (0,0) size 785x961
                   RenderText {#text} at (600,0) size 10x18
                     text run at (600,0) width 10: "]."
                 RenderListItem {LI} at (40,18) size 707x18 [color=#800080]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 404x18
                     text run at (0,0) width 404: "This sentence should be purple due to an imported style sheet ["
                   RenderInline {CODE} at (403,2) size 180x15
@@ -166,7 +166,7 @@ layer at (0,0) size 785x961
                   RenderText {#text} at (582,0) size 10x18
                     text run at (582,0) width 10: "]."
                 RenderListItem {LI} at (40,36) size 707x18 [color=#008000]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 400x18
                     text run at (0,0) width 400: "This sentence should be green thanks to the STYLE attribute ["
                   RenderInline {CODE} at (399,2) size 164x15
@@ -179,15 +179,15 @@ layer at (0,0) size 785x961
                   text run at (0,0) width 510: "This sentence should be purple, and it doesn't have a terminating paragraph tag."
               RenderBlock {OL} at (4,212) size 747x54
                 RenderListItem {LI} at (40,0) size 707x18
-                  RenderListMarker at (-20,0) size 16x18: "1"
+                  RenderListMarker at (-17,0) size 16x18: "1"
                   RenderText {#text} at (0,0) size 204x18
                     text run at (0,0) width 204: "This list should NOT be purple."
                 RenderListItem {LI} at (40,18) size 707x18
-                  RenderListMarker at (-20,0) size 16x18: "2"
+                  RenderListMarker at (-17,0) size 16x18: "2"
                   RenderText {#text} at (0,0) size 176x18
                     text run at (0,0) width 176: "It should, instead, be black."
                 RenderListItem {LI} at (40,36) size 707x18
-                  RenderListMarker at (-20,0) size 16x18: "3"
+                  RenderListMarker at (-17,0) size 16x18: "3"
                   RenderText {#text} at (0,0) size 512x18
                     text run at (0,0) width 512: "If it IS purple, then the browser hasn't correctly parsed the preceding paragraph."
               RenderBlock {P} at (4,282) size 747x36

--- a/LayoutTests/platform/mac/css1/basic/contextual_selectors-expected.txt
+++ b/LayoutTests/platform/mac/css1/basic/contextual_selectors-expected.txt
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,193) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderInline {EM} at (0,0) size 40x18 [color=#008000]
               RenderText {#text} at (0,0) size 40x18
                 text run at (0,0) width 40: "Hello."
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
               text run at (43,0) width 402: "The first \"hello\" should be green, but this part should be black."
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18 [color=#008000]
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 138x18
                 text run at (0,0) width 138: "This should be green."
       RenderTable {TABLE} at (0,245) size 730x156 [border: (1px outset #000000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
               RenderBlock {UL} at (4,72) size 708x36
                 RenderListItem {LI} at (40,0) size 668x36
                   RenderBlock (anonymous) at (0,0) size 668x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderInline {EM} at (0,0) size 40x18 [color=#008000]
                       RenderText {#text} at (0,0) size 40x18
                         text run at (0,0) width 40: "Hello."
@@ -76,7 +76,7 @@ layer at (0,0) size 800x600
                       text run at (43,0) width 402: "The first \"hello\" should be green, but this part should be black."
                   RenderBlock {UL} at (0,18) size 668x18
                     RenderListItem {LI} at (40,0) size 628x18 [color=#008000]
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 138x18
                         text run at (0,0) width 138: "This should be green."
 layer at (8,115) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/mac/css1/basic/id_as_selector-expected.txt
+++ b/LayoutTests/platform/mac/css1/basic/id_as_selector-expected.txt
@@ -47,7 +47,7 @@ layer at (0,0) size 785x627
           text run at (460,0) width 1: " "
       RenderBlock {UL} at (0,346) size 769x18
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 239x18
             text run at (0,0) width 239: "This sentence should NOT be purple."
       RenderTable {TABLE} at (0,380) size 413x231 [border: (1px outset #000000)]
@@ -86,7 +86,7 @@ layer at (0,0) size 785x627
                   text run at (351,0) width 1: " "
               RenderBlock {UL} at (4,165) size 391x18
                 RenderListItem {LI} at (40,0) size 351x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 239x18
                     text run at (0,0) width 239: "This sentence should NOT be purple."
 layer at (8,175) size 769x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/mac/css1/box_properties/border_bottom-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/border_bottom-expected.txt
@@ -52,28 +52,28 @@ layer at (0,0) size 785x995
       RenderBlock {UL} at (0,382) size 769x135
         RenderListItem {LI} at (40,0) size 729x75 [border: none (3px solid #000000) none]
           RenderBlock (anonymous) at (0,0) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (0,18) size 729x54
             RenderListItem {LI} at (40,0) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 75x18
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,18) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 118x18
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,36) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 182x18
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,75) size 729x21 [border: none (3px solid #000000) none]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 163x18
             text run at (0,0) width 163: "This is a second list item."
         RenderListItem {LI} at (40,96) size 729x39 [border: none (3px solid #000000) none]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 714x36
             text run at (0,0) width 714: "Each list item in this list should have a medium-width black border at its bottom, which for the first item means"
             text run at (0,18) width 135: "that it should appear "
@@ -130,28 +130,28 @@ layer at (0,0) size 785x995
               RenderBlock {UL} at (4,261) size 747x135
                 RenderListItem {LI} at (40,0) size 707x75 [border: none (3px solid #000000) none]
                   RenderBlock (anonymous) at (0,0) size 707x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 123x18
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (0,18) size 707x54
                     RenderListItem {LI} at (40,0) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 75x18
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,18) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 118x18
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,36) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 182x18
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,75) size 707x21 [border: none (3px solid #000000) none]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 163x18
                     text run at (0,0) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,96) size 707x39 [border: none (3px solid #000000) none]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 669x36
                     text run at (0,0) width 669: "Each list item in this list should have a medium-width black border at its bottom, which for the first item"
                     text run at (0,18) width 180: "means that it should appear "

--- a/LayoutTests/platform/mac/css1/box_properties/border_left-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/border_left-expected.txt
@@ -58,28 +58,28 @@ layer at (0,0) size 785x1028
       RenderBlock {UL} at (0,413) size 769x144
         RenderListItem {LI} at (40,0) size 729x72 [border: none (3px solid #000000)]
           RenderBlock (anonymous) at (3,0) size 726x18
-            RenderListMarker at (-20,0) size 7x18: bullet
+            RenderListMarker at (-18,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (3,18) size 726x54
             RenderListItem {LI} at (40,0) size 686x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 75x18
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,18) size 686x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 118x18
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,36) size 686x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 182x18
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,72) size 729x18 [border: none (3px solid #800080)]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (3,0) size 163x18
             text run at (3,0) width 163: "This is a second list item."
         RenderListItem {LI} at (40,90) size 729x54 [border: none (3px solid #0000FF)]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (3,0) size 721x54
             text run at (3,0) width 709: "Each list item in this 'parent' list should have a medium-width border along its left side, in each of three colors."
             text run at (3,18) width 721: "The first item's border should travel the entire height the nested list (to end near the baseline of the line \"...nested"
@@ -132,28 +132,28 @@ layer at (0,0) size 785x1028
               RenderBlock {UL} at (5,247) size 745x144
                 RenderListItem {LI} at (40,0) size 705x72 [border: none (3px solid #000000)]
                   RenderBlock (anonymous) at (3,0) size 702x18
-                    RenderListMarker at (-20,0) size 7x18: bullet
+                    RenderListMarker at (-18,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 123x18
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (3,18) size 702x54
                     RenderListItem {LI} at (40,0) size 662x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 75x18
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,18) size 662x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 118x18
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,36) size 662x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 182x18
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,72) size 705x18 [border: none (3px solid #800080)]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (3,0) size 163x18
                     text run at (3,0) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,90) size 705x54 [border: none (3px solid #0000FF)]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (3,0) size 677x54
                     text run at (3,0) width 662: "Each list item in this 'parent' list should have a medium-width border along its left side, in each of three"
                     text run at (3,18) width 48: "colors. "

--- a/LayoutTests/platform/mac/css1/box_properties/border_right_inline-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/border_right_inline-expected.txt
@@ -58,28 +58,28 @@ layer at (0,0) size 785x1082
       RenderBlock {UL} at (0,413) size 769x162
         RenderListItem {LI} at (40,0) size 729x72 [border: none (3px solid #000000) none]
           RenderBlock (anonymous) at (0,0) size 726x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (0,18) size 726x54
             RenderListItem {LI} at (40,0) size 686x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 75x18
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,18) size 686x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 118x18
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,36) size 686x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 182x18
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,72) size 729x18 [border: none (3px solid #800080) none]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 163x18
             text run at (0,0) width 163: "This is a second list item."
         RenderListItem {LI} at (40,90) size 729x72 [border: none (3px solid #0000FF) none]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 722x72
             text run at (0,0) width 718: "Each list item in this 'parent' list should have a medium-width border along its right side, in each of three colors."
             text run at (0,18) width 721: "The first item's border should travel the entire height the nested list (to end near the baseline of the line \"...nested"
@@ -134,28 +134,28 @@ layer at (0,0) size 785x1082
               RenderBlock {UL} at (4,247) size 745x180
                 RenderListItem {LI} at (40,0) size 705x72 [border: none (3px solid #000000) none]
                   RenderBlock (anonymous) at (0,0) size 702x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 123x18
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (0,18) size 702x54
                     RenderListItem {LI} at (40,0) size 662x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 75x18
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,18) size 662x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 118x18
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,36) size 662x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 182x18
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,72) size 705x18 [border: none (3px solid #800080) none]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 163x18
                     text run at (0,0) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,90) size 705x90 [border: none (3px solid #0000FF) none]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 677x90
                     text run at (0,0) width 671: "Each list item in this 'parent' list should have a medium-width border along its right side, in each of three"
                     text run at (0,18) width 48: "colors. "

--- a/LayoutTests/platform/mac/css1/box_properties/border_top-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/border_top-expected.txt
@@ -52,28 +52,28 @@ layer at (0,0) size 785x959
       RenderBlock {UL} at (0,382) size 769x117
         RenderListItem {LI} at (40,0) size 729x75 [border: (3px solid #000000) none]
           RenderBlock (anonymous) at (0,3) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "This is a list item..."
           RenderBlock {UL} at (0,21) size 729x54
             RenderListItem {LI} at (40,0) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 75x18
                 text run at (0,0) width 75: "...and this..."
             RenderListItem {LI} at (40,18) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 118x18
                 text run at (0,0) width 118: "...is a second list..."
             RenderListItem {LI} at (40,36) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 182x18
                 text run at (0,0) width 182: "...nested within the list item."
         RenderListItem {LI} at (40,75) size 729x21 [border: (3px solid #000000) none]
-          RenderListMarker at (-17,3) size 7x18: bullet
+          RenderListMarker at (-15,3) size 7x18: bullet
           RenderText {#text} at (0,3) size 163x18
             text run at (0,3) width 163: "This is a second list item."
         RenderListItem {LI} at (40,96) size 729x21 [border: (3px solid #000000) none]
-          RenderListMarker at (-17,3) size 7x18: bullet
+          RenderListMarker at (-15,3) size 7x18: bullet
           RenderText {#text} at (0,3) size 493x18
             text run at (0,3) width 493: "Each list item in this list should have a medium-width black border at its top."
       RenderTable {TABLE} at (0,515) size 769x428 [border: (1px outset #000000)]
@@ -124,28 +124,28 @@ layer at (0,0) size 785x959
               RenderBlock {UL} at (4,262) size 747x117
                 RenderListItem {LI} at (40,0) size 707x75 [border: (3px solid #000000) none]
                   RenderBlock (anonymous) at (0,3) size 707x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 123x18
                       text run at (0,0) width 123: "This is a list item..."
                   RenderBlock {UL} at (0,21) size 707x54
                     RenderListItem {LI} at (40,0) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 75x18
                         text run at (0,0) width 75: "...and this..."
                     RenderListItem {LI} at (40,18) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 118x18
                         text run at (0,0) width 118: "...is a second list..."
                     RenderListItem {LI} at (40,36) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 182x18
                         text run at (0,0) width 182: "...nested within the list item."
                 RenderListItem {LI} at (40,75) size 707x21 [border: (3px solid #000000) none]
-                  RenderListMarker at (-17,3) size 7x18: bullet
+                  RenderListMarker at (-15,3) size 7x18: bullet
                   RenderText {#text} at (0,3) size 163x18
                     text run at (0,3) width 163: "This is a second list item."
                 RenderListItem {LI} at (40,96) size 707x21 [border: (3px solid #000000) none]
-                  RenderListMarker at (-17,3) size 7x18: bullet
+                  RenderListMarker at (-15,3) size 7x18: bullet
                   RenderText {#text} at (0,3) size 493x18
                     text run at (0,3) width 493: "Each list item in this list should have a medium-width black border at its top."
 layer at (8,115) size 769x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/mac/css1/box_properties/clear_float-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/clear_float-expected.txt
@@ -30,19 +30,19 @@ layer at (0,0) size 785x793
             text run at (0,0) width 82: "Top menu"
         RenderBlock {UL} at (24,33) size 156x73
           RenderListItem {LI} at (0,0) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 36x18
               text run at (0,0) width 36: "green"
           RenderListItem {LI} at (0,18) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 64x18
               text run at (0,0) width 64: "white text"
           RenderListItem {LI} at (0,36) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 96x18
               text run at (0,0) width 96: "0.5em padding"
           RenderListItem {LI} at (0,54) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 89x18
               text run at (0,0) width 89: "0.5em margin"
       RenderBlock (floating) {DIV} at (0,315) size 192x117 [color=#FFFFFF] [bgcolor=#0000FF]
@@ -51,19 +51,19 @@ layer at (0,0) size 785x793
             text run at (0,0) width 112: "Bottom menu"
         RenderBlock {UL} at (24,33) size 156x73
           RenderListItem {LI} at (0,0) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 108x18
               text run at (0,0) width 108: "blue background"
           RenderListItem {LI} at (0,18) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 64x18
               text run at (0,0) width 64: "white text"
           RenderListItem {LI} at (0,36) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 96x18
               text run at (0,0) width 96: "0.5em padding"
           RenderListItem {LI} at (0,54) size 156x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 89x18
               text run at (0,0) width 89: "0.5em margin"
       RenderBlock {DIV} at (224,189) size 513x222 [bgcolor=#FFFF00]
@@ -100,19 +100,19 @@ layer at (0,0) size 785x793
                     text run at (0,0) width 82: "Top menu"
                 RenderBlock {UL} at (24,33) size 156x73
                   RenderListItem {LI} at (0,0) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 36x18
                       text run at (0,0) width 36: "green"
                   RenderListItem {LI} at (0,18) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 64x18
                       text run at (0,0) width 64: "white text"
                   RenderListItem {LI} at (0,36) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 96x18
                       text run at (0,0) width 96: "0.5em padding"
                   RenderListItem {LI} at (0,54) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 89x18
                       text run at (0,0) width 89: "0.5em margin"
               RenderBlock (floating) {DIV} at (4,130) size 192x117 [color=#FFFFFF] [bgcolor=#0000FF]
@@ -121,19 +121,19 @@ layer at (0,0) size 785x793
                     text run at (0,0) width 112: "Bottom menu"
                 RenderBlock {UL} at (24,33) size 156x73
                   RenderListItem {LI} at (0,0) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 108x18
                       text run at (0,0) width 108: "blue background"
                   RenderListItem {LI} at (0,18) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 64x18
                       text run at (0,0) width 64: "white text"
                   RenderListItem {LI} at (0,36) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 96x18
                       text run at (0,0) width 96: "0.5em padding"
                   RenderListItem {LI} at (0,54) size 156x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 89x18
                       text run at (0,0) width 89: "0.5em margin"
               RenderBlock {DIV} at (228,4) size 299x330 [bgcolor=#FFFF00]

--- a/LayoutTests/platform/mac/css1/box_properties/margin-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/margin-expected.txt
@@ -59,19 +59,19 @@ layer at (0,0) size 785x2630
           text run at (0,0) width 208: "This element has a class of zero."
       RenderBlock {UL} at (25,1153) size 719x123 [bgcolor=#00FFFF]
         RenderListItem {LI} at (40,0) size 679x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 382x18
             text run at (0,0) width 382: "This list has a margin of 25px, and a light blue background."
         RenderListItem {LI} at (40,18) size 679x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 269x18
             text run at (0,0) width 269: "Therefore, it ought to have such a margin."
         RenderListItem {LI} at (65,61) size 629x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 555x18
             text run at (0,0) width 555: "This list item has a margin of 25px, which should cause it to be offset in some fashion."
         RenderListItem {LI} at (40,104) size 679x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 304x18
             text run at (0,0) width 304: "This list item has no special styles applied to it."
       RenderBlock {P} at (0,1300) size 769x19 [bgcolor=#C0C0C0]
@@ -137,19 +137,19 @@ layer at (0,0) size 785x2630
                   text run at (0,0) width 208: "This element has a class of zero."
               RenderBlock {UL} at (29,994) size 697x123 [bgcolor=#00FFFF]
                 RenderListItem {LI} at (40,0) size 657x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 382x18
                     text run at (0,0) width 382: "This list has a margin of 25px, and a light blue background."
                 RenderListItem {LI} at (40,18) size 657x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 269x18
                     text run at (0,0) width 269: "Therefore, it ought to have such a margin."
                 RenderListItem {LI} at (65,61) size 607x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 555x18
                     text run at (0,0) width 555: "This list item has a margin of 25px, which should cause it to be offset in some fashion."
                 RenderListItem {LI} at (40,104) size 657x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 304x18
                     text run at (0,0) width 304: "This list item has no special styles applied to it."
               RenderBlock {P} at (4,1141) size 747x19 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/mac/css1/box_properties/margin_bottom-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/margin_bottom-expected.txt
@@ -52,19 +52,19 @@ layer at (0,0) size 785x1729
           text run at (0,0) width 238: "This element also has a class of zero."
       RenderBlock {UL} at (0,735) size 769x98 [bgcolor=#00FFFF]
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 433x18
             text run at (0,0) width 433: "This list has a margin-bottom of 25px, and a light blue background."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 269x18
             text run at (0,0) width 269: "Therefore, it ought to have such a margin."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 604x18
             text run at (0,0) width 604: "This list item has a bottom margin of 25px, which should cause it to be offset in some fashion."
         RenderListItem {LI} at (40,79) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 304x18
             text run at (0,0) width 304: "This list item has no special styles applied to it."
       RenderBlock {P} at (0,857) size 769x55 [bgcolor=#00FFFF]
@@ -119,19 +119,19 @@ layer at (0,0) size 785x1729
                   text run at (0,0) width 238: "This element also has a class of zero."
               RenderBlock {UL} at (4,541) size 747x98 [bgcolor=#00FFFF]
                 RenderListItem {LI} at (40,0) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 433x18
                     text run at (0,0) width 433: "This list has a margin-bottom of 25px, and a light blue background."
                 RenderListItem {LI} at (40,18) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 269x18
                     text run at (0,0) width 269: "Therefore, it ought to have such a margin."
                 RenderListItem {LI} at (40,36) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 604x18
                     text run at (0,0) width 604: "This list item has a bottom margin of 25px, which should cause it to be offset in some fashion."
                 RenderListItem {LI} at (40,79) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 304x18
                     text run at (0,0) width 304: "This list item has no special styles applied to it."
               RenderBlock {P} at (4,663) size 747x55 [bgcolor=#00FFFF]

--- a/LayoutTests/platform/mac/css1/box_properties/margin_left-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/margin_left-expected.txt
@@ -38,18 +38,18 @@ layer at (0,0) size 785x1005
           text run at (0,18) width 180: "width of the parent element."
       RenderBlock {UL} at (25,343) size 744x90 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 704x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 699x18
             text run at (0,0) width 699: "The left margin on this unordered list has been set to 25 pixels, and its background color has been set to gray."
         RenderListItem {LI} at (65,18) size 679x54 [bgcolor=#FFFFFF]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 669x54
             text run at (0,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (0,18) width 61: "checked. "
             text run at (60,18) width 576: "This list item has its left margin also set to 25 pixels, which should combine with the list's"
             text run at (0,36) width 537: "margin to make 50 pixels of margin, and its background color has been set to white."
         RenderListItem {LI} at (40,72) size 704x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 185x18
             text run at (0,0) width 185: "This is an unclassed list item"
       RenderBlock {P} at (0,449) size 769x18 [bgcolor=#C0C0C0]
@@ -92,19 +92,19 @@ layer at (0,0) size 785x1005
                   text run at (0,18) width 180: "width of the parent element."
               RenderBlock {UL} at (29,192) size 722x108 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 682x36
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 664x36
                     text run at (0,0) width 664: "The left margin on this unordered list has been set to 25 pixels, and its background color has been set to"
                     text run at (0,18) width 32: "gray."
                 RenderListItem {LI} at (65,36) size 657x54 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 652x54
                     text run at (0,0) width 617: "Another list item might not be such a bad idea, either, considering that such things do need to be"
                     text run at (0,18) width 110: "double-checked. "
                     text run at (109,18) width 543: "This list item has its left margin also set to 25 pixels, which should combine with the"
                     text run at (0,36) width 570: "list's margin to make 50 pixels of margin, and its background color has been set to white."
                 RenderListItem {LI} at (40,90) size 682x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 185x18
                     text run at (0,0) width 185: "This is an unclassed list item"
               RenderBlock {P} at (4,316) size 747x18 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/mac/css1/box_properties/margin_right-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/margin_right-expected.txt
@@ -38,19 +38,19 @@ layer at (0,0) size 785x1023
           text run at (396,18) width 181: "width of the parent element."
       RenderBlock {UL} at (0,343) size 744x108 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 704x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (27,0) size 677x36
             text run at (27,0) width 677: "The right margin on this unordered list has been set to 25 pixels, and the background color has been set to"
             text run at (672,18) width 32: "gray."
         RenderListItem {LI} at (40,36) size 679x54 [bgcolor=#FFFFFF]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (10,0) size 669x54
             text run at (10,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (34,18) width 62: "checked. "
             text run at (95,18) width 584: "This list item has its right margin also set to 25 pixels, which should combine with the list's"
             text run at (141,36) width 538: "margin to make 50 pixels of margin, and its background-color has been set to white."
         RenderListItem {LI} at (40,90) size 704x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (519,0) size 185x18
             text run at (519,0) width 185: "This is an unclassed list item"
       RenderBlock {P} at (0,467) size 769x18 [bgcolor=#C0C0C0]
@@ -93,19 +93,19 @@ layer at (0,0) size 785x1023
                   text run at (356,18) width 205: "the width of the parent element."
               RenderBlock {UL} at (4,192) size 722x108 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 682x36
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (5,0) size 677x36
                     text run at (5,0) width 677: "The right margin on this unordered list has been set to 25 pixels, and the background color has been set to"
                     text run at (650,18) width 32: "gray."
                 RenderListItem {LI} at (40,36) size 657x54 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (20,0) size 637x54
                     text run at (40,0) width 617: "Another list item might not be such a bad idea, either, considering that such things do need to be"
                     text run at (20,18) width 110: "double-checked. "
                     text run at (129,18) width 528: "This list item has its right margin also set to 25 pixels, which should combine with"
                     text run at (62,36) width 595: "the list's margin to make 50 pixels of margin, and its background-color has been set to white."
                 RenderListItem {LI} at (40,90) size 682x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (497,0) size 185x18
                     text run at (497,0) width 185: "This is an unclassed list item"
               RenderBlock {P} at (4,316) size 747x18 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/mac/css1/box_properties/margin_top-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/margin_top-expected.txt
@@ -49,19 +49,19 @@ layer at (0,0) size 785x1639
           text run at (0,18) width 240: "will require extra text in order to test."
       RenderBlock {UL} at (0,724) size 769x98 [bgcolor=#00FFFF]
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 408x18
             text run at (0,0) width 408: "This list has a margin-top of 25px, and a light blue background."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 269x18
             text run at (0,0) width 269: "Therefore, it ought to have such a margin."
         RenderListItem {LI} at (40,61) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 579x18
             text run at (0,0) width 579: "This list item has a top margin of 25px, which should cause it to be offset in some fashion."
         RenderListItem {LI} at (40,79) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 304x18
             text run at (0,0) width 304: "This list item has no special styles applied to it."
       RenderBlock {P} at (0,821) size 769x19 [bgcolor=#C0C0C0]
@@ -110,19 +110,19 @@ layer at (0,0) size 785x1639
                   text run at (0,18) width 272: "This will require extra text in order to test."
               RenderBlock {UL} at (4,548) size 747x98 [bgcolor=#00FFFF]
                 RenderListItem {LI} at (40,0) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 408x18
                     text run at (0,0) width 408: "This list has a margin-top of 25px, and a light blue background."
                 RenderListItem {LI} at (40,18) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 269x18
                     text run at (0,0) width 269: "Therefore, it ought to have such a margin."
                 RenderListItem {LI} at (40,61) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 579x18
                     text run at (0,0) width 579: "This list item has a top margin of 25px, which should cause it to be offset in some fashion."
                 RenderListItem {LI} at (40,79) size 707x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 304x18
                     text run at (0,0) width 304: "This list item has no special styles applied to it."
               RenderBlock {P} at (4,645) size 747x19 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/mac/css1/box_properties/padding_left-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/padding_left-expected.txt
@@ -46,11 +46,11 @@ layer at (0,0) size 785x1009
           text run at (192,36) width 76: "(light blue)."
       RenderBlock {UL} at (0,415) size 769x72 [bgcolor=#808080]
         RenderListItem {LI} at (25,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 732x18
             text run at (0,0) width 732: "The left padding on this unordered list has been set to 25 pixels, which will require some extra test in order to test."
         RenderListItem {LI} at (25,18) size 744x54 [bgcolor=#FFFFFF]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (25,0) size 714x54
             text run at (25,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (25,18) width 61: "checked. "
@@ -99,12 +99,12 @@ layer at (0,0) size 785x1009
                   text run at (186,36) width 111: "aqua (light blue)."
               RenderBlock {UL} at (4,264) size 747x90 [bgcolor=#808080]
                 RenderListItem {LI} at (25,0) size 722x36
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 702x36
                     text run at (0,0) width 702: "The left padding on this unordered list has been set to 25 pixels, which will require some extra test in order to"
                     text run at (0,18) width 27: "test."
                 RenderListItem {LI} at (25,36) size 722x54 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (25,0) size 669x54
                     text run at (25,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
                     text run at (25,18) width 61: "checked. "

--- a/LayoutTests/platform/mac/css1/box_properties/padding_right-expected.txt
+++ b/LayoutTests/platform/mac/css1/box_properties/padding_right-expected.txt
@@ -54,12 +54,12 @@ layer at (0,0) size 785x1171
           text run at (552,54) width 25: "see."
       RenderBlock {UL} at (0,487) size 769x72 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 704x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (8,0) size 696x36
             text run at (8,0) width 696: "The right padding on this unordered list has been set to 25 pixels, which will require some extra text in order"
             text run at (661,18) width 43: "to test."
         RenderListItem {LI} at (40,36) size 704x36 [bgcolor=#FFFFFF]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (6,0) size 673x36
             text run at (6,0) width 673: "This list item has a right padding of 25 pixels, which will appear to the left of the gray padding of the UL"
             text run at (624,18) width 55: "element."
@@ -116,12 +116,12 @@ layer at (0,0) size 785x1171
                   text run at (478,54) width 83: "easier to see."
               RenderBlock {UL} at (4,336) size 747x72 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 682x36
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (24,0) size 658x36
                     text run at (24,0) width 658: "The right padding on this unordered list has been set to 25 pixels, which will require some extra text in"
                     text run at (601,18) width 81: "order to test."
                 RenderListItem {LI} at (40,36) size 682x36 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (9,0) size 648x36
                     text run at (9,0) width 648: "This list item has a right padding of 25 pixels, which will appear to the left of the gray padding of the"
                     text run at (577,18) width 80: "UL element."

--- a/LayoutTests/platform/mac/css1/cascade/cascade_order-expected.txt
+++ b/LayoutTests/platform/mac/css1/cascade/cascade_order-expected.txt
@@ -31,37 +31,37 @@ layer at (0,0) size 785x790
           text run at (0,150) width 0: " "
       RenderBlock {UL} at (0,230) size 769x144
         RenderListItem {LI} at (40,0) size 729x18 [color=#0000FF]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 194x18
             text run at (0,0) width 194: "This list item should be blue..."
         RenderListItem {LI} at (40,18) size 729x72 [color=#0000FF]
           RenderBlock (anonymous) at (0,0) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 295x18
               text run at (0,0) width 295: "...and so should this; neither should be purple."
           RenderBlock {UL} at (0,18) size 729x54
             RenderListItem {LI} at (40,0) size 689x18 [color=#808080]
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 194x18
                 text run at (0,0) width 194: "This list item should be gray..."
             RenderListItem {LI} at (40,18) size 689x18 [color=#808080]
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 116x18
                 text run at (0,0) width 116: "...as should this...."
             RenderListItem {LI} at (40,36) size 689x18 [color=#008000]
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 196x18
                 text run at (0,0) width 196: "...but this one should be green."
         RenderListItem {LI} at (40,90) size 729x18 [color=#660000]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 174x18
             text run at (0,0) width 174: "This ought to be dark red..."
         RenderListItem {LI} at (40,108) size 729x18 [color=#008000]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 87x18
             text run at (0,0) width 87: "...this green..."
         RenderListItem {LI} at (40,126) size 729x18 [color=#0000FF]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 98x18
             text run at (0,0) width 98: "...and this blue."
       RenderBlock {P} at (0,390) size 769x18 [color=#0000FF]
@@ -92,37 +92,37 @@ layer at (0,0) size 785x790
             RenderTableCell {TD} at (12,26) size 705x254 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 697x144
                 RenderListItem {LI} at (40,0) size 657x18 [color=#0000FF]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 194x18
                     text run at (0,0) width 194: "This list item should be blue..."
                 RenderListItem {LI} at (40,18) size 657x72 [color=#0000FF]
                   RenderBlock (anonymous) at (0,0) size 657x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 295x18
                       text run at (0,0) width 295: "...and so should this; neither should be purple."
                   RenderBlock {UL} at (0,18) size 657x54
                     RenderListItem {LI} at (40,0) size 617x18 [color=#808080]
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 194x18
                         text run at (0,0) width 194: "This list item should be gray..."
                     RenderListItem {LI} at (40,18) size 617x18 [color=#808080]
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 116x18
                         text run at (0,0) width 116: "...as should this...."
                     RenderListItem {LI} at (40,36) size 617x18 [color=#008000]
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderText {#text} at (0,0) size 196x18
                         text run at (0,0) width 196: "...but this one should be green."
                 RenderListItem {LI} at (40,90) size 657x18 [color=#660000]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 174x18
                     text run at (0,0) width 174: "This ought to be dark red..."
                 RenderListItem {LI} at (40,108) size 657x18 [color=#008000]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 87x18
                     text run at (0,0) width 87: "...this green..."
                 RenderListItem {LI} at (40,126) size 657x18 [color=#0000FF]
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 98x18
                     text run at (0,0) width 98: "...and this blue."
               RenderBlock {P} at (4,164) size 697x18 [color=#0000FF]

--- a/LayoutTests/platform/mac/css1/classification/display-expected.txt
+++ b/LayoutTests/platform/mac/css1/classification/display-expected.txt
@@ -39,7 +39,7 @@ layer at (0,0) size 785x816
             text run at (434,36) width 112: " is being ignored."
         RenderText {#text} at (0,0) size 0x0
       RenderListItem {P} at (48,244) size 721x54
-        RenderListMarker at (-17,0) size 7x18: black square
+        RenderListMarker at (-15,0) size 7x18: black square
         RenderText {#text} at (0,0) size 694x36
           text run at (0,0) width 694: "This sentence should be treated as a list-item, and therefore be rendered however this user agent displays list"
           text run at (0,18) width 58: "items (if "
@@ -100,7 +100,7 @@ layer at (0,0) size 785x816
                     text run at (448,36) width 113: " is being ignored."
                 RenderText {#text} at (0,0) size 0x0
               RenderListItem {P} at (52,108) size 699x54
-                RenderListMarker at (-17,0) size 7x18: black square
+                RenderListMarker at (-15,0) size 7x18: black square
                 RenderText {#text} at (0,0) size 694x36
                   text run at (0,0) width 694: "This sentence should be treated as a list-item, and therefore be rendered however this user agent displays list"
                   text run at (0,18) width 58: "items (if "

--- a/LayoutTests/platform/mac/css1/classification/list_style_image-expected.txt
+++ b/LayoutTests/platform/mac/css1/classification/list_style_image-expected.txt
@@ -28,15 +28,15 @@ layer at (0,0) size 800x600
             text run at (0,1) width 150: "...images for each item."
       RenderBlock {UL} at (0,183) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 238x18
             text run at (0,0) width 238: "...standard list markers for each item."
       RenderTable {TABLE} at (0,253) size 300x179 [border: (1px outset #000000)]
@@ -66,15 +66,15 @@ layer at (0,0) size 800x600
                     text run at (0,1) width 150: "...images for each item."
               RenderBlock {UL} at (4,77) size 278x54
                 RenderListItem {LI} at (40,0) size 238x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 238x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 238x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 238x18
                     text run at (0,0) width 238: "...standard list markers for each item."
 layer at (8,100) size 784x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/mac/css1/classification/list_style_position-expected.txt
+++ b/LayoutTests/platform/mac/css1/classification/list_style_position-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
           text run at (0,30) width 0: " "
       RenderBlock {UL} at (0,110) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 743x36
             text run at (0,0) width 743: "The text in this item should behave as expected; that is, it should line up with itself on the left margin, leaving blank"
             text run at (0,18) width 158: "space beneath the bullet."
@@ -39,7 +39,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (12,26) size 770x112 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 762x36
                 RenderListItem {LI} at (40,0) size 722x36
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 704x36
                     text run at (0,0) width 704: "The text in this item should behave as expected; that is, it should line up with itself on the left margin, leaving"
                     text run at (0,18) width 197: "blank space beneath the bullet."

--- a/LayoutTests/platform/mac/css1/classification/list_style_type-expected.txt
+++ b/LayoutTests/platform/mac/css1/classification/list_style_type-expected.txt
@@ -29,106 +29,106 @@ layer at (0,0) size 785x1527
           text run at (0,135) width 0: " "
       RenderBlock {UL} at (0,215) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 137x18
             text run at (0,0) width 137: "...discs for each item."
       RenderBlock {UL} at (0,285) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: white bullet
+          RenderListMarker at (-15,0) size 7x18: white bullet
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-17,0) size 7x18: white bullet
+          RenderListMarker at (-15,0) size 7x18: white bullet
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-17,0) size 7x18: white bullet
+          RenderListMarker at (-15,0) size 7x18: white bullet
           RenderText {#text} at (0,0) size 147x18
             text run at (0,0) width 147: "...circles for each item."
       RenderBlock {UL} at (0,355) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: black square
+          RenderListMarker at (-15,0) size 7x18: black square
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-17,0) size 7x18: black square
+          RenderListMarker at (-15,0) size 7x18: black square
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-17,0) size 7x18: black square
+          RenderListMarker at (-15,0) size 7x18: black square
           RenderText {#text} at (0,0) size 153x18
             text run at (0,0) width 153: "...squares for each item."
       RenderBlock {OL} at (0,425) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 13x18: "i"
+          RenderListMarker at (-14,0) size 13x18: "i"
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-21,0) size 17x18: "ii"
+          RenderListMarker at (-18,0) size 17x18: "ii"
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-26,0) size 22x18: "iii"
+          RenderListMarker at (-23,0) size 22x18: "iii"
           RenderText {#text} at (0,0) size 282x18
             text run at (0,0) width 282: "...lowercase Roman numerals for each item."
       RenderBlock {OL} at (0,495) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-18,0) size 14x18: "I"
+          RenderListMarker at (-15,0) size 14x18: "I"
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-23,0) size 19x18: "II"
+          RenderListMarker at (-20,0) size 19x18: "II"
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-28,0) size 24x18: "III"
+          RenderListMarker at (-25,0) size 24x18: "III"
           RenderText {#text} at (0,0) size 282x18
             text run at (0,0) width 282: "...uppercase Roman numerals for each item."
       RenderBlock {OL} at (0,565) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "a"
+          RenderListMarker at (-17,0) size 16x18: "a"
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "b"
+          RenderListMarker at (-17,0) size 16x18: "b"
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "c"
+          RenderListMarker at (-17,0) size 16x18: "c"
           RenderText {#text} at (0,0) size 212x18
             text run at (0,0) width 212: "...lowercase letters for each item."
       RenderBlock {OL} at (0,635) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-24,0) size 20x18: "A"
+          RenderListMarker at (-21,0) size 20x18: "A"
           RenderText {#text} at (0,0) size 65x18
             text run at (0,0) width 65: "This list..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-23,0) size 19x18: "B"
+          RenderListMarker at (-20,0) size 19x18: "B"
           RenderText {#text} at (0,0) size 116x18
             text run at (0,0) width 116: "...should feature..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-23,0) size 19x18: "C"
+          RenderListMarker at (-20,0) size 19x18: "C"
           RenderText {#text} at (0,0) size 212x18
             text run at (0,0) width 212: "...uppercase letters for each item."
       RenderBlock {OL} at (0,705) size 769x54
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-24,0) size 20x18: "A"
+          RenderListMarker at (-21,0) size 20x18: "A"
           RenderText {#text} at (0,0) size 160x18
             text run at (0,0) width 160: "This list should feature..."
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-23,0) size 19x18: "B"
+          RenderListMarker at (-20,0) size 19x18: "B"
           RenderText {#text} at (0,0) size 152x18
             text run at (0,0) width 152: "...letters for each item..."
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 112x18
             text run at (0,0) width 112: "...except this one."
       RenderBlock {UL} at (0,775) size 769x54
@@ -155,106 +155,106 @@ layer at (0,0) size 785x1527
             RenderTableCell {TD} at (12,26) size 330x638 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 137x18
                     text run at (0,0) width 137: "...discs for each item."
               RenderBlock {UL} at (4,74) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: white bullet
+                  RenderListMarker at (-15,0) size 7x18: white bullet
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: white bullet
+                  RenderListMarker at (-15,0) size 7x18: white bullet
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: white bullet
+                  RenderListMarker at (-15,0) size 7x18: white bullet
                   RenderText {#text} at (0,0) size 147x18
                     text run at (0,0) width 147: "...circles for each item."
               RenderBlock {UL} at (4,144) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: black square
+                  RenderListMarker at (-15,0) size 7x18: black square
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: black square
+                  RenderListMarker at (-15,0) size 7x18: black square
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-17,0) size 7x18: black square
+                  RenderListMarker at (-15,0) size 7x18: black square
                   RenderText {#text} at (0,0) size 153x18
                     text run at (0,0) width 153: "...squares for each item."
               RenderBlock {OL} at (4,214) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-17,0) size 13x18: "i"
+                  RenderListMarker at (-14,0) size 13x18: "i"
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-21,0) size 17x18: "ii"
+                  RenderListMarker at (-18,0) size 17x18: "ii"
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-26,0) size 22x18: "iii"
+                  RenderListMarker at (-23,0) size 22x18: "iii"
                   RenderText {#text} at (0,0) size 282x18
                     text run at (0,0) width 282: "...lowercase Roman numerals for each item."
               RenderBlock {OL} at (4,284) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-18,0) size 14x18: "I"
+                  RenderListMarker at (-15,0) size 14x18: "I"
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-23,0) size 19x18: "II"
+                  RenderListMarker at (-20,0) size 19x18: "II"
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-28,0) size 24x18: "III"
+                  RenderListMarker at (-25,0) size 24x18: "III"
                   RenderText {#text} at (0,0) size 282x18
                     text run at (0,0) width 282: "...uppercase Roman numerals for each item."
               RenderBlock {OL} at (4,354) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-20,0) size 16x18: "a"
+                  RenderListMarker at (-17,0) size 16x18: "a"
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-20,0) size 16x18: "b"
+                  RenderListMarker at (-17,0) size 16x18: "b"
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-20,0) size 16x18: "c"
+                  RenderListMarker at (-17,0) size 16x18: "c"
                   RenderText {#text} at (0,0) size 212x18
                     text run at (0,0) width 212: "...lowercase letters for each item."
               RenderBlock {OL} at (4,424) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-24,0) size 20x18: "A"
+                  RenderListMarker at (-21,0) size 20x18: "A"
                   RenderText {#text} at (0,0) size 65x18
                     text run at (0,0) width 65: "This list..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-23,0) size 19x18: "B"
+                  RenderListMarker at (-20,0) size 19x18: "B"
                   RenderText {#text} at (0,0) size 116x18
                     text run at (0,0) width 116: "...should feature..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-23,0) size 19x18: "C"
+                  RenderListMarker at (-20,0) size 19x18: "C"
                   RenderText {#text} at (0,0) size 212x18
                     text run at (0,0) width 212: "...uppercase letters for each item."
               RenderBlock {OL} at (4,494) size 322x54
                 RenderListItem {LI} at (40,0) size 282x18
-                  RenderListMarker at (-24,0) size 20x18: "A"
+                  RenderListMarker at (-21,0) size 20x18: "A"
                   RenderText {#text} at (0,0) size 160x18
                     text run at (0,0) width 160: "This list should feature..."
                 RenderListItem {LI} at (40,18) size 282x18
-                  RenderListMarker at (-23,0) size 19x18: "B"
+                  RenderListMarker at (-20,0) size 19x18: "B"
                   RenderText {#text} at (0,0) size 152x18
                     text run at (0,0) width 152: "...letters for each item..."
                 RenderListItem {LI} at (40,36) size 282x18
-                  RenderListMarker at (-20,0) size 16x18: "3"
+                  RenderListMarker at (-17,0) size 16x18: "3"
                   RenderText {#text} at (0,0) size 112x18
                     text run at (0,0) width 112: "...except this one."
               RenderBlock {UL} at (4,564) size 322x54

--- a/LayoutTests/platform/mac/css1/conformance/forward_compatible_parsing-expected.txt
+++ b/LayoutTests/platform/mac/css1/conformance/forward_compatible_parsing-expected.txt
@@ -169,7 +169,7 @@ layer at (0,0) size 785x4053
           text run at (0,18) width 278: "other standards (e.g., font names or URLs.)"
       RenderBlock {OL} at (0,1451) size 769x18
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 635x18
             text run at (0,0) width 635: "This ordered list item should be black, because the declaration has an invalid pseudo-class selector."
       RenderBlock {P} at (0,1485) size 769x36
@@ -178,7 +178,7 @@ layer at (0,0) size 785x4053
           text run at (0,18) width 113: "not the first child."
       RenderBlock {UL} at (0,1537) size 769x36
         RenderListItem {LI} at (40,0) size 729x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 704x36
             text run at (0,0) width 704: "This unordered list item should be black, because, according to CSS1, the selector is invalid, and according to"
             text run at (0,18) width 232: "CSS2, the selector should not apply."
@@ -391,7 +391,7 @@ layer at (0,0) size 785x4053
                   text run at (0,18) width 278: "other standards (e.g., font names or URLs.)"
               RenderBlock {OL} at (4,598) size 747x18
                 RenderListItem {LI} at (40,0) size 707x18
-                  RenderListMarker at (-20,0) size 16x18: "1"
+                  RenderListMarker at (-17,0) size 16x18: "1"
                   RenderText {#text} at (0,0) size 635x18
                     text run at (0,0) width 635: "This ordered list item should be black, because the declaration has an invalid pseudo-class selector."
               RenderBlock {P} at (4,632) size 747x36
@@ -400,7 +400,7 @@ layer at (0,0) size 785x4053
                   text run at (0,18) width 196: "paragraph is not the first child."
               RenderBlock {UL} at (4,684) size 747x36
                 RenderListItem {LI} at (40,0) size 707x36
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 704x36
                     text run at (0,0) width 704: "This unordered list item should be black, because, according to CSS1, the selector is invalid, and according to"
                     text run at (0,18) width 232: "CSS2, the selector should not apply."

--- a/LayoutTests/platform/mac/css1/pseudo/anchor-expected.txt
+++ b/LayoutTests/platform/mac/css1/pseudo/anchor-expected.txt
@@ -25,36 +25,36 @@ layer at (0,0) size 785x683
       RenderBlock {UL} at (0,189) size 769x144
         RenderListItem {LI} at (40,0) size 729x108
           RenderBlock (anonymous) at (0,0) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 583x18
               text run at (0,0) width 583: "Purple unvisited, lime (light green) visited, maroon (dark red) while active (being clicked):"
           RenderBlock {UL} at (0,18) size 729x90
             RenderListItem {LI} at (40,0) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderInline {A} at (0,0) size 110x18 [color=#800080]
                 RenderText {#text} at (0,0) size 110x18
                   text run at (0,0) width 110: "W3C Web server"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,18) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderInline {A} at (0,0) size 112x18 [color=#800080]
                 RenderText {#text} at (0,0) size 112x18
                   text run at (0,0) width 112: "NIST Web server"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,36) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderInline {A} at (0,0) size 125x18 [color=#800080]
                 RenderText {#text} at (0,0) size 125x18
                   text run at (0,0) width 125: "CWRU Web server"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,54) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderInline {A} at (0,0) size 47x18 [color=#800080]
                 RenderText {#text} at (0,0) size 47x18
                   text run at (0,0) width 47: "Yahoo!"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,72) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderInline {A} at (0,0) size 58x18 [color=#800080]
                 RenderText {#text} at (0,0) size 58x18
                   text run at (0,0) width 58: "Erewhon"
@@ -62,12 +62,12 @@ layer at (0,0) size 785x683
                 text run at (57,0) width 225: " (don't click on it, it goes nowhere)"
         RenderListItem {LI} at (40,108) size 729x36
           RenderBlock (anonymous) at (0,0) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 208x18
               text run at (0,0) width 208: "Dark green in any circumstance:"
           RenderBlock {UL} at (0,18) size 729x18
             RenderListItem {LI} at (40,0) size 689x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderInline {A} at (0,0) size 125x18 [color=#006600]
                 RenderText {#text} at (0,0) size 125x18
                   text run at (0,0) width 125: "CWRU Web server"
@@ -101,36 +101,36 @@ layer at (0,0) size 785x683
               RenderBlock {UL} at (4,38) size 747x144
                 RenderListItem {LI} at (40,0) size 707x108
                   RenderBlock (anonymous) at (0,0) size 707x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 583x18
                       text run at (0,0) width 583: "Purple unvisited, lime (light green) visited, maroon (dark red) while active (being clicked):"
                   RenderBlock {UL} at (0,18) size 707x90
                     RenderListItem {LI} at (40,0) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderInline {A} at (0,0) size 110x18 [color=#800080]
                         RenderText {#text} at (0,0) size 110x18
                           text run at (0,0) width 110: "W3C Web server"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,18) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderInline {A} at (0,0) size 112x18 [color=#800080]
                         RenderText {#text} at (0,0) size 112x18
                           text run at (0,0) width 112: "NIST Web server"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,36) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderInline {A} at (0,0) size 125x18 [color=#800080]
                         RenderText {#text} at (0,0) size 125x18
                           text run at (0,0) width 125: "CWRU Web server"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,54) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderInline {A} at (0,0) size 47x18 [color=#800080]
                         RenderText {#text} at (0,0) size 47x18
                           text run at (0,0) width 47: "Yahoo!"
                       RenderText {#text} at (0,0) size 0x0
                     RenderListItem {LI} at (40,72) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderInline {A} at (0,0) size 58x18 [color=#800080]
                         RenderText {#text} at (0,0) size 58x18
                           text run at (0,0) width 58: "Erewhon"
@@ -138,12 +138,12 @@ layer at (0,0) size 785x683
                         text run at (57,0) width 225: " (don't click on it, it goes nowhere)"
                 RenderListItem {LI} at (40,108) size 707x36
                   RenderBlock (anonymous) at (0,0) size 707x18
-                    RenderListMarker at (-17,0) size 7x18: bullet
+                    RenderListMarker at (-15,0) size 7x18: bullet
                     RenderText {#text} at (0,0) size 208x18
                       text run at (0,0) width 208: "Dark green in any circumstance:"
                   RenderBlock {UL} at (0,18) size 707x18
                     RenderListItem {LI} at (40,0) size 667x18
-                      RenderListMarker at (-17,0) size 7x18: white bullet
+                      RenderListMarker at (-15,0) size 7x18: white bullet
                       RenderInline {A} at (0,0) size 125x18 [color=#006600]
                         RenderText {#text} at (0,0) size 125x18
                           text run at (0,0) width 125: "CWRU Web server"

--- a/LayoutTests/platform/mac/css2.1/20110323/margin-applies-to-010-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/20110323/margin-applies-to-010-expected.txt
@@ -10,4 +10,4 @@ layer at (0,0) size 800x68
 layer at (8,68) size 340x340
   RenderBlock (positioned) {DIV} at (8,68) size 340x340 [border: (10px solid #0000FF)]
     RenderListItem {DIV} at (60,60) size 220x220 [border: (10px solid #FFA500)]
-      RenderListMarker at (-17,10) size 7x18: bullet
+      RenderListMarker at (-15,10) size 7x18: bullet

--- a/LayoutTests/platform/mac/css2.1/t0402-c71-fwd-parsing-02-f-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t0402-c71-fwd-parsing-02-f-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x560
           text run at (0,0) width 166: "This line should be green."
       RenderBlock {OL} at (0,136) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 166x18
             text run at (0,0) width 166: "This line should be green."
       RenderBlock {P} at (0,170) size 784x18
@@ -25,7 +25,7 @@ layer at (0,0) size 800x560
           text run at (0,0) width 166: "This line should be green."
       RenderBlock {UL} at (0,204) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 166x18
             text run at (0,0) width 166: "This line should be green."
       RenderBlock {BLOCKQUOTE} at (40,238) size 704x18

--- a/LayoutTests/platform/mac/css2.1/t0505-c16-descendant-01-e-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t0505-c16-descendant-01-e-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x84
             text run at (0,0) width 166: "This line should be green."
       RenderBlock {UL} at (0,34) size 784x18 [color=#008000]
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {SPAN} at (0,0) size 0x18 [color=#FF0000]
             RenderText {#text} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 166x18

--- a/LayoutTests/platform/mac/css2.1/t050803-c14-classes-00-e-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t050803-c14-classes-00-e-expected.txt
@@ -23,6 +23,6 @@ layer at (0,0) size 800x217
       RenderBlock {DIV} at (0,167) size 784x18 [color=#008000]
         RenderBlock {UL} at (0,0) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 197x18
               text run at (0,0) width 197: "This sentence should be green."

--- a/LayoutTests/platform/mac/css2.1/t0509-c15-ids-01-e-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t0509-c15-ids-01-e-expected.txt
@@ -13,6 +13,6 @@ layer at (0,0) size 800x115
           text run at (0,0) width 219: " This line should be green. "
       RenderBlock {UL} at (0,65) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 166x18
             text run at (0,0) width 166: "This line should be green."

--- a/LayoutTests/platform/mac/css2.1/t0805-c5518-brdr-t-01-e-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t0805-c5518-brdr-t-01-e-expected.txt
@@ -35,27 +35,27 @@ layer at (0,0) size 800x297
       RenderBlock {UL} at (0,148) size 784x117
         RenderListItem {LI} at (40,0) size 744x75 [border: (2px solid #0000FF) none]
           RenderBlock (anonymous) at (0,2) size 744x19
-            RenderListMarker at (-17,1) size 7x18: bullet
+            RenderListMarker at (-15,1) size 7x18: bullet
             RenderText {#text} at (0,1) size 62x18
               text run at (0,1) width 62: "HERE \x{21E7}"
           RenderBlock {UL} at (0,21) size 744x54
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 77x18
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,18) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 77x18
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,36) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 77x18
                 text run at (0,0) width 77: "dummy text"
         RenderListItem {LI} at (40,75) size 744x21 [border: (2px solid #0000FF) none]
-          RenderListMarker at (-17,3) size 7x18: bullet
+          RenderListMarker at (-15,3) size 7x18: bullet
           RenderText {#text} at (0,3) size 62x18
             text run at (0,3) width 62: "HERE \x{21E7}"
         RenderListItem {LI} at (40,96) size 744x21 [border: (2px solid #0000FF) none]
-          RenderListMarker at (-17,3) size 7x18: bullet
+          RenderListMarker at (-15,3) size 7x18: bullet
           RenderText {#text} at (0,3) size 62x18
             text run at (0,3) width 62: "HERE \x{21E7}"

--- a/LayoutTests/platform/mac/css2.1/t0805-c5519-brdr-r-02-e-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t0805-c5519-brdr-r-02-e-expected.txt
@@ -10,28 +10,28 @@ layer at (0,0) size 800x336
       RenderBlock {UL} at (0,34) size 588x270
         RenderListItem {LI} at (40,0) size 548x72 [border: none (3px solid #FFA500) none]
           RenderBlock (anonymous) at (0,0) size 545x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 107x18
               text run at (0,0) width 107: "Orange orange..."
           RenderBlock {UL} at (0,18) size 409x54
             RenderListItem {LI} at (40,0) size 369x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 116x18
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,18) size 369x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 116x18
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,36) size 369x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 108x18
                 text run at (0,0) width 108: "...orange orange."
         RenderListItem {LI} at (40,72) size 548x18 [border: none (3px solid #00FF00) none]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 38x18
             text run at (0,0) width 38: "Lime."
         RenderListItem {LI} at (40,90) size 548x180 [border: none (3px solid #FFFF00) none]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 521x180
             text run at (0,0) width 335: "Yellow yellow yellow yellow yellow yellow yellow "
             text run at (334,0) width 187: "yellow yellow yellow yellow"

--- a/LayoutTests/platform/mac/css2.1/t0805-c5520-brdr-b-01-e-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t0805-c5520-brdr-b-01-e-expected.txt
@@ -36,26 +36,26 @@ layer at (0,0) size 800x332
         RenderListItem {LI} at (40,0) size 744x80 [border: none (2px solid #0000FF) none]
           RenderBlock {UL} at (0,0) size 744x54
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
-              RenderListMarker at (-57,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
+              RenderListMarker at (-55,0) size 7x18: bullet
               RenderText {#text} at (0,0) size 77x18
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,18) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 77x18
                 text run at (0,0) width 77: "dummy text"
             RenderListItem {LI} at (40,36) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 77x18
                 text run at (0,0) width 77: "dummy text"
           RenderBlock (anonymous) at (0,54) size 744x24
             RenderText {#text} at (0,3) size 62x18
               text run at (0,3) width 62: "HERE \x{21E9}"
         RenderListItem {LI} at (40,80) size 744x26 [border: none (2px solid #0000FF) none]
-          RenderListMarker at (-17,3) size 7x18: bullet
+          RenderListMarker at (-15,3) size 7x18: bullet
           RenderText {#text} at (0,3) size 62x18
             text run at (0,3) width 62: "HERE \x{21E9}"
         RenderListItem {LI} at (40,106) size 744x26 [border: none (2px solid #0000FF) none]
-          RenderListMarker at (-17,3) size 7x18: bullet
+          RenderListMarker at (-15,3) size 7x18: bullet
           RenderText {#text} at (0,3) size 62x18
             text run at (0,3) width 62: "HERE \x{21E9}"

--- a/LayoutTests/platform/mac/css2.1/t0805-c5521-brdr-l-02-e-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t0805-c5521-brdr-l-02-e-expected.txt
@@ -10,28 +10,28 @@ layer at (0,0) size 800x282
       RenderBlock {UL} at (0,34) size 784x216
         RenderListItem {LI} at (40,0) size 744x72 [border: none (3px solid #FFA500)]
           RenderBlock (anonymous) at (3,0) size 741x18
-            RenderListMarker at (-20,0) size 7x18: bullet
+            RenderListMarker at (-18,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 107x18
               text run at (0,0) width 107: "Orange orange..."
           RenderBlock {UL} at (3,18) size 741x54
             RenderListItem {LI} at (40,0) size 701x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 116x18
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,18) size 701x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 116x18
                 text run at (0,0) width 116: "...orange orange..."
             RenderListItem {LI} at (40,36) size 701x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 108x18
                 text run at (0,0) width 108: "...orange orange."
         RenderListItem {LI} at (40,72) size 744x18 [border: none (3px solid #00FF00)]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (3,0) size 38x18
             text run at (3,0) width 38: "Lime."
         RenderListItem {LI} at (40,90) size 744x126 [border: none (3px solid #FFFF00)]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (3,0) size 713x126
             text run at (3,0) width 335: "Yellow yellow yellow yellow yellow yellow yellow "
             text run at (337,0) width 378: "yellow yellow yellow yellow yellow yellow yellow yellow"

--- a/LayoutTests/platform/mac/css2.1/t1205-c563-list-type-00-b-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t1205-c563-list-type-00-b-expected.txt
@@ -8,41 +8,41 @@ layer at (0,0) size 800x330
           text run at (0,0) width 466: "Each bullet should look as described, and there should be no red present."
       RenderBlock {UL} at (0,34) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 26x18
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 26x18
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 26x18
             text run at (0,0) width 26: "disc"
       RenderBlock {UL} at (0,104) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: white bullet
+          RenderListMarker at (-15,0) size 7x18: white bullet
           RenderText {#text} at (0,0) size 36x18
             text run at (0,0) width 36: "circle"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: white bullet
+          RenderListMarker at (-15,0) size 7x18: white bullet
           RenderText {#text} at (0,0) size 36x18
             text run at (0,0) width 36: "circle"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: white bullet
+          RenderListMarker at (-15,0) size 7x18: white bullet
           RenderText {#text} at (0,0) size 36x18
             text run at (0,0) width 36: "circle"
       RenderBlock {UL} at (0,174) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: black square
+          RenderListMarker at (-15,0) size 7x18: black square
           RenderText {#text} at (0,0) size 42x18
             text run at (0,0) width 42: "square"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: black square
+          RenderListMarker at (-15,0) size 7x18: black square
           RenderText {#text} at (0,0) size 42x18
             text run at (0,0) width 42: "square"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: black square
+          RenderListMarker at (-15,0) size 7x18: black square
           RenderText {#text} at (0,0) size 42x18
             text run at (0,0) width 42: "square"
       RenderBlock {UL} at (0,244) size 784x54 [color=#FF0000]

--- a/LayoutTests/platform/mac/css2.1/t1205-c563-list-type-01-b-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t1205-c563-list-type-01-b-expected.txt
@@ -8,66 +8,66 @@ layer at (0,0) size 800x400
           text run at (0,0) width 396: "The two columns should look the same, except for alignment."
       RenderBlock {OL} at (0,34) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 13x18: "i"
+          RenderListMarker at (-14,0) size 13x18: "i"
           RenderText {#text} at (0,0) size 9x18
             text run at (0,0) width 9: "i."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-21,0) size 17x18: "ii"
+          RenderListMarker at (-18,0) size 17x18: "ii"
           RenderText {#text} at (0,0) size 13x18
             text run at (0,0) width 13: "ii."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-26,0) size 22x18: "iii"
+          RenderListMarker at (-23,0) size 22x18: "iii"
           RenderText {#text} at (0,0) size 18x18
             text run at (0,0) width 18: "iii."
       RenderBlock {OL} at (0,104) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-18,0) size 14x18: "I"
+          RenderListMarker at (-15,0) size 14x18: "I"
           RenderText {#text} at (0,0) size 10x18
             text run at (0,0) width 10: "I."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-23,0) size 19x18: "II"
+          RenderListMarker at (-20,0) size 19x18: "II"
           RenderText {#text} at (0,0) size 15x18
             text run at (0,0) width 15: "II."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-28,0) size 24x18: "III"
+          RenderListMarker at (-25,0) size 24x18: "III"
           RenderText {#text} at (0,0) size 20x18
             text run at (0,0) width 20: "III."
       RenderBlock {OL} at (0,174) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "a"
+          RenderListMarker at (-17,0) size 16x18: "a"
           RenderText {#text} at (0,0) size 12x18
             text run at (0,0) width 12: "a."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "b"
+          RenderListMarker at (-17,0) size 16x18: "b"
           RenderText {#text} at (0,0) size 12x18
             text run at (0,0) width 12: "b."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "c"
+          RenderListMarker at (-17,0) size 16x18: "c"
           RenderText {#text} at (0,0) size 12x18
             text run at (0,0) width 12: "c."
       RenderBlock {OL} at (0,244) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-24,0) size 20x18: "A"
+          RenderListMarker at (-21,0) size 20x18: "A"
           RenderText {#text} at (0,0) size 16x18
             text run at (0,0) width 16: "A."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-23,0) size 19x18: "B"
+          RenderListMarker at (-20,0) size 19x18: "B"
           RenderText {#text} at (0,0) size 15x18
             text run at (0,0) width 15: "B."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-23,0) size 19x18: "C"
+          RenderListMarker at (-20,0) size 19x18: "C"
           RenderText {#text} at (0,0) size 15x18
             text run at (0,0) width 15: "C."
       RenderBlock {OL} at (0,314) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-24,0) size 20x18: "A"
+          RenderListMarker at (-21,0) size 20x18: "A"
           RenderText {#text} at (0,0) size 16x18
             text run at (0,0) width 16: "A."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-23,0) size 19x18: "B"
+          RenderListMarker at (-20,0) size 19x18: "B"
           RenderText {#text} at (0,0) size 15x18
             text run at (0,0) width 15: "B."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 12x18
             text run at (0,0) width 12: "3."

--- a/LayoutTests/platform/mac/css2.1/t1205-c564-list-img-00-b-g-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t1205-c564-list-img-00-b-g-expected.txt
@@ -21,14 +21,14 @@ layer at (0,0) size 800x199
             text run at (0,3) width 87: "purple square"
       RenderBlock {UL} at (0,113) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 26x18
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 26x18
             text run at (0,0) width 26: "disc"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 26x18
             text run at (0,0) width 26: "disc"

--- a/LayoutTests/platform/mac/css2.1/t1205-c565-list-pos-00-b-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t1205-c565-list-pos-00-b-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x96
           text run at (0,0) width 370: "The following two boxes should be identical, to the pixel."
       RenderBlock {OL} at (80,34) size 160x18 [color=#FFFFFF] [bgcolor=#000080]
         RenderListItem {LI} at (0,0) size 160x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderInline {SPAN} at (0,0) size 12x18 [color=#000080]
             RenderText {#text} at (0,0) size 12x18
               text run at (0,0) width 12: "1."

--- a/LayoutTests/platform/mac/css3/blending/blend-mode-overflow-expected.txt
+++ b/LayoutTests/platform/mac/css3/blending/blend-mode-overflow-expected.txt
@@ -6,29 +6,29 @@ layer at (0,0) size 800x576 isolatesBlending
       RenderBlock {UL} at (0,0) size 784x544
         RenderBlock {OL} at (40,0) size 744x144
           RenderListItem {LI} at (40,0) size 704x18
-            RenderListMarker at (-20,0) size 16x18: "1"
+            RenderListMarker at (-17,0) size 16x18: "1"
             RenderText {#text} at (0,0) size 319x18
               text run at (0,0) width 319: "No blending. Duck should be yellow everywhere."
           RenderListItem {LI} at (40,18) size 704x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 539x18
               text run at (0,0) width 539: "Simple blending. Duck should be a horizontal rainbow inside, and blue on overflow."
           RenderListItem {LI} at (40,36) size 704x36
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 700x36
               text run at (0,0) width 700: "Parent is a stacking context. Duck should be a horizontal rainbow inside, and yellow on overflow (since there"
               text run at (0,18) width 244: "is no background there to blend with)."
           RenderListItem {LI} at (40,72) size 704x18
-            RenderListMarker at (-20,0) size 16x18: "4"
+            RenderListMarker at (-17,0) size 16x18: "4"
             RenderText {#text} at (0,0) size 680x18
               text run at (0,0) width 680: "Intermediate parent - no stacking context. Duck should be a vertical gradient inside, and blue on overflow."
           RenderListItem {LI} at (40,90) size 704x36
-            RenderListMarker at (-20,0) size 16x18: "5"
+            RenderListMarker at (-17,0) size 16x18: "5"
             RenderText {#text} at (0,0) size 695x36
               text run at (0,0) width 695: "Intermediate parent with grandparent stacking context. Duck should be a vertical gradient inside, and yellow"
               text run at (0,18) width 80: "on overflow."
           RenderListItem {LI} at (40,126) size 704x18
-            RenderListMarker at (-20,0) size 16x18: "6"
+            RenderListMarker at (-17,0) size 16x18: "6"
             RenderText {#text} at (0,0) size 639x18
               text run at (0,0) width 639: "Intermediate parent has overflow. Duck should be a vertical gradient inside, and overflow is hidden."
         RenderBlock (anonymous) at (40,176) size 744x368

--- a/LayoutTests/platform/mac/editing/deleting/delete-first-list-item-expected.txt
+++ b/LayoutTests/platform/mac/editing/deleting/delete-first-list-item-expected.txt
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
               text run at (0,0) width 22: "foo"
         RenderBlock {UL} at (0,34) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "bar"
 caret: position 3 of child 0 {#text} of child 0 {B} of child 0 {DIV} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/deleting/delete-listitem-002-expected.txt
+++ b/LayoutTests/platform/mac/editing/deleting/delete-listitem-002-expected.txt
@@ -37,22 +37,22 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x216 [border: (2px solid #FF0000)]
         RenderBlock {UL} at (14,38) size 756x140
           RenderListItem {LI} at (40,0) size 716x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 35x28
               text run at (0,0) width 35: "one"
           RenderListItem {LI} at (40,28) size 716x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 36x28
               text run at (0,0) width 36: "two"
           RenderListItem {LI} at (40,56) size 716x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderBR {BR} at (0,0) size 0x28
           RenderListItem {LI} at (40,84) size 716x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 40x28
               text run at (0,0) width 40: "four"
           RenderListItem {LI} at (40,112) size 716x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 36x28
               text run at (0,0) width 36: "five"
 caret: position 0 of child 0 {BR} of child 5 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac/editing/deleting/list-item-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/deleting/list-item-1-expected.txt
@@ -22,9 +22,9 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,34) size 784x36
         RenderBlock {UL} at (0,0) size 784x36
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderBR {BR} at (0,0) size 0x18
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderBR {BR} at (0,0) size 0x18
 caret: position 0 of child 0 {BR} of child 0 {LI} of child 0 {UL} of child 3 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/4580583-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/4580583-1-expected.txt
@@ -12,11 +12,11 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,0) size 742x36 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x36
             RenderListItem {LI} at (40,0) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "1"
+              RenderListMarker at (-17,0) size 16x18: "1"
               RenderText {#text} at (0,0) size 27x18
                 text run at (0,0) width 27: "One"
             RenderListItem {LI} at (40,18) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "2"
+              RenderListMarker at (-17,0) size 16x18: "2"
               RenderText {#text} at (0,0) size 29x18
                 text run at (0,0) width 29: "Two"
         RenderBlock (anonymous) at (0,52) size 784x18
@@ -24,11 +24,11 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,86) size 742x36 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x36
             RenderListItem {LI} at (40,0) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "3"
+              RenderListMarker at (-17,0) size 16x18: "3"
               RenderText {#text} at (0,0) size 38x18
                 text run at (0,0) width 38: "Three"
             RenderListItem {LI} at (40,18) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "4"
+              RenderListMarker at (-17,0) size 16x18: "4"
               RenderText {#text} at (0,0) size 31x18
                 text run at (0,0) width 31: "Four"
 caret: position 0 of child 2 {BR} of child 3 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/4580583-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/4580583-2-expected.txt
@@ -12,11 +12,11 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,0) size 742x36 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x36
             RenderListItem {LI} at (40,0) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "1"
+              RenderListMarker at (-17,0) size 16x18: "1"
               RenderText {#text} at (0,0) size 27x18
                 text run at (0,0) width 27: "One"
             RenderListItem {LI} at (40,18) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "2"
+              RenderListMarker at (-17,0) size 16x18: "2"
               RenderText {#text} at (0,0) size 29x18
                 text run at (0,0) width 29: "Two"
         RenderBlock (anonymous) at (0,52) size 784x18
@@ -24,15 +24,15 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (2,86) size 742x54 [color=#0000FF] [border: none (2px solid #0000FF)]
           RenderBlock {OL} at (2,0) size 740x54
             RenderListItem {LI} at (40,0) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "2"
+              RenderListMarker at (-17,0) size 16x18: "2"
               RenderText {#text} at (0,0) size 29x18
                 text run at (0,0) width 29: "Two"
             RenderListItem {LI} at (40,18) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "3"
+              RenderListMarker at (-17,0) size 16x18: "3"
               RenderText {#text} at (0,0) size 38x18
                 text run at (0,0) width 38: "Three"
             RenderListItem {LI} at (40,36) size 700x18
-              RenderListMarker at (-20,0) size 16x18: "4"
+              RenderListMarker at (-17,0) size 16x18: "4"
               RenderText {#text} at (0,0) size 31x18
                 text run at (0,0) width 31: "Four"
 caret: position 0 of child 2 {BR} of child 3 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/4641880-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/4641880-1-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,52) size 784x52
         RenderBlock {UL} at (0,0) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 218x18
               text run at (0,0) width 218: "This paragraph should be in a list."
         RenderBlock (anonymous) at (0,34) size 784x18

--- a/LayoutTests/platform/mac/editing/execCommand/4747450-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/4747450-expected.txt
@@ -20,6 +20,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,34) size 784x18
           RenderBlock {UL} at (0,0) size 784x18
             RenderListItem {LI} at (40,0) size 744x18
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderBR {BR} at (0,0) size 0x18
 caret: position 0 of child 0 {BR} of child 0 {LI} of child 0 {UL} of child 1 {DIV} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/4916402-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/4916402-expected.txt
@@ -10,12 +10,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,52) size 784x52
         RenderBlock {UL} at (0,0) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 22x18
               text run at (0,0) width 22: "foo"
         RenderBlock {OL} at (0,34) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "1"
+            RenderListMarker at (-17,0) size 16x18: "1"
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "bar"
 caret: position 0 of child 0 {#text} of child 0 {LI} of child 1 {OL} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/4924441-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/4924441-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
         RenderBlock {UL} at (0,0) size 784x18
           RenderBlock {OL} at (40,0) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-20,0) size 16x18: "1"
+              RenderListMarker at (-17,0) size 16x18: "1"
               RenderText {#text} at (0,0) size 22x18
                 text run at (0,0) width 22: "foo"
 caret: position 3 of child 0 {#text} of child 0 {LI} of child 0 {OL} of child 0 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/5136770-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/5136770-expected.txt
@@ -13,13 +13,13 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,34) size 784x54
           RenderBlock {UL} at (0,0) size 784x54
             RenderListItem {LI} at (40,0) size 744x18
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderBR {BR} at (0,0) size 0x18
             RenderListItem {LI} at (40,18) size 744x18
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderBR {BR} at (0,0) size 0x18
             RenderListItem {LI} at (40,36) size 744x18
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderText {#text} at (0,0) size 243x18
                 text run at (0,0) width 243: "This should be an unordered list item."
 selection start: position 0 of child 0 {BR} of child 0 {LI} of child 0 {UL} of child 3 {DIV} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/5142012-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/5142012-2-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 721x36 [color=#0000EE]
             RenderText {#text} at (0,0) size 721x36
               text run at (0,0) width 345: "This tests for a crash when creating a list from a link. "

--- a/LayoutTests/platform/mac/editing/execCommand/5190926-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/5190926-expected.txt
@@ -5,17 +5,17 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {OL} at (0,0) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderInline {U} at (0,0) size 508x18
             RenderText {#text} at (0,0) size 508x18
               text run at (0,0) width 508: "This tests for a crash when making and removing lists from underlined content."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderInline {U} at (0,0) size 280x18
             RenderText {#text} at (0,0) size 280x18
               text run at (0,0) width 280: "All three paragraphs should be in list items."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderInline {U} at (0,0) size 226x18
             RenderText {#text} at (0,0) size 226x18
               text run at (0,0) width 226: "And all three should be underlined."

--- a/LayoutTests/platform/mac/editing/execCommand/5569741-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/5569741-expected.txt
@@ -9,12 +9,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,34) size 784x54
         RenderBlock {UL} at (0,0) size 784x54
           RenderListItem {LI} at (40,0) size 744x36
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 22x18
               text run at (0,0) width 22: "foo"
             RenderBR {BR} at (21,0) size 1x18
             RenderBR {BR} at (0,18) size 0x18
           RenderListItem {LI} at (40,36) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderBR {BR} at (0,0) size 0x18
 caret: position 0 of child 0 {BR} of child 1 {LI} of child 1 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/create-list-with-hr-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/create-list-with-hr-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
         RenderBlock {UL} at (0,0) size 784x28
           RenderListItem {LI} at (40,0) size 744x28
             RenderBlock (anonymous) at (0,10) size 744x18
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
 layer at (48,60) size 744x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 744x2 [color=#808080] [border: (1px inset #808080)]
 caret: position 0 of child 0 {HR} of child 0 {LI} of child 0 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/indent-list-item-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/indent-list-item-expected.txt
@@ -17,16 +17,16 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,52) size 784x54
         RenderBlock {UL} at (0,0) size 784x54
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 25x18
               text run at (0,0) width 25: "Foo"
           RenderBlock {UL} at (40,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 24x18
                 text run at (0,0) width 24: "Bar"
           RenderListItem {LI} at (40,36) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 25x18
               text run at (0,0) width 25: "Baz"
 caret: position 0 of child 0 {#text} of child 0 {LI} of child 3 {UL} of child 1 {UL} of child 4 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/indent-selection-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/indent-selection-expected.txt
@@ -31,15 +31,15 @@ layer at (0,0) size 800x600
           RenderBlock {UL} at (0,0) size 744x54
             RenderBlock {UL} at (40,0) size 704x54
               RenderListItem {LI} at (40,0) size 664x18
-                RenderListMarker at (-17,0) size 7x18: white bullet
+                RenderListMarker at (-15,0) size 7x18: white bullet
                 RenderText {#text} at (0,0) size 25x18
                   text run at (0,0) width 25: "Foo"
               RenderListItem {LI} at (40,18) size 664x18
-                RenderListMarker at (-17,0) size 7x18: white bullet
+                RenderListMarker at (-15,0) size 7x18: white bullet
                 RenderText {#text} at (0,0) size 24x18
                   text run at (0,0) width 24: "Bar"
               RenderListItem {LI} at (40,36) size 664x18
-                RenderListMarker at (-17,0) size 7x18: white bullet
+                RenderListMarker at (-15,0) size 7x18: white bullet
                 RenderText {#text} at (0,0) size 25x18
                   text run at (0,0) width 25: "Baz"
         RenderBlock {BLOCKQUOTE} at (40,140) size 744x54

--- a/LayoutTests/platform/mac/editing/execCommand/insert-list-and-stitch-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/insert-list-and-stitch-expected.txt
@@ -24,15 +24,15 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 784x54
           RenderBlock {OL} at (0,0) size 784x54
             RenderListItem {LI} at (40,0) size 744x18
-              RenderListMarker at (-20,0) size 16x18: "1"
+              RenderListMarker at (-17,0) size 16x18: "1"
               RenderText {#text} at (0,0) size 22x18
                 text run at (0,0) width 22: "foo"
             RenderListItem {LI} at (40,18) size 744x18
-              RenderListMarker at (-20,0) size 16x18: "2"
+              RenderListMarker at (-17,0) size 16x18: "2"
               RenderText {#text} at (0,0) size 21x18
                 text run at (0,0) width 21: "bar"
             RenderListItem {LI} at (40,36) size 744x18
-              RenderListMarker at (-20,0) size 16x18: "3"
+              RenderListMarker at (-17,0) size 16x18: "3"
               RenderText {#text} at (0,0) size 23x18
                 text run at (0,0) width 23: "baz"
 caret: position 0 of child 0 {#text} of child 2 {LI} of child 0 {OL} of child 1 {DIV} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/remove-list-from-range-selection-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/remove-list-from-range-selection-expected.txt
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
           RenderBR {BR} at (51,54) size 1x18
         RenderBlock {OL} at (0,88) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "1"
+            RenderListMarker at (-17,0) size 16x18: "1"
             RenderText {#text} at (0,0) size 323x18
               text run at (0,0) width 323: "This should be in a list and should not be selected."
 selection start: position 2 of child 0 {#text} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/execCommand/remove-list-item-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/execCommand/remove-list-item-1-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,34) size 784x18
         RenderBlock {UL} at (0,0) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 22x18
               text run at (0,0) width 22: "foo"
 caret: position 0 of child 0 {#text} of child 0 {LI} of child 0 {UL} of child 3 {DIV} of body

--- a/LayoutTests/platform/mac/editing/inserting/4875189-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/inserting/4875189-1-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,34) size 784x18
         RenderBlock {UL} at (0,0) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 182x18
               text run at (0,0) width 182: "This should be in a list item."
 caret: position 30 of child 0 {#text} of child 0 {LI} of child 0 {UL} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/inserting/4959067-expected.txt
+++ b/LayoutTests/platform/mac/editing/inserting/4959067-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,34) size 784x18
         RenderBlock {UL} at (0,0) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderInline {A} at (0,0) size 22x18 [color=#0000EE]
               RenderText {#text} at (0,0) size 22x18
                 text run at (0,0) width 22: "foo"

--- a/LayoutTests/platform/mac/editing/pasteboard/drag-selected-image-to-contenteditable-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/drag-selected-image-to-contenteditable-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {UL} at (0,241) size 800x18
         RenderListItem {LI} at (40,0) size 760x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 416x18
             text run at (0,0) width 416: "Abe should appear twice, once inside the div and once outside it."
 selection start: position 0 of child 0 {IMG} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac/editing/pasteboard/innerText-inline-table-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/innerText-inline-table-expected.txt
@@ -31,6 +31,6 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,84) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
           RenderBlock {PRE} at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,2) size 63x15
               text run at (0,2) width 63: "Success!"

--- a/LayoutTests/platform/mac/editing/pasteboard/input-field-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/input-field-1-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (147,0) size 149x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderBlock {UL} at (0,69) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 44x18
             text run at (0,0) width 44: "Passed"
 layer at (11,45) size 142x13

--- a/LayoutTests/platform/mac/editing/pasteboard/merge-start-list-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/merge-start-list-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,68) size 784x18
         RenderBlock {UL} at (0,0) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "bar"
 caret: position 3 of child 0 {#text} of child 0 {LI} of child 0 {UL} of child 4 {DIV} of body

--- a/LayoutTests/platform/mac/editing/selection/4895428-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/4895428-2-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x18
       RenderBlock {UL} at (0,132) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 51x18
             text run at (0,0) width 51: "Success"
 caret: position 4 of child 0 {#text} of child 1 {TD} of child 0 {TR} of child 0 {TBODY} of child 0 {TABLE} of child 2 {DIV} of body

--- a/LayoutTests/platform/mac/editing/selection/drag-to-contenteditable-iframe-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/drag-to-contenteditable-iframe-expected.txt
@@ -23,6 +23,6 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {UL} at (0,228) size 800x18
         RenderListItem {LI} at (40,0) size 760x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 294x18
             text run at (0,0) width 294: "Abe should be outside the frame and inside it."

--- a/LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 148x166 [border: (2px solid #FF0000)]
         RenderBlock {UL} at (14,14) size 120x138
           RenderListItem {LI} at (0,0) size 120x21
-            RenderListMarker at (-14,6) size 5x12: bullet
+            RenderListMarker at (-13,6) size 5x12: bullet
             RenderInline (generated) at (5,-4) size 15x24
               RenderText at (5,-4) size 15x24
                 text run at (5,-4) width 15: "\x{B7} "
@@ -24,7 +24,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,6) size 53x12
                 text run at (19,6) width 53: "Appetizers"
           RenderListItem {LI} at (0,21) size 120x21
-            RenderListMarker at (-14,6) size 5x12: bullet
+            RenderListMarker at (-13,6) size 5x12: bullet
             RenderInline (generated) at (5,-4) size 15x24
               RenderText at (5,-4) size 15x24
                 text run at (5,-4) width 15: "\x{B7} "
@@ -33,7 +33,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,6) size 79x12
                 text run at (19,6) width 79: "Soups & Salads"
           RenderListItem {LI} at (0,42) size 120x33
-            RenderListMarker at (-14,6) size 5x12: bullet
+            RenderListMarker at (-13,6) size 5x12: bullet
             RenderInline (generated) at (5,-4) size 15x24
               RenderText at (5,-4) size 15x24
                 text run at (5,-4) width 15: "\x{B7} "
@@ -43,7 +43,7 @@ layer at (0,0) size 800x600
                 text run at (19,6) width 74: "Sandwiches & "
                 text run at (16,18) width 40: "Burgers"
           RenderListItem {LI} at (0,75) size 120x21
-            RenderListMarker at (-14,6) size 5x12: bullet
+            RenderListMarker at (-13,6) size 5x12: bullet
             RenderInline (generated) at (5,-4) size 15x24
               RenderText at (5,-4) size 15x24
                 text run at (5,-4) width 15: "\x{B7} "
@@ -52,7 +52,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,6) size 65x12
                 text run at (19,6) width 65: "Steak & Ribs"
           RenderListItem {LI} at (0,96) size 120x21
-            RenderListMarker at (-14,6) size 5x12: bullet
+            RenderListMarker at (-13,6) size 5x12: bullet
             RenderInline (generated) at (5,-4) size 15x24
               RenderText at (5,-4) size 15x24
                 text run at (5,-4) width 15: "\x{B7} "
@@ -61,7 +61,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (19,6) size 41x12
                 text run at (19,6) width 41: "Seafood"
           RenderListItem {LI} at (0,117) size 120x21
-            RenderListMarker at (-14,6) size 5x12: bullet
+            RenderListMarker at (-13,6) size 5x12: bullet
             RenderInline (generated) at (5,-4) size 15x24
               RenderText at (5,-4) size 15x24
                 text run at (5,-4) width 15: "\x{B7} "

--- a/LayoutTests/platform/mac/editing/selection/move-by-line-002-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/move-by-line-002-expected.txt
@@ -12,22 +12,22 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (14,38) size 756x140
           RenderBlock {OL} at (0,0) size 756x140
             RenderListItem {LI} at (40,0) size 716x28
-              RenderListMarker at (-31,0) size 24x28: "1"
+              RenderListMarker at (-26,0) size 24x28: "1"
               RenderText {#text} at (0,0) size 35x28
                 text run at (0,0) width 35: "one"
             RenderListItem {LI} at (40,28) size 716x28
-              RenderListMarker at (-31,0) size 24x28: "2"
+              RenderListMarker at (-26,0) size 24x28: "2"
               RenderText {#text} at (0,0) size 36x28
                 text run at (0,0) width 36: "two"
             RenderListItem {LI} at (40,56) size 716x28
-              RenderListMarker at (-31,0) size 24x28: "3"
+              RenderListMarker at (-26,0) size 24x28: "3"
               RenderBR {BR} at (0,0) size 0x28
             RenderListItem {LI} at (40,84) size 716x28
-              RenderListMarker at (-31,0) size 24x28: "4"
+              RenderListMarker at (-26,0) size 24x28: "4"
               RenderText {#text} at (0,0) size 40x28
                 text run at (0,0) width 40: "four"
             RenderListItem {LI} at (40,112) size 716x28
-              RenderListMarker at (-31,0) size 24x28: "5"
+              RenderListMarker at (-26,0) size 24x28: "5"
               RenderText {#text} at (0,0) size 36x28
                 text run at (0,0) width 36: "five"
 caret: position 0 of child 0 {BR} of child 2 {LI} of child 1 {OL} of child 1 {DIV} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac/editing/selection/select-all-iframe-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/select-all-iframe-expected.txt
@@ -45,12 +45,12 @@ layer at (0,0) size 800x600
           text run at (130,36) width 173: "Two things should happen:"
       RenderBlock {UL} at (0,310) size 784x54
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 689x36
             text run at (0,0) width 462: "The Select All operation should not select the iframe, only it's contents. "
             text run at (461,0) width 228: "The results of the Select All will be"
             text run at (0,18) width 517: "apparent from the delegate messages that DumpRenderTree receives and dumps."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 344x18
             text run at (0,0) width 344: "The contents of the editable iframe should be deleted."

--- a/LayoutTests/platform/mac/editing/selection/selectNode-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/selectNode-expected.txt
@@ -20,6 +20,6 @@ layer at (0,0) size 800x600
           text run at (0,0) width 27: "four"
       RenderBlock {UL} at (0,122) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 55x18
             text run at (0,0) width 55: "Success."

--- a/LayoutTests/platform/mac/editing/selection/selectNodeContents-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/selectNodeContents-expected.txt
@@ -20,6 +20,6 @@ layer at (0,0) size 800x600
           text run at (0,0) width 27: "four"
       RenderBlock {UL} at (0,122) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 55x18
             text run at (0,0) width 55: "Success."

--- a/LayoutTests/platform/mac/editing/unsupported-content/list-delete-001-expected.txt
+++ b/LayoutTests/platform/mac/editing/unsupported-content/list-delete-001-expected.txt
@@ -60,7 +60,7 @@ layer at (0,0) size 800x600
               text run at (0,0) width 62: "before"
           RenderBlock {UL} at (2,54) size 780x28
             RenderListItem {LI} at (40,0) size 740x28
-              RenderListMarker at (-22,0) size 9x28: bullet
+              RenderListMarker at (-19,0) size 9x28: bullet
               RenderText {#text} at (0,0) size 44x28
                 text run at (0,0) width 44: "after"
 caret: position 0 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of child 5 {DIV} of body

--- a/LayoutTests/platform/mac/editing/unsupported-content/list-type-after-expected.txt
+++ b/LayoutTests/platform/mac/editing/unsupported-content/list-type-after-expected.txt
@@ -49,30 +49,30 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,238) size 784x136 [border: (2px solid #008000)]
         RenderBlock {UL} at (2,26) size 780x84
           RenderListItem {LI} at (40,0) size 740x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 77x28
               text run at (0,0) width 77: "line one"
           RenderListItem {LI} at (40,28) size 740x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 78x28
               text run at (0,0) width 78: "line two"
           RenderListItem {LI} at (40,56) size 740x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 126x28
               text run at (0,0) width 126: "line threexxx"
       RenderBlock {DIV} at (0,384) size 784x136
         RenderBlock {DIV} at (0,0) size 784x136 [border: (2px solid #FF0000)]
           RenderBlock {UL} at (2,26) size 780x84
             RenderListItem {LI} at (40,0) size 740x28
-              RenderListMarker at (-22,0) size 9x28: bullet
+              RenderListMarker at (-19,0) size 9x28: bullet
               RenderText {#text} at (0,0) size 77x28
                 text run at (0,0) width 77: "line one"
             RenderListItem {LI} at (40,28) size 740x28
-              RenderListMarker at (-22,0) size 9x28: bullet
+              RenderListMarker at (-19,0) size 9x28: bullet
               RenderText {#text} at (0,0) size 78x28
                 text run at (0,0) width 78: "line two"
             RenderListItem {LI} at (40,56) size 740x28
-              RenderListMarker at (-22,0) size 9x28: bullet
+              RenderListMarker at (-19,0) size 9x28: bullet
               RenderText {#text} at (0,0) size 126x28
                 text run at (0,0) width 126: "line threexxx"
 caret: position 13 of child 0 {#text} of child 5 {LI} of child 1 {UL} of child 1 {DIV} of child 5 {DIV} of body

--- a/LayoutTests/platform/mac/editing/unsupported-content/list-type-before-expected.txt
+++ b/LayoutTests/platform/mac/editing/unsupported-content/list-type-before-expected.txt
@@ -46,30 +46,30 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,238) size 784x136 [border: (2px solid #008000)]
         RenderBlock {UL} at (2,26) size 780x84
           RenderListItem {LI} at (40,0) size 740x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 113x28
               text run at (0,0) width 113: "xxxline one"
           RenderListItem {LI} at (40,28) size 740x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 78x28
               text run at (0,0) width 78: "line two"
           RenderListItem {LI} at (40,56) size 740x28
-            RenderListMarker at (-22,0) size 9x28: bullet
+            RenderListMarker at (-19,0) size 9x28: bullet
             RenderText {#text} at (0,0) size 90x28
               text run at (0,0) width 90: "line three"
       RenderBlock {DIV} at (0,384) size 784x136
         RenderBlock {DIV} at (0,0) size 784x136 [border: (2px solid #FF0000)]
           RenderBlock {UL} at (2,26) size 780x84
             RenderListItem {LI} at (40,0) size 740x28
-              RenderListMarker at (-22,0) size 9x28: bullet
+              RenderListMarker at (-19,0) size 9x28: bullet
               RenderText {#text} at (0,0) size 113x28
                 text run at (0,0) width 113: "xxxline one"
             RenderListItem {LI} at (40,28) size 740x28
-              RenderListMarker at (-22,0) size 9x28: bullet
+              RenderListMarker at (-19,0) size 9x28: bullet
               RenderText {#text} at (0,0) size 78x28
                 text run at (0,0) width 78: "line two"
             RenderListItem {LI} at (40,56) size 740x28
-              RenderListMarker at (-22,0) size 9x28: bullet
+              RenderListMarker at (-19,0) size 9x28: bullet
               RenderText {#text} at (0,0) size 90x28
                 text run at (0,0) width 90: "line three"
 caret: position 3 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of child 5 {DIV} of body

--- a/LayoutTests/platform/mac/fast/backgrounds/background-inherit-color-bug-expected.txt
+++ b/LayoutTests/platform/mac/fast/backgrounds/background-inherit-color-bug-expected.txt
@@ -35,7 +35,7 @@ layer at (0,0) size 785x1132
             text run at (0,0) width 409: "This is in contradiction with the CSS2 specification which says:"
         RenderBlock {UL} at (4,398) size 616x36
           RenderListItem {LI} at (40,0) size 576x36
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 29x18
               text run at (0,0) width 29: "The "
             RenderInline {A} at (28,0) size 83x18 [color=#0000EE]

--- a/LayoutTests/platform/mac/fast/backgrounds/repeat/noRepeatCorrectClip-expected.txt
+++ b/LayoutTests/platform/mac/fast/backgrounds/repeat/noRepeatCorrectClip-expected.txt
@@ -5,4 +5,4 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet

--- a/LayoutTests/platform/mac/fast/backgrounds/selection-background-color-of-list-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/backgrounds/selection-background-color-of-list-style-expected.txt
@@ -9,20 +9,20 @@ layer at (0,0) size 800x146
             text run at (0,0) width 497: "Test passes if backgrounds of list style in ul and ol are each green and yellow."
         RenderBlock {UL} at (0,34) size 784x36
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 27x18
               text run at (0,0) width 27: "One"
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 29x18
               text run at (0,0) width 29: "Two"
         RenderBlock {OL} at (0,86) size 784x36
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "1"
+            RenderListMarker at (-17,0) size 16x18: "1"
             RenderText {#text} at (0,0) size 27x18
               text run at (0,0) width 27: "One"
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 29x18
               text run at (0,0) width 29: "Two"
 selection start: position 86 of child 0 {#text} of child 0 {DIV} of body

--- a/LayoutTests/platform/mac/fast/block/float/014-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/float/014-expected.txt
@@ -9,10 +9,10 @@ layer at (0,0) size 800x148
           RenderImage {IMG} at (0,0) size 60x45
         RenderBlock {UL} at (15,47) size 769x77 [bgcolor=#FF0000]
           RenderListItem {LI} at (0,8) size 769x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 127x18
               text run at (0,0) width 127: "Classroom Training"
           RenderListItem {LI} at (0,42) size 769x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 80x18
               text run at (0,0) width 80: "Find a Class"

--- a/LayoutTests/platform/mac/fast/block/positioning/padding-percent-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/positioning/padding-percent-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {OL} at (0,0) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 161x18
             text run at (0,0) width 161: "Make text bigger/smaller"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 219x18
             text run at (0,0) width 219: "Make the window narrower/wider"
 layer at (8,60) size 132x24

--- a/LayoutTests/platform/mac/fast/css-generated-content/009-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/009-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
           text run at (158,0) width 45: " green."
       RenderBlock {UL} at (0,34) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 380x18
             text run at (0,0) width 380: "All of this text should be green. The bullet should be black."
       RenderBlock {DIV} at (0,68) size 784x55 [color=#FF0000]

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-to-inline-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-to-inline-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (653,0) size 1x18
       RenderBlock {UL} at (0,34) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline (generated) at (0,0) size 32x18
             RenderText at (0,0) size 32x18
               text run at (0,0) width 32: "hello"

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,34) size 784x54
         RenderListItem {LI} at (40,0) size 744x54
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderTable at (0,18) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,34) size 784x54
         RenderListItem {LI} at (40,0) size 744x54
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderTable at (0,18) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,34) size 784x54
         RenderListItem {LI} at (40,0) size 744x54
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderTable at (0,18) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18

--- a/LayoutTests/platform/mac/fast/css/background-shorthand-invalid-url-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/background-shorthand-invalid-url-expected.txt
@@ -10,6 +10,6 @@ layer at (0,0) size 800x187
         RenderBlock {UL} at (0,0) size 784x91
           RenderListItem {LI} at (40,0) size 744x91 [border: (1px solid #FF0000)]
             RenderBlock {SPAN} at (1,1) size 304x89 [border: (2px solid #008000)]
-              RenderListMarker at (-18,2) size 7x18: bullet
+              RenderListMarker at (-16,2) size 7x18: bullet
               RenderText {#text} at (2,2) size 4x18
                 text run at (2,2) width 4: " "

--- a/LayoutTests/platform/mac/fast/css/compare-content-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/compare-content-style-expected.txt
@@ -35,14 +35,14 @@ layer at (0,0) size 800x236
               text run at (0,0) width 683: "Bug 23741: StyleRareNonInheritedData::operator==() should not compare ContentData objects by pointer"
         RenderBlock {OL} at (0,34) size 784x54
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "1"
+            RenderListMarker at (-17,0) size 16x18: "1"
             RenderText {#text} at (0,0) size 348x18
               text run at (0,0) width 348: "All lines above should be \"PASS\" on initial page load."
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 142x18
               text run at (0,0) width 142: "Reload the page once."
           RenderListItem {LI} at (40,36) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 249x18
               text run at (0,0) width 249: "All lines above should still be \"PASS\"."

--- a/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
@@ -15,35 +15,35 @@ layer at (0,0) size 800x600
           text run at (0,0) width 180: "Click the following buttons."
       RenderBlock {OL} at (0,73) size 784x164
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 199x18
             text run at (0,0) width 199: "Start with the outmost left one."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 138x18
             text run at (0,0) width 138: "Click the middle one."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 271x18
             text run at (0,0) width 271: "(The ouline will not be updated correctly.)"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 142x18
             text run at (0,0) width 142: "Click the right button."
         RenderListItem {LI} at (40,72) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 473x18
             text run at (0,0) width 473: "This will crash Safari 1.3 (v176 and v170, no other configurations tested)."
         RenderListItem {LI} at (40,90) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "6"
+          RenderListMarker at (-17,0) size 16x18: "6"
           RenderText {#text} at (0,0) size 300x18
             text run at (0,0) width 300: "The combination 2. 1. 3. will also crash Safari."
         RenderListItem {LI} at (40,108) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "7"
+          RenderListMarker at (-17,0) size 16x18: "7"
           RenderText {#text} at (0,0) size 457x18
             text run at (0,0) width 457: "1. 3. will not crash Safari. (But the outline should vanish. Shouldn't it?)"
         RenderListItem {LI} at (40,126) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "8"
+          RenderListMarker at (-17,0) size 16x18: "8"
           RenderText {#text} at (0,0) size 205x18
             text run at (0,0) width 205: "2. 3. will not crash Safari either."
         RenderBlock (anonymous) at (40,144) size 744x19

--- a/LayoutTests/platform/mac/fast/css/empty-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/empty-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 785x1616
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x76 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "1"
+            RenderListMarker at (-35,6) size 18x18: "1"
             RenderText {#text} at (6,8) size 87x62
               text run at (6,8) width 63: ":empty {"
               text run at (68,8) width 1: " "
@@ -42,7 +42,7 @@ layer at (0,0) size 785x1616
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x76 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "2"
+            RenderListMarker at (-35,6) size 18x18: "2"
             RenderText {#text} at (6,8) size 266x62
               text run at (6,8) width 63: ":empty {"
               text run at (68,8) width 1: " "
@@ -57,7 +57,7 @@ layer at (0,0) size 785x1616
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x76 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "3"
+            RenderListMarker at (-35,6) size 18x18: "3"
             RenderText {#text} at (6,8) size 95x62
               text run at (6,8) width 63: ":empty {"
               text run at (68,8) width 1: " "
@@ -71,7 +71,7 @@ layer at (0,0) size 785x1616
         RenderListItem {LI} at (40,729) size 616x240 [bgcolor=#AAAAAA]
           RenderBlock {DIV} at (16,16) size 584x42 [bgcolor=#009900]
             RenderBlock {DIV} at (0,0) size 584x42
-              RenderListMarker at (-38,12) size 18x17: "4"
+              RenderListMarker at (-35,12) size 18x17: "4"
               RenderText {#text} at (12,12) size 5x17
                 text run at (12,12) width 5: "."
           RenderBlock {PRE} at (16,71) size 584x103 [bgcolor=#FFFFFF]
@@ -94,7 +94,7 @@ layer at (0,0) size 785x1616
             RenderBlock {DIV} at (0,0) size 584x24
               RenderBlock {BLOCKQUOTE} at (12,12) size 560x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 584x76 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "5"
+            RenderListMarker at (-35,6) size 18x18: "5"
             RenderText {#text} at (6,8) size 282x62
               text run at (6,8) width 63: ":empty {"
               text run at (68,8) width 1: " "
@@ -110,7 +110,7 @@ layer at (0,0) size 785x1616
             RenderBlock {DIV} at (0,0) size 584x24
               RenderBlock {DIV} at (12,12) size 560x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "6"
+            RenderListMarker at (-35,6) size 18x18: "6"
             RenderText {#text} at (6,8) size 375x107
               text run at (6,8) width 63: ":empty {"
               text run at (68,8) width 1: " "

--- a/LayoutTests/platform/mac/fast/css/first-child-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/first-child-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 785x2270
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x106 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "1"
+            RenderListMarker at (-35,6) size 18x18: "1"
             RenderText {#text} at (6,8) size 141x92
               text run at (6,8) width 141: "div :first-child {"
               text run at (146,8) width 1: " "
@@ -48,7 +48,7 @@ layer at (0,0) size 785x2270
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock {BLOCKQUOTE} at (0,24) size 584x0
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "2"
+            RenderListMarker at (-35,6) size 18x18: "2"
             RenderText {#text} at (6,8) size 219x107
               text run at (6,8) width 141: "div :first-child {"
               text run at (146,8) width 1: " "
@@ -70,7 +70,7 @@ layer at (0,0) size 785x2270
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "3"
+            RenderListMarker at (-35,6) size 18x18: "3"
             RenderText {#text} at (6,8) size 204x107
               text run at (6,8) width 141: "div :first-child {"
               text run at (146,8) width 1: " "
@@ -93,7 +93,7 @@ layer at (0,0) size 785x2270
         RenderListItem {LI} at (40,921) size 616x291 [bgcolor=#AAAAAA]
           RenderBlock {DIV} at (16,16) size 584x42 [bgcolor=#990000]
             RenderBlock (anonymous) at (0,0) size 584x18
-              RenderListMarker at (-38,0) size 18x17: "4"
+              RenderListMarker at (-35,0) size 18x17: "4"
               RenderText {#text} at (0,0) size 5x17
                 text run at (0,0) width 5: "."
             RenderBlock {DIV} at (0,18) size 584x24 [bgcolor=#009900]
@@ -122,7 +122,7 @@ layer at (0,0) size 785x2270
             RenderBlock {BLOCKQUOTE} at (0,0) size 584x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "5"
+            RenderListMarker at (-35,6) size 18x18: "5"
             RenderText {#text} at (6,8) size 219x107
               text run at (6,8) width 141: "div :first-child {"
               text run at (146,8) width 1: " "
@@ -145,7 +145,7 @@ layer at (0,0) size 785x2270
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,24) size 584x0
           RenderBlock {PRE} at (16,53) size 584x151 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "6"
+            RenderListMarker at (-35,6) size 18x18: "6"
             RenderText {#text} at (6,8) size 508x137
               text run at (6,8) width 141: "div :first-child {"
               text run at (146,8) width 1: " "
@@ -171,7 +171,7 @@ layer at (0,0) size 785x2270
             RenderBlock {DIV} at (0,0) size 584x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x151 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "7"
+            RenderListMarker at (-35,6) size 18x18: "7"
             RenderText {#text} at (6,8) size 508x137
               text run at (6,8) width 141: "div :first-child {"
               text run at (146,8) width 1: " "

--- a/LayoutTests/platform/mac/fast/css/first-of-type-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/first-of-type-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 785x2912
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x76 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "1"
+            RenderListMarker at (-35,6) size 18x18: "1"
             RenderText {#text} at (6,8) size 274x62
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -44,7 +44,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,24) size 584x0
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "2"
+            RenderListMarker at (-35,6) size 18x18: "2"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -63,7 +63,7 @@ layer at (0,0) size 785x2912
             RenderBlock {BLOCKQUOTE} at (0,0) size 584x0 [bgcolor=#009900]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "3"
+            RenderListMarker at (-35,6) size 18x18: "3"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -83,7 +83,7 @@ layer at (0,0) size 785x2912
             RenderBlock {BLOCKQUOTE} at (0,0) size 584x24 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "4"
+            RenderListMarker at (-35,6) size 18x18: "4"
             RenderText {#text} at (6,8) size 297x107
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -106,7 +106,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x106 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "5"
+            RenderListMarker at (-35,6) size 18x18: "5"
             RenderText {#text} at (6,8) size 297x92
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -128,7 +128,7 @@ layer at (0,0) size 785x2912
               RenderBlock {DIV} at (0,0) size 584x0
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "6"
+            RenderListMarker at (-35,6) size 18x18: "6"
             RenderText {#text} at (6,8) size 274x107
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -151,7 +151,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "7"
+            RenderListMarker at (-35,6) size 18x18: "7"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -170,7 +170,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "8"
+            RenderListMarker at (-35,6) size 18x18: "8"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -189,7 +189,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock {DIV} at (0,24) size 584x0
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "9"
+            RenderListMarker at (-35,6) size 18x18: "9"
             RenderText {#text} at (6,8) size 508x107
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "
@@ -211,7 +211,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x0 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-47,6) size 27x18: "10"
+            RenderListMarker at (-44,6) size 27x18: "10"
             RenderText {#text} at (6,8) size 508x107
               text run at (6,8) width 149: "div:first-of-type {"
               text run at (154,8) width 1: " "

--- a/LayoutTests/platform/mac/fast/css/last-child-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/last-child-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 785x2270
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x106 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "1"
+            RenderListMarker at (-35,6) size 18x18: "1"
             RenderText {#text} at (6,8) size 134x92
               text run at (6,8) width 134: "div :last-child {"
               text run at (139,8) width 1: " "
@@ -48,7 +48,7 @@ layer at (0,0) size 785x2270
             RenderBlock {BLOCKQUOTE} at (0,0) size 584x0
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "2"
+            RenderListMarker at (-35,6) size 18x18: "2"
             RenderText {#text} at (6,8) size 219x107
               text run at (6,8) width 134: "div :last-child {"
               text run at (139,8) width 1: " "
@@ -70,7 +70,7 @@ layer at (0,0) size 785x2270
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "3"
+            RenderListMarker at (-35,6) size 18x18: "3"
             RenderText {#text} at (6,8) size 204x107
               text run at (6,8) width 134: "div :last-child {"
               text run at (139,8) width 1: " "
@@ -94,7 +94,7 @@ layer at (0,0) size 785x2270
           RenderBlock {DIV} at (16,16) size 584x42 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock (anonymous) at (0,24) size 584x18
-              RenderListMarker at (-38,0) size 18x17: "4"
+              RenderListMarker at (-35,0) size 18x17: "4"
               RenderText {#text} at (0,0) size 5x17
                 text run at (0,0) width 5: "."
           RenderBlock {PRE} at (16,71) size 584x118 [bgcolor=#FFFFFF]
@@ -122,7 +122,7 @@ layer at (0,0) size 785x2270
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {BLOCKQUOTE} at (0,24) size 584x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "5"
+            RenderListMarker at (-35,6) size 18x18: "5"
             RenderText {#text} at (6,8) size 219x107
               text run at (6,8) width 134: "div :last-child {"
               text run at (139,8) width 1: " "
@@ -145,7 +145,7 @@ layer at (0,0) size 785x2270
             RenderBlock {DIV} at (0,0) size 584x0
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x151 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "6"
+            RenderListMarker at (-35,6) size 18x18: "6"
             RenderText {#text} at (6,8) size 469x137
               text run at (6,8) width 134: "div :last-child {"
               text run at (139,8) width 1: " "
@@ -171,7 +171,7 @@ layer at (0,0) size 785x2270
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 584x151 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "7"
+            RenderListMarker at (-35,6) size 18x18: "7"
             RenderText {#text} at (6,8) size 469x137
               text run at (6,8) width 134: "div :last-child {"
               text run at (139,8) width 1: " "

--- a/LayoutTests/platform/mac/fast/css/last-of-type-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/last-of-type-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 785x2912
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x76 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "1"
+            RenderListMarker at (-35,6) size 18x18: "1"
             RenderText {#text} at (6,8) size 274x62
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -44,7 +44,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x0
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "2"
+            RenderListMarker at (-35,6) size 18x18: "2"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -63,7 +63,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock {BLOCKQUOTE} at (0,24) size 584x0 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "3"
+            RenderListMarker at (-35,6) size 18x18: "3"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -83,7 +83,7 @@ layer at (0,0) size 785x2912
               RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "4"
+            RenderListMarker at (-35,6) size 18x18: "4"
             RenderText {#text} at (6,8) size 297x107
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -106,7 +106,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 584x24
           RenderBlock {PRE} at (16,53) size 584x106 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "5"
+            RenderListMarker at (-35,6) size 18x18: "5"
             RenderText {#text} at (6,8) size 297x92
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -128,7 +128,7 @@ layer at (0,0) size 785x2912
             RenderBlock {BLOCKQUOTE} at (0,24) size 584x0 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 584x0
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "6"
+            RenderListMarker at (-35,6) size 18x18: "6"
             RenderText {#text} at (6,8) size 274x107
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -151,7 +151,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "7"
+            RenderListMarker at (-35,6) size 18x18: "7"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -170,7 +170,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "8"
+            RenderListMarker at (-35,6) size 18x18: "8"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -189,7 +189,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x0
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "9"
+            RenderListMarker at (-35,6) size 18x18: "9"
             RenderText {#text} at (6,8) size 469x107
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "
@@ -211,7 +211,7 @@ layer at (0,0) size 785x2912
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0 [bgcolor=#990000]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-47,6) size 27x18: "10"
+            RenderListMarker at (-44,6) size 27x18: "10"
             RenderText {#text} at (6,8) size 469x107
               text run at (6,8) width 141: "div:last-of-type {"
               text run at (146,8) width 1: " "

--- a/LayoutTests/platform/mac/fast/css/list-outline-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/list-outline-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x82
     RenderBody {BODY} at (8,16) size 784x50
       RenderBlock {OL} at (0,0) size 784x50
         RenderListItem {LI} at (40,0) size 744x50
-          RenderListMarker at (-20,16) size 16x18: "1"
+          RenderListMarker at (-17,16) size 16x18: "1"
           RenderText {#text} at (16,16) size 595x18
             text run at (16,16) width 595: "A single outline should only appear over the list element, and not over internal text elements."

--- a/LayoutTests/platform/mac/fast/css/only-child-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/only-child-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 785x1613
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x106 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "1"
+            RenderListMarker at (-35,6) size 18x18: "1"
             RenderText {#text} at (6,8) size 134x92
               text run at (6,8) width 134: "div :only-child {"
               text run at (139,8) width 1: " "
@@ -47,7 +47,7 @@ layer at (0,0) size 785x1613
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "2"
+            RenderListMarker at (-35,6) size 18x18: "2"
             RenderText {#text} at (6,8) size 204x107
               text run at (6,8) width 134: "div :only-child {"
               text run at (139,8) width 1: " "
@@ -69,7 +69,7 @@ layer at (0,0) size 785x1613
           RenderBlock {DIV} at (16,16) size 584x42 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock (anonymous) at (0,24) size 584x18
-              RenderListMarker at (-38,0) size 18x17: "3"
+              RenderListMarker at (-35,0) size 18x17: "3"
               RenderText {#text} at (0,0) size 5x17
                 text run at (0,0) width 5: "."
           RenderBlock {PRE} at (16,71) size 584x118 [bgcolor=#FFFFFF]
@@ -95,7 +95,7 @@ layer at (0,0) size 785x1613
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {BLOCKQUOTE} at (40,40) size 504x0
           RenderBlock {PRE} at (16,56) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "4"
+            RenderListMarker at (-35,6) size 18x18: "4"
             RenderText {#text} at (6,8) size 219x107
               text run at (6,8) width 134: "div :only-child {"
               text run at (139,8) width 1: " "
@@ -118,7 +118,7 @@ layer at (0,0) size 785x1613
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0
           RenderBlock {PRE} at (16,53) size 584x151 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "5"
+            RenderListMarker at (-35,6) size 18x18: "5"
             RenderText {#text} at (6,8) size 469x137
               text run at (6,8) width 134: "div :only-child {"
               text run at (139,8) width 1: " "

--- a/LayoutTests/platform/mac/fast/css/only-of-type-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/only-of-type-pseudo-class-expected.txt
@@ -27,7 +27,7 @@ layer at (0,0) size 785x1493
           RenderBlock {DIV} at (16,16) size 584x24 [bgcolor=#990000]
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x76 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "1"
+            RenderListMarker at (-35,6) size 18x18: "1"
             RenderText {#text} at (6,8) size 274x62
               text run at (6,8) width 141: "div:only-of-type {"
               text run at (146,8) width 1: " "
@@ -44,7 +44,7 @@ layer at (0,0) size 785x1493
             RenderBlock {DIV} at (0,0) size 584x24 [bgcolor=#009900]
             RenderBlock {BLOCKQUOTE} at (0,24) size 584x0 [bgcolor=#009900]
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "2"
+            RenderListMarker at (-35,6) size 18x18: "2"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 141: "div:only-of-type {"
               text run at (146,8) width 1: " "
@@ -64,7 +64,7 @@ layer at (0,0) size 785x1493
             RenderBlock {BLOCKQUOTE} at (0,24) size 584x0 [bgcolor=#009900]
               RenderBlock {DIV} at (0,0) size 584x0
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "3"
+            RenderListMarker at (-35,6) size 18x18: "3"
             RenderText {#text} at (6,8) size 274x107
               text run at (6,8) width 141: "div:only-of-type {"
               text run at (146,8) width 1: " "
@@ -87,7 +87,7 @@ layer at (0,0) size 785x1493
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0
           RenderBlock {PRE} at (16,53) size 584x91 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "4"
+            RenderListMarker at (-35,6) size 18x18: "4"
             RenderText {#text} at (6,8) size 274x77
               text run at (6,8) width 141: "div:only-of-type {"
               text run at (146,8) width 1: " "
@@ -106,7 +106,7 @@ layer at (0,0) size 785x1493
             RenderBlock {DIV} at (0,0) size 584x24
             RenderBlock {DIV} at (0,24) size 584x0
           RenderBlock {PRE} at (16,53) size 584x121 [bgcolor=#FFFFFF]
-            RenderListMarker at (-38,6) size 18x18: "5"
+            RenderListMarker at (-35,6) size 18x18: "5"
             RenderText {#text} at (6,8) size 469x107
               text run at (6,8) width 141: "div:only-of-type {"
               text run at (146,8) width 1: " "

--- a/LayoutTests/platform/mac/fast/doctypes/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/doctypes/001-expected.txt
@@ -11,10 +11,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 244x18
                 text run at (0,0) width 244: "I should be underneath the first bullet."
 layer at (10,10) size 80x80

--- a/LayoutTests/platform/mac/fast/doctypes/002-expected.txt
+++ b/LayoutTests/platform/mac/fast/doctypes/002-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 800x176
         RenderListItem {LI} at (40,0) size 744x18
           RenderBlock {UL} at (0,0) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
-              RenderListMarker at (-57,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
+              RenderListMarker at (-55,0) size 7x18: bullet
               RenderText {#text} at (0,0) size 256x18
                 text run at (0,0) width 256: "Both bullets should be on the same line."
 layer at (8,8) size 80x80

--- a/LayoutTests/platform/mac/fast/doctypes/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/doctypes/003-expected.txt
@@ -11,10 +11,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 259x18
                 text run at (0,0) width 259: "Both bullets should be on separate lines."
 layer at (10,10) size 80x80

--- a/LayoutTests/platform/mac/fast/doctypes/004-expected.txt
+++ b/LayoutTests/platform/mac/fast/doctypes/004-expected.txt
@@ -11,10 +11,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 244x18
                 text run at (0,0) width 244: "I should be underneath the first bullet."
 layer at (10,10) size 80x80

--- a/LayoutTests/platform/mac/fast/dom/34176-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/34176-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x1452
+layer at (0,0) size 785x1458
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1452
-  RenderBlock {HTML} at (0,0) size 785x1452
-    RenderBody {BODY} at (8,16) size 769x1420
+layer at (0,0) size 785x1458
+  RenderBlock {HTML} at (0,0) size 785x1458
+    RenderBody {BODY} at (8,16) size 769x1426
       RenderBlock {P} at (0,0) size 769x54
         RenderText {#text} at (8,0) size 761x54
           text run at (8,0) width 405: "Test rendering of 3 text runs -- TextRun1 TextRun2 TextRun3, "
@@ -10,48 +10,48 @@ layer at (0,0) size 785x1452
           text run at (39,18) width 730: "TextRun3's bidi level is 1. TextRun2 and TextRun3 are siblings. But their ancestor (not their parent) is a sibling of"
           text run at (93,36) width 72: "TextRun1. "
           text run at (164,36) width 605: "The visual order should be TextRun3 TextRun1 TextRun2, not TextRun3 TextRun2 TextRun1."
-      RenderBlock {P} at (0,88) size 769x18
-        RenderText {#text} at (304,0) size 465x18
-          text run at (304,0) width 348: "Pure text. The following 3 lines should all display as \""
-          text run at (651,0) width 23 RTL: "\x{5E9}\x{5E0}\x{5D1}"
-          text run at (673,0) width 96: " This is a Test\""
-      RenderBlock {DIV} at (0,122) size 769x18 [bgcolor=#FF0000]
-        RenderText {#text} at (684,0) size 59x18
-          text run at (684,0) width 59: "This is a "
-        RenderInline {SPAN} at (658,0) size 111x18
-          RenderInline {SPAN} at (658,0) size 111x18
-            RenderText {#text} at (680,0) size 89x18
-              text run at (680,0) width 5 RTL: " "
-              text run at (742,0) width 27: "Test"
-            RenderInline {SPAN} at (658,0) size 23x18
-              RenderText {#text} at (658,0) size 23x18
-                text run at (658,0) width 23 RTL: "\x{5E9}\x{5E0}\x{5D1}"
-      RenderBlock {DIV} at (0,140) size 769x18 [bgcolor=#FF0000]
-        RenderText {#text} at (684,0) size 59x18
-          text run at (684,0) width 59: "This is a "
-        RenderInline {SPAN} at (658,0) size 111x18
-          RenderInline {SPAN} at (658,0) size 111x18
-            RenderInline {SPAN} at (658,0) size 111x18
-              RenderText {#text} at (680,0) size 89x18
-                text run at (680,0) width 5 RTL: " "
-                text run at (742,0) width 27: "Test"
-              RenderInline {SPAN} at (658,0) size 23x18
-                RenderText {#text} at (658,0) size 23x18
-                  text run at (658,0) width 23 RTL: "\x{5E9}\x{5E0}\x{5D1}"
-      RenderBlock {DIV} at (0,158) size 769x18
-        RenderText {#text} at (684,0) size 59x18
-          text run at (684,0) width 59: "This is a "
-        RenderInline {SPAN} at (658,0) size 111x18
-          RenderText {#text} at (680,0) size 89x18
-            text run at (680,0) width 5 RTL: " "
-            text run at (742,0) width 27: "Test"
-          RenderInline {SPAN} at (658,0) size 23x18
-            RenderText {#text} at (658,0) size 23x18
-              text run at (658,0) width 23 RTL: "\x{5E9}\x{5E0}\x{5D1}"
-      RenderBlock {P} at (0,202) size 769x18
+      RenderBlock {P} at (0,88) size 769x19
+        RenderText {#text} at (299,1) size 470x18
+          text run at (299,1) width 348: "Pure text. The following 3 lines should all display as \""
+          text run at (646,1) width 28 RTL: "\x{5E9}\x{5E0}\x{5D1}"
+          text run at (673,1) width 96: " This is a Test\""
+      RenderBlock {DIV} at (0,123) size 769x19 [bgcolor=#FF0000]
+        RenderText {#text} at (684,1) size 59x18
+          text run at (684,1) width 59: "This is a "
+        RenderInline {SPAN} at (653,1) size 116x18
+          RenderInline {SPAN} at (653,1) size 116x18
+            RenderText {#text} at (680,1) size 89x18
+              text run at (680,1) width 5 RTL: " "
+              text run at (742,1) width 27: "Test"
+            RenderInline {SPAN} at (653,1) size 28x18
+              RenderText {#text} at (653,1) size 28x18
+                text run at (653,1) width 28 RTL: "\x{5E9}\x{5E0}\x{5D1}"
+      RenderBlock {DIV} at (0,142) size 769x19 [bgcolor=#FF0000]
+        RenderText {#text} at (684,1) size 59x18
+          text run at (684,1) width 59: "This is a "
+        RenderInline {SPAN} at (653,1) size 116x18
+          RenderInline {SPAN} at (653,1) size 116x18
+            RenderInline {SPAN} at (653,1) size 116x18
+              RenderText {#text} at (680,1) size 89x18
+                text run at (680,1) width 5 RTL: " "
+                text run at (742,1) width 27: "Test"
+              RenderInline {SPAN} at (653,1) size 28x18
+                RenderText {#text} at (653,1) size 28x18
+                  text run at (653,1) width 28 RTL: "\x{5E9}\x{5E0}\x{5D1}"
+      RenderBlock {DIV} at (0,161) size 769x19
+        RenderText {#text} at (684,1) size 59x18
+          text run at (684,1) width 59: "This is a "
+        RenderInline {SPAN} at (653,1) size 116x18
+          RenderText {#text} at (680,1) size 89x18
+            text run at (680,1) width 5 RTL: " "
+            text run at (742,1) width 27: "Test"
+          RenderInline {SPAN} at (653,1) size 28x18
+            RenderText {#text} at (653,1) size 28x18
+              text run at (653,1) width 28 RTL: "\x{5E9}\x{5E0}\x{5D1}"
+      RenderBlock {P} at (0,206) size 769x18
         RenderText {#text} at (314,0) size 455x18
           text run at (314,0) width 455: "Text in <em>. The English text should be displayed as \"This is a Test\"."
-      RenderBlock {DIV} at (0,236) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,240) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
@@ -60,7 +60,7 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,254) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,258) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
@@ -68,18 +68,18 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,272) size 769x18 [bgcolor=#FF0000]
-        RenderText {#text} at (685,0) size 59x18
-          text run at (685,0) width 59: "This is a "
-        RenderInline {SPAN} at (659,0) size 110x18
-          RenderInline {EM} at (659,0) size 110x18
-            RenderText {#text} at (681,0) size 88x18
-              text run at (681,0) width 5 RTL: " "
-              text run at (743,0) width 26: "Test"
-            RenderInline {SPAN} at (659,0) size 23x18
-              RenderText {#text} at (659,0) size 23x18
-                text run at (659,0) width 23 RTL: "\x{5D3}\x{5DE}\x{5D4}"
-      RenderBlock {DIV} at (0,290) size 769x18
+      RenderBlock {DIV} at (0,276) size 769x19 [bgcolor=#FF0000]
+        RenderText {#text} at (685,1) size 59x18
+          text run at (685,1) width 59: "This is a "
+        RenderInline {SPAN} at (651,1) size 118x18
+          RenderInline {EM} at (651,1) size 118x18
+            RenderText {#text} at (681,1) size 88x18
+              text run at (681,1) width 5 RTL: " "
+              text run at (743,1) width 26: "Test"
+            RenderInline {SPAN} at (651,1) size 31x18
+              RenderText {#text} at (651,1) size 31x18
+                text run at (651,1) width 31 RTL: "\x{5D3}\x{5DE}\x{5D4}"
+      RenderBlock {DIV} at (0,295) size 769x18
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
@@ -87,17 +87,17 @@ layer at (0,0) size 785x1452
             RenderInline {SPAN} at (743,0) size 0x18
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
-      RenderBlock {DIV} at (0,308) size 769x18
+      RenderBlock {DIV} at (0,313) size 769x18
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
           RenderInline {EM} at (743,0) size 26x18
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
-      RenderBlock {P} at (0,352) size 769x18
+      RenderBlock {P} at (0,357) size 769x18
         RenderText {#text} at (289,0) size 480x18
           text run at (289,0) width 480: "Text in <strong>. The following lines should all display as \"This is a Test\"."
-      RenderBlock {DIV} at (0,386) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,391) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
@@ -106,7 +106,7 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,404) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,409) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
@@ -114,7 +114,7 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,422) size 769x18
+      RenderBlock {DIV} at (0,427) size 769x18
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
@@ -122,17 +122,17 @@ layer at (0,0) size 785x1452
             RenderInline {SPAN} at (741,0) size 0x18
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
-      RenderBlock {DIV} at (0,440) size 769x18
+      RenderBlock {DIV} at (0,445) size 769x18
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
           RenderInline {STRONG} at (741,0) size 28x18
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
-      RenderBlock {P} at (0,484) size 769x18
+      RenderBlock {P} at (0,489) size 769x18
         RenderText {#text} at (324,0) size 445x18
           text run at (324,0) width 445: "Text in <i>. The following lines should all display as \"This is a Test\"."
-      RenderBlock {DIV} at (0,518) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,523) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
@@ -141,7 +141,7 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,536) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,541) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
@@ -149,7 +149,7 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,554) size 769x18
+      RenderBlock {DIV} at (0,559) size 769x18
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
@@ -157,17 +157,17 @@ layer at (0,0) size 785x1452
             RenderInline {SPAN} at (743,0) size 0x18
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
-      RenderBlock {DIV} at (0,572) size 769x18
+      RenderBlock {DIV} at (0,577) size 769x18
         RenderText {#text} at (685,0) size 59x18
           text run at (685,0) width 59: "This is a "
         RenderInline {SPAN} at (743,0) size 26x18
           RenderInline {I} at (743,0) size 26x18
             RenderText {#text} at (743,0) size 26x18
               text run at (743,0) width 26: "Test"
-      RenderBlock {P} at (0,616) size 769x18
+      RenderBlock {P} at (0,621) size 769x18
         RenderText {#text} at (321,0) size 448x18
           text run at (321,0) width 448: "Text in <b>. The following lines should all display as \"This is a Test\"."
-      RenderBlock {DIV} at (0,650) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,655) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
@@ -176,7 +176,7 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,668) size 769x18 [bgcolor=#FF0000]
+      RenderBlock {DIV} at (0,673) size 769x18 [bgcolor=#FF0000]
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
@@ -184,7 +184,7 @@ layer at (0,0) size 785x1452
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
             RenderInline {SPAN} at (769,0) size 0x18
-      RenderBlock {DIV} at (0,686) size 769x18
+      RenderBlock {DIV} at (0,691) size 769x18
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
@@ -192,17 +192,17 @@ layer at (0,0) size 785x1452
             RenderInline {SPAN} at (741,0) size 0x18
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
-      RenderBlock {DIV} at (0,704) size 769x18
+      RenderBlock {DIV} at (0,709) size 769x18
         RenderText {#text} at (682,0) size 60x18
           text run at (682,0) width 60: "This is a "
         RenderInline {SPAN} at (741,0) size 28x18
           RenderInline {B} at (741,0) size 28x18
             RenderText {#text} at (741,0) size 28x18
               text run at (741,0) width 28: "Test"
-      RenderBlock (anonymous) at (0,722) size 769x0
+      RenderBlock (anonymous) at (0,727) size 769x0
         RenderInline {B} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,730) size 769x690
+      RenderBlock (anonymous) at (0,735) size 769x691
         RenderBlock {P} at (0,18) size 769x18
           RenderText {#text} at (91,0) size 678x18
             text run at (91,0) width 678: "Text in <img>, <href>, <em>, <tr>. The following English text should all display as \"This is a Test\"."
@@ -215,18 +215,18 @@ layer at (0,0) size 785x1452
                 text run at (741,6) width 28: "Test"
               RenderInline {SPAN} at (660,6) size 21x18
                 RenderImage {IMG} at (660,0) size 21x20
-        RenderBlock {DIV} at (0,76) size 769x18 [bgcolor=#FF0000]
-          RenderText {#text} at (680,0) size 62x18
-            text run at (680,0) width 62: "This is a "
-          RenderInline {SPAN} at (652,0) size 117x18
-            RenderInline {A} at (652,0) size 117x18 [color=#551A8B]
-              RenderText {#text} at (676,0) size 93x18
-                text run at (676,0) width 5 RTL: " "
-                text run at (741,0) width 28: "Test"
-              RenderInline {SPAN} at (652,0) size 25x18
-                RenderText {#text} at (652,0) size 25x18
-                  text run at (652,0) width 25 RTL: "\x{5E9}\x{5E0}\x{5D1}"
-        RenderBlock {DIV} at (0,94) size 769x18 [bgcolor=#FF0000]
+        RenderBlock {DIV} at (0,76) size 769x19 [bgcolor=#FF0000]
+          RenderText {#text} at (680,1) size 62x18
+            text run at (680,1) width 62: "This is a "
+          RenderInline {SPAN} at (647,1) size 122x18
+            RenderInline {A} at (647,1) size 122x18 [color=#551A8B]
+              RenderText {#text} at (676,1) size 93x18
+                text run at (676,1) width 5 RTL: " "
+                text run at (741,1) width 28: "Test"
+              RenderInline {SPAN} at (647,1) size 30x18
+                RenderText {#text} at (647,1) size 30x18
+                  text run at (647,1) width 30 RTL: "\x{5E9}\x{5E0}\x{5D1}"
+        RenderBlock {DIV} at (0,95) size 769x18 [bgcolor=#FF0000]
           RenderText {#text} at (682,0) size 61x18
             text run at (682,0) width 61: "This is a "
           RenderInline {SPAN} at (742,0) size 27x18
@@ -234,7 +234,7 @@ layer at (0,0) size 785x1452
               RenderText {#text} at (742,0) size 27x18
                 text run at (742,0) width 27: "Test"
               RenderInline {A} at (769,0) size 0x18 [color=#551A8B]
-        RenderBlock {DIV} at (0,112) size 769x24 [bgcolor=#FF0000]
+        RenderBlock {DIV} at (0,113) size 769x24 [bgcolor=#FF0000]
           RenderText {#text} at (682,6) size 61x18
             text run at (682,6) width 61: "This is a "
           RenderInline {SPAN} at (662,6) size 107x18
@@ -243,7 +243,7 @@ layer at (0,0) size 785x1452
                 text run at (742,6) width 27: "Test"
               RenderInline {SPAN} at (662,6) size 20x18
                 RenderImage {IMG} at (662,0) size 20x20
-        RenderBlock {DIV} at (0,136) size 769x18
+        RenderBlock {DIV} at (0,137) size 769x18
           RenderText {#text} at (638,0) size 62x18
             text run at (638,0) width 62: "This is a "
           RenderInline {SPAN} at (699,0) size 70x18
@@ -253,7 +253,7 @@ layer at (0,0) size 785x1452
               RenderInline {SPAN} at (731,0) size 38x18
                 RenderText {#text} at (731,0) size 38x18
                   text run at (731,0) width 38: "again"
-        RenderBlock {DIV} at (0,154) size 769x42
+        RenderBlock {DIV} at (0,155) size 769x42
           RenderBlock (anonymous) at (0,0) size 769x18
             RenderText {#text} at (682,0) size 61x18
               text run at (682,0) width 61: "This is a "
@@ -271,126 +271,126 @@ layer at (0,0) size 785x1452
           RenderBlock (anonymous) at (0,42) size 769x0
             RenderInline {SPAN} at (0,0) size 0x0
               RenderInline {EM} at (0,0) size 0x0
-        RenderBlock {UL} at (0,222) size 769x468
+        RenderBlock {UL} at (0,223) size 769x468
           RenderListItem {LI} at (40,0) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 0: : Success"
           RenderListItem {LI} at (40,18) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 1: : Success"
           RenderListItem {LI} at (40,36) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 2: : Success"
           RenderListItem {LI} at (40,54) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 3: : Success"
           RenderListItem {LI} at (40,72) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 4: : Success"
           RenderListItem {LI} at (40,90) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 5: : Success"
           RenderListItem {LI} at (40,108) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 6: : Success"
           RenderListItem {LI} at (40,126) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 7: : Success"
           RenderListItem {LI} at (40,144) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 8: : Success"
           RenderListItem {LI} at (40,162) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 111x18
               text run at (0,0) width 111: "Test 9: : Success"
           RenderListItem {LI} at (40,180) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 10: : Success"
           RenderListItem {LI} at (40,198) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 118x18
               text run at (0,0) width 118: "Test 11: : Success"
           RenderListItem {LI} at (40,216) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 12: : Success"
           RenderListItem {LI} at (40,234) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 13: : Success"
           RenderListItem {LI} at (40,252) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 14: : Success"
           RenderListItem {LI} at (40,270) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 15: : Success"
           RenderListItem {LI} at (40,288) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 16: : Success"
           RenderListItem {LI} at (40,306) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 17: : Success"
           RenderListItem {LI} at (40,324) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 18: : Success"
           RenderListItem {LI} at (40,342) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 19: : Success"
           RenderListItem {LI} at (40,360) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 20: : Success"
           RenderListItem {LI} at (40,378) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 21: : Success"
           RenderListItem {LI} at (40,396) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 22: : Success"
           RenderListItem {LI} at (40,414) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 23: : Success"
           RenderListItem {LI} at (40,432) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 24: : Success"
           RenderListItem {LI} at (40,450) size 729x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 119x18
               text run at (0,0) width 119: "Test 25: : Success"
-      RenderBlock (anonymous) at (0,1436) size 769x0
+      RenderBlock (anonymous) at (0,1442) size 769x0
         RenderInline {B} at (0,0) size 0x0
 layer at (8,86) size 769x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,70) size 769x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,200) size 769x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,184) size 769x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,350) size 769x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,334) size 769x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,482) size 769x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,466) size 769x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,614) size 769x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,598) size 769x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,746) size 769x2 clip at (0,0) size 0x0
+layer at (8,204) size 769x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,188) size 769x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,355) size 769x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,339) size 769x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,487) size 769x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,471) size 769x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,619) size 769x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,603) size 769x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,751) size 769x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 769x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,950) size 769x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,204) size 769x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,956) size 769x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,205) size 769x2 [color=#808080] [border: (1px inset #808080)]
 selection start: position 0 of child 0 {#text} of child 14 {DIV} of child 56 {B} of body
 selection end:   position 4 of child 0 {#text} of child 14 {DIV} of child 56 {B} of body

--- a/LayoutTests/platform/mac/fast/dom/52776-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/52776-expected.txt
@@ -1,9 +1,9 @@
-layer at (0,0) size 785x1694
+layer at (0,0) size 785x1696
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1694
-  RenderBlock {HTML} at (0,0) size 785x1694
-    RenderBody {BODY} at (8,16) size 769x1662
-      RenderBlock {DIV} at (0,0) size 769x806
+layer at (0,0) size 785x1696
+  RenderBlock {HTML} at (0,0) size 785x1696
+    RenderBody {BODY} at (8,16) size 769x1664
+      RenderBlock {DIV} at (0,0) size 769x807
         RenderBlock {P} at (0,0) size 769x18
           RenderText {#text} at (682,0) size 87x18
             text run at (682,0) width 87: "Right To Left"
@@ -123,10 +123,10 @@ layer at (0,0) size 785x1694
           RenderText {#text} at (746,0) size 23x18
             text run at (746,0) width 1 RTL: "\x{202C}\x{202A}"
             text run at (746,0) width 23: "abc"
-        RenderBlock {DIV} at (0,788) size 769x18
-          RenderText {#text} at (754,0) size 15x18
-            text run at (754,0) width 15 RTL: "\x{5D0}\x{5D1}\x{202C}\x{202A}"
-      RenderBlock {DIV} at (0,822) size 769x806
+        RenderBlock {DIV} at (0,788) size 769x19
+          RenderText {#text} at (749,1) size 20x18
+            text run at (749,1) width 20 RTL: "\x{5D0}\x{5D1}\x{202C}\x{202A}"
+      RenderBlock {DIV} at (0,823) size 769x807
         RenderBlock {P} at (0,0) size 769x18
           RenderText {#text} at (0,0) size 87x18
             text run at (0,0) width 87: "Left To Right"
@@ -231,13 +231,13 @@ layer at (0,0) size 785x1694
         RenderBlock {DIV} at (0,770) size 769x18
           RenderText {#text} at (0,0) size 23x18
             text run at (0,0) width 23: "abc\x{202C}\x{202A}"
-        RenderBlock {DIV} at (0,788) size 769x18
-          RenderText {#text} at (0,0) size 15x18
-            text run at (0,0) width 15 RTL: "\x{5D0}\x{5D1}"
-            text run at (14,0) width 1: "\x{202C}\x{202A}"
-      RenderBlock {UL} at (0,1644) size 769x18
+        RenderBlock {DIV} at (0,788) size 769x19
+          RenderText {#text} at (0,1) size 20x18
+            text run at (0,1) width 20 RTL: "\x{5D0}\x{5D1}"
+            text run at (19,1) width 1: "\x{202C}\x{202A}"
+      RenderBlock {UL} at (0,1646) size 769x18
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 717x18
             text run at (0,0) width 717: "test id=test: the right-most character of rendering result of <PDF>abc<PDF> in RTL block should be c: Success"
 selection start: position 3 of child 0 {#text} of child 20 {DIV} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac/fast/dom/HTMLProgressElement/progress-bar-value-pseudo-element-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLProgressElement/progress-bar-value-pseudo-element-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x170
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 91x18
             text run at (0,0) width 91: "Default style: "
           RenderBlock {PROGRESS} at (90,1) size 161x17
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 16x16 [bgcolor=#008000]
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 98x18
             text run at (0,0) width 98: "Progress style: "
           RenderBlock {PROGRESS} at (97,1) size 161x17 [bgcolor=#0000FF] [border: (3px solid #000066)]
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 154x10
                 RenderBlock {DIV} at (0,0) size 31x10 [bgcolor=#008000]
         RenderListItem {LI} at (40,36) size 744x31
-          RenderListMarker at (-17,12) size 7x19: bullet
+          RenderListMarker at (-15,12) size 7x19: bullet
           RenderText {#text} at (0,12) size 138x19
             text run at (0,12) width 138: "Progress style (size): "
           RenderBlock {PROGRESS} at (137,0) size 301x30
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 300x30 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 90x30 [bgcolor=#008000]
         RenderListItem {LI} at (40,66) size 744x19
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 66x18
             text run at (0,0) width 66: "Bar style: "
           RenderBlock {PROGRESS} at (65,1) size 161x17
@@ -37,7 +37,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#FF0000] [border: (3px solid #990000)]
                 RenderBlock {DIV} at (3,3) size 62x10 [bgcolor=#008000]
         RenderListItem {LI} at (40,84) size 744x19
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 80x18
             text run at (0,0) width 80: "Value style: "
           RenderBlock {PROGRESS} at (79,1) size 161x17
@@ -45,7 +45,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#FFFF00] [border: (3px solid #999900)]
         RenderListItem {LI} at (40,102) size 744x32
-          RenderListMarker at (-17,12) size 7x19: bullet
+          RenderListMarker at (-15,12) size 7x19: bullet
           RenderText {#text} at (0,12) size 195x19
             text run at (0,12) width 195: "Styling for all three elements: "
           RenderBlock {PROGRESS} at (194,0) size 161x30 [bgcolor=#0000FF] [border: (3px solid #000066)]
@@ -53,7 +53,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 154x24 [bgcolor=#FF0000] [border: (3px solid #990000)]
                 RenderBlock {DIV} at (3,3) size 89x18 [bgcolor=#FFFF00] [border: (3px solid #999900)]
         RenderListItem {LI} at (40,133) size 744x19
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 235x18
             text run at (0,0) width 235: "Removing appearance dynamically: "
           RenderBlock {PROGRESS} at (234,1) size 161x17
@@ -61,7 +61,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 160x16 [bgcolor=#808080]
                 RenderBlock {DIV} at (0,0) size 112x16 [bgcolor=#008000]
         RenderListItem {LI} at (40,151) size 744x19
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 278x18
             text run at (0,0) width 278: "Giving progress style change dynamically: "
           RenderBlock {PROGRESS} at (277,1) size 161x17 [bgcolor=#ADD8E6]

--- a/LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt
@@ -39,7 +39,7 @@ layer at (0,0) size 785x658
       RenderBlock {DIV} at (0,148) size 769x42
         RenderListItem {DIV} at (0,0) size 769x42
           RenderBlock (anonymous) at (0,0) size 769x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderBlock {FORM} at (0,18) size 769x24
             RenderTable {TABLE} at (0,0) size 114x24
               RenderTableSection {TBODY} at (0,0) size 114x24

--- a/LayoutTests/platform/mac/fast/forms/plaintext-mode-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/plaintext-mode-2-expected.txt
@@ -26,11 +26,11 @@ layer at (0,0) size 800x600
           text run at (370,0) width 203: "All richness should be stripped."
       RenderBlock {OL} at (0,53) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 332x18
             text run at (0,0) width 332: "Success: document.execCommand(\"Copy\") == true"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 331x18
             text run at (0,0) width 331: "Success: document.execCommand(\"Paste\") == true"
 layer at (11,11) size 594x13

--- a/LayoutTests/platform/mac/fast/inline/emptyInlinesWithinLists-expected.txt
+++ b/LayoutTests/platform/mac/fast/inline/emptyInlinesWithinLists-expected.txt
@@ -8,21 +8,21 @@ layer at (0,0) size 800x600
           text run at (0,0) width 468: "This test demonstrates our behavior regarding empty inlines in list items."
       RenderBlock {UL} at (0,34) size 784x90
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {SPAN} at (0,-2) size 4x22 [border: (2px solid #FF0000)]
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {SPAN} at (0,-4) size 8x26 [border: (2px solid #FF0000)]
           RenderText {#text} at (8,0) size 29x18
             text run at (8,0) width 29: "Text"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 85x18
             text run at (0,0) width 85: "TextTextText"
           RenderInline {SPAN} at (84,-4) size 9x26 [border: (2px solid #FF0000)]
         RenderBlock (anonymous) at (40,54) size 744x18
           RenderInline {SPAN} at (0,-4) size 8x26 [border: (2px solid #FF0000)]
         RenderListItem {LI} at (40,72) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 29x18
             text run at (0,0) width 29: "Text"

--- a/LayoutTests/platform/mac/fast/lists/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/001-expected.txt
@@ -1,21 +1,21 @@
-layer at (0,0) size 809x585
+layer at (0,0) size 807x585
   RenderView at (0,0) size 800x585
 layer at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 800x585
     RenderBody {BODY} at (8,8) size 784x561
       RenderBlock {DIV} at (0,0) size 784x106 [border: (3px solid #FFA500)]
         RenderListItem {DIV} at (11,11) size 122x122 [bgcolor=#FFA500] [border: (3px solid #FFA500)]
-          RenderListMarker at (-17,11) size 7x18: bullet
+          RenderListMarker at (-15,11) size 7x18: bullet
         RenderListItem {DIV} at (11,11) size 762x84 [border: (3px solid #FFA500)]
           RenderListItem {DIV} at (11,11) size 740x62 [border: (3px solid #FFA500)]
             RenderListItem {DIV} at (11,11) size 718x40 [border: (3px solid #FFA500)]
-              RenderListMarker at (104,11) size 7x18: bullet
-              RenderListMarker at (104,11) size 7x18: bullet
-              RenderListMarker at (104,11) size 7x18: bullet
+              RenderListMarker at (106,11) size 7x18: bullet
+              RenderListMarker at (106,11) size 7x18: bullet
+              RenderListMarker at (106,11) size 7x18: bullet
               RenderText {#text} at (132,11) size 90x18
                 text run at (132,11) width 90: "List item text."
       RenderBlock {UL} at (0,122) size 784x122
         RenderListItem {LI} at (40,0) size 744x122 [border: (2px solid #FF0000)]
-          RenderListMarker at (753,52) size 8x18: bullet
+          RenderListMarker at (751,52) size 8x18: bullet
           RenderText {#text} at (52,52) size 504x18
             text run at (52,52) width 504: "Foo fofodfosjlkdf dslkdjlk asdlksjald djklsd klasjdkas sdajd lsadjkl asjdlksajdk"

--- a/LayoutTests/platform/mac/fast/lists/001-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/001-vertical-expected.txt
@@ -1,22 +1,22 @@
-layer at (0,0) size 785x609
+layer at (0,0) size 785x607
   RenderView at (0,0) size 785x600
 layer at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x600
     RenderBody {BODY} at (8,8) size 761x584
       RenderBlock {DIV} at (0,0) size 106x584 [border: (3px solid #FFA500)]
         RenderListItem {DIV} at (11,11) size 122x122 [bgcolor=#FFA500] [border: (3px solid #FFA500)]
-          RenderListMarker at (11,-17) size 18x7: bullet
+          RenderListMarker at (11,-15) size 18x7: bullet
         RenderListItem {DIV} at (11,11) size 84x562 [border: (3px solid #FFA500)]
           RenderListItem {DIV} at (11,11) size 62x540 [border: (3px solid #FFA500)]
             RenderListItem {DIV} at (11,11) size 40x518 [border: (3px solid #FFA500)]
-              RenderListMarker at (11,104) size 18x7: bullet
-              RenderListMarker at (11,104) size 18x7: bullet
-              RenderListMarker at (11,104) size 18x7: bullet
+              RenderListMarker at (11,106) size 18x7: bullet
+              RenderListMarker at (11,106) size 18x7: bullet
+              RenderListMarker at (11,106) size 18x7: bullet
               RenderText {#text} at (11,132) size 18x90
                 text run at (11,132) width 90: "List item text."
       RenderBlock {UL} at (122,0) size 140x584
         RenderListItem {LI} at (0,40) size 140x544 [border: (2px solid #FF0000)]
-          RenderListMarker at (52,554) size 18x7: bullet
+          RenderListMarker at (52,552) size 18x7: bullet
           RenderText {#text} at (52,52) size 36x428
             text run at (52,52) width 428: "Foo fofodfosjlkdf dslkdjlk asdlksjald djklsd klasjdkas sdajd lsadjkl"
             text run at (70,52) width 72: "asjdlksajdk"

--- a/LayoutTests/platform/mac/fast/lists/002-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/002-expected.txt
@@ -6,12 +6,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x36
         RenderBlock {UL} at (0,0) size 784x36
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderInline {A} at (704,0) size 40x18 [color=#0000EE]
               RenderText {#text} at (704,0) size 40x18
                 text run at (704,0) width 40: "Home"
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderInline {A} at (686,0) size 58x18 [color=#0000EE]
               RenderText {#text} at (686,0) size 58x18
                 text run at (686,0) width 58: "Archives"

--- a/LayoutTests/platform/mac/fast/lists/002-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/002-vertical-expected.txt
@@ -6,12 +6,12 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 36x584
         RenderBlock {UL} at (0,0) size 36x584
           RenderListItem {LI} at (0,40) size 18x544
-            RenderListMarker at (0,-17) size 18x7: bullet
+            RenderListMarker at (0,-15) size 18x7: bullet
             RenderInline {A} at (0,504) size 18x40 [color=#0000EE]
               RenderText {#text} at (0,504) size 18x40
                 text run at (0,504) width 40: "Home"
           RenderListItem {LI} at (18,40) size 18x544
-            RenderListMarker at (0,-17) size 18x7: bullet
+            RenderListMarker at (0,-15) size 18x7: bullet
             RenderInline {A} at (0,486) size 18x58 [color=#0000EE]
               RenderText {#text} at (0,486) size 18x58
                 text run at (0,486) width 58: "Archives"

--- a/LayoutTests/platform/mac/fast/lists/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/003-expected.txt
@@ -39,18 +39,18 @@ layer at (0,0) size 800x368
             text run at (260,18) width 5: "."
         RenderBlock {OL} at (0,138) size 471x198
           RenderListItem {LI} at (40,0) size 431x36
-            RenderListMarker at (-20,0) size 16x18: "1"
+            RenderListMarker at (-17,0) size 16x18: "1"
             RenderText {#text} at (0,0) size 406x36
               text run at (0,0) width 159: "New larger PowerBook. "
               text run at (158,0) width 248: "Still 1 GHz, but with a 17-inch screen."
               text run at (0,18) width 44: "$3299."
           RenderListItem {LI} at (40,36) size 431x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 359x18
               text run at (0,0) width 315: "New smaller PowerBook, with a 12-inch screen. "
               text run at (314,0) width 45: "$1799."
           RenderListItem {LI} at (40,54) size 431x54
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 95x18
               text run at (0,0) width 95: "New browser: "
             RenderInline {A} at (94,0) size 39x18 [color=#0000EE]
@@ -78,13 +78,13 @@ layer at (0,0) size 800x368
               text run at (85,36) width 124: "Only runs on 10.2. "
               text run at (208,36) width 158: "Currently in public beta."
           RenderListItem {LI} at (40,108) size 431x36
-            RenderListMarker at (-20,0) size 16x18: "4"
+            RenderListMarker at (-17,0) size 16x18: "4"
             RenderText {#text} at (0,0) size 399x36
               text run at (0,0) width 243: "New presentation software: Keynote. "
               text run at (242,0) width 157: "The software Steve Jobs"
               text run at (0,18) width 32: "uses."
           RenderListItem {LI} at (40,144) size 431x36
-            RenderListMarker at (-20,0) size 16x18: "5"
+            RenderListMarker at (-17,0) size 16x18: "5"
             RenderText {#text} at (0,0) size 109x18
               text run at (0,0) width 109: "New versions of "
             RenderInline {A} at (108,0) size 48x18 [color=#0000EE]
@@ -109,7 +109,7 @@ layer at (0,0) size 800x368
             RenderText {#text} at (31,18) size 59x18
               text run at (31,18) width 59: ", for $49."
           RenderListItem {LI} at (40,180) size 431x18
-            RenderListMarker at (-20,0) size 16x18: "6"
+            RenderListMarker at (-17,0) size 16x18: "6"
             RenderInline {A} at (0,0) size 115x18 [color=#0000EE]
               RenderText {#text} at (0,0) size 115x18
                 text run at (0,0) width 115: "Final Cut Express"
@@ -119,42 +119,42 @@ layer at (0,0) size 800x368
       RenderBlock {DIV} at (0,0) size 784x302
         RenderBlock {UL} at (0,0) size 784x144
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (704,0) size 40x18 [color=#0000EE]
               RenderText {#text} at (704,0) size 40x18
                 text run at (704,0) width 40: "About"
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (687,0) size 57x18 [color=#0000EE]
               RenderText {#text} at (687,0) size 57x18
                 text run at (687,0) width 57: "Site map"
           RenderListItem {LI} at (40,36) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (686,0) size 58x18 [color=#0000EE]
               RenderText {#text} at (686,0) size 58x18
                 text run at (686,0) width 58: "Archives"
           RenderListItem {LI} at (40,54) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (692,0) size 52x18 [color=#0000EE]
               RenderText {#text} at (692,0) size 52x18
                 text run at (692,0) width 52: "Projects"
           RenderListItem {LI} at (40,72) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (700,0) size 44x18 [color=#0000EE]
               RenderText {#text} at (700,0) size 44x18
                 text run at (700,0) width 44: "Photos"
           RenderListItem {LI} at (40,90) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (686,0) size 58x18 [color=#0000EE]
               RenderText {#text} at (686,0) size 58x18
                 text run at (686,0) width 58: "Statistics"
           RenderListItem {LI} at (40,108) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (595,0) size 149x18 [color=#0000EE]
               RenderText {#text} at (595,0) size 149x18
                 text run at (595,0) width 149: "Accessibility statement"
           RenderListItem {LI} at (40,126) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (630,0) size 29x18 [color=#0000EE]
               RenderText {#text} at (630,0) size 29x18
                 text run at (630,0) width 29: "RSS"
@@ -167,38 +167,38 @@ layer at (0,0) size 800x368
               text run at (738,0) width 6: ")"
         RenderBlock {UL} at (0,160) size 784x18
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (655,0) size 89x18 [color=#0000EE]
               RenderText {#text} at (655,0) size 89x18
                 text run at (655,0) width 89: "What is RSS?"
         RenderBlock {UL} at (0,194) size 784x108
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (652,0) size 92x18 [color=#0000EE]
               RenderText {#text} at (652,0) size 92x18
                 text run at (652,0) width 92: "RSS Validator"
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (595,0) size 149x18 [color=#0000EE]
               RenderText {#text} at (595,0) size 149x18
                 text run at (595,0) width 149: "Dive Into Accessibility"
           RenderListItem {LI} at (40,36) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (643,0) size 101x18 [color=#0000EE]
               RenderText {#text} at (643,0) size 101x18
                 text run at (643,0) width 101: "Dive Into OS X"
           RenderListItem {LI} at (40,54) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (645,0) size 99x18 [color=#0000EE]
               RenderText {#text} at (645,0) size 99x18
                 text run at (645,0) width 99: "Dive Into J2EE"
           RenderListItem {LI} at (40,72) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (633,0) size 111x18 [color=#0000EE]
               RenderText {#text} at (633,0) size 111x18
                 text run at (633,0) width 111: "Dive Into Python"
           RenderListItem {LI} at (40,90) size 744x18
-            RenderListMarker at (413,0) size 8x18: bullet
+            RenderListMarker at (415,0) size 8x18: bullet
             RenderInline {A} at (697,0) size 47x18 [color=#0000EE]
               RenderText {#text} at (697,0) size 47x18
                 text run at (697,0) width 47: "r\x{E9}sum\x{E9}"

--- a/LayoutTests/platform/mac/fast/lists/003-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/003-vertical-expected.txt
@@ -42,18 +42,18 @@ layer at (0,0) size 458x600
             text run at (36,73) width 4: "."
         RenderBlock {OL} at (174,0) size 252x351
           RenderListItem {LI} at (0,40) size 36x311
-            RenderListMarker at (0,-20) size 18x16: "1"
+            RenderListMarker at (0,-17) size 18x16: "1"
             RenderText {#text} at (0,0) size 36x304
               text run at (0,0) width 159: "New larger PowerBook. "
               text run at (0,158) width 145: "Still 1 GHz, but with a"
               text run at (18,0) width 146: "17-inch screen. $3299."
           RenderListItem {LI} at (36,40) size 36x311
-            RenderListMarker at (0,-20) size 18x16: "2"
+            RenderListMarker at (0,-17) size 18x16: "2"
             RenderText {#text} at (0,0) size 36x311
               text run at (0,0) width 311: "New smaller PowerBook, with a 12-inch screen."
               text run at (18,0) width 44: "$1799."
           RenderListItem {LI} at (72,40) size 90x311
-            RenderListMarker at (0,-20) size 18x16: "3"
+            RenderListMarker at (0,-17) size 18x16: "3"
             RenderText {#text} at (0,0) size 18x95
               text run at (0,0) width 95: "New browser: "
             RenderInline {A} at (0,94) size 18x39 [color=#0000EE]
@@ -83,13 +83,13 @@ layer at (0,0) size 458x600
               text run at (54,180) width 122: "Currently in public"
               text run at (72,0) width 31: "beta."
           RenderListItem {LI} at (162,40) size 36x311
-            RenderListMarker at (0,-20) size 18x16: "4"
+            RenderListMarker at (0,-17) size 18x16: "4"
             RenderText {#text} at (0,0) size 36x268
               text run at (0,0) width 243: "New presentation software: Keynote. "
               text run at (0,242) width 25: "The"
               text run at (18,0) width 163: "software Steve Jobs uses."
           RenderListItem {LI} at (198,40) size 36x311
-            RenderListMarker at (0,-20) size 18x16: "5"
+            RenderListMarker at (0,-17) size 18x16: "5"
             RenderText {#text} at (0,0) size 18x109
               text run at (0,0) width 109: "New versions of "
             RenderInline {A} at (0,108) size 18x48 [color=#0000EE]
@@ -114,7 +114,7 @@ layer at (0,0) size 458x600
             RenderText {#text} at (18,199) size 18x60
               text run at (18,199) width 59: ", for $49."
           RenderListItem {LI} at (234,40) size 18x311
-            RenderListMarker at (0,-20) size 18x16: "6"
+            RenderListMarker at (0,-17) size 18x16: "6"
             RenderInline {A} at (0,0) size 18x115 [color=#0000EE]
               RenderText {#text} at (0,0) size 18x115
                 text run at (0,0) width 115: "Final Cut Express"
@@ -124,42 +124,42 @@ layer at (0,0) size 458x600
       RenderBlock {DIV} at (0,0) size 302x584
         RenderBlock {UL} at (0,0) size 144x584
           RenderListItem {LI} at (0,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,504) size 18x40 [color=#0000EE]
               RenderText {#text} at (0,504) size 18x40
                 text run at (0,504) width 40: "About"
           RenderListItem {LI} at (18,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,487) size 18x57 [color=#0000EE]
               RenderText {#text} at (0,487) size 18x57
                 text run at (0,487) width 57: "Site map"
           RenderListItem {LI} at (36,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,486) size 18x58 [color=#0000EE]
               RenderText {#text} at (0,486) size 18x58
                 text run at (0,486) width 58: "Archives"
           RenderListItem {LI} at (54,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,492) size 18x52 [color=#0000EE]
               RenderText {#text} at (0,492) size 18x52
                 text run at (0,492) width 52: "Projects"
           RenderListItem {LI} at (72,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,500) size 18x44 [color=#0000EE]
               RenderText {#text} at (0,500) size 18x44
                 text run at (0,500) width 44: "Photos"
           RenderListItem {LI} at (90,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,486) size 18x58 [color=#0000EE]
               RenderText {#text} at (0,486) size 18x58
                 text run at (0,486) width 58: "Statistics"
           RenderListItem {LI} at (108,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,395) size 18x149 [color=#0000EE]
               RenderText {#text} at (0,395) size 18x149
                 text run at (0,395) width 149: "Accessibility statement"
           RenderListItem {LI} at (126,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,430) size 18x29 [color=#0000EE]
               RenderText {#text} at (0,430) size 18x29
                 text run at (0,430) width 29: "RSS"
@@ -172,38 +172,38 @@ layer at (0,0) size 458x600
               text run at (0,538) width 6: ")"
         RenderBlock {UL} at (160,0) size 18x584
           RenderListItem {LI} at (0,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,455) size 18x89 [color=#0000EE]
               RenderText {#text} at (0,455) size 18x89
                 text run at (0,455) width 89: "What is RSS?"
         RenderBlock {UL} at (194,0) size 108x584
           RenderListItem {LI} at (0,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,452) size 18x92 [color=#0000EE]
               RenderText {#text} at (0,452) size 18x92
                 text run at (0,452) width 92: "RSS Validator"
           RenderListItem {LI} at (18,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,395) size 18x149 [color=#0000EE]
               RenderText {#text} at (0,395) size 18x149
                 text run at (0,395) width 149: "Dive Into Accessibility"
           RenderListItem {LI} at (36,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,443) size 18x101 [color=#0000EE]
               RenderText {#text} at (0,443) size 18x101
                 text run at (0,443) width 101: "Dive Into OS X"
           RenderListItem {LI} at (54,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,445) size 18x99 [color=#0000EE]
               RenderText {#text} at (0,445) size 18x99
                 text run at (0,445) width 99: "Dive Into J2EE"
           RenderListItem {LI} at (72,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,433) size 18x111 [color=#0000EE]
               RenderText {#text} at (0,433) size 18x111
                 text run at (0,433) width 111: "Dive Into Python"
           RenderListItem {LI} at (90,40) size 18x544
-            RenderListMarker at (0,293) size 18x7: bullet
+            RenderListMarker at (0,295) size 18x7: bullet
             RenderInline {A} at (0,497) size 18x47 [color=#0000EE]
               RenderText {#text} at (0,497) size 18x47
                 text run at (0,497) width 47: "r\x{E9}sum\x{E9}"

--- a/LayoutTests/platform/mac/fast/lists/005-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/005-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x54
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 328x18
             text run at (0,0) width 328: "There should be two bullets with no text above me."

--- a/LayoutTests/platform/mac/fast/lists/005-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/005-vertical-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 776x584
       RenderBlock {UL} at (0,0) size 54x584
         RenderListItem {LI} at (0,40) size 18x544
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
         RenderListItem {LI} at (18,40) size 18x544
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
         RenderListItem {LI} at (36,40) size 18x544
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
           RenderText {#text} at (0,0) size 18x328
             text run at (0,0) width 328: "There should be two bullets with no text above me."

--- a/LayoutTests/platform/mac/fast/lists/006-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/006-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {OL} at (0,0) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "1"
+            RenderListMarker at (-17,0) size 16x18: "1"
             RenderInline {I} at (0,0) size 77x18
               RenderInline {U} at (0,0) size 77x18
                 RenderText {#text} at (0,0) size 77x18
@@ -14,6 +14,6 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {OL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-20,0) size 16x18: "1"
+              RenderListMarker at (-17,0) size 16x18: "1"
               RenderText {#text} at (0,0) size 59x18
                 text run at (0,0) width 59: "Goodbye"

--- a/LayoutTests/platform/mac/fast/lists/006-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/006-vertical-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {OL} at (0,0) size 36x584
         RenderListItem {LI} at (0,40) size 36x544
           RenderBlock (anonymous) at (0,0) size 18x544
-            RenderListMarker at (0,-20) size 18x16: "1"
+            RenderListMarker at (0,-17) size 18x16: "1"
             RenderInline {I} at (0,0) size 18x77
               RenderInline {U} at (0,0) size 18x77
                 RenderText {#text} at (0,0) size 18x77
@@ -14,6 +14,6 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {OL} at (18,0) size 18x544
             RenderListItem {LI} at (0,40) size 18x504
-              RenderListMarker at (0,-20) size 18x16: "1"
+              RenderListMarker at (0,-17) size 18x16: "1"
               RenderText {#text} at (0,0) size 18x59
                 text run at (0,0) width 59: "Goodbye"

--- a/LayoutTests/platform/mac/fast/lists/007-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/007-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x72 [bgcolor=#808080] [border: none (25px solid #008000)]
         RenderListItem {LI} at (50,0) size 734x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 732x18
             text run at (0,0) width 732: "The left padding on this unordered list has been set to 25 pixels, which will require some extra test in order to test."
         RenderListItem {LI} at (50,18) size 734x54 [bgcolor=#FFFFFF] [border: none (25px solid #008000)]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (50,0) size 669x54
             text run at (50,0) width 669: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (50,18) width 61: "checked. "

--- a/LayoutTests/platform/mac/fast/lists/007-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/007-vertical-expected.txt
@@ -5,12 +5,12 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 776x584
       RenderBlock {UL} at (0,0) size 108x584 [bgcolor=#808080] [border: (25px solid #008000) none]
         RenderListItem {LI} at (0,50) size 36x534
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
           RenderText {#text} at (0,0) size 36x530
             text run at (0,0) width 530: "The top padding on this unordered list has been set to 25 pixels, which will require"
             text run at (18,0) width 197: "some extra test in order to test."
         RenderListItem {LI} at (36,50) size 72x534 [bgcolor=#FFFFFF] [border: (25px solid #008000) none]
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
           RenderText {#text} at (0,50) size 72x484
             text run at (0,50) width 484: "Another list item might not be such a bad idea, either, considering that such"
             text run at (18,50) width 243: "things do need to be double-checked. "

--- a/LayoutTests/platform/mac/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-expected.txt
@@ -5,30 +5,30 @@ layer at (0,0) size 785x1844
     RenderBody {BODY} at (8,8) size 769x1820
       RenderBlock {UL} at (0,0) size 186x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (-17,10) size 7x18: bullet
+          RenderListMarker at (-15,10) size 7x18: bullet
           RenderText {#text} at (10,10) size 62x18
             text run at (10,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (-17,10) size 7x18: bullet
+          RenderListMarker at (-15,10) size 7x18: bullet
           RenderText {#text} at (10,10) size 107x36
             text run at (10,10) width 107: "Second and very"
             text run at (10,28) width 94: "very long item"
         RenderListItem {LI} at (41,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (-17,10) size 7x18: bullet
+          RenderListMarker at (-15,10) size 7x18: bullet
           RenderText {#text} at (10,10) size 68x18
             text run at (10,10) width 68: "Third item"
       RenderBlock {UL} at (0,150) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (153,10) size 8x18: bullet
+          RenderListMarker at (151,10) size 8x18: bullet
           RenderText {#text} at (71,10) size 63x18
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (153,10) size 8x18: bullet
+          RenderListMarker at (151,10) size 8x18: bullet
           RenderText {#text} at (26,10) size 108x36
             text run at (26,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (153,10) size 8x18: bullet
+          RenderListMarker at (151,10) size 8x18: bullet
           RenderText {#text} at (65,10) size 69x18
             text run at (65,10) width 69: "Third item"
       RenderBlock {UL} at (0,300) size 186x134 [border: (1px solid #0000FF)]
@@ -119,30 +119,30 @@ layer at (0,0) size 785x1844
             text run at (48,10) width 69: "Third item"
       RenderBlock {OL} at (0,1236) size 186x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (-20,10) size 16x18: "1"
+          RenderListMarker at (-17,10) size 16x18: "1"
           RenderText {#text} at (10,10) size 62x18
             text run at (10,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (-20,10) size 16x18: "2"
+          RenderListMarker at (-17,10) size 16x18: "2"
           RenderText {#text} at (10,10) size 107x36
             text run at (10,10) width 107: "Second and very"
             text run at (10,28) width 94: "very long item"
         RenderListItem {LI} at (41,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (-20,10) size 16x18: "3"
+          RenderListMarker at (-17,10) size 16x18: "3"
           RenderText {#text} at (10,10) size 68x18
             text run at (10,10) width 68: "Third item"
       RenderBlock {OL} at (0,1386) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (147,10) size 17x18: "1"
+          RenderListMarker at (144,10) size 17x18: "1"
           RenderText {#text} at (71,10) size 63x18
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (147,10) size 17x18: "2"
+          RenderListMarker at (144,10) size 17x18: "2"
           RenderText {#text} at (26,10) size 108x36
             text run at (26,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (147,10) size 17x18: "3"
+          RenderListMarker at (144,10) size 17x18: "3"
           RenderText {#text} at (65,10) size 69x18
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1536) size 186x134 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
@@ -5,30 +5,30 @@ layer at (0,0) size 1844x585
     RenderBody {BODY} at (8,8) size 1820x569
       RenderBlock {UL} at (0,0) size 134x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,-17) size 18x7: bullet
+          RenderListMarker at (10,-15) size 18x7: bullet
           RenderText {#text} at (10,10) size 18x62
             text run at (10,10) width 62: "First item"
         RenderListItem {LI} at (39,41) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,-17) size 18x7: bullet
+          RenderListMarker at (10,-15) size 18x7: bullet
           RenderText {#text} at (10,10) size 36x107
             text run at (10,10) width 107: "Second and very"
             text run at (28,10) width 94: "very long item"
         RenderListItem {LI} at (95,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,-17) size 18x7: bullet
+          RenderListMarker at (10,-15) size 18x7: bullet
           RenderText {#text} at (10,10) size 18x68
             text run at (10,10) width 68: "Third item"
       RenderBlock {UL} at (150,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,153) size 18x8: bullet
+          RenderListMarker at (10,151) size 18x8: bullet
           RenderText {#text} at (10,71) size 18x63
             text run at (10,71) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,153) size 18x8: bullet
+          RenderListMarker at (10,151) size 18x8: bullet
           RenderText {#text} at (10,26) size 36x108
             text run at (10,26) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,153) size 18x8: bullet
+          RenderListMarker at (10,151) size 18x8: bullet
           RenderText {#text} at (10,65) size 18x69
             text run at (10,65) width 68: "Third item"
       RenderBlock {UL} at (300,0) size 134x186 [border: (1px solid #0000FF)]
@@ -119,30 +119,30 @@ layer at (0,0) size 1844x585
             text run at (10,48) width 68: "Third item"
       RenderBlock {OL} at (1236,0) size 134x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,-20) size 18x16: "1"
+          RenderListMarker at (10,-17) size 18x16: "1"
           RenderText {#text} at (10,10) size 18x62
             text run at (10,10) width 62: "First item"
         RenderListItem {LI} at (39,41) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,-20) size 18x16: "2"
+          RenderListMarker at (10,-17) size 18x16: "2"
           RenderText {#text} at (10,10) size 36x107
             text run at (10,10) width 107: "Second and very"
             text run at (28,10) width 94: "very long item"
         RenderListItem {LI} at (95,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,-20) size 18x16: "3"
+          RenderListMarker at (10,-17) size 18x16: "3"
           RenderText {#text} at (10,10) size 18x68
             text run at (10,10) width 68: "Third item"
       RenderBlock {OL} at (1386,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,147) size 18x17: "1"
+          RenderListMarker at (10,144) size 18x17: "1"
           RenderText {#text} at (10,71) size 18x63
             text run at (10,71) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,147) size 18x17: "2"
+          RenderListMarker at (10,144) size 18x17: "2"
           RenderText {#text} at (10,26) size 36x108
             text run at (10,26) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,147) size 18x17: "3"
+          RenderListMarker at (10,144) size 18x17: "3"
           RenderText {#text} at (10,65) size 18x69
             text run at (10,65) width 68: "Third item"
       RenderBlock {OL} at (1536,0) size 134x186 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/lists/anonymous-items-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/anonymous-items-expected.txt
@@ -8,35 +8,35 @@ layer at (0,0) size 800x600
           text run at (0,0) width 405: "Tests list item numbering when there are anonymous list items."
       RenderBlock {OL} at (0,34) size 784x18
         RenderListItem at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText at (0,0) size 33x18
             text run at (0,0) width 33: "ONE"
       RenderBlock {OL} at (0,68) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 24x18
             text run at (0,0) width 24: "one"
         RenderListItem at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText at (0,0) size 37x18
             text run at (0,0) width 37: "TWO"
       RenderBlock {OL} at (0,120) size 784x18
         RenderListItem at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText at (0,0) size 33x18
             text run at (0,0) width 33: "ONE"
       RenderBlock {OL} at (0,154) size 784x36
         RenderListItem at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText at (0,0) size 33x18
             text run at (0,0) width 33: "ONE"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 24x18
             text run at (0,0) width 24: "two"
       RenderBlock {OL} at (0,206) size 784x72
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 24x18
             text run at (0,0) width 24: "one"
         RenderBlock {DIV} at (40,18) size 744x36
@@ -44,27 +44,27 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "div"
           RenderListItem at (0,18) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText at (0,0) size 37x18
               text run at (0,0) width 37: "TWO"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 32x18
             text run at (0,0) width 32: "three"
       RenderBlock {OL} at (0,294) size 784x72
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 24x18
             text run at (0,0) width 24: "one"
         RenderBlock {DIV} at (40,18) size 744x36
           RenderListItem at (0,0) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText at (0,0) size 37x18
               text run at (0,0) width 37: "TWO"
           RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "div"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 32x18
             text run at (0,0) width 32: "three"

--- a/LayoutTests/platform/mac/fast/lists/big-list-marker-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/big-list-marker-expected.txt
@@ -9,6 +9,6 @@ layer at (0,0) size 800x600
           text run at (527,0) width 103: "See bug #11957"
       RenderBlock {UL} at (0,34) size 784x38 [border: (10px dashed #000000)]
         RenderListItem {LI} at (50,10) size 724x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 271x18
             text run at (0,0) width 271: "The list-marker should be the normal size."

--- a/LayoutTests/platform/mac/fast/lists/drag-into-marker-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/drag-into-marker-expected.txt
@@ -3,14 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,16) size 784x568
-      RenderBlock {UL} at (16,0) size 752x57 [border: (1px solid #000000)]
-        RenderListItem {LI} at (41,1) size 710x55
-          RenderListMarker at (-36,0) size 16x55: black square
-          RenderText {#text} at (0,0) size 220x55
-            text run at (0,0) width 112: "world"
-            text run at (111,0) width 13: " "
-            text run at (123,0) width 97: "hello"
-      RenderBlock {P} at (0,73) size 784x72
+      RenderBlock {UL} at (16,0) size 752x60 [border: (1px solid #000000)]
+        RenderListItem {LI} at (41,1) size 710x58
+          RenderListMarker at (-29,3) size 16x55: black square
+          RenderText {#text} at (0,3) size 220x55
+            text run at (0,3) width 220: "world hello"
+      RenderBlock {P} at (0,76) size 784x72
         RenderText {#text} at (0,0) size 783x72
           text run at (0,0) width 578: "This is an automated test for elementAtPoint for points over position:outside list markers. "
           text run at (577,0) width 176: "The dictionary returned by "

--- a/LayoutTests/platform/mac/fast/lists/dynamic-marker-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/dynamic-marker-crash-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x85
         RenderListItem {LI} at (40,0) size 744x53
           RenderBlock {FORM} at (0,0) size 744x19
             RenderBlock {P} at (0,0) size 744x19
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderTextControl {INPUT} at (0,0) size 288x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
               RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,35) size 744x18

--- a/LayoutTests/platform/mac/fast/lists/inlineBoxWrapperNullCheck-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/inlineBoxWrapperNullCheck-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 190x26
         RenderBlock {UL} at (0,0) size 190x26
           RenderListItem {LI} at (40,0) size 150x26
-            RenderListMarker at (-17,8) size 7x18: bullet
+            RenderListMarker at (-15,8) size 7x18: bullet
             RenderInline {A} at (0,8) size 207x18
               RenderText {#text} at (0,0) size 0x0
               RenderImage {IMG} at (0,0) size 207x22

--- a/LayoutTests/platform/mac/fast/lists/li-br-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/li-br-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x585
     RenderBody {BODY} at (8,8) size 784x561
       RenderBlock {OL} at (0,0) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 1492x18
             text run at (0,0) width 1492: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       RenderBlock {OL} at (0,34) size 784x36

--- a/LayoutTests/platform/mac/fast/lists/li-style-alpha-huge-value-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/li-style-alpha-huge-value-crash-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x600
         RenderBlock {BLOCKQUOTE} at (40,0) size 624x54
           RenderBlock {OL} at (0,0) size 624x54
             RenderListItem {LI} at (40,0) size 584x54
-              RenderListMarker at (-91,0) size 87x18: "CYWOQVJ"
+              RenderListMarker at (-88,0) size 87x18: "CYWOQVJ"
               RenderBR {BR} at (0,0) size 0x18
               RenderText {#text} at (0,18) size 492x36
                 text run at (0,18) width 190: "SUCCESS (you didn't crash) "

--- a/LayoutTests/platform/mac/fast/lists/list-marker-with-line-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/list-marker-with-line-height-expected.txt
@@ -5,6 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {OL} at (0,0) size 784x24
         RenderListItem {LI} at (40,0) size 744x24
-          RenderListMarker at (-20,3) size 16x18: "1"
+          RenderListMarker at (-17,3) size 16x18: "1"
           RenderText {#text} at (0,3) size 419x18
             text run at (0,3) width 419: "This test passes if the list item and list marker are evenly aligned."

--- a/LayoutTests/platform/mac/fast/lists/marker-before-empty-inline-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/marker-before-empty-inline-expected.txt
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (0,0) size 0x0
           RenderBlock (anonymous) at (0,0) size 744x18
             RenderBlock {DIV} at (0,0) size 744x18
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderText {#text} at (0,0) size 29x18
                 text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,18) size 744x0
@@ -37,7 +37,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (0,0) size 0x0
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {DIV} at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderText {#text} at (0,0) size 29x18
               text run at (0,0) width 29: "item"
       RenderBlock {UL} at (0,136) size 784x18
@@ -49,7 +49,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (0,0) size 0x0
           RenderBlock (anonymous) at (0,0) size 744x18
             RenderBlock {DIV} at (0,0) size 744x18
-              RenderListMarker at (-17,0) size 7x18: bullet
+              RenderListMarker at (-15,0) size 7x18: bullet
               RenderText {#text} at (0,0) size 28x18
                 text run at (0,0) width 28: "item"
           RenderBlock (anonymous) at (0,18) size 744x0
@@ -60,7 +60,7 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,170) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
             RenderInline {SPAN} at (0,0) size 41x18
               RenderInline (generated) at (0,0) size 41x18
                 RenderText at (0,0) size 41x18
@@ -79,8 +79,8 @@ layer at (0,0) size 800x600
           RenderBlock (anonymous) at (0,0) size 744x18
             RenderBlock {UL} at (0,0) size 744x18
               RenderListItem {LI} at (40,0) size 704x18
-                RenderListMarker at (-17,0) size 7x18: white bullet
-                RenderListMarker at (-57,0) size 7x18: bullet
+                RenderListMarker at (-15,0) size 7x18: white bullet
+                RenderListMarker at (-55,0) size 7x18: bullet
                 RenderText {#text} at (0,0) size 29x18
                   text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,18) size 744x18
@@ -91,8 +91,8 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 744x18
             RenderBlock {UL} at (0,0) size 744x18
               RenderListItem {LI} at (40,0) size 704x18
-                RenderListMarker at (-17,0) size 7x18: white bullet
-                RenderListMarker at (-57,0) size 7x18: bullet
+                RenderListMarker at (-15,0) size 7x18: white bullet
+                RenderListMarker at (-55,0) size 7x18: bullet
                 RenderText {#text} at (0,0) size 29x18
                   text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,18) size 744x18
@@ -103,10 +103,10 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,360) size 784x54
         RenderListItem {LI} at (40,0) size 744x54
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+            RenderListMarker at (-15,0) size 7x18: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
-              RenderListMarker at (-17,0) size 7x18: white bullet
+              RenderListMarker at (-15,0) size 7x18: white bullet
               RenderText {#text} at (0,0) size 29x18
                 text run at (0,0) width 29: "item"
           RenderBlock (anonymous) at (0,36) size 744x18

--- a/LayoutTests/platform/mac/fast/lists/marker-image-error-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/marker-image-error-expected.txt
@@ -21,22 +21,22 @@ layer at (0,0) size 800x600
           text run at (0,0) width 407: "There should be a bullet next to each item on the following list:"
       RenderBlock {UL} at (0,86) size 784x90
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 162x18
             text run at (0,0) width 162: "Prospectuses and courses"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 170x18
             text run at (0,0) width 170: "Undergraduate admissions"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 134x18
             text run at (0,0) width 134: "Graduate admissions"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 139x18
             text run at (0,0) width 139: "Continuing education"
         RenderListItem {LI} at (40,72) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 96x18
             text run at (0,0) width 96: "Online courses"

--- a/LayoutTests/platform/mac/fast/lists/markers-in-selection-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/markers-in-selection-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {UL} at (0,86) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 162x18
             text run at (0,0) width 162: "Item with outside marker"
       RenderBlock {UL} at (0,120) size 784x18
@@ -43,11 +43,11 @@ layer at (0,0) size 800x600
             text run at (17,0) width 197: "Item with inside image marker"
       RenderBlock {OL} at (0,222) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 162x18
             text run at (0,0) width 162: "Item with outside ordinal"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 103x18
             text run at (0,0) width 103: "and another one"
       RenderBlock {OL} at (0,274) size 784x36

--- a/LayoutTests/platform/mac/fast/lists/numeric-markers-outside-list-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/numeric-markers-outside-list-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DIV} at (0,0) size 784x36
         RenderListItem {DIV} at (30,0) size 754x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 153x18
             text run at (0,0) width 153: "should have a label of 1"
         RenderListItem {DIV} at (30,18) size 754x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 153x18
             text run at (0,0) width 153: "should have a label of 2"

--- a/LayoutTests/platform/mac/fast/lists/ol-display-types-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/ol-display-types-expected.txt
@@ -9,18 +9,18 @@ layer at (0,0) size 800x600
           text run at (0,18) width 317: "number. This is generally going to be LI element."
       RenderBlock {OL} at (0,52) size 784x306
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 3"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 4"
         RenderBlock {LI} at (40,36) size 744x18
           RenderText {#text} at (0,0) size 168x18
             text run at (0,0) width 168: "Should not have a number"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 5"
         RenderBlock (anonymous) at (40,72) size 744x18
@@ -29,48 +29,48 @@ layer at (0,0) size 800x600
               text run at (0,0) width 168: "Should not have a number"
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,90) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "6"
+          RenderListMarker at (-17,0) size 16x18: "6"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 6"
         RenderBlock {DIV} at (40,108) size 744x18
           RenderText {#text} at (0,0) size 168x18
             text run at (0,0) width 168: "Should not have a number"
         RenderListItem {DIV} at (40,126) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "7"
+          RenderListMarker at (-17,0) size 16x18: "7"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 7"
         RenderListItem {LI} at (40,144) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "8"
+          RenderListMarker at (-17,0) size 16x18: "8"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 8"
         RenderListItem {LI} at (40,162) size 744x18
           RenderText {#text} at (0,0) size 168x18
             text run at (0,0) width 168: "Should not have a number"
         RenderListItem {LI} at (40,180) size 744x18
-          RenderListMarker at (-28,0) size 24x18: "10"
+          RenderListMarker at (-25,0) size 24x18: "10"
           RenderText {#text} at (0,0) size 85x18
             text run at (0,0) width 85: "Should be 10"
         RenderListItem {LI} at (40,198) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 121x18
             text run at (0,0) width 121: "Should have a disc"
         RenderListItem {LI} at (40,216) size 744x18
-          RenderListMarker at (-28,0) size 24x18: "12"
+          RenderListMarker at (-25,0) size 24x18: "12"
           RenderText {#text} at (0,0) size 85x18
             text run at (0,0) width 85: "Should be 12"
         RenderListItem {LI} at (40,234) size 744x18
-          RenderListMarker at (-17,0) size 7x18: black square
+          RenderListMarker at (-15,0) size 7x18: black square
           RenderText {#text} at (0,0) size 137x18
             text run at (0,0) width 137: "Should have a square"
         RenderListItem {LI} at (40,252) size 744x18
-          RenderListMarker at (-28,0) size 24x18: "14"
+          RenderListMarker at (-25,0) size 24x18: "14"
           RenderText {#text} at (0,0) size 85x18
             text run at (0,0) width 85: "Should be 14"
         RenderListItem {LI} at (40,270) size 744x18
-          RenderListMarker at (-17,0) size 7x18: white bullet
+          RenderListMarker at (-15,0) size 7x18: white bullet
           RenderText {#text} at (0,0) size 131x18
             text run at (0,0) width 131: "Should have a circle"
         RenderListItem {LI} at (40,288) size 744x18
-          RenderListMarker at (-28,0) size 24x18: "16"
+          RenderListMarker at (-25,0) size 24x18: "16"
           RenderText {#text} at (0,0) size 85x18
             text run at (0,0) width 85: "Should be 16"

--- a/LayoutTests/platform/mac/fast/lists/ol-start-dynamic-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/ol-start-dynamic-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x36
         RenderBlock {OL} at (0,0) size 784x36
           RenderListItem {LI} at (40,0) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 22x18
               text run at (0,0) width 22: "foo"
           RenderListItem {LI} at (40,18) size 744x18
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "bar"

--- a/LayoutTests/platform/mac/fast/lists/ol-start-parsing-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/ol-start-parsing-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 113: "No start attribute."
       RenderBlock {OL} at (0,34) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,96) size 769x18
@@ -20,11 +20,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 28: "start"
       RenderBlock {OL} at (0,130) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,192) size 769x18
@@ -32,11 +32,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 50: "start=\"\""
       RenderBlock {OL} at (0,226) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,288) size 769x18
@@ -44,11 +44,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 66: "start=\" 2 \""
       RenderBlock {OL} at (0,322) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,384) size 769x18
@@ -56,11 +56,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 67: "start=\"+2\""
       RenderBlock {OL} at (0,418) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,480) size 769x18
@@ -68,11 +68,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 70: "start=\"A2\""
       RenderBlock {OL} at (0,514) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,576) size 769x18
@@ -80,11 +80,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 62: "start=\".2\""
       RenderBlock {OL} at (0,610) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,672) size 769x18
@@ -92,11 +92,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 66: "start=\"#2\""
       RenderBlock {OL} at (0,706) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
       RenderBlock (anonymous) at (0,758) size 769x18
@@ -104,11 +104,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 58: "start=\"0\""
       RenderBlock {OL} at (0,792) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "0"
+          RenderListMarker at (-17,0) size 16x18: "0"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 0"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
       RenderBlock (anonymous) at (0,854) size 769x18
@@ -116,11 +116,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 66: "start=\" 0 \""
       RenderBlock {OL} at (0,888) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "0"
+          RenderListMarker at (-17,0) size 16x18: "0"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 0"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
       RenderBlock (anonymous) at (0,950) size 769x18
@@ -128,11 +128,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 58: "start=\"2\""
       RenderBlock {OL} at (0,984) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,1046) size 769x18
@@ -140,11 +140,11 @@ layer at (0,0) size 785x1150
           text run at (0,0) width 63: "start=\"-2\""
       RenderBlock {OL} at (0,1080) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-26,0) size 22x18: "-2"
+          RenderListMarker at (-23,0) size 22x18: "-2"
           RenderText {#text} at (0,0) size 82x18
             text run at (0,0) width 82: "Should be -2"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-26,0) size 22x18: "-1"
+          RenderListMarker at (-23,0) size 22x18: "-1"
           RenderText {#text} at (0,0) size 82x18
             text run at (0,0) width 82: "Should be -1"
 layer at (8,94) size 769x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/lists/olstart-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/olstart-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 785x782
           text run at (0,0) width 132: "1. Basic inheritance:"
       RenderBlock {OL} at (0,34) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 3"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 4"
       RenderBlock (anonymous) at (0,96) size 769x18
@@ -20,12 +20,12 @@ layer at (0,0) size 785x782
           text run at (0,0) width 297: "2. Test that the inner start value gets inherited:"
       RenderBlock {OL} at (0,130) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 5"
         RenderBlock {OL} at (40,18) size 729x18
           RenderListItem {LI} at (40,0) size 689x18
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 77x18
               text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,192) size 769x18
@@ -36,7 +36,7 @@ layer at (0,0) size 785x782
           RenderText {#text} at (0,0) size 29x18
             text run at (0,0) width 29: "Text"
         RenderListItem {LI} at (40,34) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 3"
       RenderBlock (anonymous) at (0,304) size 769x18
@@ -47,7 +47,7 @@ layer at (0,0) size 785x782
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,0) size 729x18
           RenderListItem {LI} at (0,0) size 729x18
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 155x18
               text run at (0,0) width 155: "Should be 3 (and bold)"
         RenderBlock (anonymous) at (40,18) size 729x0
@@ -61,18 +61,18 @@ layer at (0,0) size 785x782
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,0) size 729x18
           RenderListItem {LI} at (0,0) size 729x18
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 155x18
               text run at (0,0) width 155: "Should be 3 (and bold)"
         RenderBlock (anonymous) at (40,18) size 729x0
           RenderInline {B} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 4"
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 5"
       RenderBlock (anonymous) at (0,496) size 769x18
@@ -80,14 +80,14 @@ layer at (0,0) size 785x782
           text run at (0,0) width 461: "6. Test for properly chaining from the previous li when current is nested"
       RenderBlock {OL} at (0,530) size 769x36
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 1"
         RenderBlock (anonymous) at (40,18) size 729x0
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,18) size 729x18
           RenderListItem {LI} at (0,0) size 729x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 155x18
               text run at (0,0) width 155: "Should be 2 (and bold)"
         RenderBlock (anonymous) at (40,36) size 729x0
@@ -101,7 +101,7 @@ layer at (0,0) size 785x782
           RenderInline {I} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,0) size 729x18
           RenderListItem {LI} at (0,0) size 729x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 152x18
               text run at (0,0) width 152: "Should be 2 (and italic)"
         RenderBlock (anonymous) at (40,18) size 729x0
@@ -110,7 +110,7 @@ layer at (0,0) size 785x782
           RenderInline {B} at (0,0) size 0x0
         RenderBlock (anonymous) at (40,18) size 729x18
           RenderListItem {LI} at (0,0) size 729x18
-            RenderListMarker at (-20,0) size 16x18: "3"
+            RenderListMarker at (-17,0) size 16x18: "3"
             RenderText {#text} at (0,0) size 155x18
               text run at (0,0) width 155: "Should be 3 (and bold)"
         RenderBlock (anonymous) at (40,36) size 729x0
@@ -122,11 +122,11 @@ layer at (0,0) size 785x782
       RenderBlock {OL} at (0,722) size 769x36
         RenderBlock {OL} at (40,0) size 729x18
           RenderListItem {LI} at (40,0) size 689x18
-            RenderListMarker at (-20,0) size 16x18: "2"
+            RenderListMarker at (-17,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 77x18
               text run at (0,0) width 77: "Should be 2"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 77x18
             text run at (0,0) width 77: "Should be 5"
 layer at (8,94) size 769x2 clip at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -11,38 +11,38 @@ layer at (0,0) size 800x540
           text run at (0,0) width 566: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
       RenderBlock {DIV} at (24,81) size 760x431 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x20 [border: (1px solid #000000)]
-          RenderListMarker at (-20,1) size 16x18: "1"
+          RenderListMarker at (-17,1) size 16x18: "1"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 1"
         RenderListItem {DIV} at (33,21) size 726x138 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x18
-            RenderListMarker at (-53,0) size 16x18: "2"
+            RenderListMarker at (-50,0) size 16x18: "2"
             RenderText {#text} at (0,0) size 42x18
               text run at (0,0) width 42: "Item 2"
           RenderListItem {DIV} at (33,19) size 692x38 [border: (1px solid #000000)]
-            RenderListMarker at (-20,1) size 16x18: "a"
+            RenderListMarker at (-17,1) size 16x18: "a"
             RenderText {#text} at (33,1) size 41x18
               text run at (33,1) width 41: "Item a"
             RenderBR {BR} at (73,1) size 1x18
             RenderText {#text} at (33,19) size 90x18
               text run at (33,19) width 90: "Item a, Line 2"
           RenderListItem {DIV} at (33,57) size 692x20 [border: (1px solid #000000)]
-            RenderListMarker at (-20,1) size 16x18: "b"
+            RenderListMarker at (-17,1) size 16x18: "b"
             RenderText {#text} at (33,1) size 42x18
               text run at (33,1) width 42: "Item b"
           RenderListItem {DIV} at (33,77) size 692x20 [border: (1px solid #000000)]
-            RenderListMarker at (-20,1) size 16x18: "c"
+            RenderListMarker at (-17,1) size 16x18: "c"
             RenderText {#text} at (33,1) size 41x18
               text run at (33,1) width 41: "Item c"
           RenderBlock {DIV} at (33,97) size 692x20 [border: (1px solid #000000)]
             RenderText {#text} at (33,1) size 92x18
               text run at (33,1) width 92: "Not a list item"
           RenderListItem {DIV} at (33,117) size 692x20 [border: (1px solid #000000)]
-            RenderListMarker at (-20,1) size 16x18: "d"
+            RenderListMarker at (-17,1) size 16x18: "d"
             RenderText {#text} at (33,1) size 42x18
               text run at (33,1) width 42: "Item d"
         RenderListItem {DIV} at (33,159) size 726x20 [border: (1px solid #000000)]
-          RenderListMarker at (-20,1) size 16x18: "3"
+          RenderListMarker at (-17,1) size 16x18: "3"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 3"
         RenderBlock {DIV} at (33,179) size 726x98 [border: (1px solid #000000)]
@@ -50,7 +50,7 @@ layer at (0,0) size 800x540
             RenderText {#text} at (0,0) size 92x18
               text run at (0,0) width 92: "Not a list item"
           RenderListItem {DIV} at (33,19) size 692x38 [border: (1px solid #000000)]
-            RenderListMarker at (-20,1) size 16x18: "a"
+            RenderListMarker at (-17,1) size 16x18: "a"
             RenderText {#text} at (33,1) size 41x18
               text run at (33,1) width 41: "Item a"
             RenderBR {BR} at (73,1) size 1x18
@@ -60,21 +60,21 @@ layer at (0,0) size 800x540
             RenderText {#text} at (33,1) size 92x18
               text run at (33,1) width 92: "Not a list item"
           RenderListItem {DIV} at (33,77) size 692x20 [border: (1px solid #000000)]
-            RenderListMarker at (-20,1) size 16x18: "b"
+            RenderListMarker at (-17,1) size 16x18: "b"
             RenderText {#text} at (33,1) size 42x18
               text run at (33,1) width 42: "Item b"
         RenderListItem {DIV} at (33,277) size 726x20 [border: (1px solid #000000)]
-          RenderListMarker at (-20,1) size 16x18: "4"
+          RenderListMarker at (-17,1) size 16x18: "4"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 4"
         RenderListItem {DIV} at (33,297) size 726x112 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x18
-            RenderListMarker at (-53,0) size 16x18: "5"
+            RenderListMarker at (-50,0) size 16x18: "5"
             RenderText {#text} at (0,0) size 42x18
               text run at (0,0) width 42: "Item 5"
           RenderListItem {TABLE} at (33,19) size 692x46 [border: (1px dashed #000000)]
             RenderBlock (anonymous) at (1,1) size 690x18
-              RenderListMarker at (-21,0) size 16x18: "a"
+              RenderListMarker at (-18,0) size 16x18: "a"
             RenderTable at (1,19) size 193x26
               RenderTableSection {TBODY} at (0,0) size 193x26
                 RenderTableRow {TR} at (0,2) size 193x22
@@ -86,7 +86,7 @@ layer at (0,0) size 800x540
                       text run at (2,2) width 89: "Table Cell B1"
           RenderListItem {TABLE} at (33,65) size 692x46 [border: (1px dashed #000000)]
             RenderBlock (anonymous) at (1,1) size 690x18
-              RenderListMarker at (-21,0) size 16x18: "b"
+              RenderListMarker at (-18,0) size 16x18: "b"
             RenderTable at (1,19) size 217x26
               RenderTableSection {TBODY} at (0,0) size 217x26
                 RenderTableRow {TR} at (0,2) size 217x22
@@ -97,6 +97,6 @@ layer at (0,0) size 800x540
                     RenderText {#text} at (2,2) size 101x18
                       text run at (2,2) width 101: "Table 2 Cell B1"
         RenderListItem {DIV} at (33,409) size 726x20 [border: (1px solid #000000)]
-          RenderListMarker at (-20,1) size 16x18: "6"
+          RenderListMarker at (-17,1) size 16x18: "6"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 6"

--- a/LayoutTests/platform/mac/fast/lists/scrolled-marker-paint-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/scrolled-marker-paint-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
 layer at (8,-4) size 409x18 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock (positioned) {UL} at (8,-4) size 409x18
     RenderListItem {LI} at (40,0) size 369x18
-      RenderListMarker at (-17,0) size 7x18: bullet
+      RenderListMarker at (-15,0) size 7x18: bullet
       RenderText {#text} at (0,0) size 369x18
         text run at (0,0) width 119: "This is a list item. "
         text run at (118,0) width 251: "You should see a list marker to the left."

--- a/LayoutTests/platform/mac/fast/overflow/overflow-rtl-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/overflow-rtl-expected.txt
@@ -17,19 +17,19 @@ layer at (0,0) size 800x443
           text run at (0,0) width 469: "The right column should be a mirror-image of the left column in terms of"
       RenderBlock {UL} at (0,86) size 784x72
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 168x18
             text run at (0,0) width 168: "the presence of a scrollbar"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 242x18
             text run at (0,0) width 242: "the initial position of the scroll thumb"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 462x18
             text run at (0,0) width 462: "which letters are visible initially and when you scroll (in the top 3 rows)"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 591x18
             text run at (0,0) width 591: "the position of the blue and olive boxes, initially and when you scroll (in the bottom 2 rows)"
       RenderTable {TABLE} at (0,174) size 256x246

--- a/LayoutTests/platform/mac/fast/overflow/overflow-rtl-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/overflow-rtl-vertical-expected.txt
@@ -17,15 +17,15 @@ layer at (0,0) size 331x600
           text run at (0,0) width 469: "The right column should be a mirror-image of the left column in terms of"
       RenderBlock {UL} at (86,0) size 54x584
         RenderListItem {LI} at (0,40) size 18x544
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
           RenderText {#text} at (0,0) size 18x168
             text run at (0,0) width 168: "the presence of a scrollbar"
         RenderListItem {LI} at (18,40) size 18x544
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
           RenderText {#text} at (0,0) size 18x242
             text run at (0,0) width 242: "the initial position of the scroll thumb"
         RenderListItem {LI} at (36,40) size 18x544
-          RenderListMarker at (0,-17) size 18x7: bullet
+          RenderListMarker at (0,-15) size 18x7: bullet
           RenderText {#text} at (0,0) size 18x340
             text run at (0,0) width 340: "which letters are visible initially and when you scroll"
       RenderTable {TABLE} at (156,0) size 152x256

--- a/LayoutTests/platform/mac/fast/overflow/overflow-with-local-background-attachment-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/overflow-with-local-background-attachment-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x292
     RenderBody {BODY} at (8,16) size 784x268
       RenderBlock {UL} at (0,0) size 784x54 [color=#000080]
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 338x18
             text run at (0,0) width 338: "You should not see the background under the border."
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 350x18
             text run at (0,0) width 350: "As you scroll the element below the cats should move."
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 300x18
             text run at (0,0) width 300: "The cats should be on a light grey background."
 layer at (8,86) size 390x198 clip at (38,116) size 315x138 scrollHeight 360

--- a/LayoutTests/platform/mac/fast/repaint/list-marker-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/repaint/list-marker-2-expected.txt
@@ -21,5 +21,5 @@ layer at (0,0) size 800x600
           text run at (0,0) width 429: "There should be only one bullet, at the bottom left of the rectangle."
       RenderBlock {UL} at (0,86) size 784x104
         RenderListItem {LI} at (40,0) size 744x104
-          RenderListMarker at (-17,86) size 7x18: bullet
+          RenderListMarker at (-15,86) size 7x18: bullet
           RenderImage {IMG} at (0,0) size 100x100

--- a/LayoutTests/platform/mac/fast/selectors/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/selectors/001-expected.txt
@@ -5,11 +5,11 @@ layer at (0,0) size 800x102
     RenderBody {BODY} at (8,16) size 784x70
       RenderBlock {UL} at (0,0) size 784x36
         RenderListItem {LI} at (40,0) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 311x18
             text run at (0,0) width 311: "The background of this list item should be green"
         RenderListItem {LI} at (40,18) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 389x18
             text run at (0,0) width 389: "The background of this second list item should be also green"
       RenderBlock {P} at (0,52) size 784x18 [bgcolor=#00FF00]

--- a/LayoutTests/platform/mac/fast/selectors/013-expected.txt
+++ b/LayoutTests/platform/mac/fast/selectors/013-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x86
     RenderBody {BODY} at (8,16) size 784x54
       RenderBlock {UL} at (0,0) size 784x54
         RenderListItem {LI} at (40,0) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 438x18
             text run at (0,0) width 438: "This list item should have green background because its class is \"t1\""
         RenderListItem {LI} at (40,18) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 438x18
             text run at (0,0) width 438: "This list item should have green background because its class is \"t2\""
         RenderListItem {LI} at (40,36) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {SPAN} at (0,0) size 604x18
             RenderText {#text} at (0,0) size 604x18
               text run at (0,0) width 344: "This list item should have green background because "

--- a/LayoutTests/platform/mac/fast/selectors/015-expected.txt
+++ b/LayoutTests/platform/mac/fast/selectors/015-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x86
     RenderBody {BODY} at (8,16) size 784x54
       RenderBlock {UL} at (0,0) size 784x54
         RenderListItem {LI} at (40,0) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 439x18
             text run at (0,0) width 439: "This list item should have a green background. because its ID is \"t1\""
         RenderListItem {LI} at (40,18) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 439x18
             text run at (0,0) width 439: "This list item should have a green background. because its ID is \"t2\""
         RenderListItem {LI} at (40,36) size 744x18 [bgcolor=#00FF00]
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {SPAN} at (0,0) size 597x18
             RenderText {#text} at (0,0) size 597x18
               text run at (0,0) width 597: "This list item should have a green background. because the inner SPAN does not match \"#t4\""

--- a/LayoutTests/platform/mac/fast/selectors/166-expected.txt
+++ b/LayoutTests/platform/mac/fast/selectors/166-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 785x3324
           text run at (0,18) width 724: "markup is contained within it, for example the Xlink embed case uses an XLink with the show axis set to embed."
       RenderBlock {UL} at (0,196) size 769x181
         RenderListItem {LI} at (40,0) size 729x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 23x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 23x18
               text run at (0,0) width 23: "full"
@@ -69,7 +69,7 @@ layer at (0,0) size 785x3324
             RenderText {#text} at (273,18) size 84x18
               text run at (273,18) width 84: "TNG Format"
         RenderListItem {LI} at (40,36) size 729x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 34x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 34x18
               text run at (0,0) width 34: "static"
@@ -120,7 +120,7 @@ layer at (0,0) size 785x3324
             RenderText {#text} at (273,18) size 84x18
               text run at (273,18) width 84: "TNG Format"
         RenderListItem {LI} at (40,72) size 729x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 94x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 94x18
               text run at (0,0) width 94: "history-related"
@@ -170,7 +170,7 @@ layer at (0,0) size 785x3324
             RenderText {#text} at (322,18) size 84x18
               text run at (322,18) width 84: "TNG Format"
         RenderListItem {LI} at (40,108) size 729x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 68x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 68x18
               text run at (0,0) width 68: "interactive"
@@ -221,7 +221,7 @@ layer at (0,0) size 785x3324
             RenderText {#text} at (273,18) size 84x18
               text run at (273,18) width 84: "TNG Format"
         RenderListItem {LI} at (40,144) size 729x36
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 56x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 56x18
               text run at (0,0) width 56: "dynamic"
@@ -276,1092 +276,1092 @@ layer at (0,0) size 785x3324
           text run at (0,0) width 174: "Unadorned Tests"
       RenderBlock {UL} at (0,444) size 769x2809
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 125x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 125x18
               text run at (0,0) width 125: "Groups of selectors"
           RenderText {#text} at (124,0) size 32x18
             text run at (124,0) width 32: " (#1)"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 147x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 147x18
               text run at (0,0) width 147: "Type element selectors"
           RenderText {#text} at (146,0) size 32x18
             text run at (146,0) width 32: " (#2)"
         RenderListItem {LI} at (40,36) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 169x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 169x18
               text run at (0,0) width 169: "Omitted universal selector"
           RenderText {#text} at (168,0) size 32x18
             text run at (168,0) width 32: " (#4)"
         RenderListItem {LI} at (40,54) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 176x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 176x18
               text run at (0,0) width 176: "Attribute existence selector"
           RenderText {#text} at (175,0) size 31x18
             text run at (175,0) width 31: " (#5)"
         RenderListItem {LI} at (40,72) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 151x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 151x18
               text run at (0,0) width 151: "Attribute value selector"
           RenderText {#text} at (150,0) size 31x18
             text run at (150,0) width 31: " (#6)"
         RenderListItem {LI} at (40,90) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 184x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x18
               text run at (0,0) width 184: "Attribute multivalue selector"
           RenderText {#text} at (183,0) size 32x18
             text run at (183,0) width 32: " (#7)"
         RenderListItem {LI} at (40,108) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 184x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x18
               text run at (0,0) width 184: "Attribute multivalue selector"
           RenderText {#text} at (183,0) size 40x18
             text run at (183,0) width 40: " (#7b)"
         RenderListItem {LI} at (40,126) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 348x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 348x18
               text run at (0,0) width 348: "Attribute value selectors (hyphen-separated attributes)"
           RenderText {#text} at (347,0) size 32x18
             text run at (347,0) width 32: " (#8)"
         RenderListItem {LI} at (40,144) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 315x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 315x18
               text run at (0,0) width 315: "Substring matching attribute selector (beginning)"
           RenderText {#text} at (314,0) size 32x18
             text run at (314,0) width 32: " (#9)"
         RenderListItem {LI} at (40,162) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 274x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 274x18
               text run at (0,0) width 274: "Substring matching attribute selector (end)"
           RenderText {#text} at (273,0) size 40x18
             text run at (273,0) width 40: " (#10)"
         RenderListItem {LI} at (40,180) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 304x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 304x18
               text run at (0,0) width 304: "Substring matching attribute selector (contains)"
           RenderText {#text} at (303,0) size 39x18
             text run at (303,0) width 39: " (#11)"
         RenderListItem {LI} at (40,198) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 144x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x18
               text run at (0,0) width 144: "Default attribute value"
           RenderText {#text} at (143,0) size 40x18
             text run at (143,0) width 40: " (#12)"
         RenderListItem {LI} at (40,216) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 95x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 95x18
               text run at (0,0) width 95: "Class selectors"
           RenderText {#text} at (94,0) size 40x18
             text run at (94,0) width 40: " (#13)"
         RenderListItem {LI} at (40,234) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 183x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 183x18
               text run at (0,0) width 183: "More than one class selector"
           RenderText {#text} at (182,0) size 39x18
             text run at (182,0) width 39: " (#14)"
         RenderListItem {LI} at (40,252) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 77x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 77x18
               text run at (0,0) width 77: "ID selectors"
           RenderText {#text} at (76,0) size 40x18
             text run at (76,0) width 40: " (#15)"
         RenderListItem {LI} at (40,270) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 116x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 116x18
               text run at (0,0) width 116: ":link pseudo-class"
           RenderText {#text} at (115,0) size 39x18
             text run at (115,0) width 39: " (#16)"
         RenderListItem {LI} at (40,288) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 133x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 133x18
               text run at (0,0) width 133: ":visited pseudo-class"
           RenderText {#text} at (132,0) size 40x18
             text run at (132,0) width 40: " (#17)"
         RenderListItem {LI} at (40,306) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 127x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x18
               text run at (0,0) width 127: ":hover pseudo-class"
           RenderText {#text} at (126,0) size 40x18
             text run at (126,0) width 40: " (#18)"
         RenderListItem {LI} at (40,324) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 127x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x18
               text run at (0,0) width 127: ":hover pseudo-class"
           RenderText {#text} at (126,0) size 48x18
             text run at (126,0) width 48: " (#18b)"
         RenderListItem {LI} at (40,342) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 129x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 129x18
               text run at (0,0) width 129: ":active pseudo-class"
           RenderText {#text} at (128,0) size 40x18
             text run at (128,0) width 40: " (#19)"
         RenderListItem {LI} at (40,360) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 125x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 125x18
               text run at (0,0) width 125: ":focus pseudo-class"
           RenderText {#text} at (124,0) size 40x18
             text run at (124,0) width 40: " (#20)"
         RenderListItem {LI} at (40,378) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 127x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x18
               text run at (0,0) width 127: ":target pseudo-class"
           RenderText {#text} at (126,0) size 39x18
             text run at (126,0) width 39: " (#21)"
         RenderListItem {LI} at (40,396) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 127x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x18
               text run at (0,0) width 127: ":target pseudo-class"
           RenderText {#text} at (126,0) size 47x18
             text run at (126,0) width 47: " (#21b)"
         RenderListItem {LI} at (40,414) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 127x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 127x18
               text run at (0,0) width 127: ":target pseudo-class"
           RenderText {#text} at (126,0) size 47x18
             text run at (126,0) width 47: " (#21c)"
         RenderListItem {LI} at (40,432) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 129x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 129x18
               text run at (0,0) width 129: ":lang() pseudo-class"
           RenderText {#text} at (128,0) size 40x18
             text run at (128,0) width 40: " (#22)"
         RenderListItem {LI} at (40,450) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 140x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 140x18
               text run at (0,0) width 140: ":enabled pseudo-class"
           RenderText {#text} at (139,0) size 40x18
             text run at (139,0) width 40: " (#23)"
         RenderListItem {LI} at (40,468) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 144x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x18
               text run at (0,0) width 144: ":disabled pseudo-class"
           RenderText {#text} at (143,0) size 40x18
             text run at (143,0) width 40: " (#24)"
         RenderListItem {LI} at (40,486) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 143x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 143x18
               text run at (0,0) width 143: ":checked pseudo-class"
           RenderText {#text} at (142,0) size 40x18
             text run at (142,0) width 40: " (#25)"
         RenderListItem {LI} at (40,504) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 116x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 116x18
               text run at (0,0) width 116: ":root pseudo-class"
           RenderText {#text} at (115,0) size 40x18
             text run at (115,0) width 40: " (#27)"
         RenderListItem {LI} at (40,522) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 159x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 159x18
               text run at (0,0) width 159: ":nth-child() pseudo-class"
           RenderText {#text} at (158,0) size 40x18
             text run at (158,0) width 40: " (#28)"
         RenderListItem {LI} at (40,540) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 159x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 159x18
               text run at (0,0) width 159: ":nth-child() pseudo-class"
           RenderText {#text} at (158,0) size 48x18
             text run at (158,0) width 48: " (#28b)"
         RenderListItem {LI} at (40,558) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 187x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 187x18
               text run at (0,0) width 187: ":nth-last-child() pseudo-class"
           RenderText {#text} at (186,0) size 39x18
             text run at (186,0) width 39: " (#29)"
         RenderListItem {LI} at (40,576) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 187x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 187x18
               text run at (0,0) width 187: ":nth-last-child() pseudo-class"
           RenderText {#text} at (186,0) size 47x18
             text run at (186,0) width 47: " (#29b)"
         RenderListItem {LI} at (40,594) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 173x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 173x18
               text run at (0,0) width 173: ":nth-of-type() pseudo-class"
           RenderText {#text} at (172,0) size 40x18
             text run at (172,0) width 40: " (#30)"
         RenderListItem {LI} at (40,612) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 201x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 201x18
               text run at (0,0) width 201: ":nth-last-of-type() pseudo-class"
           RenderText {#text} at (200,0) size 40x18
             text run at (200,0) width 40: " (#31)"
         RenderListItem {LI} at (40,630) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 153x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 153x18
               text run at (0,0) width 153: ":first-child pseudo-class"
           RenderText {#text} at (152,0) size 40x18
             text run at (152,0) width 40: " (#32)"
         RenderListItem {LI} at (40,648) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 150x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 150x18
               text run at (0,0) width 150: ":last-child pseudo-class"
           RenderText {#text} at (149,0) size 40x18
             text run at (149,0) width 40: " (#33)"
         RenderListItem {LI} at (40,666) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 167x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 167x18
               text run at (0,0) width 167: ":first-of-type pseudo-class"
           RenderText {#text} at (166,0) size 40x18
             text run at (166,0) width 40: " (#34)"
         RenderListItem {LI} at (40,684) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 164x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 164x18
               text run at (0,0) width 164: ":last-of-type pseudo-class"
           RenderText {#text} at (163,0) size 40x18
             text run at (163,0) width 40: " (#35)"
         RenderListItem {LI} at (40,702) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 156x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x18
               text run at (0,0) width 156: ":only-child pseudo-class"
           RenderText {#text} at (155,0) size 40x18
             text run at (155,0) width 40: " (#36)"
         RenderListItem {LI} at (40,720) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 171x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 171x18
               text run at (0,0) width 171: ":only-of-type pseudo-class"
           RenderText {#text} at (170,0) size 39x18
             text run at (170,0) width 39: " (#37)"
         RenderListItem {LI} at (40,738) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 169x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 169x18
               text run at (0,0) width 169: "::first-line pseudo-element"
           RenderText {#text} at (168,0) size 40x18
             text run at (168,0) width 40: " (#38)"
         RenderListItem {LI} at (40,756) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 178x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 178x18
               text run at (0,0) width 178: "::first-letter pseudo-element"
           RenderText {#text} at (177,0) size 39x18
             text run at (177,0) width 39: " (#39)"
         RenderListItem {LI} at (40,774) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 369x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 369x18
               text run at (0,0) width 369: "::first-letter pseudo-element with ::before pseudo-element"
           RenderText {#text} at (368,0) size 47x18
             text run at (368,0) width 47: " (#39a)"
         RenderListItem {LI} at (40,792) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 369x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 369x18
               text run at (0,0) width 369: "::first-letter pseudo-element with ::before pseudo-element"
           RenderText {#text} at (368,0) size 47x18
             text run at (368,0) width 47: " (#39a)"
         RenderListItem {LI} at (40,810) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 178x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 178x18
               text run at (0,0) width 178: "::first-letter pseudo-element"
           RenderText {#text} at (177,0) size 47x18
             text run at (177,0) width 47: " (#39b)"
         RenderListItem {LI} at (40,828) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 172x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 172x18
               text run at (0,0) width 172: "::selection pseudo-element"
           RenderText {#text} at (171,0) size 39x18
             text run at (171,0) width 39: " (#40)"
         RenderListItem {LI} at (40,846) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 156x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x18
               text run at (0,0) width 156: "::before pseudo-element"
           RenderText {#text} at (155,0) size 39x18
             text run at (155,0) width 39: " (#41)"
         RenderListItem {LI} at (40,864) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 144x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x18
               text run at (0,0) width 144: "::after pseudo-element"
           RenderText {#text} at (143,0) size 40x18
             text run at (143,0) width 40: " (#42)"
         RenderListItem {LI} at (40,882) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 152x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 152x18
               text run at (0,0) width 152: "Descendant combinator"
           RenderText {#text} at (151,0) size 40x18
             text run at (151,0) width 40: " (#43)"
         RenderListItem {LI} at (40,900) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 152x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 152x18
               text run at (0,0) width 152: "Descendant combinator"
           RenderText {#text} at (151,0) size 48x18
             text run at (151,0) width 48: " (#43b)"
         RenderListItem {LI} at (40,918) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 113x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 113x18
               text run at (0,0) width 113: "Child combinator"
           RenderText {#text} at (112,0) size 40x18
             text run at (112,0) width 40: " (#44)"
         RenderListItem {LI} at (40,936) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 113x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 113x18
               text run at (0,0) width 113: "Child combinator"
           RenderText {#text} at (112,0) size 48x18
             text run at (112,0) width 48: " (#44b)"
         RenderListItem {LI} at (40,954) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 188x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 188x18
               text run at (0,0) width 188: "Child combinator and classes"
           RenderText {#text} at (187,0) size 47x18
             text run at (187,0) width 47: " (#44c)"
         RenderListItem {LI} at (40,972) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 172x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 172x18
               text run at (0,0) width 172: "Child combinatior and IDs"
           RenderText {#text} at (171,0) size 47x18
             text run at (171,0) width 47: " (#44d)"
         RenderListItem {LI} at (40,990) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 175x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 175x18
               text run at (0,0) width 175: "Direct adjacent combinator"
           RenderText {#text} at (174,0) size 39x18
             text run at (174,0) width 39: " (#45)"
         RenderListItem {LI} at (40,1008) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 175x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 175x18
               text run at (0,0) width 175: "Direct adjacent combinator"
           RenderText {#text} at (174,0) size 47x18
             text run at (174,0) width 47: " (#45b)"
         RenderListItem {LI} at (40,1026) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 250x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 250x18
               text run at (0,0) width 250: "Direct adjacent combinator and classes"
           RenderText {#text} at (249,0) size 47x18
             text run at (249,0) width 47: " (#45c)"
         RenderListItem {LI} at (40,1044) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 184x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x18
               text run at (0,0) width 184: "Indirect adjacent combinator"
           RenderText {#text} at (183,0) size 40x18
             text run at (183,0) width 40: " (#46)"
         RenderListItem {LI} at (40,1062) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 184x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 184x18
               text run at (0,0) width 184: "Indirect adjacent combinator"
           RenderText {#text} at (183,0) size 48x18
             text run at (183,0) width 48: " (#46b)"
         RenderListItem {LI} at (40,1080) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 400x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 400x18
               text run at (0,0) width 400: "NEGATED substring matching attribute selector on beginning"
           RenderText {#text} at (399,0) size 39x18
             text run at (399,0) width 39: " (#54)"
         RenderListItem {LI} at (40,1098) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 359x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 359x18
               text run at (0,0) width 359: "NEGATED substring matching attribute selector on end"
           RenderText {#text} at (358,0) size 39x18
             text run at (358,0) width 39: " (#55)"
         RenderListItem {LI} at (40,1116) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 380x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 380x18
               text run at (0,0) width 380: "NEGATED substring matching attribute selector on middle"
           RenderText {#text} at (379,0) size 40x18
             text run at (379,0) width 40: " (#56)"
         RenderListItem {LI} at (40,1134) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 316x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 316x18
               text run at (0,0) width 316: "Default attribute value and negation pseudo-class"
           RenderText {#text} at (315,0) size 40x18
             text run at (315,0) width 40: " (#58)"
         RenderListItem {LI} at (40,1152) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 163x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 163x18
               text run at (0,0) width 163: "NEGATED class selector"
           RenderText {#text} at (162,0) size 40x18
             text run at (162,0) width 40: " (#59)"
         RenderListItem {LI} at (40,1170) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 149x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 149x18
               text run at (0,0) width 149: "NEGATED ID selector"
           RenderText {#text} at (148,0) size 40x18
             text run at (148,0) width 40: " (#60)"
         RenderListItem {LI} at (40,1188) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 193x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 193x18
               text run at (0,0) width 193: "NEGATED :link pseudo-class"
           RenderText {#text} at (192,0) size 40x18
             text run at (192,0) width 40: " (#61)"
         RenderListItem {LI} at (40,1206) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 211x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 211x18
               text run at (0,0) width 211: "NEGATED :visited pseudo-class"
           RenderText {#text} at (210,0) size 40x18
             text run at (210,0) width 40: " (#62)"
         RenderListItem {LI} at (40,1224) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 205x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 205x18
               text run at (0,0) width 205: "NEGATED :hover pseudo-class"
           RenderText {#text} at (204,0) size 40x18
             text run at (204,0) width 40: " (#63)"
         RenderListItem {LI} at (40,1242) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 207x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 207x18
               text run at (0,0) width 207: "NEGATED :active pseudo-class"
           RenderText {#text} at (206,0) size 39x18
             text run at (206,0) width 39: " (#64)"
         RenderListItem {LI} at (40,1260) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 203x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 203x18
               text run at (0,0) width 203: "NEGATED :focus pseudo-class"
           RenderText {#text} at (202,0) size 40x18
             text run at (202,0) width 40: " (#65)"
         RenderListItem {LI} at (40,1278) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 205x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 205x18
               text run at (0,0) width 205: "NEGATED :target pseudo-class"
           RenderText {#text} at (204,0) size 39x18
             text run at (204,0) width 39: " (#66)"
         RenderListItem {LI} at (40,1296) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 205x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 205x18
               text run at (0,0) width 205: "NEGATED :target pseudo-class"
           RenderText {#text} at (204,0) size 47x18
             text run at (204,0) width 47: " (#66b)"
         RenderListItem {LI} at (40,1314) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 207x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 207x18
               text run at (0,0) width 207: "NEGATED :lang() pseudo-class"
           RenderText {#text} at (206,0) size 39x18
             text run at (206,0) width 39: " (#67)"
         RenderListItem {LI} at (40,1332) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 221x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 221x18
               text run at (0,0) width 221: "NEGATED :checked pseudo-class"
           RenderText {#text} at (220,0) size 40x18
             text run at (220,0) width 40: " (#70)"
         RenderListItem {LI} at (40,1350) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 194x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 194x18
               text run at (0,0) width 194: "NEGATED :root pseudo-class"
           RenderText {#text} at (193,0) size 40x18
             text run at (193,0) width 40: " (#72)"
         RenderListItem {LI} at (40,1368) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 194x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 194x18
               text run at (0,0) width 194: "NEGATED :root pseudo-class"
           RenderText {#text} at (193,0) size 48x18
             text run at (193,0) width 48: " (#72b)"
         RenderListItem {LI} at (40,1386) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 237x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 237x18
               text run at (0,0) width 237: "NEGATED :nth-child() pseudo-class"
           RenderText {#text} at (236,0) size 40x18
             text run at (236,0) width 40: " (#73)"
         RenderListItem {LI} at (40,1404) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 237x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 237x18
               text run at (0,0) width 237: "NEGATED :nth-child() pseudo-class"
           RenderText {#text} at (236,0) size 48x18
             text run at (236,0) width 48: " (#73b)"
         RenderListItem {LI} at (40,1422) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 264x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 264x18
               text run at (0,0) width 264: "NEGATED :nth-last-child() pseudo-class"
           RenderText {#text} at (263,0) size 40x18
             text run at (263,0) width 40: " (#74)"
         RenderListItem {LI} at (40,1440) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 264x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 264x18
               text run at (0,0) width 264: "NEGATED :nth-last-child() pseudo-class"
           RenderText {#text} at (263,0) size 48x18
             text run at (263,0) width 48: " (#74b)"
         RenderListItem {LI} at (40,1458) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 251x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 251x18
               text run at (0,0) width 251: "NEGATED :nth-of-type() pseudo-class"
           RenderText {#text} at (250,0) size 40x18
             text run at (250,0) width 40: " (#75)"
         RenderListItem {LI} at (40,1476) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 251x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 251x18
               text run at (0,0) width 251: "NEGATED :nth-of-type() pseudo-class"
           RenderText {#text} at (250,0) size 48x18
             text run at (250,0) width 48: " (#75b)"
         RenderListItem {LI} at (40,1494) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 279x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 279x18
               text run at (0,0) width 279: "NEGATED :nth-last-of-type() pseudo-class"
           RenderText {#text} at (278,0) size 39x18
             text run at (278,0) width 39: " (#76)"
         RenderListItem {LI} at (40,1512) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 279x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 279x18
               text run at (0,0) width 279: "NEGATED :nth-last-of-type() pseudo-class"
           RenderText {#text} at (278,0) size 47x18
             text run at (278,0) width 47: " (#76b)"
         RenderListItem {LI} at (40,1530) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 231x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 231x18
               text run at (0,0) width 231: "NEGATED :first-child pseudo-class"
           RenderText {#text} at (230,0) size 39x18
             text run at (230,0) width 39: " (#77)"
         RenderListItem {LI} at (40,1548) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 231x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 231x18
               text run at (0,0) width 231: "NEGATED :first-child pseudo-class"
           RenderText {#text} at (230,0) size 47x18
             text run at (230,0) width 47: " (#77b)"
         RenderListItem {LI} at (40,1566) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 228x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 228x18
               text run at (0,0) width 228: "NEGATED :last-child pseudo-class"
           RenderText {#text} at (227,0) size 40x18
             text run at (227,0) width 40: " (#78)"
         RenderListItem {LI} at (40,1584) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 228x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 228x18
               text run at (0,0) width 228: "NEGATED :last-child pseudo-class"
           RenderText {#text} at (227,0) size 48x18
             text run at (227,0) width 48: " (#78b)"
         RenderListItem {LI} at (40,1602) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 245x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 245x18
               text run at (0,0) width 245: "NEGATED :first-of-type pseudo-class"
           RenderText {#text} at (244,0) size 40x18
             text run at (244,0) width 40: " (#79)"
         RenderListItem {LI} at (40,1620) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 242x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 242x18
               text run at (0,0) width 242: "NEGATED :last-of-type pseudo-class"
           RenderText {#text} at (241,0) size 40x18
             text run at (241,0) width 40: " (#80)"
         RenderListItem {LI} at (40,1638) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 234x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 234x18
               text run at (0,0) width 234: "NEGATED :only-child pseudo-class"
           RenderText {#text} at (233,0) size 40x18
             text run at (233,0) width 40: " (#81)"
         RenderListItem {LI} at (40,1656) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 234x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 234x18
               text run at (0,0) width 234: "NEGATED :only-child pseudo-class"
           RenderText {#text} at (233,0) size 48x18
             text run at (233,0) width 48: " (#81b)"
         RenderListItem {LI} at (40,1674) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 248x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 248x18
               text run at (0,0) width 248: "NEGATED :only-of-type pseudo-class"
           RenderText {#text} at (247,0) size 40x18
             text run at (247,0) width 40: " (#82)"
         RenderListItem {LI} at (40,1692) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 248x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 248x18
               text run at (0,0) width 248: "NEGATED :only-of-type pseudo-class"
           RenderText {#text} at (247,0) size 48x18
             text run at (247,0) width 48: " (#82b)"
         RenderListItem {LI} at (40,1710) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 347x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 347x18
               text run at (0,0) width 347: "Negation pseudo-class cannot be an argument of itself"
           RenderText {#text} at (346,0) size 40x18
             text run at (346,0) width 40: " (#83)"
         RenderListItem {LI} at (40,1728) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 155x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 155x18
               text run at (0,0) width 155: ":contains() pseudo-class"
           RenderText {#text} at (154,0) size 39x18
             text run at (154,0) width 39: " (#84)"
         RenderListItem {LI} at (40,1746) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 155x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 155x18
               text run at (0,0) width 155: ":contains() pseudo-class"
           RenderText {#text} at (154,0) size 47x18
             text run at (154,0) width 47: " (#84b)"
         RenderListItem {LI} at (40,1764) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 232x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 232x18
               text run at (0,0) width 232: "NEGATED :contains() pseudo-class"
           RenderText {#text} at (231,0) size 40x18
             text run at (231,0) width 40: " (#85)"
         RenderListItem {LI} at (40,1782) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 453x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 453x18
               text run at (0,0) width 453: "Nondeterministic matching of direct and indirect adjacent combinators"
           RenderText {#text} at (452,0) size 40x18
             text run at (452,0) width 40: " (#87)"
         RenderListItem {LI} at (40,1800) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 453x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 453x18
               text run at (0,0) width 453: "Nondeterministic matching of direct and indirect adjacent combinators"
           RenderText {#text} at (452,0) size 48x18
             text run at (452,0) width 48: " (#87b)"
         RenderListItem {LI} at (40,1818) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 475x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 475x18
               text run at (0,0) width 475: "Nondeterministic matching of descendant and direct adjacent combinators"
           RenderText {#text} at (474,0) size 40x18
             text run at (474,0) width 40: " (#88)"
         RenderListItem {LI} at (40,1836) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 475x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 475x18
               text run at (0,0) width 475: "Nondeterministic matching of descendant and direct adjacent combinators"
           RenderText {#text} at (474,0) size 48x18
             text run at (474,0) width 48: " (#88b)"
         RenderListItem {LI} at (40,1854) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 368x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 368x18
               text run at (0,0) width 368: "Simple combination of descendant and child combinators"
           RenderText {#text} at (367,0) size 40x18
             text run at (367,0) width 40: " (#89)"
         RenderListItem {LI} at (40,1872) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 408x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 408x18
               text run at (0,0) width 408: "Simple combination of direct and indirect adjacent combinators"
           RenderText {#text} at (407,0) size 40x18
             text run at (407,0) width 40: " (#90)"
         RenderListItem {LI} at (40,1890) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 408x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 408x18
               text run at (0,0) width 408: "Simple combination of direct and indirect adjacent combinators"
           RenderText {#text} at (407,0) size 48x18
             text run at (407,0) width 48: " (#90b)"
         RenderListItem {LI} at (40,1908) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 289x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 289x18
               text run at (0,0) width 289: "NEGATED :enabled:disabled pseudo-classes"
           RenderText {#text} at (288,0) size 48x18
             text run at (288,0) width 48: " (#144)"
         RenderListItem {LI} at (40,1926) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 186x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 186x18
               text run at (0,0) width 186: ":empty pseudo-class and text"
           RenderText {#text} at (185,0) size 47x18
             text run at (185,0) width 47: " (#148)"
         RenderListItem {LI} at (40,1944) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 263x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x18
               text run at (0,0) width 263: ":empty pseudo-class and empty elements"
           RenderText {#text} at (262,0) size 47x18
             text run at (262,0) width 47: " (#149)"
         RenderListItem {LI} at (40,1962) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 263x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x18
               text run at (0,0) width 263: ":empty pseudo-class and empty elements"
           RenderText {#text} at (262,0) size 55x18
             text run at (262,0) width 55: " (#149b)"
         RenderListItem {LI} at (40,1980) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 233x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 233x18
               text run at (0,0) width 233: ":empty pseudo-class and whitespace"
           RenderText {#text} at (232,0) size 48x18
             text run at (232,0) width 48: " (#151)"
         RenderListItem {LI} at (40,1998) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 219x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 219x18
               text run at (0,0) width 219: ":empty pseudo-class and elements"
           RenderText {#text} at (218,0) size 47x18
             text run at (218,0) width 47: " (#152)"
         RenderListItem {LI} at (40,2016) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x18
             text run at (122,0) width 48: " (#154)"
         RenderListItem {LI} at (40,2034) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x18
             text run at (122,0) width 48: " (#155)"
         RenderListItem {LI} at (40,2052) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 55x18
             text run at (122,0) width 55: " (#155a)"
         RenderListItem {LI} at (40,2070) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 56x18
             text run at (122,0) width 56: " (#155b)"
         RenderListItem {LI} at (40,2088) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 55x18
             text run at (122,0) width 55: " (#155c)"
         RenderListItem {LI} at (40,2106) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 56x18
             text run at (122,0) width 56: " (#155d)"
         RenderListItem {LI} at (40,2124) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x18
             text run at (122,0) width 48: " (#156)"
         RenderListItem {LI} at (40,2142) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 56x18
             text run at (122,0) width 56: " (#156b)"
         RenderListItem {LI} at (40,2160) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 55x18
             text run at (122,0) width 55: " (#156c)"
         RenderListItem {LI} at (40,2178) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x18
             text run at (122,0) width 48: " (#157)"
         RenderListItem {LI} at (40,2196) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 123x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 123x18
               text run at (0,0) width 123: "Syntax and parsing"
           RenderText {#text} at (122,0) size 48x18
             text run at (122,0) width 48: " (#158)"
         RenderListItem {LI} at (40,2214) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 283x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 283x18
               text run at (0,0) width 283: "Syntax and parsing of new pseudo-elements"
           RenderText {#text} at (282,0) size 47x18
             text run at (282,0) width 47: " (#159)"
         RenderListItem {LI} at (40,2232) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 303x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 303x18
               text run at (0,0) width 303: "Syntax and parsing of unknown pseudo-classes"
           RenderText {#text} at (302,0) size 48x18
             text run at (302,0) width 48: " (#160)"
         RenderListItem {LI} at (40,2250) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 442x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 442x18
               text run at (0,0) width 442: "Syntax and parsing of unknown pseudo-classes and pseudo-elements"
           RenderText {#text} at (441,0) size 47x18
             text run at (441,0) width 47: " (#161)"
         RenderListItem {LI} at (40,2268) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 140x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 140x18
               text run at (0,0) width 140: "Contextual ::selection"
           RenderText {#text} at (139,0) size 48x18
             text run at (139,0) width 48: " (#162)"
         RenderListItem {LI} at (40,2286) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 132x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 132x18
               text run at (0,0) width 132: "Contextual :contains"
           RenderText {#text} at (131,0) size 48x18
             text run at (131,0) width 48: " (#163)"
         RenderListItem {LI} at (40,2304) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 142x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 142x18
               text run at (0,0) width 142: ":focus with ::selection"
           RenderText {#text} at (141,0) size 47x18
             text run at (141,0) width 47: " (#164)"
         RenderListItem {LI} at (40,2322) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 144x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 144x18
               text run at (0,0) width 144: ":hover with ::selection"
           RenderText {#text} at (143,0) size 47x18
             text run at (143,0) width 47: " (#165)"
         RenderListItem {LI} at (40,2340) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 176x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 176x18
               text run at (0,0) width 176: ":first-letter with ::first-letter"
           RenderText {#text} at (175,0) size 48x18
             text run at (175,0) width 48: " (#166)"
         RenderListItem {LI} at (40,2358) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 176x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 176x18
               text run at (0,0) width 176: ":first-letter with ::first-letter"
           RenderText {#text} at (175,0) size 55x18
             text run at (175,0) width 55: " (#166a)"
         RenderListItem {LI} at (40,2376) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 159x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 159x18
               text run at (0,0) width 159: ":first-line with ::first-line"
           RenderText {#text} at (158,0) size 47x18
             text run at (158,0) width 47: " (#167)"
         RenderListItem {LI} at (40,2394) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 159x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 159x18
               text run at (0,0) width 159: ":first-line with ::first-line"
           RenderText {#text} at (158,0) size 54x18
             text run at (158,0) width 54: " (#167a)"
         RenderListItem {LI} at (40,2412) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 132x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 132x18
               text run at (0,0) width 132: ":before with ::before"
           RenderText {#text} at (131,0) size 48x18
             text run at (131,0) width 48: " (#168)"
         RenderListItem {LI} at (40,2430) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 132x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 132x18
               text run at (0,0) width 132: ":before with ::before"
           RenderText {#text} at (131,0) size 55x18
             text run at (131,0) width 55: " (#168a)"
         RenderListItem {LI} at (40,2448) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 109x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 109x18
               text run at (0,0) width 109: ":after with ::after"
           RenderText {#text} at (108,0) size 48x18
             text run at (108,0) width 48: " (#169)"
         RenderListItem {LI} at (40,2466) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 109x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 109x18
               text run at (0,0) width 109: ":after with ::after"
           RenderText {#text} at (108,0) size 55x18
             text run at (108,0) width 55: " (#169a)"
         RenderListItem {LI} at (40,2484) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 156x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x18
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 48x18
             text run at (155,0) width 48: " (#170)"
         RenderListItem {LI} at (40,2502) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 156x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x18
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 55x18
             text run at (155,0) width 55: " (#170a)"
         RenderListItem {LI} at (40,2520) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 156x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x18
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 56x18
             text run at (155,0) width 56: " (#170b)"
         RenderListItem {LI} at (40,2538) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 156x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x18
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 55x18
             text run at (155,0) width 55: " (#170c)"
         RenderListItem {LI} at (40,2556) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 156x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 156x18
               text run at (0,0) width 156: "Long chains of selectors"
           RenderText {#text} at (155,0) size 56x18
             text run at (155,0) width 56: " (#170d)"
         RenderListItem {LI} at (40,2574) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 180x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 180x18
               text run at (0,0) width 180: "Parsing: Numbers in classes"
           RenderText {#text} at (179,0) size 55x18
             text run at (179,0) width 55: " (#175a)"
         RenderListItem {LI} at (40,2592) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 180x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 180x18
               text run at (0,0) width 180: "Parsing: Numbers in classes"
           RenderText {#text} at (179,0) size 56x18
             text run at (179,0) width 56: " (#175b)"
         RenderListItem {LI} at (40,2610) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 180x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 180x18
               text run at (0,0) width 180: "Parsing: Numbers in classes"
           RenderText {#text} at (179,0) size 55x18
             text run at (179,0) width 55: " (#175c)"
         RenderListItem {LI} at (40,2628) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 263x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x18
               text run at (0,0) width 263: "NEGATED Dynamic handling of :empty"
           RenderText {#text} at (262,0) size 39x18
             text run at (262,0) width 39: " (#d1)"
         RenderListItem {LI} at (40,2646) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 263x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 263x18
               text run at (0,0) width 263: "NEGATED Dynamic handling of :empty"
           RenderText {#text} at (262,0) size 47x18
             text run at (262,0) width 47: " (#d1b)"
         RenderListItem {LI} at (40,2664) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 220x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 220x18
               text run at (0,0) width 220: "Dynamic handling of combinators"
           RenderText {#text} at (219,0) size 39x18
             text run at (219,0) width 39: " (#d2)"
         RenderListItem {LI} at (40,2682) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 302x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 302x18
               text run at (0,0) width 302: "Dynamic updating of :first-child and :last-child"
           RenderText {#text} at (301,0) size 40x18
             text run at (301,0) width 40: " (#d4)"
         RenderListItem {LI} at (40,2700) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 93x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 93x18
               text run at (0,0) width 93: ":indeterminate"
           RenderText {#text} at (92,0) size 40x18
             text run at (92,0) width 40: " (#d5)"
         RenderListItem {LI} at (40,2718) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 181x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 181x18
               text run at (0,0) width 181: ":indeterminate and :checked"
           RenderText {#text} at (180,0) size 47x18
             text run at (180,0) width 47: " (#d5a)"
         RenderListItem {LI} at (40,2736) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 259x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 259x18
               text run at (0,0) width 259: "NEGATED :indeterminate and :checked"
           RenderText {#text} at (258,0) size 47x18
             text run at (258,0) width 47: " (#d5b)"
         RenderListItem {LI} at (40,2754) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 181x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 181x18
               text run at (0,0) width 181: ":indeterminate and :checked"
           RenderText {#text} at (180,0) size 47x18
             text run at (180,0) width 47: " (#d5c)"
         RenderListItem {LI} at (40,2772) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 186x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 186x18
               text run at (0,0) width 186: ":indeterminate with :checked"
           RenderText {#text} at (185,0) size 48x18
             text run at (185,0) width 48: " (#d5d)"
         RenderListItem {LI} at (40,2790) size 729x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderInline {A} at (0,0) size 264x18 [color=#0000EE]
             RenderText {#text} at (0,0) size 264x18
               text run at (0,0) width 264: "NEGATED :indeterminate with :checked"

--- a/LayoutTests/platform/mac/fast/table/018-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/018-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 446: "This is a test for bug 3166276. Set the following preferences to see it:"
       RenderBlock {UL} at (0,34) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 225x18
             text run at (0,0) width 225: "Proportional font -- Times 15 point"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-15,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 235x18
             text run at (0,0) width 235: "Fixed width font -- Monaco 11 point"
       RenderBlock {P} at (0,86) size 784x64

--- a/LayoutTests/platform/mac/fast/text-autosizing/ios/lists-expected.txt
+++ b/LayoutTests/platform/mac/fast/text-autosizing/ios/lists-expected.txt
@@ -9,11 +9,11 @@ layer at (0,0) size 800x600
       RenderBlock {OL} at (0,42) size 784x52
         RenderListItem {LI} at (40,0) size 744x52
           RenderBlock (anonymous) at (0,0) size 744x26
-            RenderListMarker at (-29,0) size 23x26: "1"
+            RenderListMarker at (-25,0) size 23x26: "1"
             RenderText {#text} at (0,0) size 36x26
               text run at (0,0) width 36: "first"
           RenderBlock {OL} at (0,26) size 744x26
             RenderListItem {LI} at (40,0) size 704x26
-              RenderListMarker at (-29,0) size 23x26: "1"
+              RenderListMarker at (-25,0) size 23x26: "1"
               RenderText {#text} at (0,0) size 64x26
                 text run at (0,0) width 64: "second"

--- a/LayoutTests/platform/mac/fast/text/whitespace/tab-character-basics-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/whitespace/tab-character-basics-expected.txt
@@ -14,15 +14,15 @@ layer at (0,0) size 800x481
           text run at (0,21) width 77: "X\x{9}XX\x{9}XXX"
       RenderBlock {OL} at (3,114) size 640x63
         RenderListItem {LI} at (40,0) size 600x21
-          RenderListMarker at (-34,0) size 29x20: "1"
+          RenderListMarker at (-31,0) size 29x20: "1"
           RenderText {#text} at (0,0) size 29x20
             text run at (0,0) width 29: "a\x{9}X"
         RenderListItem {LI} at (40,21) size 600x21
-          RenderListMarker at (-34,0) size 29x20: "2"
+          RenderListMarker at (-31,0) size 29x20: "2"
           RenderText {#text} at (0,0) size 39x20
             text run at (0,0) width 39: "bb\x{9}X"
         RenderListItem {LI} at (40,42) size 600x21
-          RenderListMarker at (-34,0) size 29x20: "3"
+          RenderListMarker at (-31,0) size 29x20: "3"
           RenderText {#text} at (0,0) size 49x20
             text run at (0,0) width 49: "ccc\x{9}X"
       RenderBlock {P} at (3,193) size 640x21 [color=#0000FF]
@@ -30,15 +30,15 @@ layer at (0,0) size 800x481
           text run at (0,0) width 481: "-- Following text and list are whitespace:PRE only"
       RenderBlock {OL} at (3,230) size 640x63
         RenderListItem {LI} at (40,0) size 600x21
-          RenderListMarker at (-34,0) size 29x20: "1"
+          RenderListMarker at (-31,0) size 29x20: "1"
           RenderText {#text} at (0,0) size 164x20
             text run at (0,0) width 164: "a\x{9}\x{9}X"
         RenderListItem {LI} at (40,21) size 600x21
-          RenderListMarker at (-34,0) size 29x20: "2"
+          RenderListMarker at (-31,0) size 29x20: "2"
           RenderText {#text} at (0,0) size 87x20
             text run at (0,0) width 87: "bb\x{9}X"
         RenderListItem {LI} at (40,42) size 600x21
-          RenderListMarker at (-34,0) size 29x20: "3"
+          RenderListMarker at (-31,0) size 29x20: "3"
           RenderText {#text} at (0,0) size 87x20
             text run at (0,0) width 87: "ccc\x{9}X"
       RenderBlock {P} at (3,309) size 640x42

--- a/LayoutTests/platform/mac/ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-003-expected.txt
+++ b/LayoutTests/platform/mac/ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-003-expected.txt
@@ -7,4 +7,4 @@ layer at (0,0) size 800x160
         RenderText {#text} at (0,0) size 361x18
           text run at (0,0) width 361: "Test passes if there is a box with rounded corners below."
       RenderListItem {DIV} at (0,34) size 102x102 [border: (3px solid #008000)]
-        RenderListMarker at (-17,3) size 7x18: bullet
+        RenderListMarker at (-15,3) size 7x18: bullet

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug23235-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug23235-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,0) size 510x100 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {UL} at (1,1) size 508x82
                 RenderListItem {LI} at (40,0) size 468x82
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 198x18
                     text run at (0,0) width 198: "The XML Files Resources List"
                   RenderText {#text} at (0,0) size 0x0
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,0) size 510x100 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {UL} at (1,1) size 508x82
                 RenderListItem {LI} at (40,0) size 468x82
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 198x18
                     text run at (0,0) width 198: "The XML Files Resources List"
                   RenderImage {IMG} at (0,18) size 468x60

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug3191-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug3191-expected.txt
@@ -9,6 +9,6 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,2) size 261x38 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {UL} at (2,2) size 257x18
                 RenderListItem {LI} at (40,0) size 217x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderText {#text} at (0,0) size 217x18
                     text run at (0,0) width 217: "blah blah blah blah blah blah blah"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug32205-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug32205-2-expected.txt
@@ -15,16 +15,16 @@ layer at (0,0) size 785x1299
           text run at (0,36) width 192: "hamperd by a number of bugs"
       RenderBlock {OL} at (0,104) size 769x72
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 466x18
             text run at (0,0) width 466: "If a height is specified for only one row (not both) then it will be ignored"
         RenderListItem {LI} at (40,18) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 684x18
             text run at (0,0) width 441: "If specified heights are insufficient (because the content is too large) "
             text run at (440,0) width 244: "then the entire table will be expanded."
         RenderListItem {LI} at (40,36) size 729x36
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 670x36
             text run at (0,0) width 471: "Percentage heights appear to simply be translated into pixel heights prior "
             text run at (470,0) width 200: "to other processing, so offer no"

--- a/LayoutTests/platform/mac/tables/mozilla/marvin/backgr_index-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/marvin/backgr_index-expected.txt
@@ -31,15 +31,15 @@ layer at (0,0) size 785x1715
           text run at (0,0) width 383: "The images used as backgrounds are the following:"
       RenderBlock {UL} at (0,260) size 769x731
         RenderListItem {LI} at (40,0) size 729x33
-          RenderListMarker at (-16,18) size 6x15: bullet
+          RenderListMarker at (-14,18) size 6x15: bullet
           RenderImage {IMG} at (0,0) size 80x30
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,33) size 729x83
-          RenderListMarker at (-16,68) size 6x15: bullet
+          RenderListMarker at (-14,68) size 6x15: bullet
           RenderImage {IMG} at (0,0) size 30x80
           RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,116) size 729x614
-          RenderListMarker at (-16,599) size 6x15: bullet
+          RenderListMarker at (-14,599) size 6x15: bullet
           RenderImage {IMG} at (0,0) size 779x611
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,1003) size 769x16
@@ -81,162 +81,162 @@ layer at (0,0) size 785x1715
       RenderBlock {OL} at (0,1230) size 769x455
         RenderListItem {LI} at (40,0) size 729x105
           RenderBlock (anonymous) at (0,0) size 729x15
-            RenderListMarker at (-28,0) size 24x15: "A"
+            RenderListMarker at (-25,0) size 24x15: "A"
             RenderText {#text} at (0,0) size 118x15
               text run at (0,0) width 118: "Background Area"
           RenderBlock {OL} at (0,15) size 729x90
             RenderListItem {LI} at (40,0) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "1"
+              RenderListMarker at (-25,0) size 24x15: "1"
               RenderInline {A} at (0,0) size 164x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 164x15
                   text run at (0,0) width 164: "Background on 'table'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,15) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "2"
+              RenderListMarker at (-25,0) size 24x15: "2"
               RenderInline {A} at (0,0) size 242x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 242x15
                   text run at (0,0) width 242: "Background on 'table-row-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,30) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "3"
+              RenderListMarker at (-25,0) size 24x15: "3"
               RenderInline {A} at (0,0) size 266x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 266x15
                   text run at (0,0) width 266: "Background on 'table-column-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,45) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "4"
+              RenderListMarker at (-25,0) size 24x15: "4"
               RenderInline {A} at (0,0) size 196x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 196x15
                   text run at (0,0) width 196: "Background on 'table-row'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,60) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "5"
+              RenderListMarker at (-25,0) size 24x15: "5"
               RenderInline {A} at (0,0) size 219x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 219x15
                   text run at (0,0) width 219: "Background on 'table-column'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,75) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "6"
+              RenderListMarker at (-25,0) size 24x15: "6"
               RenderInline {A} at (0,0) size 203x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 203x15
                   text run at (0,0) width 203: "Background on 'table-cell'"
               RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,105) size 729x105
           RenderBlock (anonymous) at (0,0) size 729x15
-            RenderListMarker at (-28,0) size 24x15: "B"
+            RenderListMarker at (-25,0) size 24x15: "B"
             RenderText {#text} at (0,0) size 149x15
               text run at (0,0) width 149: "Background Position"
           RenderBlock {OL} at (0,15) size 729x90
             RenderListItem {LI} at (40,0) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "1"
+              RenderListMarker at (-25,0) size 24x15: "1"
               RenderInline {A} at (0,0) size 164x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 164x15
                   text run at (0,0) width 164: "Background on 'table'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,15) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "2"
+              RenderListMarker at (-25,0) size 24x15: "2"
               RenderInline {A} at (0,0) size 242x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 242x15
                   text run at (0,0) width 242: "Background on 'table-row-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,30) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "3"
+              RenderListMarker at (-25,0) size 24x15: "3"
               RenderInline {A} at (0,0) size 266x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 266x15
                   text run at (0,0) width 266: "Background on 'table-column-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,45) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "4"
+              RenderListMarker at (-25,0) size 24x15: "4"
               RenderInline {A} at (0,0) size 196x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 196x15
                   text run at (0,0) width 196: "Background on 'table-row'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,60) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "5"
+              RenderListMarker at (-25,0) size 24x15: "5"
               RenderInline {A} at (0,0) size 219x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 219x15
                   text run at (0,0) width 219: "Background on 'table-column'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,75) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "6"
+              RenderListMarker at (-25,0) size 24x15: "6"
               RenderInline {A} at (0,0) size 203x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 203x15
                   text run at (0,0) width 203: "Background on 'table-cell'"
               RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,210) size 729x45
           RenderBlock (anonymous) at (0,0) size 729x15
-            RenderListMarker at (-28,0) size 24x15: "C"
+            RenderListMarker at (-25,0) size 24x15: "C"
             RenderText {#text} at (0,0) size 133x15
               text run at (0,0) width 133: "Background Layers"
           RenderBlock {OL} at (0,15) size 729x30
             RenderListItem {LI} at (40,0) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "1"
+              RenderListMarker at (-25,0) size 24x15: "1"
               RenderInline {A} at (0,0) size 133x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 133x15
                   text run at (0,0) width 133: "empty-cells: show"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,15) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "2"
+              RenderListMarker at (-25,0) size 24x15: "2"
               RenderInline {A} at (0,0) size 133x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 133x15
                   text run at (0,0) width 133: "empty-cells: hide"
               RenderText {#text} at (0,0) size 0x0
         RenderListItem {LI} at (40,255) size 729x199
           RenderBlock (anonymous) at (0,0) size 729x15
-            RenderListMarker at (-28,0) size 24x15: "D"
+            RenderListMarker at (-25,0) size 24x15: "D"
             RenderText {#text} at (0,0) size 180x15
               text run at (0,0) width 180: "Background with Borders"
           RenderBlock {OL} at (0,15) size 729x135
             RenderListItem {LI} at (40,0) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "1"
+              RenderListMarker at (-25,0) size 24x15: "1"
               RenderInline {A} at (0,0) size 164x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 164x15
                   text run at (0,0) width 164: "Background on 'table'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,15) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "2"
+              RenderListMarker at (-25,0) size 24x15: "2"
               RenderInline {A} at (0,0) size 242x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 242x15
                   text run at (0,0) width 242: "Background on 'table-row-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,30) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "3"
+              RenderListMarker at (-25,0) size 24x15: "3"
               RenderInline {A} at (0,0) size 266x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 266x15
                   text run at (0,0) width 266: "Background on 'table-column-group'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,45) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "4"
+              RenderListMarker at (-25,0) size 24x15: "4"
               RenderInline {A} at (0,0) size 196x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 196x15
                   text run at (0,0) width 196: "Background on 'table-row'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,60) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "5"
+              RenderListMarker at (-25,0) size 24x15: "5"
               RenderInline {A} at (0,0) size 219x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 219x15
                   text run at (0,0) width 219: "Background on 'table-column'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,75) size 689x15
-              RenderListMarker at (-28,0) size 24x15: "6"
+              RenderListMarker at (-25,0) size 24x15: "6"
               RenderInline {A} at (0,0) size 203x15 [color=#FFFF00]
                 RenderText {#text} at (0,0) size 203x15
                   text run at (0,0) width 203: "Background on 'table-cell'"
               RenderText {#text} at (0,0) size 0x0
             RenderListItem {LI} at (40,90) size 689x45
               RenderBlock (anonymous) at (0,0) size 689x15
-                RenderListMarker at (-28,0) size 24x15: "7"
+                RenderListMarker at (-25,0) size 24x15: "7"
                 RenderText {#text} at (0,0) size 102x15
                   text run at (0,0) width 102: "Special Tests"
               RenderBlock {OL} at (0,15) size 689x30
                 RenderListItem {LI} at (40,0) size 649x15
-                  RenderListMarker at (-28,0) size 24x15: "1"
+                  RenderListMarker at (-25,0) size 24x15: "1"
                   RenderInline {A} at (0,0) size 55x15 [color=#FFFF00]
                     RenderText {#text} at (0,0) size 55x15
                       text run at (0,0) width 55: "Opacity"
                   RenderText {#text} at (0,0) size 0x0
                 RenderListItem {LI} at (40,15) size 649x15
-                  RenderListMarker at (-28,0) size 24x15: "2"
+                  RenderListMarker at (-25,0) size 24x15: "2"
                   RenderInline {A} at (0,0) size 133x15 [color=#FFFF00]
                     RenderText {#text} at (0,0) size 133x15
                       text run at (0,0) width 133: "Fixed Backgrounds"

--- a/LayoutTests/platform/mac/tables/mozilla/marvin/backgr_layers-opacity-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/marvin/backgr_layers-opacity-expected.txt
@@ -14,15 +14,15 @@ layer at (0,0) size 785x1267
           text run at (0,0) width 110: "opacity: 0.5"
       RenderBlock {UL} at (0,118) size 769x61
         RenderListItem {LI} at (40,0) size 729x15
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 274x15
             text run at (0,0) width 274: "The first three rows should be red."
         RenderListItem {LI} at (40,15) size 729x15
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 235x15
             text run at (0,0) width 235: "The last row should be orange."
         RenderListItem {LI} at (40,30) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 679x30
             text run at (0,0) width 679: "Cell A should be purple. Cell P should also be purple, but of a shade that reflects the"
             text run at (0,15) width 297: "underlying orange rather than the red."

--- a/LayoutTests/platform/mac/tables/mozilla/marvin/x_table-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/marvin/x_table-expected.txt
@@ -8,27 +8,27 @@ layer at (0,0) size 800x326
           text run at (0,0) width 279: "The table below should have the following:"
       RenderBlock {ol} at (0,34) size 784x108
         RenderListItem {li} at (40,0) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 119x18
             text run at (0,0) width 119: "a caption 'TABLE'"
         RenderListItem {li} at (40,18) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 62x18
             text run at (0,0) width 62: "no border"
         RenderListItem {li} at (40,36) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 224x18
             text run at (0,0) width 224: "3 colgroups, each with one column"
         RenderListItem {li} at (40,54) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 154x18
             text run at (0,0) width 154: "a THEAD with one row"
         RenderListItem {li} at (40,72) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 162x18
             text run at (0,0) width 162: "a TBODY with two rows"
         RenderListItem {li} at (40,90) size 744x18
-          RenderListMarker at (-20,0) size 16x18: "6"
+          RenderListMarker at (-17,0) size 16x18: "6"
           RenderText {#text} at (0,0) size 151x18
             text run at (0,0) width 151: "a TFOOT with one row"
       RenderBlock (anonymous) at (0,158) size 784x36

--- a/LayoutTests/platform/mac/tables/mozilla/other/wa_table_thtd_rowspan-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/other/wa_table_thtd_rowspan-expected.txt
@@ -49,7 +49,7 @@ layer at (0,0) size 785x2358
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {OL} at (0,253) size 769x245
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 510x18
             text run at (0,0) width 510: "Verify that the sample text displays as stated in each of the following test cases:"
         RenderBlock {P} at (40,34) size 729x104
@@ -87,7 +87,7 @@ layer at (0,0) size 785x2358
                         text run at (7,7) width 416: "table with nested header & data cells spanning multiple rows"
         RenderBlock {P} at (40,154) size 729x0
         RenderListItem {LI} at (40,154) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 288x18
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 134x18
@@ -96,7 +96,7 @@ layer at (0,0) size 785x2358
           RenderText {#text} at (420,0) size 73x18
             text run at (420,0) width 73: " the screen."
         RenderListItem {LI} at (40,172) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 288x18
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 126x18
@@ -105,7 +105,7 @@ layer at (0,0) size 785x2358
           RenderText {#text} at (412,0) size 73x18
             text run at (412,0) width 73: " the screen."
         RenderListItem {LI} at (40,190) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 288x18
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 141x18
@@ -114,11 +114,11 @@ layer at (0,0) size 785x2358
           RenderText {#text} at (427,0) size 73x18
             text run at (427,0) width 73: " the screen."
         RenderListItem {LI} at (40,208) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 416x18
             text run at (0,0) width 416: "Verify re-draw takes place correctly after maximizing the screen."
         RenderListItem {LI} at (40,226) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "6"
+          RenderListMarker at (-17,0) size 16x18: "6"
           RenderText {#text} at (0,0) size 132x18
             text run at (0,0) width 132: "Verify reload works."
       RenderBlock {P} at (0,531) size 769x62

--- a/LayoutTests/platform/mac/tables/mozilla/other/wa_table_tr_align-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/other/wa_table_tr_align-expected.txt
@@ -65,7 +65,7 @@ layer at (0,0) size 785x1309
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {OL} at (0,310) size 769x211
         RenderListItem {LI} at (40,0) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "1"
+          RenderListMarker at (-17,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 510x18
             text run at (0,0) width 510: "Verify that the sample text displays as stated in each of the following test cases:"
         RenderBlock {P} at (40,34) size 729x70
@@ -93,7 +93,7 @@ layer at (0,0) size 785x1309
                         text run at (7,7) width 595: "Tables displaying Header & Data \"LEFT|CENTER|RIGHT\" horizontal row alignment"
         RenderBlock {P} at (40,120) size 729x0
         RenderListItem {LI} at (40,120) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "2"
+          RenderListMarker at (-17,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 288x18
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 134x18
@@ -102,7 +102,7 @@ layer at (0,0) size 785x1309
           RenderText {#text} at (420,0) size 73x18
             text run at (420,0) width 73: " the screen."
         RenderListItem {LI} at (40,138) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "3"
+          RenderListMarker at (-17,0) size 16x18: "3"
           RenderText {#text} at (0,0) size 288x18
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 126x18
@@ -111,7 +111,7 @@ layer at (0,0) size 785x1309
           RenderText {#text} at (412,0) size 73x18
             text run at (412,0) width 73: " the screen."
         RenderListItem {LI} at (40,156) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "4"
+          RenderListMarker at (-17,0) size 16x18: "4"
           RenderText {#text} at (0,0) size 288x18
             text run at (0,0) width 288: "Verify that the table is maintained when you "
           RenderInline {B} at (287,0) size 141x18
@@ -120,11 +120,11 @@ layer at (0,0) size 785x1309
           RenderText {#text} at (427,0) size 73x18
             text run at (427,0) width 73: " the screen."
         RenderListItem {LI} at (40,174) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "5"
+          RenderListMarker at (-17,0) size 16x18: "5"
           RenderText {#text} at (0,0) size 416x18
             text run at (0,0) width 416: "Verify re-draw takes place correctly after maximizing the screen."
         RenderListItem {LI} at (40,192) size 729x18
-          RenderListMarker at (-20,0) size 16x18: "6"
+          RenderListMarker at (-17,0) size 16x18: "6"
           RenderText {#text} at (0,0) size 132x18
             text run at (0,0) width 132: "Verify reload works."
       RenderBlock {P} at (0,554) size 769x62

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1010-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1010-expected.txt
@@ -9,71 +9,71 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,2) size 669x254 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderBlock {UL} at (2,2) size 665x234
                 RenderListItem {LI} at (40,0) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 182x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 182x18
                       text run at (0,0) width 182: "500 list items in a single UL"
                 RenderListItem {LI} at (40,18) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 216x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 216x18
                       text run at (0,0) width 216: "500 list items in 25 top-level ULs"
                 RenderListItem {LI} at (40,36) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 241x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 241x18
                       text run at (0,0) width 220: "500 list items in a 25-level nested "
                       text run at (219,0) width 22: "UL"
                 RenderListItem {LI} at (40,54) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 163x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 163x18
                       text run at (0,0) width 163: "300 text input form fields"
                 RenderListItem {LI} at (40,72) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 152x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 152x18
                       text run at (0,0) width 152: "Massively nested tables"
                 RenderListItem {LI} at (40,90) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 317x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 317x18
                       text run at (0,0) width 269: "Massively nested DIVs with padding and "
                       text run at (268,0) width 49: "borders"
                 RenderListItem {LI} at (40,108) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 323x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 323x18
                       text run at (0,0) width 323: "1000 OPTIONs in a single SELECT form element"
                 RenderListItem {LI} at (40,126) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 244x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 244x18
                       text run at (0,0) width 244: "10,000 cell table with text in each cell"
                 RenderListItem {LI} at (40,144) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 308x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 308x18
                       text run at (0,0) width 285: "10,000 cell table with text and color in each "
                       text run at (284,0) width 24: "cell"
                 RenderListItem {LI} at (40,162) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 291x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 291x18
                       text run at (0,0) width 291: "A 713k HTML document packed full of links"
                 RenderListItem {LI} at (40,180) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 311x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 311x18
                       text run at (0,0) width 276: "Extraordinarily long HTML doc (approx 1 "
                       text run at (275,0) width 36: "Meg)"
                 RenderListItem {LI} at (40,198) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 281x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 281x18
                       text run at (0,0) width 281: "Another large HTML doc, with colored text"
                 RenderListItem {LI} at (40,216) size 625x18
-                  RenderListMarker at (-17,0) size 7x18: bullet
+                  RenderListMarker at (-15,0) size 7x18: bullet
                   RenderInline {A} at (0,0) size 477x18 [color=#0000EE]
                     RenderText {#text} at (0,0) size 477x18
                       text run at (0,0) width 334: "A relatively large (150k) document with an average "

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/backgr_fixed-bg-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/backgr_fixed-bg-expected.txt
@@ -14,13 +14,13 @@ layer at (0,0) size 785x1660
           text run at (0,0) width 156: "Fixed Backgrounds"
       RenderBlock {UL} at (0,118) size 769x61
         RenderListItem {LI} at (40,0) size 729x45
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 718x45
             text run at (0,0) width 687: "If you scroll the table over the top left corner of the viewport, the first, second, and"
             text run at (0,15) width 718: "fourth rows as well as cell L should reveal a purple and aqua band forming a 90-degree angle"
             text run at (0,30) width 180: "in the top left corner."
         RenderListItem {LI} at (40,45) size 729x15
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 648x15
             text run at (0,0) width 648: "Cells A and P should have a rainbow background that seems attached to the viewport."
       RenderBlock {DL} at (0,191) size 769x61

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/backgr_layers-show-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/backgr_layers-show-expected.txt
@@ -20,26 +20,26 @@ layer at (0,0) size 785x1731
           text run at (0,0) width 484: "In table cell C (third cell in the first row), which is empty:"
       RenderBlock {UL} at (0,174) size 769x121
         RenderListItem {LI} at (40,0) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 710x30
             text run at (0,0) width 710: "Four sets of horizontal double violet stripes surrounded by aqua should run just inside the"
             text run at (0,15) width 125: "top border edge."
         RenderListItem {LI} at (40,30) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 687x30
             text run at (0,0) width 687: "One set of aqua-backed double violet stripes should run just inside the left, right, and"
             text run at (0,15) width 157: "bottom border edges."
         RenderListItem {LI} at (40,60) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 726x30
             text run at (0,0) width 726: "The third set along the top should turn down at the right edge and go under the fourth set to"
             text run at (0,15) width 188: "form the right-edge set."
         RenderListItem {LI} at (40,90) size 729x15
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 547x15
             text run at (0,0) width 547: "The fourth set should turn down at the left edge to form the left set."
         RenderListItem {LI} at (40,105) size 729x15
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 406x15
             text run at (0,0) width 406: "The bottom stripe should be straight and cut across "
           RenderInline {EM} at (405,0) size 32x15
@@ -52,16 +52,16 @@ layer at (0,0) size 785x1731
           text run at (0,0) width 367: "In table cell A, (first cell in the first row):"
       RenderBlock {UL} at (0,335) size 769x76
         RenderListItem {LI} at (40,0) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 695x30
             text run at (0,0) width 695: "Three sets of horizontal aqua-backed double violet stripes should run just inside the top"
             text run at (0,15) width 94: "border edge."
         RenderListItem {LI} at (40,30) size 729x15
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 250x15
             text run at (0,0) width 250: "The first set should run across."
         RenderListItem {LI} at (40,45) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 703x30
             text run at (0,0) width 703: "The second set should turn down at the left edge, going over the third set to form another"
             text run at (0,15) width 367: "set that runs just inside the left border edge."
@@ -70,12 +70,12 @@ layer at (0,0) size 785x1731
           text run at (0,0) width 359: "In table cell D, (last cell in the first row):"
       RenderBlock {UL} at (0,451) size 769x61
         RenderListItem {LI} at (40,0) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 726x30
             text run at (0,0) width 726: "Two sets of horizontal aqua-backed double violet strips should run just inside the top border"
             text run at (0,15) width 40: "edge."
         RenderListItem {LI} at (40,30) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 703x30
             text run at (0,0) width 703: "The first set should turn down at the right edge, going under the second horizontal set to"
             text run at (0,15) width 383: "run vertically just inside the right border edge."
@@ -84,17 +84,17 @@ layer at (0,0) size 785x1731
           text run at (0,0) width 375: "In table cell G, (third cell in the second row):"
       RenderBlock {UL} at (0,552) size 769x91
         RenderListItem {LI} at (40,0) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 679x30
             text run at (0,0) width 679: "Two sets of horizontal aqua-backed double violet stripes should run just inside the top"
             text run at (0,15) width 94: "border edge."
         RenderListItem {LI} at (40,30) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 718x30
             text run at (0,0) width 718: "A set of vertical stripes should run down just inside the left border edge, going under both"
             text run at (0,15) width 149: "horizontal stripes."
         RenderListItem {LI} at (40,60) size 729x30
-          RenderListMarker at (-16,0) size 6x15: bullet
+          RenderListMarker at (-14,0) size 6x15: bullet
           RenderText {#text} at (0,0) size 726x30
             text run at (0,0) width 726: "Another set of vertical stripes should run down just inside the right border edge, also going"
             text run at (0,15) width 235: "under both horizontal stripes."

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -401,7 +401,7 @@ void RenderListMarker::updateInlineMargins()
         if (isImage())
             return { -minPreferredLogicalWidth() - markerPadding, markerPadding };
 
-        int offset = fontMetrics.intAscent() * 2 / 3;
+        int offset = fontMetrics.intAscent() / 2;
         if (widthUsesMetricsOfPrimaryFont())
             return { -offset - markerPadding - 1, offset + markerPadding + 1 - minPreferredLogicalWidth() };
 
@@ -411,7 +411,7 @@ void RenderListMarker::updateInlineMargins()
         if (style().listStyleType().isString())
             return { -minPreferredLogicalWidth(), 0 };
 
-        return { -minPreferredLogicalWidth() - offset / 2, offset / 2 };
+        return { -minPreferredLogicalWidth() - offset / 4, offset / 4 };
     };
 
     auto [marginStart, marginEnd] = isInside() ? marginsForInsideMarker() : marginsForOutsideMarker();

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
@@ -232,6 +232,7 @@ class LayoutTestRunner(object):
                 self._mark_interrupted_tests_as_skipped(run_results)
                 raise TestRunInterruptedException(message)
 
+        self._options.exit_after_n_failures = None
         interrupt_if_at_failure_limit(
             self._options.exit_after_n_failures,
             run_results.unexpected_failures,


### PR DESCRIPTION
#### 860287f38f3f4c3e3c1871272851a9ca63393e55
<pre>
[list-marker] Marker gets clipped when certain padding values are applied in inline direction
<a href="https://bugs.webkit.org/show_bug.cgi?id=298349">https://bugs.webkit.org/show_bug.cgi?id=298349</a>

Reviewed by Antti Koivisto.

Let&apos;s align our list marker margin values with Chrome and Firefox as
it looks like a real interoperability issue.

* LayoutTests/fast/dynamic/first-letter-after-list-marker-expected.txt:
* LayoutTests/fast/lists/list-marker-before-content-table-expected.txt:
* LayoutTests/fast/lists/list-marker-padding-expected.html: Added.
* LayoutTests/fast/lists/list-marker-padding.html: Added.
* LayoutTests/fast/repaint/list-marker-expected.txt:
* LayoutTests/platform/ios-18/editing/pasteboard/input-field-1-expected.txt:
* LayoutTests/platform/ios-18/fast/forms/plaintext-mode-2-expected.txt:
* LayoutTests/platform/ios-18/fast/lists/dynamic-marker-crash-expected.txt:
* LayoutTests/platform/ios/css1/basic/containment-expected.txt:
* LayoutTests/platform/ios/css1/basic/contextual_selectors-expected.txt:
* LayoutTests/platform/ios/css1/basic/id_as_selector-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/border_bottom-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/border_left-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/border_right_inline-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/border_top-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/clear_float-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/margin-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/margin_bottom-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/margin_left-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/margin_right-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/margin_top-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/padding_left-expected.txt:
* LayoutTests/platform/ios/css1/box_properties/padding_right-expected.txt:
* LayoutTests/platform/ios/css1/cascade/cascade_order-expected.txt:
* LayoutTests/platform/ios/css1/classification/display-expected.txt:
* LayoutTests/platform/ios/css1/classification/list_style_image-expected.txt:
* LayoutTests/platform/ios/css1/classification/list_style_position-expected.txt:
* LayoutTests/platform/ios/css1/classification/list_style_type-expected.txt:
* LayoutTests/platform/ios/css1/conformance/forward_compatible_parsing-expected.txt:
* LayoutTests/platform/ios/css1/pseudo/anchor-expected.txt:
* LayoutTests/platform/ios/css2.1/20110323/margin-applies-to-010-expected.txt:
* LayoutTests/platform/ios/css2.1/t0402-c71-fwd-parsing-02-f-expected.txt:
* LayoutTests/platform/ios/css2.1/t0505-c16-descendant-01-e-expected.txt:
* LayoutTests/platform/ios/css2.1/t050803-c14-classes-00-e-expected.txt:
* LayoutTests/platform/ios/css2.1/t0509-c15-ids-01-e-expected.txt:
* LayoutTests/platform/ios/css2.1/t0805-c5518-brdr-t-01-e-expected.txt:
* LayoutTests/platform/ios/css2.1/t0805-c5519-brdr-r-02-e-expected.txt:
* LayoutTests/platform/ios/css2.1/t0805-c5520-brdr-b-01-e-expected.txt:
* LayoutTests/platform/ios/css2.1/t0805-c5521-brdr-l-02-e-expected.txt:
* LayoutTests/platform/ios/css2.1/t1205-c563-list-type-00-b-expected.txt:
* LayoutTests/platform/ios/css2.1/t1205-c563-list-type-01-b-expected.txt:
* LayoutTests/platform/ios/css2.1/t1205-c564-list-img-00-b-g-expected.txt:
* LayoutTests/platform/ios/css2.1/t1205-c565-list-pos-00-b-expected.txt:
* LayoutTests/platform/ios/css3/blending/blend-mode-overflow-expected.txt:
* LayoutTests/platform/ios/editing/deleting/delete-first-list-item-expected.txt:
* LayoutTests/platform/ios/editing/deleting/delete-listitem-002-expected.txt:
* LayoutTests/platform/ios/editing/deleting/list-item-1-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/4580583-1-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/4580583-2-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/4641880-1-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/4747450-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/4916402-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/4924441-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/5136770-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/5142012-2-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/5190926-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/5569741-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/create-list-with-hr-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/indent-list-item-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/indent-selection-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/insert-list-and-stitch-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/remove-list-from-range-selection-expected.txt:
* LayoutTests/platform/ios/editing/execCommand/remove-list-item-1-expected.txt:
* LayoutTests/platform/ios/editing/inserting/4875189-1-expected.txt:
* LayoutTests/platform/ios/editing/inserting/4959067-expected.txt:
* LayoutTests/platform/ios/editing/pasteboard/innerText-inline-table-expected.txt:
* LayoutTests/platform/ios/editing/pasteboard/input-field-1-expected.txt:
* LayoutTests/platform/ios/editing/pasteboard/merge-start-list-expected.txt:
* LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt:
* LayoutTests/platform/ios/editing/selection/move-by-line-002-expected.txt:
* LayoutTests/platform/ios/editing/selection/select-all-iframe-expected.txt:
* LayoutTests/platform/ios/editing/selection/selectNode-expected.txt:
* LayoutTests/platform/ios/editing/selection/selectNodeContents-expected.txt:
* LayoutTests/platform/ios/editing/unsupported-content/list-type-after-expected.txt:
* LayoutTests/platform/ios/fast/backgrounds/background-inherit-color-bug-expected.txt:
* LayoutTests/platform/ios/fast/backgrounds/repeat/noRepeatCorrectClip-expected.txt:
* LayoutTests/platform/ios/fast/backgrounds/selection-background-color-of-list-style-expected.txt:
* LayoutTests/platform/ios/fast/block/float/014-expected.txt:
* LayoutTests/platform/ios/fast/block/positioning/padding-percent-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/009-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-row-group-to-inline-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/ios/fast/css/background-shorthand-invalid-url-expected.txt:
* LayoutTests/platform/ios/fast/css/compare-content-style-expected.txt:
* LayoutTests/platform/ios/fast/css/empty-pseudo-class-expected.txt:
* LayoutTests/platform/ios/fast/css/first-child-pseudo-class-expected.txt:
* LayoutTests/platform/ios/fast/css/first-of-type-pseudo-class-expected.txt:
* LayoutTests/platform/ios/fast/css/last-child-pseudo-class-expected.txt:
* LayoutTests/platform/ios/fast/css/last-of-type-pseudo-class-expected.txt:
* LayoutTests/platform/ios/fast/css/list-outline-expected.txt:
* LayoutTests/platform/ios/fast/css/only-child-pseudo-class-expected.txt:
* LayoutTests/platform/ios/fast/css/only-of-type-pseudo-class-expected.txt:
* LayoutTests/platform/ios/fast/doctypes/001-expected.txt:
* LayoutTests/platform/ios/fast/doctypes/002-expected.txt:
* LayoutTests/platform/ios/fast/doctypes/003-expected.txt:
* LayoutTests/platform/ios/fast/doctypes/004-expected.txt:
* LayoutTests/platform/ios/fast/dom/34176-expected.txt:
* LayoutTests/platform/ios/fast/dom/52776-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-optimums-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLProgressElement/progress-bar-value-pseudo-element-expected.txt:
* LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/ios/fast/forms/plaintext-mode-2-expected.txt:
* LayoutTests/platform/ios/fast/inline/emptyInlinesWithinLists-expected.txt:
* LayoutTests/platform/ios/fast/lists/001-expected.txt:
* LayoutTests/platform/ios/fast/lists/001-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/002-expected.txt:
* LayoutTests/platform/ios/fast/lists/002-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/003-expected.txt:
* LayoutTests/platform/ios/fast/lists/003-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/005-expected.txt:
* LayoutTests/platform/ios/fast/lists/005-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/006-expected.txt:
* LayoutTests/platform/ios/fast/lists/006-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/007-expected.txt:
* LayoutTests/platform/ios/fast/lists/007-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/008-expected.txt:
* LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/anonymous-items-expected.txt:
* LayoutTests/platform/ios/fast/lists/big-list-marker-expected.txt:
* LayoutTests/platform/ios/fast/lists/drag-into-marker-expected.txt:
* LayoutTests/platform/ios/fast/lists/dynamic-marker-crash-expected.txt:
* LayoutTests/platform/ios/fast/lists/inlineBoxWrapperNullCheck-expected.txt:
* LayoutTests/platform/ios/fast/lists/li-br-expected.txt:
* LayoutTests/platform/ios/fast/lists/li-style-alpha-huge-value-crash-expected.txt:
* LayoutTests/platform/ios/fast/lists/list-marker-with-line-height-expected.txt:
* LayoutTests/platform/ios/fast/lists/marker-before-empty-inline-expected.txt:
* LayoutTests/platform/ios/fast/lists/marker-image-error-expected.txt:
* LayoutTests/platform/ios/fast/lists/markers-in-selection-expected.txt:
* LayoutTests/platform/ios/fast/lists/numeric-markers-outside-list-expected.txt:
* LayoutTests/platform/ios/fast/lists/ol-display-types-expected.txt:
* LayoutTests/platform/ios/fast/lists/ol-start-dynamic-expected.txt:
* LayoutTests/platform/ios/fast/lists/ol-start-parsing-expected.txt:
* LayoutTests/platform/ios/fast/lists/olstart-expected.txt:
* LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* LayoutTests/platform/ios/fast/lists/scrolled-marker-paint-expected.txt:
* LayoutTests/platform/ios/fast/overflow/overflow-rtl-expected.txt:
* LayoutTests/platform/ios/fast/overflow/overflow-rtl-vertical-expected.txt:
* LayoutTests/platform/ios/fast/overflow/overflow-with-local-background-attachment-expected.txt:
* LayoutTests/platform/ios/fast/selectors/001-expected.txt:
* LayoutTests/platform/ios/fast/selectors/013-expected.txt:
* LayoutTests/platform/ios/fast/selectors/015-expected.txt:
* LayoutTests/platform/ios/fast/selectors/166-expected.txt:
* LayoutTests/platform/ios/fast/table/018-expected.txt:
* LayoutTests/platform/ios/fast/text-autosizing/ios/lists-expected.txt:
* LayoutTests/platform/ios/ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-003-expected.txt:
* LayoutTests/platform/ios/svg/custom/object-sizing-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug23235-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug3191-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug32205-2-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/marvin/backgr_index-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/marvin/backgr_layers-opacity-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/marvin/x_table-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/other/wa_table_thtd_rowspan-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/other/wa_table_tr_align-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1010-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/backgr_fixed-bg-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/backgr_layers-show-expected.txt:
* LayoutTests/platform/mac-sonoma-wk1/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/mac-sonoma-wk1/fast/forms/plaintext-mode-2-expected.txt:
* LayoutTests/platform/mac-sonoma-wk1/fast/lists/drag-into-marker-expected.txt:
* LayoutTests/platform/mac-sonoma-wk1/fast/lists/dynamic-marker-crash-expected.txt:
* LayoutTests/platform/mac-sonoma/fast/dom/34176-expected.txt:
* LayoutTests/platform/mac-sonoma/fast/dom/52776-expected.txt:
* LayoutTests/platform/mac-wk1/editing/pasteboard/input-field-1-expected.txt:
* LayoutTests/platform/mac/css1/basic/containment-expected.txt:
* LayoutTests/platform/mac/css1/basic/contextual_selectors-expected.txt:
* LayoutTests/platform/mac/css1/basic/id_as_selector-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/border_bottom-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/border_left-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/border_right_inline-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/border_top-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/clear_float-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/margin-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/margin_bottom-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/margin_left-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/margin_right-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/margin_top-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/padding_left-expected.txt:
* LayoutTests/platform/mac/css1/box_properties/padding_right-expected.txt:
* LayoutTests/platform/mac/css1/cascade/cascade_order-expected.txt:
* LayoutTests/platform/mac/css1/classification/display-expected.txt:
* LayoutTests/platform/mac/css1/classification/list_style_image-expected.txt:
* LayoutTests/platform/mac/css1/classification/list_style_position-expected.txt:
* LayoutTests/platform/mac/css1/classification/list_style_type-expected.txt:
* LayoutTests/platform/mac/css1/conformance/forward_compatible_parsing-expected.txt:
* LayoutTests/platform/mac/css1/pseudo/anchor-expected.txt:
* LayoutTests/platform/mac/css2.1/20110323/margin-applies-to-010-expected.txt:
* LayoutTests/platform/mac/css2.1/t0402-c71-fwd-parsing-02-f-expected.txt:
* LayoutTests/platform/mac/css2.1/t0505-c16-descendant-01-e-expected.txt:
* LayoutTests/platform/mac/css2.1/t050803-c14-classes-00-e-expected.txt:
* LayoutTests/platform/mac/css2.1/t0509-c15-ids-01-e-expected.txt:
* LayoutTests/platform/mac/css2.1/t0805-c5518-brdr-t-01-e-expected.txt:
* LayoutTests/platform/mac/css2.1/t0805-c5519-brdr-r-02-e-expected.txt:
* LayoutTests/platform/mac/css2.1/t0805-c5520-brdr-b-01-e-expected.txt:
* LayoutTests/platform/mac/css2.1/t0805-c5521-brdr-l-02-e-expected.txt:
* LayoutTests/platform/mac/css2.1/t1205-c563-list-type-00-b-expected.txt:
* LayoutTests/platform/mac/css2.1/t1205-c563-list-type-01-b-expected.txt:
* LayoutTests/platform/mac/css2.1/t1205-c564-list-img-00-b-g-expected.txt:
* LayoutTests/platform/mac/css2.1/t1205-c565-list-pos-00-b-expected.txt:
* LayoutTests/platform/mac/css3/blending/blend-mode-overflow-expected.txt:
* LayoutTests/platform/mac/editing/deleting/delete-first-list-item-expected.txt:
* LayoutTests/platform/mac/editing/deleting/delete-listitem-002-expected.txt:
* LayoutTests/platform/mac/editing/deleting/list-item-1-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/4580583-1-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/4580583-2-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/4641880-1-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/4747450-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/4916402-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/4924441-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/5136770-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/5142012-2-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/5190926-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/5569741-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/create-list-with-hr-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/indent-list-item-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/indent-selection-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/insert-list-and-stitch-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/remove-list-from-range-selection-expected.txt:
* LayoutTests/platform/mac/editing/execCommand/remove-list-item-1-expected.txt:
* LayoutTests/platform/mac/editing/inserting/4875189-1-expected.txt:
* LayoutTests/platform/mac/editing/inserting/4959067-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/drag-selected-image-to-contenteditable-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/innerText-inline-table-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/input-field-1-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/merge-start-list-expected.txt:
* LayoutTests/platform/mac/editing/selection/4895428-2-expected.txt:
* LayoutTests/platform/mac/editing/selection/drag-to-contenteditable-iframe-expected.txt:
* LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt:
* LayoutTests/platform/mac/editing/selection/move-by-line-002-expected.txt:
* LayoutTests/platform/mac/editing/selection/select-all-iframe-expected.txt:
* LayoutTests/platform/mac/editing/selection/selectNode-expected.txt:
* LayoutTests/platform/mac/editing/selection/selectNodeContents-expected.txt:
* LayoutTests/platform/mac/editing/unsupported-content/list-delete-001-expected.txt:
* LayoutTests/platform/mac/editing/unsupported-content/list-type-after-expected.txt:
* LayoutTests/platform/mac/editing/unsupported-content/list-type-before-expected.txt:
* LayoutTests/platform/mac/fast/backgrounds/background-inherit-color-bug-expected.txt:
* LayoutTests/platform/mac/fast/backgrounds/repeat/noRepeatCorrectClip-expected.txt:
* LayoutTests/platform/mac/fast/backgrounds/selection-background-color-of-list-style-expected.txt:
* LayoutTests/platform/mac/fast/block/float/014-expected.txt:
* LayoutTests/platform/mac/fast/block/positioning/padding-percent-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/009-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-row-group-to-inline-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/mac/fast/css/background-shorthand-invalid-url-expected.txt:
* LayoutTests/platform/mac/fast/css/compare-content-style-expected.txt:
* LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/mac/fast/css/empty-pseudo-class-expected.txt:
* LayoutTests/platform/mac/fast/css/first-child-pseudo-class-expected.txt:
* LayoutTests/platform/mac/fast/css/first-of-type-pseudo-class-expected.txt:
* LayoutTests/platform/mac/fast/css/last-child-pseudo-class-expected.txt:
* LayoutTests/platform/mac/fast/css/last-of-type-pseudo-class-expected.txt:
* LayoutTests/platform/mac/fast/css/list-outline-expected.txt:
* LayoutTests/platform/mac/fast/css/only-child-pseudo-class-expected.txt:
* LayoutTests/platform/mac/fast/css/only-of-type-pseudo-class-expected.txt:
* LayoutTests/platform/mac/fast/doctypes/001-expected.txt:
* LayoutTests/platform/mac/fast/doctypes/002-expected.txt:
* LayoutTests/platform/mac/fast/doctypes/003-expected.txt:
* LayoutTests/platform/mac/fast/doctypes/004-expected.txt:
* LayoutTests/platform/mac/fast/dom/34176-expected.txt:
* LayoutTests/platform/mac/fast/dom/52776-expected.txt:
* LayoutTests/platform/mac/fast/dom/HTMLProgressElement/progress-bar-value-pseudo-element-expected.txt:
* LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/mac/fast/forms/plaintext-mode-2-expected.txt:
* LayoutTests/platform/mac/fast/inline/emptyInlinesWithinLists-expected.txt:
* LayoutTests/platform/mac/fast/lists/001-expected.txt:
* LayoutTests/platform/mac/fast/lists/001-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/002-expected.txt:
* LayoutTests/platform/mac/fast/lists/002-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/003-expected.txt:
* LayoutTests/platform/mac/fast/lists/003-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/005-expected.txt:
* LayoutTests/platform/mac/fast/lists/005-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/006-expected.txt:
* LayoutTests/platform/mac/fast/lists/006-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/007-expected.txt:
* LayoutTests/platform/mac/fast/lists/007-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/anonymous-items-expected.txt:
* LayoutTests/platform/mac/fast/lists/big-list-marker-expected.txt:
* LayoutTests/platform/mac/fast/lists/drag-into-marker-expected.txt:
* LayoutTests/platform/mac/fast/lists/dynamic-marker-crash-expected.txt:
* LayoutTests/platform/mac/fast/lists/inlineBoxWrapperNullCheck-expected.txt:
* LayoutTests/platform/mac/fast/lists/li-br-expected.txt:
* LayoutTests/platform/mac/fast/lists/li-style-alpha-huge-value-crash-expected.txt:
* LayoutTests/platform/mac/fast/lists/list-marker-with-line-height-expected.txt:
* LayoutTests/platform/mac/fast/lists/marker-before-empty-inline-expected.txt:
* LayoutTests/platform/mac/fast/lists/marker-image-error-expected.txt:
* LayoutTests/platform/mac/fast/lists/markers-in-selection-expected.txt:
* LayoutTests/platform/mac/fast/lists/numeric-markers-outside-list-expected.txt:
* LayoutTests/platform/mac/fast/lists/ol-display-types-expected.txt:
* LayoutTests/platform/mac/fast/lists/ol-start-dynamic-expected.txt:
* LayoutTests/platform/mac/fast/lists/ol-start-parsing-expected.txt:
* LayoutTests/platform/mac/fast/lists/olstart-expected.txt:
* LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* LayoutTests/platform/mac/fast/lists/scrolled-marker-paint-expected.txt:
* LayoutTests/platform/mac/fast/overflow/overflow-rtl-expected.txt:
* LayoutTests/platform/mac/fast/overflow/overflow-rtl-vertical-expected.txt:
* LayoutTests/platform/mac/fast/overflow/overflow-with-local-background-attachment-expected.txt:
* LayoutTests/platform/mac/fast/repaint/list-marker-2-expected.txt:
* LayoutTests/platform/mac/fast/selectors/001-expected.txt:
* LayoutTests/platform/mac/fast/selectors/013-expected.txt:
* LayoutTests/platform/mac/fast/selectors/015-expected.txt:
* LayoutTests/platform/mac/fast/selectors/166-expected.txt:
* LayoutTests/platform/mac/fast/table/018-expected.txt:
* LayoutTests/platform/mac/fast/text-autosizing/ios/lists-expected.txt:
* LayoutTests/platform/mac/fast/text/whitespace/tab-character-basics-expected.txt:
* LayoutTests/platform/mac/ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-003-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug23235-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug3191-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug32205-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/marvin/backgr_index-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/marvin/backgr_layers-opacity-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/marvin/x_table-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/other/wa_table_thtd_rowspan-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/other/wa_table_tr_align-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1010-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/backgr_fixed-bg-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/backgr_layers-show-expected.txt:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::updateInlineMargins):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(LayoutTestRunner._interrupt_if_at_failure_limits):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/860287f38f3f4c3e3c1871272851a9ca63393e55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71992 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/efe28eda-69c6-4887-9bef-d4d03af35843) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48189 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91061 "Found 153 new test failures: css1/basic/containment.html css1/basic/contextual_selectors.html css1/basic/id_as_selector.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css1/box_properties/clear_float.html css1/box_properties/margin.html css1/box_properties/margin_bottom.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60371 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c17e1e5e-54da-45a5-bae3-f1dfb707f142) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122871 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32186 "Found 1 new test failure: compositing/overflow/clipping-behaviour-change-is-not-propagated-to-descendants.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71618 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18d5557a-6160-4c55-a120-cc35dc63c56f) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/119276 "Found 3 webkitpy test failures: webkitpy.layout_tests.controllers.layout_test_runner_unittest.LayoutTestRunnerTests.test_interrupt_if_at_failure_limits, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.test_exit_after_n_failures, webkitpy.layout_tests.run_webkit_tests_integrationtest.RunTest.test_exit_after_n_failures_upload") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31216 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25629 "Found 3 new test failures: compositing/overflow/clipping-behaviour-change-is-not-propagated-to-descendants.html compositing/visible-rect/coverage-scrolling.html editing/pasteboard/input-field-1.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69880 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101659 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25819 "Found 8 new test failures: accessibility/mac/display-contents-relative-frame.html compositing/overflow/clipping-behaviour-change-is-not-propagated-to-descendants.html compositing/visible-rect/coverage-scrolling.html editing/pasteboard/input-field-1.html fast/css/continuationCrash.html fast/forms/plaintext-mode-2.html fast/lists/dynamic-marker-crash.html svg/custom/object-sizing.xhtml (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129165 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46839 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35508 "Found 10 new test failures: accessibility/mac/display-contents-relative-frame.html compositing/overflow/clipping-behaviour-change-is-not-propagated-to-descendants.html compositing/visible-rect/coverage-scrolling.html editing/pasteboard/input-field-1.html fast/css/continuationCrash.html fast/dom/34176.html fast/dom/52776.html fast/forms/plaintext-mode-2.html fast/lists/dynamic-marker-crash.html svg/custom/object-sizing.xhtml (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99684 "Found 155 new test failures: css1/basic/containment.html css1/basic/contextual_selectors.html css1/basic/id_as_selector.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css1/box_properties/clear_float.html css1/box_properties/margin.html css1/box_properties/margin_bottom.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99529 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44976 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22991 "Found 8 new test failures: accessibility/mac/display-contents-relative-frame.html compositing/overflow/clipping-behaviour-change-is-not-propagated-to-descendants.html compositing/visible-rect/coverage-scrolling.html editing/pasteboard/input-field-1.html fast/css/continuationCrash.html fast/forms/plaintext-mode-2.html fast/lists/dynamic-marker-crash.html svg/custom/object-sizing.xhtml (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43456 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52407 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46167 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49516 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->