### PR TITLE
Filter primitive subregion with relative values should properly render referenced elements

### DIFF
--- a/LayoutTests/svg/filters/svg-filter-external-references-expected.html
+++ b/LayoutTests/svg/filters/svg-filter-external-references-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            background: rgb(200, 200, 200);
+        }
+
+        .filtered-by-css {
+            background-color: green;
+            width: 121px;
+            height: 121px;
+        }
+    </style>
+</head>
+
+<body>
+    <svg width="200" height="200" style="background: rgb(200, 200, 200);">
+        <rect x="0" y="0" width="121" height="121" fill="green" />
+    </svg>
+
+    <div class="container">
+        <div class="filtered-by-css"></div>
+    </div>
+</body>
+
+</html>

--- a/LayoutTests/svg/filters/svg-filter-external-references.html
+++ b/LayoutTests/svg/filters/svg-filter-external-references.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            background: rgb(200, 200, 200);
+        }
+
+        .filtered-by-css {
+            background-color: red;
+            filter: url(#floodFilter);
+            width: 100px;
+            height: 100px;
+            transform: translate(10px, 10px);
+        }
+    </style>
+</head>
+
+<body>
+    <svg width="0" height="0" style="position: absolute;">
+        <defs>
+            <filter id="floodFilter" primitiveUnits="objectBoundingBox">
+                <feFlood flood-color="green" width="120%" height="120%" />
+            </filter>
+        </defs>
+    </svg>
+
+    <svg width="200" height="200" style="background: rgb(200, 200, 200);">
+        <rect x="10" y="10" width="100" height="100" fill="red" filter="url(#floodFilter)" />
+    </svg>
+
+    <div class="container">
+        <div class="filtered-by-css"></div>
+    </div>
+</body>
+
+</html>

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -57,19 +57,49 @@ SVGLengthContext::SVGLengthContext(const SVGElement* context)
 
 SVGLengthContext::~SVGLengthContext() = default;
 
+static inline float dimensionForLengthMode(SVGLengthMode mode, FloatSize viewportSize)
+{
+    switch (mode) {
+    case SVGLengthMode::Width:
+        return viewportSize.width();
+    case SVGLengthMode::Height:
+        return viewportSize.height();
+    case SVGLengthMode::Other:
+        return viewportSize.diagonalLength() / std::numbers::sqrt2_v<float>;
+    }
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
 FloatRect SVGLengthContext::resolveRectangle(const SVGElement* context, SVGUnitTypes::SVGUnitType type, const FloatRect& viewport, const SVGLengthValue& x, const SVGLengthValue& y, const SVGLengthValue& width, const SVGLengthValue& height)
 {
     ASSERT(type != SVGUnitTypes::SVG_UNIT_TYPE_UNKNOWN);
-    if (type != SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE) {
-        auto viewportSize = viewport.size();
-        return FloatRect(
-            convertValueFromPercentageToUserUnits(x.valueAsPercentage(), x.lengthMode(), viewportSize) + viewport.x(),
-            convertValueFromPercentageToUserUnits(y.valueAsPercentage(), y.lengthMode(), viewportSize) + viewport.y(),
-            convertValueFromPercentageToUserUnits(width.valueAsPercentage(), width.lengthMode(), viewportSize),
-            convertValueFromPercentageToUserUnits(height.valueAsPercentage(), height.lengthMode(), viewportSize));
-    }
 
     SVGLengthContext lengthContext(context);
+    auto viewportSize = lengthContext.viewportSize().value_or(FloatSize { });
+
+    if (type != SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE || viewportSize.isEmpty()) {
+        viewportSize = viewport.size();
+
+        auto convertLength = [&](const SVGLengthValue& length) -> float {
+            if (length.lengthType() == SVGLengthType::Percentage)
+                return length.valueAsPercentage() * dimensionForLengthMode(length.lengthMode(), viewportSize);
+
+            float rawValue = length.valueInSpecifiedUnits();
+
+            // userSpaceOnUse with empty viewport: unitless values
+            // need percentage conversion
+            if (type == SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE)
+                rawValue = rawValue / 100.f;
+
+            return rawValue * dimensionForLengthMode(length.lengthMode(), viewportSize);
+        };
+
+        return FloatRect(
+            convertLength(x) + viewport.x(), convertLength(y) + viewport.y(),
+            convertLength(width), convertLength(height));
+    }
+
     return FloatRect(x.value(lengthContext), y.value(lengthContext), width.value(lengthContext), height.value(lengthContext));
 }
 
@@ -95,20 +125,6 @@ float SVGLengthContext::resolveLength(const SVGElement* context, SVGUnitTypes::S
 
     // FIXME: valueAsPercentage() won't be correct for eg. cm units. They need to be resolved in user space and then be considered in objectBoundingBox space.
     return x.valueAsPercentage();
-}
-
-static inline float dimensionForLengthMode(SVGLengthMode mode, FloatSize viewportSize)
-{
-    switch (mode) {
-    case SVGLengthMode::Width:
-        return viewportSize.width();
-    case SVGLengthMode::Height:
-        return viewportSize.height();
-    case SVGLengthMode::Other:
-        return viewportSize.diagonalLength() / std::numbers::sqrt2_v<float>;
-    }
-    ASSERT_NOT_REACHED();
-    return 0;
 }
 
 float SVGLengthContext::valueForLength(const Length& length, SVGLengthMode lengthMode)


### PR DESCRIPTION
#### 4c23e972c221
<pre>
Filter primitive subregion with relative values should properly render referenced elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=298540">https://bugs.webkit.org/show_bug.cgi?id=298540</a>
<a href="https://rdar.apple.com/154363710">rdar://154363710</a>

Reviewed by NOBODY (OOPS!).

SVG filters can be defined independently and referenced via CSS
or another SVG. In this scenario, when a filter primitive uses a
percentage-based subregion, the current implementation fails to render
the referenced element due to empty viewport information.

To solve this, we fallback to object bounding box behavior and use the
given viewport size.

* LayoutTests/svg/filters/svg-filter-external-references-expected.html: Added.
* LayoutTests/svg/filters/svg-filter-external-references.html: Added.
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::dimensionForLengthMode):
(WebCore::SVGLengthContext::resolveRectangle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c23e972c22175a7a963ad49bba387207d8d3831

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99a29866-7521-482f-a885-065af8098536) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92006 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61211 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75f39298-7756-4192-b3d1-0bffbde3f2fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124072 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33151 "Found 1 new test failure: svg/filters/svg-filter-external-references.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7bbdf68-9f96-44e7-9ed6-d493a7750ccf) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32175 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26671 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71131 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130392 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100614 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100517 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23968 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44741 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53618 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47376 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50723 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->