### PR TITLE
[Filters] Add a separate feature flag for the CoreGraphics blur filter

### DIFF
--- a/LayoutTests/css3/filters/effect-graphics-context-blur-expected.html
+++ b/LayoutTests/css3/filters/effect-graphics-context-blur-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+</head>
+<body>
+    <img src="resources/reference.png" style="filter: blur(0)">
+    <img src="resources/reference.png" style="filter: blur(2px)">
+    <img src="resources/reference.png" style="filter: blur(3px)">
+    <img src="resources/reference.png" style="filter: blur(10px)"> 
+</body>
+</html>

--- a/LayoutTests/css3/filters/effect-graphics-context-blur.html
+++ b/LayoutTests/css3/filters/effect-graphics-context-blur.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-32; totalPixels=0-62403" />
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+</head>
+<script>
+    if (window.internals)
+        internals.settings.setGraphicsContextBlurFilterEnabled?.(true);
+</script>
+<body>
+    <img src="resources/reference.png" style="filter: blur(0)">
+    <img src="resources/reference.png" style="filter: blur(2px)">
+    <img src="resources/reference.png" style="filter: blur(3px)">
+    <img src="resources/reference.png" style="filter: blur(10px)"> 
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3264,6 +3264,22 @@ GoogleAntiFlickerOptimizationQuirkEnabled:
     WebCore:
       default: true
 
+GraphicsContextBlurFilterEnabled:
+   type: bool
+   status: unstable
+   category: media
+   webcoreOnChange: setNeedsRelayoutAllFrames
+   humanReadableName: "GraphicsContext Blur Filter Rendering"
+   humanReadableDescription: "GraphicsContext Blur Filter Rendering"
+   condition: USE(GRAPHICS_CONTEXT_FILTERS)
+   defaultValue:
+     WebKitLegacy:
+       default: false
+     WebKit:
+       default: false
+     WebCore:
+       default: false
+
 GraphicsContextFiltersEnabled:
    type: bool
    status: mature

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4849,6 +4849,8 @@ OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes() const
 #if USE(GRAPHICS_CONTEXT_FILTERS)
     if (settings().graphicsContextFiltersEnabled())
         modes.add(FilterRenderingMode::GraphicsContext);
+    if (settings().graphicsContextBlurFilterEnabled())
+        modes.add(FilterRenderingMode::GraphicsContextBlur);
 #endif
     return modes;
 }

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -121,7 +121,7 @@ bool FEColorMatrix::resultIsAlphaImage(std::span<const Ref<FilterImage>>) const
     return m_type == ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA;
 }
 
-OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes() const
+OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE)
@@ -137,7 +137,7 @@ OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes() co
         || m_type == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE)
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif
-    return modes;
+    return modes & preferredFilterRenderingModes;
 }
 
 std::unique_ptr<FilterEffectApplier> FEColorMatrix::createAcceleratedApplier() const

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -60,7 +60,7 @@ private:
 
     bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const override;
 
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -66,7 +66,7 @@ bool FEComponentTransfer::operator==(const FEComponentTransfer& other) const
     return FilterEffect::operator==(other) && m_functions == other.m_functions;
 }
 
-OptionSet<FilterRenderingMode> FEComponentTransfer::supportedFilterRenderingModes() const
+OptionSet<FilterRenderingMode> FEComponentTransfer::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(SKIA)
@@ -76,7 +76,7 @@ OptionSet<FilterRenderingMode> FEComponentTransfer::supportedFilterRenderingMode
     if (FEComponentTransferCoreImageApplier::supportsCoreImageRendering(*this))
         modes.add(FilterRenderingMode::Accelerated);
 #endif
-    return modes;
+    return modes & preferredFilterRenderingModes;
 }
 
 std::unique_ptr<FilterEffectApplier> FEComponentTransfer::createAcceleratedApplier() const

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -93,7 +93,7 @@ private:
 
     bool operator==(const FilterEffect& other) const override { return areEqual<FEComponentTransfer>(*this, other); }
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const override;
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -137,7 +137,7 @@ IntOutsets FEDropShadow::calculateOutsets(const FloatSize& offset, const FloatSi
     return { top, right, bottom, left };
 }
 
-OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes() const
+OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(SKIA)
@@ -147,7 +147,7 @@ OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes() con
     if (m_stdX == m_stdY)
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif
-    return modes;
+    return modes & preferredFilterRenderingModes;
 }
 
 std::optional<GraphicsStyle> FEDropShadow::createGraphicsStyle(GraphicsContext& context, const Filter& filter) const

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.h
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.h
@@ -64,7 +64,7 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const override;
 
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -59,7 +59,7 @@ private:
 
     bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const override;
 
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -97,7 +97,7 @@ RenderingMode Filter::renderingMode() const
 
 void Filter::setFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes)
 {
-    m_filterRenderingModes = preferredFilterRenderingModes & supportedFilterRenderingModes();
+    m_filterRenderingModes = supportedFilterRenderingModes(preferredFilterRenderingModes);
     ASSERT(m_filterRenderingModes.contains(FilterRenderingMode::Software));
 }
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -206,7 +206,7 @@ FilterStyleVector FilterEffect::createFilterStyles(GraphicsContext& context, con
 
 FilterStyle FilterEffect::createFilterStyle(GraphicsContext& context, const Filter& filter, const FilterStyle& input, const std::optional<FilterEffectGeometry>& geometry) const
 {
-    ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
+    ASSERT(filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
     auto primitiveSubregion = calculatePrimitiveSubregion(filter, { &input.primitiveSubregion, 1 }, geometry);
     auto imageRect = calculateImageRect(filter, { &input.imageRect, 1 }, primitiveSubregion);

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -93,7 +93,7 @@ public:
     static AtomString sourceGraphicName() { return filterName(Type::SourceGraphic); }
     AtomString filterName() const { return filterName(m_filterType); }
 
-    virtual OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const { return FilterRenderingMode::Software; }
+    virtual OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const { return FilterRenderingMode::Software; }
     virtual RefPtr<FilterImage> apply(const Filter&, FilterImage&, FilterResults&) { return nullptr; }
     virtual FilterStyleVector createFilterStyles(GraphicsContext&, const Filter&, const FilterStyle&) const { return { }; }
 

--- a/Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp
@@ -35,6 +35,7 @@ TextStream& operator<<(TextStream& ts, FilterRenderingMode mode)
     case FilterRenderingMode::Software: ts << "Software"; break;
     case FilterRenderingMode::Accelerated: ts << "Accelerated"; break;
     case FilterRenderingMode::GraphicsContext: ts << "GraphicsContext"; break;
+    case FilterRenderingMode::GraphicsContextBlur: ts << "GraphicsContextBlur"; break;
     }
 
     return ts;

--- a/Source/WebCore/platform/graphics/filters/FilterRenderingMode.h
+++ b/Source/WebCore/platform/graphics/filters/FilterRenderingMode.h
@@ -32,7 +32,8 @@ namespace WebCore {
 enum class FilterRenderingMode : uint8_t {
     Software        = 1 << 0,
     Accelerated     = 1 << 1,
-    GraphicsContext = 1 << 2
+    GraphicsContext = 1 << 2,
+    GraphicsContextBlur = 1 << 3 // FIXME: Remove this mode once the CG blur filter is enabled by default.
 };
 
 constexpr OptionSet<FilterRenderingMode> allFilterRenderingModes = {

--- a/Source/WebCore/platform/graphics/filters/SourceAlpha.cpp
+++ b/Source/WebCore/platform/graphics/filters/SourceAlpha.cpp
@@ -41,13 +41,13 @@ SourceAlpha::SourceAlpha(DestinationColorSpace colorSpace)
 {
 }
 
-OptionSet<FilterRenderingMode> SourceAlpha::supportedFilterRenderingModes() const
+OptionSet<FilterRenderingMode> SourceAlpha::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE)
     modes.add(FilterRenderingMode::Accelerated);
 #endif
-    return modes;
+    return modes & preferredFilterRenderingModes;
 }
 
 std::unique_ptr<FilterEffectApplier> SourceAlpha::createSoftwareApplier() const

--- a/Source/WebCore/platform/graphics/filters/SourceAlpha.h
+++ b/Source/WebCore/platform/graphics/filters/SourceAlpha.h
@@ -35,7 +35,7 @@ public:
 private:
     explicit SourceAlpha(DestinationColorSpace);
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/SourceGraphic.cpp
+++ b/Source/WebCore/platform/graphics/filters/SourceGraphic.cpp
@@ -45,7 +45,7 @@ SourceGraphic::SourceGraphic(DestinationColorSpace colorSpace)
 {
 }
 
-OptionSet<FilterRenderingMode> SourceGraphic::supportedFilterRenderingModes() const
+OptionSet<FilterRenderingMode> SourceGraphic::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE) || USE(SKIA)
@@ -54,7 +54,7 @@ OptionSet<FilterRenderingMode> SourceGraphic::supportedFilterRenderingModes() co
 #if USE(GRAPHICS_CONTEXT_FILTERS)
     modes.add(FilterRenderingMode::GraphicsContext);
 #endif
-    return modes;
+    return modes & preferredFilterRenderingModes;
 }
 
 std::unique_ptr<FilterEffectApplier> SourceGraphic::createAcceleratedApplier() const

--- a/Source/WebCore/platform/graphics/filters/SourceGraphic.h
+++ b/Source/WebCore/platform/graphics/filters/SourceGraphic.h
@@ -38,7 +38,7 @@ private:
 
     unsigned numberOfEffectInputs() const override { return 0; }
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const override;
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -344,12 +344,12 @@ FilterEffectVector CSSFilter::effectsOfType(FilterFunction::Type filterType) con
     return effects;
 }
 
-OptionSet<FilterRenderingMode> CSSFilter::supportedFilterRenderingModes() const
+OptionSet<FilterRenderingMode> CSSFilter::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = allFilterRenderingModes;
 
     for (auto& function : m_functions)
-        modes = modes & function->supportedFilterRenderingModes();
+        modes = modes & function->supportedFilterRenderingModes(preferredFilterRenderingModes);
 
     ASSERT(modes);
     return modes;
@@ -357,9 +357,11 @@ OptionSet<FilterRenderingMode> CSSFilter::supportedFilterRenderingModes() const
 
 RefPtr<FilterImage> CSSFilter::apply(FilterImage* sourceImage, FilterResults& results)
 {
+    ASSERT(filterRenderingModes().contains(FilterRenderingMode::Software));
+
     if (!sourceImage)
         return nullptr;
-    
+
     RefPtr<FilterImage> result = sourceImage;
 
     for (auto& function : m_functions) {
@@ -373,7 +375,7 @@ RefPtr<FilterImage> CSSFilter::apply(FilterImage* sourceImage, FilterResults& re
 
 FilterStyleVector CSSFilter::createFilterStyles(GraphicsContext& context, const FilterStyle& sourceStyle) const
 {
-    ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
+    ASSERT(filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
     FilterStyleVector styles;
     FilterStyle lastStyle = sourceStyle;

--- a/Source/WebCore/rendering/CSSFilter.h
+++ b/Source/WebCore/rendering/CSSFilter.h
@@ -64,7 +64,7 @@ private:
 
     bool buildFilterFunctions(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const final;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const final;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
 

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -255,12 +255,12 @@ FloatPoint3D SVGFilter::resolvedPoint3D(const FloatPoint3D& point) const
     return resolvedPoint;
 }
 
-OptionSet<FilterRenderingMode> SVGFilter::supportedFilterRenderingModes() const
+OptionSet<FilterRenderingMode> SVGFilter::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = allFilterRenderingModes;
 
     for (auto& effect : m_effects)
-        modes = modes & effect->supportedFilterRenderingModes();
+        modes = modes & effect->supportedFilterRenderingModes(preferredFilterRenderingModes);
 
     ASSERT(modes);
     return modes;
@@ -312,7 +312,7 @@ RefPtr<FilterImage> SVGFilter::apply(const Filter&, FilterImage& sourceImage, Fi
 RefPtr<FilterImage> SVGFilter::apply(FilterImage* sourceImage, FilterResults& results)
 {
     ASSERT(!m_expression.isEmpty());
-    ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::Software));
+    ASSERT(filterRenderingModes().contains(FilterRenderingMode::Software));
 
     FilterImageVector stack;
 
@@ -365,7 +365,7 @@ FilterStyleVector SVGFilter::createFilterStyles(GraphicsContext& context, const 
 FilterStyleVector SVGFilter::createFilterStyles(GraphicsContext& context, const FilterStyle& sourceStyle) const
 {
     ASSERT(!m_expression.isEmpty());
-    ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
+    ASSERT(filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
     FilterStyleVector styles;
     FilterStyle lastStyle = sourceStyle;

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -74,7 +74,7 @@ private:
     FloatSize resolvedSize(const FloatSize&) const final;
     FloatPoint3D resolvedPoint3D(const FloatPoint3D&) const final;
 
-    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const final;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const final;
 
     RefPtr<FilterImage> apply(const Filter&, FilterImage& sourceImage, FilterResults&) final;
     FilterStyleVector createFilterStyles(GraphicsContext&, const Filter&, const FilterStyle& sourceStyle) const final;


### PR DESCRIPTION
#### 65cc730040c930985928b10e275c8678266ffc70
<pre>
[Filters] Add a separate feature flag for the CoreGraphics blur filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=298544">https://bugs.webkit.org/show_bug.cgi?id=298544</a>
<a href="https://rdar.apple.com/160131901">rdar://160131901</a>

Reviewed by Simon Fraser.

A new FilterRenderingMode named GraphicsContextBlur will be added temporarily to
tell FEGaussianBlur that CoreGraphics blur filter is enabled.

Instead of and-ing the final result of supportedFilterRenderingModes with the
preferredFilterRenderingModes, Filter will pass preferredFilterRenderingModes to
all its children which will do the and-ing before they return to the caller.

Page will add GraphicsContextBlur in preferredFilterRenderingModes() if the new
feature flag is enabled.

FEGaussianBlur::supportedFilterRenderingModes() will add GraphicsContext if the
radius is the same in the x-direction and the y-direction and the
preferredFilterRenderingModes has GraphicsContextBlur.

* LayoutTests/css3/filters/effect-graphics-context-blur-expected.html: Added.
* LayoutTests/css3/filters/effect-graphics-context-blur.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::preferredFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/FEDropShadow.h:
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::supportedFilterRenderingModes const):
(WebCore::FEGaussianBlur::createGraphicsStyle const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.h:
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::setFilterRenderingModes):
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::createFilterStyle const):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
(WebCore::FilterFunction::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/filters/FilterRenderingMode.h:
* Source/WebCore/platform/graphics/filters/SourceAlpha.cpp:
(WebCore::SourceAlpha::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/SourceAlpha.h:
* Source/WebCore/platform/graphics/filters/SourceGraphic.cpp:
(WebCore::SourceGraphic::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/SourceGraphic.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::supportedFilterRenderingModes const):
(WebCore::CSSFilter::apply):
(WebCore::CSSFilter::createFilterStyles const):
* Source/WebCore/rendering/CSSFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::supportedFilterRenderingModes const):
(WebCore::SVGFilter::apply):
(WebCore::SVGFilter::createFilterStyles const):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:

Canonical link: <a href="https://commits.webkit.org/299740@main">https://commits.webkit.org/299740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f072a85f7e7cae4e55629f35ff2ba299230c6317

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72072 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4c3be23-7ed8-46ac-aa8e-b1f4ca03d764) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91127 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60440 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f554a160-6622-4563-9484-73a9673b6804) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71682 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1595ecc-cdd6-4c01-a2df-b41fe287d24d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69968 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112124 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129249 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118515 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99746 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25290 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45049 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43540 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46781 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52487 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147214 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46247 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37827 "Found 1 new JSC binary failure: testapi, Found 18660 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Closures/closure-funcexpr-eval.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49596 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47933 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->