### PR TITLE
[css-anchor-position-1] New default anchor should restart anchor maching to pick up the new anchor

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7500,7 +7500,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-00
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-to-fixed-anchor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-colspan-003.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 20ba8be4af52496e49284f7b6bd78fb5d47fc2af
<pre>
[css-anchor-position-1] New default anchor should restart anchor maching to pick up the new anchor
<a href="https://rdar.apple.com/159899182">rdar://159899182</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298422">https://bugs.webkit.org/show_bug.cgi?id=298422</a>

Reviewed by Antti Koivisto.

The default anchor of an anchor-positioned element can change after it has reached
the Positioned stage. Given an anchor-positioned element that initially defaults
to anchor --a, and has a position option that defaults to anchor --b:
* The element is first fully resolved (unti Positioned stage) with the base style
* The base style causes it to overflow, so it tries the position option
* Now the element defaults to anchor --b, but since stage == Positioned,
  we don&apos;t restart the anchor maching process to pick up anchor --b
* Result: the element can&apos;t find anchor --b and can&apos;t position relative to it.

This is demonstrated in test
imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-to-fixed-anchor.html
Fix this by restarting the matching process if we found a new default anchor.

This exposes a bug where an anchor-positioned element can get stuck in
ResolveAnchorFunction stage indefinitely. Take the previous scenario:
* When we find a new default anchor, we set the stage to FindAnchors to restart
  the anchor matching process
* After a layout round, the stage changes to ResolveAnchorFunctions (because the
  element uses anchor function)
* An element can only move from ResolveAnchorFunctions to Resolved if it
  evaluates an anchor function, which moves the stage to Resolved. However,
  we&apos;re trying position options, and the position option styles are already
  evaluated ahead of time. So we don&apos;t re-evaluate the anchor functions, we
  simply apply the pre-generated style. This means the stage don&apos;t have the
  opportunity to move to Resolved.
* The element is then stuck in ResolveAnchorFunctions, because
  AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout
  doesn&apos;t move ResolveAnchorFunctions to other stages.

Fix this by changing
AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout
to move elements in ResolveAnchorFunctions stage to Positioned.

Test: LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-to-fixed-anchor.html

* LayoutTests/TestExpectations:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility):

Canonical link: <a href="https://commits.webkit.org/300142@main">https://commits.webkit.org/300142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97c8a8db7f2d9b5486edbd4fab05114996956cad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73568 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d21c541f-1435-4ac8-a5c3-c1d326bd337e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f824daa-e687-4c18-95ec-44f2d911fefb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72944 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ffd8115-9901-499e-ba57-f07a397442ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26983 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71510 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130760 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100854 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100761 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24253 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53984 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47743 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51089 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->