### PR TITLE
Start addressing Safer CPP warnings in IndexedDB code

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.h
@@ -92,7 +92,9 @@ protected:
 private:
     bool sourcesDeleted() const;
     IDBObjectStore& effectiveObjectStore() const;
+    Ref<IDBObjectStore> protectedEffectiveObjectStore() const;
     IDBTransaction& transaction() const;
+    Ref<IDBTransaction> protectedTransaction() const;
 
     void uncheckedIterateCursor(const IDBKeyData&, unsigned count);
     void uncheckedIterateCursor(const IDBKeyData&, const IDBKeyData&);

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/EventNames.h>
 #include <WebCore/EventTarget.h>
 #include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/IDBActiveDOMObject.h>

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -52,6 +52,7 @@ public:
     const String& name() const;
     ExceptionOr<void> setName(const String&);
     IDBObjectStore& objectStore();
+    Ref<IDBObjectStore> protectedObjectStore();
     const IDBKeyPath& keyPath() const;
     bool unique() const;
     bool multiEntry() const;
@@ -108,7 +109,7 @@ private:
 
     // IDBIndex objects are always owned by their referencing IDBObjectStore.
     // Indexes will never outlive ObjectStores so its okay to keep a raw C++ reference here.
-    CheckedRef<IDBObjectStore> m_objectStore;
+    const CheckedRef<IDBObjectStore> m_objectStore;
 };
 
 WebCoreOpaqueRoot root(IDBIndex*);

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -138,6 +138,11 @@ IDBTransaction& IDBObjectStore::transaction()
     return m_transaction.get();
 }
 
+Ref<IDBTransaction> IDBObjectStore::protectedTransaction()
+{
+    return transaction();
+}
+
 bool IDBObjectStore::autoIncrement() const
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_transaction->database().originThread()));

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -75,6 +75,7 @@ public:
     const std::optional<IDBKeyPath>& keyPath() const;
     Ref<DOMStringList> indexNames() const;
     IDBTransaction& transaction();
+    Ref<IDBTransaction> protectedTransaction();
     bool autoIncrement() const;
 
     struct IndexParameters {

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -147,6 +147,7 @@ public:
     bool didDispatchAbortOrCommit() const { return m_didDispatchAbortOrCommit; }
 
     IDBClient::IDBConnectionProxy& connectionProxy();
+    Ref<IDBClient::IDBConnectionProxy> protectedConnectionProxy();
     void connectionClosedFromServer(const IDBError&);
     void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
 
@@ -239,6 +240,8 @@ private:
     void trySchedulePendingOperationTimer();
     void addCursorRequest(IDBRequest&);
 
+    void assertCurrentThreadAccessThreadLocalData() const;
+
     const Ref<IDBDatabase> m_database;
     IDBTransactionInfo m_info;
 
@@ -292,5 +295,17 @@ public:
 private:
     RefPtr<IDBTransaction> m_transaction;
 };
+
+#if !ASSERT_ENABLED
+ALWAYS_INLINE void IDBTransaction::assertCurrentThreadAccessThreadLocalData() const
+{
+}
+#endif
+
+inline bool IDBTransaction::isActive() const
+{
+    assertCurrentThreadAccessThreadLocalData();
+    return m_state == IndexedDB::TransactionState::Active;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -187,7 +187,7 @@ private:
     HashMap<IDBResourceIdentifier, Ref<IDBDatabaseNameAndVersionRequest>> m_databaseInfoCallbacks WTF_GUARDED_BY_LOCK(m_databaseInfoMapLock);
 
     CrossThreadQueue<CrossThreadTask> m_mainThreadQueue;
-    RefPtr<IDBConnectionToServer> m_mainThreadProtector WTF_GUARDED_BY_LOCK(m_mainThreadTaskLock);
+    bool m_hasScheduledMainThreadTasks WTF_GUARDED_BY_LOCK(m_mainThreadTaskLock) { false };
     PAL::SessionID m_sessionID;
 };
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -45,151 +45,151 @@ IDBConnectionToClient::IDBConnectionToClient(IDBConnectionToClientDelegate& dele
 IDBConnectionIdentifier IDBConnectionToClient::identifier() const
 {
     ASSERT(m_delegate);
-    return *m_delegate->identifier();
+    return *CheckedRef { *m_delegate }->identifier();
 }
 
 void IDBConnectionToClient::didDeleteDatabase(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didDeleteDatabase(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didDeleteDatabase(result);
 }
 
 void IDBConnectionToClient::didOpenDatabase(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didOpenDatabase(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didOpenDatabase(result);
 }
 
 void IDBConnectionToClient::didAbortTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
 {
-    if (m_delegate)
-        m_delegate->didAbortTransaction(transactionIdentifier, error);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didAbortTransaction(transactionIdentifier, error);
 }
 
 void IDBConnectionToClient::didCreateObjectStore(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didCreateObjectStore(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didCreateObjectStore(result);
 }
 
 void IDBConnectionToClient::didDeleteObjectStore(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didDeleteObjectStore(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didDeleteObjectStore(result);
 }
 
 void IDBConnectionToClient::didRenameObjectStore(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didRenameObjectStore(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didRenameObjectStore(result);
 }
 
 void IDBConnectionToClient::didClearObjectStore(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didClearObjectStore(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didClearObjectStore(result);
 }
 
 void IDBConnectionToClient::didCreateIndex(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didCreateIndex(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didCreateIndex(result);
 }
 
 void IDBConnectionToClient::didDeleteIndex(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didDeleteIndex(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didDeleteIndex(result);
 }
 
 void IDBConnectionToClient::didRenameIndex(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didRenameIndex(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didRenameIndex(result);
 }
 
 void IDBConnectionToClient::didPutOrAdd(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didPutOrAdd(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didPutOrAdd(result);
 }
 
 void IDBConnectionToClient::didGetRecord(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didGetRecord(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didGetRecord(result);
 }
 
 void IDBConnectionToClient::didGetAllRecords(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didGetAllRecords(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didGetAllRecords(result);
 }
 
 void IDBConnectionToClient::didGetCount(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didGetCount(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didGetCount(result);
 }
 
 void IDBConnectionToClient::didDeleteRecord(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didDeleteRecord(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didDeleteRecord(result);
 }
 
 void IDBConnectionToClient::didOpenCursor(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didOpenCursor(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didOpenCursor(result);
 }
 
 void IDBConnectionToClient::didIterateCursor(const IDBResultData& result)
 {
-    if (m_delegate)
-        m_delegate->didIterateCursor(result);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didIterateCursor(result);
 }
 
 void IDBConnectionToClient::didCommitTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
 {
-    if (m_delegate)
-        m_delegate->didCommitTransaction(transactionIdentifier, error);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didCommitTransaction(transactionIdentifier, error);
 }
 
 void IDBConnectionToClient::fireVersionChangeEvent(UniqueIDBDatabaseConnection& connection, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion)
 {
-    if (m_delegate)
-        m_delegate->fireVersionChangeEvent(connection, requestIdentifier, requestedVersion);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->fireVersionChangeEvent(connection, requestIdentifier, requestedVersion);
 }
 
 void IDBConnectionToClient::generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const std::optional<IDBKeyPath>& keyPath, const IDBKeyData& key, const IDBValue& value, std::optional<int64_t> recordID)
 {
-    if (m_delegate)
-        m_delegate->generateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->generateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID);
 }
 
 void IDBConnectionToClient::didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
 {
-    if (m_delegate)
-        m_delegate->didStartTransaction(transactionIdentifier, error);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didStartTransaction(transactionIdentifier, error);
 }
 
 void IDBConnectionToClient::didCloseFromServer(UniqueIDBDatabaseConnection& connection, const IDBError& error)
 {
-    if (m_delegate)
-        m_delegate->didCloseFromServer(connection, error);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didCloseFromServer(connection, error);
 }
 
 void IDBConnectionToClient::notifyOpenDBRequestBlocked(const IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion)
 {
-    if (m_delegate)
-        m_delegate->notifyOpenDBRequestBlocked(requestIdentifier, oldVersion, newVersion);
+    if (CheckedPtr delegate = m_delegate)
+        delegate->notifyOpenDBRequestBlocked(requestIdentifier, oldVersion, newVersion);
 }
 
 void IDBConnectionToClient::didGetAllDatabaseNamesAndVersions(const IDBResourceIdentifier& requestIdentifier, Vector<IDBDatabaseNameAndVersion>&& databases)
 {
-    if (m_delegate)
-        m_delegate->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTFMove(databases));
+    if (CheckedPtr delegate = m_delegate)
+        delegate->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTFMove(databases));
 }
 
 void IDBConnectionToClient::registerDatabaseConnection(UniqueIDBDatabaseConnection& connection)

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -83,7 +83,7 @@ private:
     MemoryBackingStoreTransaction(MemoryIDBBackingStore&, const IDBTransactionInfo&);
     void finish();
 
-    CheckedRef<MemoryIDBBackingStore> m_backingStore;
+    const CheckedRef<MemoryIDBBackingStore> m_backingStore;
     IDBTransactionInfo m_info;
 
     std::unique_ptr<IDBDatabaseInfo> m_originalDatabaseInfo;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
@@ -84,11 +84,12 @@ void UniqueIDBDatabaseConnection::abortTransactionWithoutCallback(UniqueIDBDatab
     ASSERT(m_database);
 
     const auto& transactionIdentifier = transaction.info().identifier();
-    m_database->abortTransaction(transaction, [this, weakThis = WeakPtr { *this }, transactionIdentifier](const IDBError&) {
-        if (!weakThis)
+    m_database->abortTransaction(transaction, [weakThis = WeakPtr { *this }, transactionIdentifier](const IDBError&) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
-        ASSERT(m_transactionMap.contains(transactionIdentifier));
-        m_transactionMap.remove(transactionIdentifier);
+        ASSERT(protectedThis->m_transactionMap.contains(transactionIdentifier));
+        protectedThis->m_transactionMap.remove(transactionIdentifier);
     });
 }
 

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -22,7 +22,6 @@ Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
 Modules/WebGPU/Implementation/WebGPUTextureViewImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp
-Modules/indexeddb/IDBDatabase.h
 Modules/mediastream/RTCPeerConnection.h
 Modules/notifications/NotificationController.h
 Modules/webdatabase/DatabaseManager.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,14 +1,5 @@
 Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
-Modules/indexeddb/IDBCursor.cpp
-Modules/indexeddb/IDBIndex.cpp
-Modules/indexeddb/IDBTransaction.cpp
-Modules/indexeddb/server/IDBConnectionToClient.cpp
-Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
-Modules/indexeddb/server/MemoryIndex.cpp
-Modules/indexeddb/server/MemoryObjectStore.cpp
-Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
-Modules/indexeddb/server/SQLiteIDBCursor.cpp
 Modules/indexeddb/server/UniqueIDBDatabase.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
@@ -316,7 +307,6 @@ inspector/agents/InspectorCSSAgent.cpp
 inspector/agents/InspectorCSSAgent.h
 inspector/agents/InspectorCanvasAgent.cpp
 inspector/agents/InspectorDOMAgent.cpp
-inspector/agents/InspectorIndexedDBAgent.cpp
 inspector/agents/InspectorLayerTreeAgent.cpp
 inspector/agents/InspectorNetworkAgent.cpp
 inspector/agents/InspectorPageAgent.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,11 +1,6 @@
-Modules/indexeddb/IDBCursor.cpp
-Modules/indexeddb/IDBTransaction.cpp
 Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
 Modules/indexeddb/server/MemoryIDBBackingStore.cpp
 Modules/indexeddb/server/MemoryIndexCursor.cpp
-Modules/indexeddb/server/MemoryObjectStore.cpp
-Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
-Modules/indexeddb/server/SQLiteIDBCursor.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/UserMediaRequest.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -8,17 +8,12 @@ Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/filesystem/FileSystemFileHandle.cpp
 Modules/filesystem/WorkerFileSystemStorageConnection.cpp
 Modules/identity/CredentialRequestCoordinator.cpp
-Modules/indexeddb/IDBCursor.cpp
 Modules/indexeddb/IDBDatabase.cpp
-Modules/indexeddb/IDBIndex.cpp
 Modules/indexeddb/IDBKey.cpp
 Modules/indexeddb/IDBKeyRange.cpp
 Modules/indexeddb/IDBObjectStore.cpp
 Modules/indexeddb/IDBOpenDBRequest.cpp
 Modules/indexeddb/IDBRequest.cpp
-Modules/indexeddb/IDBTransaction.cpp
-Modules/indexeddb/client/IDBConnectionProxy.cpp
-Modules/indexeddb/server/MemoryObjectStore.cpp
 Modules/indexeddb/server/UniqueIDBDatabase.cpp
 Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
 Modules/mediacontrols/MediaControlsHost.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,8 +1,6 @@
 Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
 Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp
-Modules/indexeddb/client/IDBConnectionProxy.cpp
-Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasource/MediaSource.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,14 +1,9 @@
 Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/indexeddb/IDBActiveDOMObjectInlines.h
-Modules/indexeddb/IDBCursor.cpp
-Modules/indexeddb/IDBIndex.cpp
 Modules/indexeddb/IDBObjectStore.cpp
-Modules/indexeddb/IDBTransaction.cpp
-Modules/indexeddb/client/IDBConnectionProxy.cpp
 Modules/indexeddb/server/IDBServer.cpp
 Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
 Modules/indexeddb/server/MemoryIDBBackingStore.cpp
-Modules/indexeddb/server/MemoryObjectStore.cpp
 Modules/indexeddb/server/UniqueIDBDatabase.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacontrols/MediaControlsHost.cpp

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -560,7 +560,7 @@ static bool getDocumentAndIDBFactoryFromFrameOrSendFailure(LocalFrame* frame, Do
         return false;
     }
 
-    Inspector::Protocol::ErrorStringOr<IDBFactory*> idbFactory = IDBFactoryFromDocument(document.value());
+    Inspector::Protocol::ErrorStringOr<IDBFactory*> idbFactory = IDBFactoryFromDocument(RefPtr { document.value() }.get());
     if (!idbFactory.has_value()) {
         callback.sendFailure(idbFactory.error());
         return false;

--- a/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h
+++ b/Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h
@@ -46,6 +46,7 @@ public:
 
     SQLiteStatement* get() { return m_statement.get(); }
     SQLiteStatement* operator->() { return m_statement.get(); }
+    SQLiteStatement& operator*() const { ASSERT(m_statement); return *m_statement; }
 
 private:
     CheckedPtr<SQLiteStatement> m_statement;


### PR DESCRIPTION
#### c86860c0fee55ad6a05397288e44d27d64baf409
<pre>
Start addressing Safer CPP warnings in IndexedDB code
<a href="https://bugs.webkit.org/show_bug.cgi?id=298531">https://bugs.webkit.org/show_bug.cgi?id=298531</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
(WebCore::IDBCursor::protectedEffectiveObjectStore const):
(WebCore::IDBCursor::transaction const):
(WebCore::IDBCursor::protectedTransaction const):
(WebCore::IDBCursor::update):
(WebCore::IDBCursor::uncheckedIterateCursor):
(WebCore::IDBCursor::deleteFunction):
(WebCore::IDBCursor::iterateWithPrefetchedRecords):
* Source/WebCore/Modules/indexeddb/IDBCursor.h:
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::setName):
(WebCore::IDBIndex::protectedObjectStore):
(WebCore::IDBIndex::doOpenCursor):
(WebCore::IDBIndex::doOpenKeyCursor):
(WebCore::IDBIndex::count):
(WebCore::IDBIndex::doCount):
(WebCore::IDBIndex::doGet):
(WebCore::IDBIndex::doGetKey):
(WebCore::IDBIndex::doGetAll):
(WebCore::IDBIndex::doGetAllKeys):
(WebCore::IDBIndex::opaqueRoot):
* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::protectedTransaction):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::IDBTransaction):
(WebCore::IDBTransaction::protectedConnectionProxy):
(WebCore::IDBTransaction::objectStore):
(WebCore::IDBTransaction::transitionedToFinishing):
(WebCore::IDBTransaction::abortInProgressOperations):
(WebCore::IDBTransaction::commit):
(WebCore::IDBTransaction::notifyDidAbort):
(WebCore::IDBTransaction::dispatchEvent):
(WebCore::IDBTransaction::createObjectStore):
(WebCore::IDBTransaction::createIndex):
(WebCore::IDBTransaction::renameIndex):
(WebCore::IDBTransaction::doRequestOpenCursor):
(WebCore::IDBTransaction::iterateCursor):
(WebCore::IDBTransaction::requestGetAllObjectStoreRecords):
(WebCore::IDBTransaction::requestGetAllIndexRecords):
(WebCore::IDBTransaction::requestGetRecord):
(WebCore::IDBTransaction::requestIndexRecord):
(WebCore::IDBTransaction::requestCount):
(WebCore::IDBTransaction::requestDeleteRecord):
(WebCore::IDBTransaction::requestClearObjectStore):
(WebCore::IDBTransaction::requestPutOrAdd):
(WebCore::IDBTransaction::connectionClosedFromServer):
(WebCore::IDBTransaction::visitReferencedObjectStores const):
(WebCore::IDBTransaction::generateIndexKeyForRecord):
(WebCore::IDBTransaction::assertCurrentThreadAccessThreadLocalData const):
(WebCore::IDBTransaction::isActive const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
(WebCore::IDBTransaction::assertCurrentThreadAccessThreadLocalData const):
(WebCore::IDBTransaction::isActive const):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::scheduleMainThreadTasks):
(WebCore::IDBClient::IDBConnectionProxy::handleMainThreadTasks):
(WebCore::IDBClient::IDBConnectionProxy::getAllDatabaseNamesAndVersions):
(WebCore::IDBClient::removeItemsMatchingCurrentThread):
(WebCore::IDBClient::setMatchingItemsContextSuspended):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp:
(WebCore::IDBServer::IDBConnectionToClient::identifier const):
(WebCore::IDBServer::IDBConnectionToClient::didDeleteDatabase):
(WebCore::IDBServer::IDBConnectionToClient::didOpenDatabase):
(WebCore::IDBServer::IDBConnectionToClient::didAbortTransaction):
(WebCore::IDBServer::IDBConnectionToClient::didCreateObjectStore):
(WebCore::IDBServer::IDBConnectionToClient::didDeleteObjectStore):
(WebCore::IDBServer::IDBConnectionToClient::didRenameObjectStore):
(WebCore::IDBServer::IDBConnectionToClient::didClearObjectStore):
(WebCore::IDBServer::IDBConnectionToClient::didCreateIndex):
(WebCore::IDBServer::IDBConnectionToClient::didDeleteIndex):
(WebCore::IDBServer::IDBConnectionToClient::didRenameIndex):
(WebCore::IDBServer::IDBConnectionToClient::didPutOrAdd):
(WebCore::IDBServer::IDBConnectionToClient::didGetRecord):
(WebCore::IDBServer::IDBConnectionToClient::didGetAllRecords):
(WebCore::IDBServer::IDBConnectionToClient::didGetCount):
(WebCore::IDBServer::IDBConnectionToClient::didDeleteRecord):
(WebCore::IDBServer::IDBConnectionToClient::didOpenCursor):
(WebCore::IDBServer::IDBConnectionToClient::didIterateCursor):
(WebCore::IDBServer::IDBConnectionToClient::didCommitTransaction):
(WebCore::IDBServer::IDBConnectionToClient::fireVersionChangeEvent):
(WebCore::IDBServer::IDBConnectionToClient::generateIndexKeyForRecord):
(WebCore::IDBServer::IDBConnectionToClient::didStartTransaction):
(WebCore::IDBServer::IDBConnectionToClient::didCloseFromServer):
(WebCore::IDBServer::IDBConnectionToClient::notifyOpenDBRequestBlocked):
(WebCore::IDBServer::IDBConnectionToClient::didGetAllDatabaseNamesAndVersions):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::objectStoreCleared):
(WebCore::IDBServer::MemoryIndex::getResultForKeyRange const):
(WebCore::IDBServer::MemoryIndex::countForKeyRange):
(WebCore::IDBServer::MemoryIndex::getAllRecords const):
(WebCore::IDBServer::MemoryIndex::putIndexKey):
(WebCore::IDBServer::MemoryIndex::removeEntriesWithValueKey):
(WebCore::IDBServer::MemoryIndex::addIndexRecord):
(WebCore::IDBServer::MemoryIndex::removeIndexRecord):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::updateIndexRecordsWithIndexKey):
(WebCore::IDBServer::MemoryObjectStore::updateIndexesForPutRecord):
(WebCore::IDBServer::MemoryObjectStore::countForKeyRange const):
(WebCore::IDBServer::MemoryObjectStore::indexValueForKeyRange const):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidBlobTables):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidRecordsTable):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsTable):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsRecordIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::createAndPopulateInitialDatabaseInfo):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidObjectStoreInfoTable):
(WebCore::IDBServer::SQLiteIDBBackingStore::migrateIndexInfoTableForIDUpdate):
(WebCore::IDBServer::SQLiteIDBBackingStore::migrateIndexRecordsTableForIDUpdate):
(WebCore::IDBServer::SQLiteIDBBackingStore::extractExistingDatabaseInfo):
(WebCore::IDBServer::SQLiteIDBBackingStore::databaseNameAndVersionFromFile):
(WebCore::IDBServer::SQLiteIDBBackingStore::getOrEstablishDatabaseInfo):
(WebCore::IDBServer::SQLiteIDBBackingStore::beginTransaction):
(WebCore::IDBServer::SQLiteIDBBackingStore::commitTransaction):
(WebCore::IDBServer::SQLiteIDBBackingStore::createObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::renameObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::clearObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedHasIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedPutIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::renameIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::keyExistsInObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteUnusedBlobFileRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteRange):
(WebCore::IDBServer::SQLiteIDBBackingStore::updateAllIndexesForAddRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::addRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getBlobRecordsForObjectStoreRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllObjectStoreRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllIndexRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::getIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey):
(WebCore::IDBServer::SQLiteIDBBackingStore::getCount):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedGetKeyGeneratorValue):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedSetKeyGeneratorValue):
(WebCore::IDBServer::SQLiteIDBBackingStore::generateKeyNumber):
(WebCore::IDBServer::SQLiteIDBBackingStore::revertGeneratedKeyNumber):
(WebCore::IDBServer::SQLiteIDBBackingStore::maybeUpdateKeyGeneratorNumber):
(WebCore::IDBServer::SQLiteIDBBackingStore::openCursor):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteBackingStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::cachedStatement):
(WebCore::IDBServer::SQLiteIDBBackingStore::closeSQLiteDB):
(WebCore::IDBServer::SQLiteIDBBackingStore::handleLowMemoryWarning):
(WebCore::IDBServer::SQLiteIDBBackingStore::addIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::updateIndexRecordsWithIndexKey):
(WebCore::IDBServer::SQLiteIDBBackingStore::forEachObjectStoreRecord):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::~SQLiteIDBCursor):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindStatement):
(WebCore::IDBServer::SQLiteIDBCursor::bindArguments):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary):
(WebCore::IDBServer::SQLiteIDBCursor::internalFetchNextRecord):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::abortTransactionWithoutCallback):
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::getDocumentAndIDBFactoryFromFrameOrSendFailure):
* Source/WebCore/platform/sql/SQLiteStatementAutoResetScope.h:
(WebCore::SQLiteStatementAutoResetScope::operator* const):

Canonical link: <a href="https://commits.webkit.org/299749@main">https://commits.webkit.org/299749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ad42913146d9e64340dd734b7bd194f0d9c3f15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120048 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72121 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9adf1417-5ad7-4016-aa85-e14e6e3ebb34) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91165 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60477 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb70eec5-5546-4302-bff8-4ec591cbf6e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71718 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e535607-1db8-411e-aeb3-93ebb77dedef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25744 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70018 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129298 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99781 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99625 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25301 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23103 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52536 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46296 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->