### PR TITLE
[JSC] WASM IPInt SIMD: implement pmin and pmax

### DIFF
--- a/JSTests/wasm/stress/simd-instructions-float.js
+++ b/JSTests/wasm/stress/simd-instructions-float.js
@@ -133,6 +133,34 @@ const floatTests = [
         [Number.NaN, Number.NaN, Number.POSITIVE_INFINITY, 2.0]
     ],
 
+    // f32x4.pmin tests (pseudo-minimum, b < a ? b : a)
+    [
+        "f32x4.pmin",
+        [1.0, 2.0, -3.0, 0.0],
+        [2.0, 1.0, -2.0, -0.0],
+        [1.0, 1.0, -3.0, 0.0]
+    ],
+    [
+        "f32x4.pmin",
+        [Number.NaN, 1.0, 2.0, Number.POSITIVE_INFINITY],
+        [1.0, Number.NaN, Number.NEGATIVE_INFINITY, 2.0],
+        [Number.NaN, 1.0, Number.NEGATIVE_INFINITY, 2.0]
+    ],
+
+    // f32x4.pmax tests (pseudo-maximum, a < b ? b : a)
+    [
+        "f32x4.pmax",
+        [1.0, 2.0, -3.0, -0.0],
+        [2.0, 1.0, -2.0, 0.0],
+        [2.0, 2.0, -2.0, -0.0]
+    ],
+    [
+        "f32x4.pmax",
+        [Number.NaN, 1.0, 2.0, Number.NEGATIVE_INFINITY],
+        [1.0, Number.NaN, Number.POSITIVE_INFINITY, 2.0],
+        [Number.NaN, 1.0, Number.POSITIVE_INFINITY, 2.0]
+    ],
+
     // f64x2.add tests
     [
         "f64x2.add",
@@ -257,6 +285,34 @@ const floatTests = [
         [Number.NaN, 1.0],
         [1.0, Number.NaN],
         [Number.NaN, Number.NaN]
+    ],
+
+     // f64x2.pmin tests (pseudo-minimum, b < a ? b : a)
+    [
+        "f64x2.pmin",
+        [1.0, 0.0],
+        [2.0, -0.0],
+        [1.0, 0.0]
+    ],
+    [
+        "f64x2.pmin",
+        [Number.NaN, 1.0],
+        [1.0, Number.NaN],
+        [Number.NaN, 1.0]
+    ],
+
+    // f64x2.pmax tests (pseudo-maximum, a < b ? b : a)
+    [
+        "f64x2.pmax",
+        [1.0, -0.0],
+        [2.0, 0.0],
+        [2.0, -0.0]
+    ],
+    [
+        "f64x2.pmax",
+        [Number.NaN, 1.0],
+        [1.0, Number.NaN],
+        [Number.NaN, 1.0]
     ]
 ];
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -5939,8 +5939,39 @@ ipintOp(_simd_f32x4_max, macro()
     nextIPIntInstruction()
 end)
 
-unimplementedInstruction(_simd_f32x4_pmin)
-unimplementedInstruction(_simd_f32x4_pmax)
+ipintOp(_simd_f32x4_pmin, macro()
+    # f32x4.pmin - pseudo-minimum of 4 32-bit floats (b < a ? b : a)
+    popVec(v1)
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Use fcmgt to compare v0 > v1, then use bsl to select
+        emit "fcmgt v18.4s, v16.4s, v17.4s"
+        emit "bsl v18.16b, v17.16b, v16.16b"
+        emit "mov v16.16b, v18.16b"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f32x4_pmax, macro()
+    # f32x4.pmax - pseudo-maximum of 4 32-bit floats (a < b ? b : a)
+    popVec(v1)
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Use fcmgt to compare v1 > v0, then use bsl to select
+        emit "fcmgt v18.4s, v17.4s, v16.4s"
+        emit "bsl v18.16b, v17.16b, v16.16b"
+        emit "mov v16.16b, v18.16b"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
 
 # 0xFD 0xEC 0x01 - 0xFD 0xF7 0x01: f64x2 operations
 
@@ -6069,8 +6100,40 @@ ipintOp(_simd_f64x2_max, macro()
     nextIPIntInstruction()
 end)
 
-unimplementedInstruction(_simd_f64x2_pmin)
-unimplementedInstruction(_simd_f64x2_pmax)
+ipintOp(_simd_f64x2_pmin, macro()
+    # f64x2.pmin - pseudo-minimum of 2 64-bit floats (b < a ? b : a)
+    popVec(v1)
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Use fcmgt to compare v0 > v1, then use bsl to select
+        emit "fcmgt v18.2d, v16.2d, v17.2d"
+        emit "bsl v18.16b, v17.16b, v16.16b"
+        emit "mov v16.16b, v18.16b"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f64x2_pmax, macro()
+    # f64x2.pmax - pseudo-maximum of 2 64-bit floats (a < b ? b : a)
+    popVec(v1)
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Use fcmgt to compare v1 > v0, then use bsl to select
+        emit "fcmgt v18.2d, v17.2d, v16.2d"
+        emit "bsl v18.16b, v17.16b, v16.16b"
+        emit "mov v16.16b, v18.16b"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
 # 0xFD 0xF8 0x01 - 0xFD 0xFF 0x01: trunc/convert
 
 unimplementedInstruction(_simd_i32x4_trunc_sat_f32x4_s)


### PR DESCRIPTION
#### 1eb14b776fc6cb1248d8a5770e064b996003ec9d
<pre>
[JSC] WASM IPInt SIMD: implement pmin and pmax
<a href="https://bugs.webkit.org/show_bug.cgi?id=298550">https://bugs.webkit.org/show_bug.cgi?id=298550</a>
<a href="https://rdar.apple.com/160139264">rdar://160139264</a>

Reviewed by Yusuke Suzuki.

Add IPInt implementations for fload pmin / pmax on ARM64.

WASM SIMD pmin and pmax are defined as
 pmin: (b &lt; a ? b : a)
 pmax: (a &lt; b ? b : a)

So, the Neon instructions fminnm and fmaxnm don&apos;t agree for
-0.0 / 0.0 and NaN cases, since -0.0 == 0.0 and NaN always
not equal. So instead, use a different instruction sequence.

Also enhance simd-instructions-lib.js to print more debug info
when a test case fails.

* JSTests/wasm/stress/simd-instructions-float.js:
* JSTests/wasm/stress/simd-instructions-lib.js:
(export.async runSIMDTests):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/299722@main">https://commits.webkit.org/299722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8715ee752a970d01dade163a28a96fe352e32005

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30322 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/126308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72051 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48248 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/126308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122930 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/32249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/107584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/126308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/25689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/69943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112103 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/101724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/25877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118494 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46898 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/35561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/129228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47264 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/103772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/45031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19077 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46760 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52466 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147193 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/46226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/49575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/47912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->