### PR TITLE
dNR: figure out the permissions story for onRuleMatchedDebug

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -901,6 +901,23 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
     return *_webExtensionContext;
 }
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+- (BOOL)_declarativeNetRequestAdditionalAnalyticsIsEnabled
+{
+    return Ref { *_webExtensionContext }->declarativeNetRequestAdditionalAnalyticsIsEnabled();
+}
+
+- (void)set_declarativeNetRequestAdditionalAnalyticsIsEnabled:(BOOL)enabled
+{
+    Ref { *_webExtensionContext }->setDeclarativeNetRequestAdditionalAnalyticsIsEnabled(enabled);
+}
+#else
+- (BOOL)_declarativeNetRequestAdditionalAnalyticsIsEnabled
+{
+    return NO;
+}
+#endif
+
 #else // ENABLE(WK_WEB_EXTENSIONS)
 
 + (instancetype)contextForExtension:(WKWebExtension *)extension
@@ -1304,6 +1321,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 - (nullable _WKWebExtensionSidebar *)sidebarForTab:(id<WKWebExtensionTab>)tab
 {
     return nil;
+}
+
+- (BOOL)_declarativeNetRequestAdditionalAnalyticsIsEnabled
+{
+    return NO;
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
@@ -37,6 +37,9 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 /*! @abstract The extension background content URL for the extension, or `nil` if the extension does not have background content. */
 @property (nonatomic, nullable, readonly) NSURL *_backgroundContentURL;
 
+/*! @abstract Whether or not `browser.declarativeNetRequest` debugging APIs such as `onRuleMatchedDebug` are allowed. */
+@property (nonatomic) BOOL _declarativeNetRequestAdditionalAnalyticsIsEnabled;
+
 /*!
  @abstract Sends a message to the JavaScript `browser.test.onMessage` API.
  @discussion Allows code to trigger a `browser.test.onMessage` event, enabling bidirectional communication during testing.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -44,6 +44,10 @@
 static NSString * const declarativeNetRequestRulesetStateKey = @"DeclarativeNetRequestRulesetState";
 static NSString * const displayBlockedResourceCountAsBadgeTextStateKey = @"DisplayBlockedResourceCountAsBadgeText";
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+static NSString * const declarativeNetRequestAdditionalAnalyticsEnabledStateKey = @"DeclarativeNetRequestAdditionalAnalyticsEnabledState";
+#endif
+
 namespace WebKit {
 
 bool WebExtensionContext::isDeclarativeNetRequestMessageAllowed(IPC::Decoder& message)
@@ -433,6 +437,21 @@ void WebExtensionContext::declarativeNetRequestUpdateSessionRules(String&& rules
 
     updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestSessionRulesStore(), @"session", apiName, rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
 }
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+bool WebExtensionContext::declarativeNetRequestAdditionalAnalyticsIsEnabled()
+{
+    return objectForKey<NSNumber>(m_state, declarativeNetRequestAdditionalAnalyticsEnabledStateKey).boolValue;
+}
+
+void WebExtensionContext::setDeclarativeNetRequestAdditionalAnalyticsIsEnabled(bool enabled)
+{
+    [m_state setObject:@(enabled) forKey:declarativeNetRequestAdditionalAnalyticsEnabledStateKey];
+    writeStateToStorage();
+
+    loadDeclarativeNetRequestRules([](bool) { });
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4669,7 +4669,11 @@ void WebExtensionContext::compileDeclarativeNetRequestRules(NSDictionary *rulesD
         auto *allJSONObjects = [_WKWebExtensionDeclarativeNetRequestTranslator jsonObjectsFromData:rulesData.get() errorStrings:&jsonDeserializationErrorStrings];
 
         NSArray<NSString *> *parsingErrorStrings;
-        auto *allConvertedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:allJSONObjects errorStrings:&parsingErrorStrings];
+        BOOL additionalAnalyticsEnabled = NO;
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+        additionalAnalyticsEnabled = declarativeNetRequestAdditionalAnalyticsIsEnabled();
+#endif
+        auto *allConvertedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:allJSONObjects additionalAnalyticsEnabled:additionalAnalyticsEnabled errorStrings:&parsingErrorStrings];
 
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
         RefPtr extension = m_extension;
@@ -4824,7 +4828,8 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 void WebExtensionContext::handleContentRuleListMatchedRule(WebExtensionTab& tab, WebCore::ContentRuleListMatchedRule& matchedRule)
 {
-    // FIXME: <158147119> Figure out the permissions story for onRuleMatchedDebug
+    // FIXME: Add check that additional analytics are enabled.
+
     if (!(hasPermission(WKWebExtensionPermissionDeclarativeNetRequestFeedback) && hasPermission(WKWebExtensionPermissionDeclarativeNetRequest) && hasPermission(URL { matchedRule.request.url }, &tab)))
         return;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
@@ -33,7 +33,7 @@ WK_EXTERN NSString * const dynamicRulesetID;
 WK_EXTERN
 @interface _WKWebExtensionDeclarativeNetRequestRule : NSObject
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString * _Nullable * _Nullable)outErrorString NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID additionalAnalyticsEnabled:(BOOL)additionalAnalyticsEnabled errorString:(NSString * _Nullable * _Nullable)outErrorString NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -114,12 +114,16 @@ typedef NS_ENUM(NSInteger, DeclarativeNetRequestRuleActionType) {
 
 using namespace WebKit;
 
-@implementation _WKWebExtensionDeclarativeNetRequestRule
+@implementation _WKWebExtensionDeclarativeNetRequestRule {
+    BOOL _additionalAnalyticsEnabled;
+}
 
-- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID errorString:(NSString **)outErrorString
+- (instancetype)initWithDictionary:(NSDictionary *)ruleDictionary rulesetID:(NSString *)rulesetID additionalAnalyticsEnabled:(BOOL)additionalAnalyticsEnabled errorString:(NSString **)outErrorString
 {
     if (!(self = [super init]))
         return nil;
+
+    _additionalAnalyticsEnabled = additionalAnalyticsEnabled;
 
     static NSArray *requiredKeysInRuleDictionary = @[
         declarativeNetRequestRuleIDKey,
@@ -885,7 +889,7 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
     } mutableCopy];
 
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-    if (includeIdentifier) {
+    if (_additionalAnalyticsEnabled && includeIdentifier) {
         convertedRule[@"_identifier"] = @(_ruleID);
         convertedRule[@"_rulesetIdentifier"] = _rulesetID;
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
@@ -30,7 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 WK_EXTERN
 @interface _WKWebExtensionDeclarativeNetRequestTranslator : NSObject
 
-+ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjects errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
++ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjects additionalAnalyticsEnabled:(BOOL)additionalAnalyticsEnabled errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
+
 + (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjectsFromData:(NSDictionary<NSString *, NSData *> *)jsonData errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
@@ -38,7 +38,7 @@ using namespace WebKit;
 
 @implementation _WKWebExtensionDeclarativeNetRequestTranslator
 
-+ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjects errorStrings:(NSArray **)outErrorStrings
++ (NSArray<NSDictionary<NSString *, id> *> *)translateRules:(NSDictionary<NSString *, NSArray<NSDictionary *> *> *)jsonObjects additionalAnalyticsEnabled:(BOOL)additionalAnalyticsEnabled errorStrings:(NSArray * _Nullable * _Nullable)outErrorStrings
 {
     NSMutableArray<_WKWebExtensionDeclarativeNetRequestRule *> *allValidatedRules = [NSMutableArray array];
     NSMutableDictionary<NSString *, NSMutableSet<NSNumber *> *> *rulesetIDsToRuleIDs = [NSMutableDictionary dictionary];
@@ -48,7 +48,7 @@ using namespace WebKit;
     for (NSString *rulesetID in jsonObjects.allKeys) {
         for (NSDictionary *ruleJSON in jsonObjects[rulesetID]) {
             NSString *errorString;
-            _WKWebExtensionDeclarativeNetRequestRule *rule = [[_WKWebExtensionDeclarativeNetRequestRule alloc] initWithDictionary:ruleJSON rulesetID:rulesetID errorString:&errorString];
+            _WKWebExtensionDeclarativeNetRequestRule *rule = [[_WKWebExtensionDeclarativeNetRequestRule alloc] initWithDictionary:ruleJSON rulesetID:rulesetID additionalAnalyticsEnabled:additionalAnalyticsEnabled errorString:&errorString];
 
             if (!rulesetIDsToRuleIDs[rulesetID])
                 rulesetIDsToRuleIDs[rulesetID] = [NSMutableSet set];

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -584,6 +584,9 @@ public:
 
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     void handleContentRuleListMatchedRule(WebExtensionTab&, WebCore::ContentRuleListMatchedRule&);
+
+    bool declarativeNetRequestAdditionalAnalyticsIsEnabled();
+    void setDeclarativeNetRequestAdditionalAnalyticsIsEnabled(bool);
 #endif
 
     // Returns whether or not there are any matched rules after the purge.

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -177,7 +177,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
     NSString *ruleErrorString;
     size_t index = 0;
     for (NSDictionary *ruleDictionary in rulesToAdd) {
-        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:dynamicRulesetID errorString:&ruleErrorString]) {
+        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:dynamicRulesetID additionalAnalyticsEnabled:NO errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
             *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;
@@ -248,7 +248,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
     NSString *ruleErrorString;
     size_t index = 0;
     for (NSDictionary *ruleDictionary in rulesToAdd) {
-        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:sessionRulesetID errorString:&ruleErrorString]) {
+        if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary rulesetID:sessionRulesetID additionalAnalyticsEnabled:NO errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
             *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString).createNSString().autorelease();
             return;


### PR DESCRIPTION
#### 1bfbda10fcd788c87615063bb0d5ad3f7c46bf50
<pre>
dNR: figure out the permissions story for onRuleMatchedDebug
<a href="https://bugs.webkit.org/show_bug.cgi?id=298539">https://bugs.webkit.org/show_bug.cgi?id=298539</a>
<a href="https://rdar.apple.com/158147119">rdar://158147119</a>

Reviewed by NOBODY (OOPS!).

This patch is not yet ready for review; it&apos;s a work-in-progress.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext _declarativeNetRequestAdditionalAnalyticsIsEnabled]):
(-[WKWebExtensionContext set_declarativeNetRequestAdditionalAnalyticsIsEnabled:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestAdditionalAnalyticsIsEnabled):
(WebKit::WebExtensionContext::setDeclarativeNetRequestAdditionalAnalyticsIsEnabled):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::handleContentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule initWithDictionary:rulesetID:additionalAnalyticsEnabled:errorString:]):
(-[_WKWebExtensionDeclarativeNetRequestRule _webKitRuleWithWebKitActionType:chromeActionType:condition:includeIdentifier:]):
(WebKit::if): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm:
(WebKit::for):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bfbda10fcd788c87615063bb0d5ad3f7c46bf50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119932 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39625 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30276 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72005 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d433755-f85e-468c-b846-931a30b53382) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40320 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48202 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60382 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ad9f414-2b68-4712-a34b-2db075c94619) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122884 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/40320 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/30276 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71628 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f62195d-ce9e-4b12-b682-86f2a1e928b9) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/40320 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/30276 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69893 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/40320 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/30276 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129178 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46852 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/48202 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99693 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47218 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/30276 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99538 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/30276 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43471 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46714 "Hash 1bfbda10 for PR 50449 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52420 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46180 "Hash 1bfbda10 for PR 50449 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49529 "Hash 1bfbda10 for PR 50449 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47866 "Hash 1bfbda10 for PR 50449 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->