### PR TITLE
Silence Safer CPP warnings in WTFString.cpp

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,5 +2,4 @@ wtf/JSONValues.cpp
 wtf/ParallelHelperPool.cpp
 wtf/WorkerPool.cpp
 wtf/text/AtomStringImpl.cpp
-wtf/text/WTFString.cpp
 wtf/text/cf/StringCF.cpp

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -71,7 +71,7 @@ char32_t String::characterStartingAt(unsigned i) const
 {
     if (!m_impl || i >= m_impl->length())
         return 0;
-    return m_impl->characterStartingAt(i);
+    SUPPRESS_UNCOUNTED_ARG return m_impl->characterStartingAt(i);
 }
 
 String makeStringByJoining(std::span<const String> strings, const String& separator)
@@ -108,67 +108,67 @@ String String::substringSharingImpl(unsigned offset, unsigned length) const
 
     if (!offset && length == stringLength)
         return *this;
-    return StringImpl::createSubstringSharingImpl(*m_impl, offset, length);
+    SUPPRESS_UNCOUNTED_ARG return StringImpl::createSubstringSharingImpl(*m_impl, offset, length);
 }
 
 String String::convertToASCIILowercase() const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->convertToASCIILowercase() : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToASCIILowercase() : String { };
 }
 
 String String::convertToASCIIUppercase() const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->convertToASCIIUppercase() : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToASCIIUppercase() : String { };
 }
 
 String String::convertToLowercaseWithoutLocale() const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->convertToLowercaseWithoutLocale() : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToLowercaseWithoutLocale() : String { };
 }
 
 String String::convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned failingIndex) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : String { };
 }
 
 String String::convertToUppercaseWithoutLocale() const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->convertToUppercaseWithoutLocale() : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToUppercaseWithoutLocale() : String { };
 }
 
 String String::convertToLowercaseWithLocale(const AtomString& localeIdentifier) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->convertToLowercaseWithLocale(localeIdentifier) : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToLowercaseWithLocale(localeIdentifier) : String { };
 }
 
 String String::convertToUppercaseWithLocale(const AtomString& localeIdentifier) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->convertToUppercaseWithLocale(localeIdentifier) : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->convertToUppercaseWithLocale(localeIdentifier) : String { };
 }
 
 String String::trim(CodeUnitMatchFunction predicate) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->trim(predicate) : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->trim(predicate) : String { };
 }
 
 String String::simplifyWhiteSpace(CodeUnitMatchFunction isWhiteSpace) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->simplifyWhiteSpace(isWhiteSpace) : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->simplifyWhiteSpace(isWhiteSpace) : String { };
 }
 
 String String::foldCase() const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->foldCase() : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->foldCase() : String { };
 }
 
 Expected<Vector<char16_t>, UTF8ConversionError> String::charactersWithoutNullTermination() const
@@ -263,7 +263,7 @@ double String::toDouble(bool* ok) const
             *ok = false;
         return 0.0;
     }
-    return m_impl->toDouble(ok);
+    SUPPRESS_UNCOUNTED_ARG return m_impl->toDouble(ok);
 }
 
 float String::toFloat(bool* ok) const
@@ -273,13 +273,13 @@ float String::toFloat(bool* ok) const
             *ok = false;
         return 0.0f;
     }
-    return m_impl->toFloat(ok);
+    SUPPRESS_UNCOUNTED_ARG return m_impl->toFloat(ok);
 }
 
 String String::isolatedCopy() const &
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->isolatedCopy() : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->isolatedCopy() : String { };
 }
 
 String String::isolatedCopy() &&
@@ -290,7 +290,7 @@ String String::isolatedCopy() &&
         return { WTFMove(*this) };
     }
 
-    return m_impl ? m_impl->isolatedCopy() : String { };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->isolatedCopy() : String { };
 }
 
 bool String::isSafeToSendToAnotherThread() const
@@ -433,7 +433,7 @@ CString String::latin1() const
 
 Expected<CString, UTF8ConversionError> String::tryGetUTF8(ConversionMode mode) const
 {
-    return m_impl ? m_impl->tryGetUTF8(mode) : CString { ""_span };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->tryGetUTF8(mode) : CString { ""_span };
 }
 
 Expected<CString, UTF8ConversionError> String::tryGetUTF8() const


### PR DESCRIPTION
#### b73d7a05de25a080731cdb01fc93b13e607f6706
<pre>
Silence Safer CPP warnings in WTFString.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298521">https://bugs.webkit.org/show_bug.cgi?id=298521</a>

Reviewed by Ryosuke Niwa.

These calls cannot cause the StringImpl to be destroyed, they are thus safe.
Given that WTFString is perf-sensitive, I believe it is best to silence these
warnings rather than doing unnecessary ref&apos;ing.

* Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::characterStartingAt const):
(WTF::String::substringSharingImpl const):
(WTF::String::convertToASCIILowercase const):
(WTF::String::convertToASCIIUppercase const):
(WTF::String::convertToLowercaseWithoutLocale const):
(WTF::String::convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit const):
(WTF::String::convertToUppercaseWithoutLocale const):
(WTF::String::convertToLowercaseWithLocale const):
(WTF::String::convertToUppercaseWithLocale const):
(WTF::String::trim const):
(WTF::String::simplifyWhiteSpace const):
(WTF::String::foldCase const):
(WTF::String::toDouble const):
(WTF::String::toFloat const):
(WTF::String::isolatedCopy const):
(WTF::String::isolatedCopy):
(WTF::String::tryGetUTF8 const):

Canonical link: <a href="https://commits.webkit.org/299721@main">https://commits.webkit.org/299721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41dbd5c003477320af7b1cfcb709702b0d034dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71953 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3488b2dd-da36-48f9-aa8f-54ac2361a4fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91035 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60340 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe5c8eb6-08dd-4b89-befe-465542b16fd6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71591 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac03b4b6-7986-41e5-a40d-8c5ebd8d49d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69840 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112005 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129126 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118396 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99652 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22955 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43406 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52368 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147094 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46128 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37797 "Found 1 new JSC binary failure: testapi, Found 18650 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/enumeration_adddelete.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->