### PR TITLE
Use CheckedPtr instead of a raw pointer in RenderLayer

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -526,6 +526,26 @@ void RenderLayer::removeChild(RenderLayer& oldChild)
         dirtyVisibleContentStatus();
 }
 
+void RenderLayer::removeForRenderTreeBeingDestroyed()
+{
+    if (auto* parent = m_parent.get()) {
+        if (parent->m_first.get() == this)
+            parent->m_first = m_next;
+        if (parent->m_last.get() == this)
+            parent->m_last = m_previous;
+    }
+    if (auto* next = m_next.get())
+        next->m_previous = m_previous;
+    if (auto* previous = m_previous.get())
+        previous->m_next = m_next;
+
+    m_parent = nullptr;
+    m_first = nullptr;
+    m_last = nullptr;
+    m_previous = nullptr;
+    m_next = nullptr;
+}
+
 void RenderLayer::dirtyPaintOrderListsOnChildChange(RenderLayer& child)
 {
     if (child.isNormalFlowOnly())
@@ -578,7 +598,7 @@ void RenderLayer::removeOnlyThisLayer()
         removeChild(*reflectionLayer);
 
     // Now walk our kids and reattach them to our parent.
-    RenderLayer* current = m_first;
+    RenderLayer* current = m_first.get();
     while (current) {
         RenderLayer* next = current->nextSibling();
         removeChild(*current);

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -182,11 +182,11 @@ public:
     RenderLayerModelObject& renderer() const { return m_renderer; }
     RenderBox* renderBox() const { return dynamicDowncast<RenderBox>(renderer()); }
 
-    RenderLayer* parent() const { return m_parent; }
-    RenderLayer* previousSibling() const { return m_previous; }
-    RenderLayer* nextSibling() const { return m_next; }
-    RenderLayer* firstChild() const { return m_first; }
-    RenderLayer* lastChild() const { return m_last; }
+    RenderLayer* parent() const { return m_parent.get(); }
+    RenderLayer* previousSibling() const { return m_previous.get(); }
+    RenderLayer* nextSibling() const { return m_next.get(); }
+    RenderLayer* firstChild() const { return m_first.get(); }
+    RenderLayer* lastChild() const { return m_last.get(); }
     bool isDescendantOf(const RenderLayer&) const;
     WEBCORE_EXPORT RenderLayer* commonAncestorWithLayer(const RenderLayer&) const;
 
@@ -201,6 +201,7 @@ public:
 
     void addChild(RenderLayer& newChild, RenderLayer* beforeChild = nullptr);
     void removeChild(RenderLayer&);
+    void removeForRenderTreeBeingDestroyed();
 
     void insertOnlyThisLayer();
     void removeOnlyThisLayer();
@@ -1404,11 +1405,11 @@ private:
 
     const CheckedRef<RenderLayerModelObject> m_renderer;
 
-    RenderLayer* m_parent { nullptr };
-    RenderLayer* m_previous { nullptr };
-    RenderLayer* m_next { nullptr };
-    RenderLayer* m_first { nullptr };
-    RenderLayer* m_last { nullptr };
+    CheckedPtr<RenderLayer> m_parent;
+    CheckedPtr<RenderLayer> m_previous;
+    CheckedPtr<RenderLayer> m_next;
+    CheckedPtr<RenderLayer> m_first;
+    CheckedPtr<RenderLayer> m_last;
 
     SingleThreadWeakPtr<RenderLayer> m_backingProviderLayer;
     SingleThreadWeakPtr<RenderLayer> m_backingProviderLayerAtEndOfCompositingUpdate;
@@ -1491,7 +1492,7 @@ inline void RenderLayer::updateZOrderLists()
 
 inline RenderLayer* RenderLayer::paintOrderParent() const
 {
-    return m_isNormalFlowOnly ? m_parent : stackingContext();
+    return m_isNormalFlowOnly ? m_parent.get() : stackingContext();
 }
 
 inline void RenderLayer::setIsHiddenByOverflowTruncation(bool isHidden)

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -105,7 +105,8 @@ void RenderLayerModelObject::willBeDestroyed()
 void RenderLayerModelObject::destroyLayer()
 {
     setHasLayer(false);
-    m_layer = nullptr;
+    if (auto layer = std::exchange(m_layer, nullptr))
+        layer->removeForRenderTreeBeingDestroyed();
 }
 
 void RenderLayerModelObject::createLayer()


### PR DESCRIPTION
#### fdb4169ec564eec754400a0d768cf6ace93523e1
<pre>
Use CheckedPtr instead of a raw pointer in RenderLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=298558">https://bugs.webkit.org/show_bug.cgi?id=298558</a>

Reviewed by NOBODY (OOPS!).

Use CheckedPtr&lt;RenderLayer&gt; instead of RenderLayer* to refer to other RenderLayers in RenderLayer.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::removeForRenderTreeBeingDestroyed):
(WebCore::RenderLayer::removeOnlyThisLayer):
* Source/WebCore/rendering/RenderLayer.h:
(WebCore::RenderLayer::paintOrderParent const):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::destroyLayer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdb4169ec564eec754400a0d768cf6ace93523e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72046 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91107 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60420 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107576 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71663 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25681 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69938 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129223 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46893 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35556 "Found 1 new test failure: http/tests/websocket/tests/hybi/alert-in-event-handler.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99728 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99573 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23040 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43514 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20143 "") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52461 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46221 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47907 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->