### PR TITLE
Address Safer CPP warnings under Modules/ShapeDetection

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
@@ -100,7 +100,8 @@ void BarcodeDetector::detect(ScriptExecutionContext& scriptExecutionContext, Ima
             return;
         }
 
-        auto imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
+        // FIXME: This is a safer cpp false positive (rdar://160082559).
+        SUPPRESS_UNCOUNTED_ARG auto imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
         if (!imageBuffer) {
             promise.resolve({ });
             return;

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp
@@ -76,7 +76,8 @@ void FaceDetector::detect(ScriptExecutionContext& scriptExecutionContext, ImageB
             return;
         }
 
-        auto imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
+        // FIXME: This is a safer cpp false positive (rdar://160082559).
+        SUPPRESS_UNCOUNTED_ARG auto imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
         if (!imageBuffer) {
             promise.resolve({ });
             return;

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
@@ -43,51 +43,51 @@ namespace WebCore::ShapeDetection {
 
 static BarcodeFormat convertSymbology(VNBarcodeSymbology symbology)
 {
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyAztec()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyAztec() }.get()])
         return BarcodeFormat::Aztec;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCodabar()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCodabar() }.get()])
         return BarcodeFormat::Codabar;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCode39()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCode39() }.get()])
         return BarcodeFormat::Code_39;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCode39Checksum()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCode39Checksum() }.get()])
         return BarcodeFormat::Code_39;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCode39FullASCII()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCode39FullASCII() }.get()])
         return BarcodeFormat::Code_39;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCode39FullASCIIChecksum()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCode39FullASCIIChecksum() }.get()])
         return BarcodeFormat::Code_39;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCode93()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCode93() }.get()])
         return BarcodeFormat::Code_93;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCode93i()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCode93i() }.get()])
         return BarcodeFormat::Code_93;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyCode128()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyCode128() }.get()])
         return BarcodeFormat::Code_128;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyDataMatrix()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyDataMatrix() }.get()])
         return BarcodeFormat::Data_matrix;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyEAN8()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyEAN8() }.get()])
         return BarcodeFormat::Ean_8;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyEAN13()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyEAN13() }.get()])
         return BarcodeFormat::Ean_13;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyGS1DataBar()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyGS1DataBar() }.get()])
         return BarcodeFormat::Unknown;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyGS1DataBarExpanded()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyGS1DataBarExpanded() }.get()])
         return BarcodeFormat::Unknown;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyGS1DataBarLimited()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyGS1DataBarLimited() }.get()])
         return BarcodeFormat::Unknown;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyI2of5()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyI2of5() }.get()])
         return BarcodeFormat::Itf;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyI2of5Checksum()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyI2of5Checksum() }.get()])
         return BarcodeFormat::Itf;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyITF14()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyITF14() }.get()])
         return BarcodeFormat::Itf;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyMicroPDF417()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyMicroPDF417() }.get()])
         return BarcodeFormat::Pdf417;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyMicroQR()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyMicroQR() }.get()])
         return BarcodeFormat::Qr_code;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyPDF417()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyPDF417() }.get()])
         return BarcodeFormat::Pdf417;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyQR()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyQR() }.get()])
         return BarcodeFormat::Qr_code;
-    if ([symbology isEqual:PAL::get_Vision_VNBarcodeSymbologyUPCE()])
+    if ([symbology isEqual:RetainPtr { PAL::get_Vision_VNBarcodeSymbologyUPCE() }.get()])
         return BarcodeFormat::Upc_e;
     return BarcodeFormat::Unknown;
 }
@@ -152,7 +152,8 @@ static RetainPtr<VNDetectBarcodesRequest> request()
     // configured the same way. This function is intended to make sure both VNDetectBarcodesRequests are
     // configured accordingly.
 
-    auto result = adoptNS([PAL::allocVNDetectBarcodesRequestInstance() init]);
+    // FIXME: This is a safer cpp false positive (rdar://160083438).
+    SUPPRESS_UNRETAINED_ARG auto result = adoptNS([PAL::allocVNDetectBarcodesRequestInstance() init]);
     configureRequestToUseCPUOrGPU(result.get());
     return result;
 }
@@ -160,11 +161,11 @@ static RetainPtr<VNDetectBarcodesRequest> request()
 void BarcodeDetectorImpl::getSupportedFormats(CompletionHandler<void(Vector<BarcodeFormat>&&)>&& completionHandler)
 {
     NSError *error = nil;
-    NSArray<VNBarcodeSymbology> *supportedSymbologies = [request() supportedSymbologiesAndReturnError:&error];
+    RetainPtr<NSArray<VNBarcodeSymbology>> supportedSymbologies = [request() supportedSymbologiesAndReturnError:&error];
 
     BarcodeFormatSet barcodeFormatsSet;
-    barcodeFormatsSet.reserveInitialCapacity(supportedSymbologies.count);
-    for (VNBarcodeSymbology symbology in supportedSymbologies)
+    barcodeFormatsSet.reserveInitialCapacity([supportedSymbologies count]);
+    for (VNBarcodeSymbology symbology in supportedSymbologies.get())
         barcodeFormatsSet.add(convertSymbology(symbology));
 
     auto barcodeFormatsVector = copyToVector(barcodeFormatsSet);
@@ -192,13 +193,14 @@ void BarcodeDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandl
     if (m_requestedBarcodeFormatSet) {
         NSMutableSet<VNBarcodeSymbology> *requestedSymbologies = [NSMutableSet setWithCapacity:m_requestedBarcodeFormatSet->size()];
         for (auto barcodeFormat : *m_requestedBarcodeFormatSet) {
-            for (auto symbology : convertBarcodeFormat(barcodeFormat))
-                [requestedSymbologies addObject:symbology];
+            for (RetainPtr symbology : convertBarcodeFormat(barcodeFormat))
+                [requestedSymbologies addObject:symbology.get()];
         }
         request.get().symbologies = requestedSymbologies.allObjects;
     }
 
-    auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    // FIXME: This is a safer cpp false positive (rdar://160083438).
+    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
@@ -87,10 +87,12 @@ void FaceDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<
         return;
     }
 
-    auto request = adoptNS([PAL::allocVNDetectFaceLandmarksRequestInstance() init]);
+    // FIXME: This is a safer cpp false positive (rdar://160083438).
+    SUPPRESS_UNRETAINED_ARG auto request = adoptNS([PAL::allocVNDetectFaceLandmarksRequestInstance() init]);
     configureRequestToUseCPUOrGPU(request.get());
 
-    auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    // FIXME: This is a safer cpp false positive (rdar://160083438).
+    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
@@ -57,10 +57,12 @@ void TextDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<
         return;
     }
 
-    auto request = adoptNS([PAL::allocVNRecognizeTextRequestInstance() init]);
+    // FIXME: This is a safer cpp false positive (rdar://160083438).
+    SUPPRESS_UNRETAINED_ARG auto request = adoptNS([PAL::allocVNRecognizeTextRequestInstance() init]);
     configureRequestToUseCPUOrGPU(request.get());
 
-    auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    // FIXME: This is a safer cpp false positive (rdar://160083438).
+    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
@@ -80,7 +80,7 @@ void configureRequestToUseCPUOrGPU(VNRequest *request)
     for (VNComputeStage computeStage in supportedComputeStageDevices) {
         bool set = false;
         for (id<MLComputeDeviceProtocol> device in supportedComputeStageDevices[computeStage]) {
-            if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClass()]) {
+            if ([device isKindOfClass:RetainPtr { PAL::getMLGPUComputeDeviceClass() }.get()]) {
                 [request setComputeDevice:device forComputeStage:computeStage];
                 set = true;
                 break;
@@ -88,7 +88,7 @@ void configureRequestToUseCPUOrGPU(VNRequest *request)
         }
         if (!set) {
             for (id<MLComputeDeviceProtocol> device in supportedComputeStageDevices[computeStage]) {
-                if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClass()]) {
+                if ([device isKindOfClass:RetainPtr { PAL::getMLGPUComputeDeviceClass() }.get()]) {
                     [request setComputeDevice:device forComputeStage:computeStage];
                     break;
                 }

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
@@ -76,7 +76,8 @@ void TextDetector::detect(ScriptExecutionContext& scriptExecutionContext, ImageB
             return;
         }
 
-        auto imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
+        // FIXME: This is a safer cpp false positive (rdar://160082559).
+        SUPPRESS_UNCOUNTED_ARG auto imageBuffer = imageBitmap.releaseReturnValue()->takeImageBuffer();
         if (!imageBuffer) {
             promise.resolve({ });
             return;

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,7 +1,4 @@
 EventNames.h
-Modules/ShapeDetection/BarcodeDetector.cpp
-Modules/ShapeDetection/FaceDetector.cpp
-Modules/ShapeDetection/TextDetector.cpp
 Modules/applepay/ApplePaySession.cpp
 Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,7 +1,3 @@
-Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
-Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
-Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
-Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
 Modules/WebGPU/GPUQueue.cpp
 Modules/applepay/ApplePayLogoSystemImage.mm
 Modules/applepay/PaymentInstallmentConfiguration.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
 accessibility/cocoa/AXCoreObjectCocoa.mm
 accessibility/cocoa/AccessibilityObjectCocoa.mm
 accessibility/mac/AXObjectCacheMac.mm


### PR DESCRIPTION
#### 722fdf8a9149696fe709f84d18b405b560092ef4
<pre>
Address Safer CPP warnings under Modules/ShapeDetection
<a href="https://bugs.webkit.org/show_bug.cgi?id=298524">https://bugs.webkit.org/show_bug.cgi?id=298524</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp:
(WebCore::BarcodeDetector::detect):
* Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp:
(WebCore::FaceDetector::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm:
(WebCore::ShapeDetection::convertSymbology):
(WebCore::ShapeDetection::request):
(WebCore::ShapeDetection::BarcodeDetectorImpl::getSupportedFormats):
(WebCore::ShapeDetection::BarcodeDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm:
(WebCore::ShapeDetection::FaceDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm:
(WebCore::ShapeDetection::TextDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm:
(WebCore::ShapeDetection::configureRequestToUseCPUOrGPU):
* Source/WebCore/Modules/ShapeDetection/TextDetector.cpp:
(WebCore::TextDetector::detect):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/299732@main">https://commits.webkit.org/299732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccb918943daab4086b2aedead6f9b5023f1c3c1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81b375e1-ce30-453a-9cc5-3a68627ffab6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48275 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c102838f-9937-443a-b5df-703a6361b6e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32264 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/107608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/71686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/899f93bc-2326-44f9-9f6f-d76ce5b855aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25711 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69974 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129255 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35582 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103794 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/99593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45051 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52493 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46253 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->