### PR TITLE
Temporal: Reimplement TemporalDuration::total() according to the spec

### DIFF
--- a/JSTests/stress/temporal-duration.js
+++ b/JSTests/stress/temporal-duration.js
@@ -240,6 +240,10 @@ shouldBe(posAbsolute.total({ unit: 'milliseconds' }), 93784005.006007);
 shouldBe(posAbsolute.total({ unit: 'microseconds' }), 93784005006.007);
 shouldBe(posAbsolute.total({ unit: 'nanoseconds' }), 93784005006007);
 shouldBe(Temporal.Duration.from('-PT123456789S').total({ unit: 'day' }), -1428.8980208333332);
+const posSubseconds = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 999, 999999, 999999999);
+const negSubseconds = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, -999, -999999, -999999999);
+shouldBe(posSubseconds.total("seconds"), 2.998998999);
+shouldBe(negSubseconds.total("seconds"), -2.998998999);
 
 // At present, toLocaleString has the same behavior as toJSON or argumentless toString.
 for (const method of ['toString', 'toJSON', 'toLocaleString']) {    

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -224,12 +224,12 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/total/calendar-possibly-required.js
     - test/built-ins/Temporal/Duration/prototype/total/calendar-temporal-object.js
     - test/built-ins/Temporal/Duration/prototype/total/does-not-accept-non-string-primitives-for-relativeTo.js
-    - test/built-ins/Temporal/Duration/prototype/total/duration-out-of-range-added-to-relativeto.js
     - test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-infinity-throws-rangeerror.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-leap-second.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeTo-must-have-required-properties.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-number.js
+    - test/built-ins/Temporal/Duration/prototype/total/relativeto-plaindatetime.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-number.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-wrong-type.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-no-time-units.js
@@ -243,10 +243,6 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-string-zoneddatetime.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-sub-minute-offset.js
     - test/built-ins/Temporal/Duration/prototype/total/relativeto-wrong-type.js
-    - test/built-ins/Temporal/Duration/prototype/total/rounds-calendar-units-in-durations-without-calendar-units.js
-    - test/built-ins/Temporal/Duration/prototype/total/rounds-durations-with-calendar-units.js
-    - test/built-ins/Temporal/Duration/prototype/total/precision-exact-mathematical-values-5.js
-    - test/built-ins/Temporal/Duration/prototype/total/throws-on-wrong-offset-for-zoneddatetime-relativeto.js
     - test/built-ins/Temporal/PlainDate/prototype/since/rounding-relative.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-ceil.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -79,9 +79,6 @@ test/built-ins/Temporal/Duration/compare/relativeto-string-limits.js:
 test/built-ins/Temporal/Duration/compare/throws-when-target-zoned-date-time-outside-valid-limits.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n, \"UTC\")')"
-test/built-ins/Temporal/Duration/from/argument-duration-max.js:
-  default: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«9007199254740994», «9007199254740992») to be true'
-  strict mode: 'Test262Error: operation succeeds with property bag with max minutes Expected SameValue(«9007199254740994», «9007199254740992») to be true'
 test/built-ins/Temporal/Duration/from/argument-duration-precision-exact-numerical-values.js:
   default: 'Test262Error: case where floating point inaccuracy brings total below limit, positive Expected SameValue(«"PT9007199254740992.000424S"», «"PT9007199254740991.975424S"») to be true'
   strict mode: 'Test262Error: case where floating point inaccuracy brings total below limit, positive Expected SameValue(«"PT9007199254740992.000424S"», «"PT9007199254740991.975424S"») to be true'
@@ -223,9 +220,6 @@ test/built-ins/Temporal/Duration/prototype/toString/throws-when-rounded-duration
 test/built-ins/Temporal/Duration/prototype/toString/total-of-duration-time-units-out-of-range.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/Duration/prototype/total/balance-subseconds.js:
-  default: 'Test262Error: Expected SameValue(«2.9989989990000003», «2.998998999») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«2.9989989990000003», «2.998998999») to be true'
 test/built-ins/Temporal/Duration/prototype/total/blank-duration.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(1n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(1n, \"UTC\")')"
@@ -235,36 +229,15 @@ test/built-ins/Temporal/Duration/prototype/total/incorrect-properties-ignored.js
 test/built-ins/Temporal/Duration/prototype/total/no-dst-day-length.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, \"+04:30\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, \"+04:30\")')"
-test/built-ins/Temporal/Duration/prototype/total/no-precision-loss-for-small-units.js:
-  default: 'Test262Error: Expected SameValue(«0.0020310000000000003», «0.002031») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«0.0020310000000000003», «0.002031») to be true'
 test/built-ins/Temporal/Duration/prototype/total/options-read-before-algorithmic-validation.js:
   default: 'Test262Error: Actual [get options.unit, get options.unit.toString, call options.unit.toString] and expected [get options.relativeTo, get options.unit, get options.unit.toString, call options.unit.toString] should have the same contents. all options should be read first'
   strict mode: 'Test262Error: Actual [get options.unit, get options.unit.toString, call options.unit.toString] and expected [get options.relativeTo, get options.unit, get options.unit.toString, call options.unit.toString] should have the same contents. all options should be read first'
-test/built-ins/Temporal/Duration/prototype/total/precision-exact-mathematical-values-1.js:
-  default: 'Test262Error: return value of total() Expected SameValue(«4000», «4000.0000000000005») to be true'
-  strict mode: 'Test262Error: return value of total() Expected SameValue(«4000», «4000.0000000000005») to be true'
-test/built-ins/Temporal/Duration/prototype/total/precision-exact-mathematical-values-2.js:
-  default: 'Test262Error: Expected SameValue(«4001», «4000.9999999999995») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«4001», «4000.9999999999995») to be true'
-test/built-ins/Temporal/Duration/prototype/total/precision-exact-mathematical-values-6.js:
-  default: 'Test262Error: hours=816, nanoseconds=2049187497660 Expected SameValue(«816.5692187493501», «816.56921874935») to be true'
-  strict mode: 'Test262Error: hours=816, nanoseconds=2049187497660 Expected SameValue(«816.5692187493501», «816.56921874935») to be true'
-test/built-ins/Temporal/Duration/prototype/total/precision-exact-mathematical-values-7.js:
-  default: 'Test262Error: seconds=0, milliseconds=950 Expected SameValue(«0.9500000000000001», «0.95») to be true'
-  strict mode: 'Test262Error: seconds=0, milliseconds=950 Expected SameValue(«0.9500000000000001», «0.95») to be true'
-test/built-ins/Temporal/Duration/prototype/total/relativeto-plaindatetime.js:
-  default: 'Error: FIXME: years, months, or weeks totalling with relativeTo not implemented yet'
-  strict mode: 'Error: FIXME: years, months, or weeks totalling with relativeTo not implemented yet'
 test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-invalid-offset-string.js:
   default: 'Test262Error: "0" is not a valid offset string Expected a TypeError but got a RangeError'
   strict mode: 'Test262Error: "0" is not a valid offset string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Duration/prototype/total/relativeto-string-limits.js:
   default: 'Test262Error: "+275760-09-13T00:00Z[UTC]" is outside the representable range for a relativeTo parameter after conversion to DateTime Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: "+275760-09-13T00:00Z[UTC]" is outside the representable range for a relativeTo parameter after conversion to DateTime Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/Duration/prototype/total/throws-if-date-time-invalid-with-plaindate-relative.js:
-  default: 'Test262Error: Expected a RangeError but got a Error'
-  strict mode: 'Test262Error: Expected a RangeError but got a Error'
 test/built-ins/Temporal/Duration/prototype/total/throws-if-date-time-invalid-with-zoneddatetime-relative.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n - 1n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n - 1n, \"UTC\")')"

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -817,6 +817,7 @@ runtime/FileBasedFuzzerAgent.cpp
 runtime/FileBasedFuzzerAgentBase.cpp
 runtime/FinalizationRegistryConstructor.cpp
 runtime/FinalizationRegistryPrototype.cpp
+runtime/FractionToDouble.cpp
 runtime/FunctionConstructor.cpp
 runtime/FunctionExecutable.cpp
 runtime/FunctionExecutableDump.cpp

--- a/Source/JavaScriptCore/runtime/FractionToDouble.cpp
+++ b/Source/JavaScriptCore/runtime/FractionToDouble.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FractionToDouble.h"
+
+#include "MathCommon.h"
+
+// The calculations here are based on algorithms from two sources. The second
+// one builds on the first.
+//
+// Shewchuk (1997). Adaptive precision floating-point arithmetic and fast robust
+//   geometric predicates. Discrete & Computational Geometry 18(3), pp. 305–363.
+//   https://doi.org/10.1007/PL00009321
+//
+// Hida, Li, Bailey (2008). Library for double-double and quad-double
+//   arithmetic. Manuscript. https://www.davidhbailey.com/dhbpapers/qd.pdf
+//   and the accompanying QD library https://github.com/BL-highprecision/QD,
+//   which is BSD-licensed.
+
+namespace JSC {
+
+// Double-double precision floating point number, represented as the unevaluated
+// sum of two doubles. In other words, dd[0] is the double approximation term
+// and dd[1] is the error term.
+//
+// There are many such representations, but only one is 'normalized' meaning the
+// dd[0] term is the most accurate possible double-precision approximation of
+// the double-double value.
+using DD = std::array<double, 2>;
+
+// Conversion of Int128 to double-double precision floating point. The
+// calculations follow from the definition of hi and lo: hi is the closest
+// double-precision approximation to the exact value (which itself will be a
+// safe integer) and lo is the error term.
+static DD int128ToDD(const Int128& value)
+{
+    double hi = static_cast<double>(value);
+    double lo = static_cast<double>(value - static_cast<Int128>(hi));
+    return { hi, lo };
+}
+
+// Computes double-double precision a + b of two doubles a and b. This is the
+// Two-Sum algorithm in theorem 7 of the Shewchuk paper.
+static DD ddSum(double a, double b)
+{
+    // First compute the double-precision approximation of the sum by regular
+    // double addition.
+    double sum = a + b;
+
+    // Compute the error term.
+    double bVirtual = sum - a;
+    double aVirtual = sum - bVirtual;
+    double bRoundoff = b - bVirtual;
+    double aRoundoff = a - aVirtual;
+    double error = aRoundoff + bRoundoff;
+
+    return { sum, error };
+}
+
+// Computes double-double precision a * b of two doubles a and b. The
+// optimization using std::fma() is suggested in section 2 of the Hida-Li-Bailey
+// paper.
+static DD ddProduct(double a, double b)
+{
+    // First compute the double-precision approximation of the product by
+    // regular double multiplication.
+    double product = a * b;
+
+    // On armv8, this emits the fnmsub instruction.
+    // On x86_64, this emits the vfmsub213sd instruction if compiled with SSE
+    // instructions. If not, it calls libm's fma(), which is comparably fast to
+    // using the Two-Product algorithm in theorem 18 of the Shewchuk paper.
+    double error = std::fma(a, b, -product);
+
+    return { product, error };
+}
+
+// Computes double-double precision numerator / denominator, where divisor is a
+// double, and rounds the result to double precision. This is described in
+// section 3.5 of the Hida-Li-Bailey paper.
+static double fractionToDoubleSlow(const Int128& numerator, double denominator)
+{
+    DD ddNumerator = int128ToDD(numerator);
+
+    // Compute a first approximation of the quotient by regular double division.
+    double quotient0 = ddNumerator[0] / denominator;
+
+    // Compute remainder, ddNumerator - quotient0 * denominator.
+    DD product = ddProduct(quotient0, denominator);
+    DD remainder = ddSum(ddNumerator[0], -product[0]);
+
+    // Compute the next approximation term.
+    double error = remainder[1] + ddNumerator[1] - product[1];
+    double quotient1 = (remainder[0] + error) / denominator;
+
+    // The result is DD { quotient0, quotient1 }. If we wanted double-double
+    // precision here, we would have to use the Fast-Two-Sum algorithm from
+    // theorem 6 of the Shewchuk paper to renormalize the two terms, but since
+    // we only need double precision we can discard the error term.
+    return quotient0 + quotient1;
+}
+
+double fractionToDouble(const Int128& numerator, double denominator)
+{
+    ASSERT(denominator > 0);
+    ASSERT(isSafeInteger(denominator));
+
+    if (!numerator)
+        return 0;
+
+    // When the denominator is 1, we are just calculating the double
+    // approximation of the numerator.
+    if (denominator == 1)
+        return static_cast<double>(numerator);
+
+    // When the numerator can be represented exactly as a double the algorithm
+    // collapses to a simple double division.
+    if (isSafeInteger(static_cast<double>(numerator))) [[likely]]
+        return static_cast<double>(numerator) / denominator;
+
+    // Otherwise use double-double precision to compute the result.
+    return fractionToDoubleSlow(numerator, denominator);
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/FractionToDouble.h
+++ b/Source/JavaScriptCore/runtime/FractionToDouble.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Int128.h>
+
+namespace JSC {
+
+static constexpr Int128 absInt128(const Int128& value)
+{
+    if (value < 0)
+        return -value;
+    return value;
+}
+
+double fractionToDouble(const Int128& numerator, double denominator);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "ISO8601.h"
 
+#include "FractionToDouble.h"
 #include "IntlObject.h"
 #include "ParseInt.h"
 #include "TemporalObject.h"

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -335,11 +335,4 @@ using CheckedInt128 = Checked<Int128, RecordOverflow>;
 
 CheckedInt128 checkedCastDoubleToInt128(double n);
 
-static constexpr Int128 absInt128(const Int128& value)
-{
-    if (value < 0)
-        return -value;
-    return value;
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "TemporalObject.h"
 
+#include "FractionToDouble.h"
 #include "FunctionPrototype.h"
 #include "IntlObjectInlines.h"
 #include "JSCJSValueInlines.h"

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -173,7 +173,7 @@ constexpr Int128 lengthInNanoseconds(TemporalUnit unit)
     case TemporalUnit::Hour:
         return 60 * lengthInNanoseconds(TemporalUnit::Minute);
     case TemporalUnit::Day:
-        return 24 * lengthInNanoseconds(TemporalUnit::Day);
+        return 24 * lengthInNanoseconds(TemporalUnit::Hour);
     default:
         break;
     }


### PR DESCRIPTION
#### ae596477c51879cd2573d03e828d948a9de500e2
<pre>
Temporal: Reimplement TemporalDuration::total() according to the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=298561">https://bugs.webkit.org/show_bug.cgi?id=298561</a>

Reviewed by Yusuke Suzuki.

This enables some of the tests for Temporal/Duration/prototype/total.

This patch was co-authored by Philip Chimento &lt;pchimento@igalia.com&gt;.

* JSTests/stress/temporal-duration.js:
* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::appendInteger):
(JSC::totalTimeDuration):
(JSC::TemporalDuration::total const):
* Source/JavaScriptCore/runtime/TemporalObject.h:
(JSC::lengthInNanoseconds):

Canonical link: <a href="https://commits.webkit.org/300802@main">https://commits.webkit.org/300802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d2b115f9d6e817e75f61363c4d1c5b4d582dbdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130710 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52229 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94255 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74855 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29013 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74183 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116079 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105070 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/29236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133403 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122452 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50873 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102549 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47891 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56490 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153548 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50200 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39026 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->