### PR TITLE
REGRESSION (295715@main): [iOS] Safari extension popup windows may open scrolled down, website may flicker during scrolling

### DIFF
--- a/LayoutTests/fast/scrolling/ios/pin-scroll-position-on-scale-change-should-not-flicker-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/pin-scroll-position-on-scale-change-should-not-flicker-expected.txt
@@ -1,0 +1,13 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Header
+This
+is
+some
+text
+to
+show
+that
+scrolling
+occurred

--- a/LayoutTests/fast/scrolling/ios/pin-scroll-position-on-scale-change-should-not-flicker.html
+++ b/LayoutTests/fast/scrolling/ios/pin-scroll-position-on-scale-change-should-not-flicker.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<style>
+
+body {
+    height: 10000px;
+    font-size: 30px;
+}
+
+.header {
+    position: fixed;
+    background: yellow;
+}
+
+.header.wide {
+    position: static;
+    width: 1000px;
+}
+
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div class="header">Header</div>
+<div>This</div>
+<div>is</div>
+<div>some</div>
+<div>text</div>
+<div>to</div>
+<div>show</div>
+<div>that</div>
+<div>scrolling</div>
+<div>occurred</div>
+
+<script>
+
+jsTestIsAsync = true;
+
+const triggerPoint = 300;
+
+async function runTest() {
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(0, 0)
+        .move(0, -triggerPoint + 10, 0.3)
+        .end()
+        .takeResult());
+    await UIHelper.waitForScrollCompletion();
+    // Wait one second to see if any flickering occurs.
+    await UIHelper.delayFor(1000);
+    finishJSTest();
+}
+
+addEventListener('scroll', () => {
+    const header = document.querySelector('.header');
+    if (window.scrollY > triggerPoint)
+        header.classList.add('wide');
+    else {
+        if (header.classList.contains('wide'))
+            testFailed("Unexpected scrolling.");
+        header.classList.remove('wide');
+    }
+});
+
+addEventListener('load', () => {
+   runTest();
+});
+
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1037,11 +1037,6 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     BOOL shouldUpdateContentOffsetForFittingScale = !shouldUpdateZoomScale && !CGSizeEqualToSize(oldContentSize, newContentSize) && (oldContentSize.height > 0) && self._isDisplayingPDF;
 
     if (shouldUpdateZoomScale || shouldUpdateContentOffsetForFittingScale) {
-        if (shouldUpdateZoomScale) {
-            LOG_WITH_STREAM(VisibleRects, stream << " updating scroll view with pageScaleFactor " << pageScaleFactor);
-            [_scrollView setZoomScale:pageScaleFactor];
-        }
-
         UIEdgeInsets contentInsets = [_scrollView adjustedContentInset];
         CGPoint minimumContentOffset = CGPointMake(-contentInsets.left, -contentInsets.top);
         CGPoint contentOffset = [_scrollView contentOffset];
@@ -1058,6 +1053,11 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
             contentOffsetX = minimumContentOffset.x + ((contentOffsetX - minimumContentOffset.x) * scaleRatio);
 
         CGFloat contentOffsetY = minimumContentOffset.y + ((contentOffset.y - minimumContentOffset.y) * scaleRatio);
+
+        if (shouldUpdateZoomScale) {
+            LOG_WITH_STREAM(VisibleRects, stream << " updating scroll view with pageScaleFactor " << pageScaleFactor);
+            [_scrollView setZoomScale:pageScaleFactor];
+        }
 
         changeContentOffsetBoundedInValidRange(_scrollView.get(), CGPointMake(contentOffsetX, contentOffsetY));
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
@@ -27,6 +27,7 @@
 
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKPreferences.h>
@@ -592,6 +593,25 @@ TEST(AnimatedResize, PinScrollPositionRelativeToTopEdgeOnPageScaleChange)
 
     EXPECT_NEAR([scrollView zoomScale], [webView frame].size.width / layoutWidth, 0.0001);
     EXPECT_TRUE(CGPointEqualToPoint([scrollView contentOffset], top));
+}
+
+TEST(AnimatedResize, PinScrollPositionRelativeToTopEdgeOnPageScaleChangeAfterIncreasedSize)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr scrollView = [webView scrollView];
+
+    static constexpr unsigned layoutWidth = 375;
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<head><meta name='viewport' content='width=%u'></head><body style='height: 10000px'>Content</body>", layoutWidth]];
+
+    EXPECT_EQ([scrollView contentOffset], CGPointZero);
+
+    [webView _beginLiveResize];
+    [webView setFrame:CGRectMake(0, 0, layoutWidth, 600)];
+    [webView _endLiveResize];
+
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ([scrollView contentOffset], CGPointZero);
 }
 
 TEST(AnimatedResize, ChangingWebViewGeometryDuringLiveResizeDoesNotHang)


### PR DESCRIPTION
#### acd5bf8f6c4985b12b7d577f199f4dea5a50f3f1
<pre>
REGRESSION (295715@main): [iOS] Safari extension popup windows may open scrolled down, website may flicker during scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=296056">https://bugs.webkit.org/show_bug.cgi?id=296056</a>
<a href="https://rdar.apple.com/155965298">rdar://155965298</a>

Reviewed by Abrar Rahman Protyasha.

295715@main inadvertently moved the zoom scale modification before computing the
scale ratio used to pin the scroll position to the top edge of the content. This
did not break PDFs since the scale ratio is computed using the ratio of the new
and old content sizes. However, the change effectively reverted 258521@main as
the scale ratio for all other web content would be 1, resulting in no content
offset adjustment, which is necessary to pin the scroll position. Instead, UIKit&apos;s
default behavior of pinning to the center occurs, resulting in unexpected jumps.

In the case of Safari extensions, the web view&apos;s width is increased during popover
presentation. This results in page scale changes for content with a fixed layout
width, and the scroll position may unexpectedly jump. Similarly, other sites, like
GitHub&apos;s Checks page, may flicker, as a wide-fixed element is added and removed
during scrolling. In that instance, page scale changes due to WebKit&apos;s shrink-to-fit
logic. This can result in an infinite loop where an element is added/removed based
on scroll position, changing the page scale, which then changes the scroll position.

Fix by moving the zoom scale modification back to where is originally was: after
computing the scale ratio, but before adjusting the content offset.

An API test is used to mimic the Safari extensions breakage, by simplying changing
the frame of the web view. This issue was not caught by the test added in 294990@main,
since that test only *decreased* the size. Additionally, 258521@main did not come
with any tests of its own. A layout test is used to mimic the flickering on GitHub.
Consequently, there now exists test coverage for scroll position pinning due to
page scale changes driven by frame changes, and WebKit&apos;s shrink-to-fit logic.

Thanks to Jessica Cheung for assisting in the investigation of this issue.

* LayoutTests/fast/scrolling/ios/pin-scroll-position-on-scale-change-should-not-flicker-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/pin-scroll-position-on-scale-change-should-not-flicker.html: Added.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST(AnimatedResize, PinScrollPositionRelativeToTopEdgeOnPageScaleChangeAfterIncreasedSize)):

Canonical link: <a href="https://commits.webkit.org/299762@main">https://commits.webkit.org/299762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c674f2e9c247797e8818c7cded460183889a491

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72059 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aad24547-6c42-42dc-9410-a19e1698208a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91117 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60429 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5bcfb29-be9f-4042-a133-3ec28b35fd01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71672 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a65365b-b5d8-4c5e-be95-effb016b4c1d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25695 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69952 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129236 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99736 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99581 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45036 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43527 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19087 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52474 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46234 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49583 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47920 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->