### PR TITLE
Crash in `WebEditorClient::clearUndoRedoOperations`

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -70,24 +70,22 @@ using namespace HTMLNames;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebEditorClient);
 
-Ref<WebPage> WebEditorClient::protectedPage() const
-{
-    return m_page.get();
-}
-
 bool WebEditorClient::shouldDeleteRange(const std::optional<SimpleRange>& range)
 {
-    return m_page->injectedBundleEditorClient().shouldDeleteRange(m_page.get(), range);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().shouldDeleteRange(*page, range) : false;
 }
 
 bool WebEditorClient::smartInsertDeleteEnabled()
 {
-    return m_page->isSmartInsertDeleteEnabled();
+    RefPtr page = m_page.get();
+    return page ? page->isSmartInsertDeleteEnabled() : false;
 }
  
 bool WebEditorClient::isSelectTrailingWhitespaceEnabled() const
 {
-    return m_page->isSelectTrailingWhitespaceEnabled();
+    RefPtr page = m_page.get();
+    return page ? page->isSelectTrailingWhitespaceEnabled() : false;
 }
 
 bool WebEditorClient::isContinuousSpellCheckingEnabled()
@@ -118,74 +116,90 @@ int WebEditorClient::spellCheckerDocumentTag()
 
 bool WebEditorClient::shouldBeginEditing(const SimpleRange& range)
 {
-    return m_page->injectedBundleEditorClient().shouldBeginEditing(m_page.get(), range);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().shouldBeginEditing(*page, range) : false;
 }
 
 bool WebEditorClient::shouldEndEditing(const SimpleRange& range)
 {
-    return m_page->injectedBundleEditorClient().shouldEndEditing(m_page.get(), range);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().shouldEndEditing(*page, range) : false;
 }
 
 bool WebEditorClient::shouldInsertNode(Node& node, const std::optional<SimpleRange>& rangeToReplace, EditorInsertAction action)
 {
-    return m_page->injectedBundleEditorClient().shouldInsertNode(m_page.get(), node, rangeToReplace, action);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().shouldInsertNode(*page, node, rangeToReplace, action) : false;
 }
 
 bool WebEditorClient::shouldInsertText(const String& text, const std::optional<SimpleRange>& rangeToReplace, EditorInsertAction action)
 {
-    return m_page->injectedBundleEditorClient().shouldInsertText(m_page.get(), text, rangeToReplace, action);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().shouldInsertText(*page, text, rangeToReplace, action) : false;
 }
 
 bool WebEditorClient::shouldChangeSelectedRange(const std::optional<SimpleRange>& fromRange, const std::optional<SimpleRange>& toRange, Affinity affinity, bool stillSelecting)
 {
-    return m_page->injectedBundleEditorClient().shouldChangeSelectedRange(m_page.get(), fromRange, toRange, affinity, stillSelecting);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().shouldChangeSelectedRange(*page, fromRange, toRange, affinity, stillSelecting) : false;
 }
     
 bool WebEditorClient::shouldApplyStyle(const StyleProperties& style, const std::optional<SimpleRange>& range)
 {
-    return m_page->injectedBundleEditorClient().shouldApplyStyle(m_page.get(), style, range);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().shouldApplyStyle(*page, style, range) : false;
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 void WebEditorClient::registerAttachmentIdentifier(const String& identifier, const String& contentType, const String& preferredFileName, Ref<FragmentedSharedBuffer>&& data)
 {
-    m_page->send(Messages::WebPageProxy::RegisterAttachmentIdentifierFromData(identifier, contentType, preferredFileName, IPC::SharedBufferReference(WTFMove(data))));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RegisterAttachmentIdentifierFromData(identifier, contentType, preferredFileName, IPC::SharedBufferReference(WTFMove(data))));
 }
 
 void WebEditorClient::registerAttachments(Vector<WebCore::SerializedAttachmentData>&& data)
 {
-    m_page->send(Messages::WebPageProxy::RegisterAttachmentsFromSerializedData(WTFMove(data)));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RegisterAttachmentsFromSerializedData(WTFMove(data)));
 }
 
 void WebEditorClient::registerAttachmentIdentifier(const String& identifier, const String& contentType, const String& filePath)
 {
-    m_page->send(Messages::WebPageProxy::RegisterAttachmentIdentifierFromFilePath(identifier, contentType, filePath));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RegisterAttachmentIdentifierFromFilePath(identifier, contentType, filePath));
 }
 
 void WebEditorClient::registerAttachmentIdentifier(const String& identifier)
 {
-    m_page->send(Messages::WebPageProxy::RegisterAttachmentIdentifier(identifier));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::RegisterAttachmentIdentifier(identifier));
 }
 
 void WebEditorClient::cloneAttachmentData(const String& fromIdentifier, const String& toIdentifier)
 {
-    m_page->send(Messages::WebPageProxy::CloneAttachmentData(fromIdentifier, toIdentifier));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::CloneAttachmentData(fromIdentifier, toIdentifier));
 }
 
 void WebEditorClient::didInsertAttachmentWithIdentifier(const String& identifier, const String& source, WebCore::AttachmentAssociatedElementType associatedElementType)
 {
-    m_page->send(Messages::WebPageProxy::DidInsertAttachmentWithIdentifier(identifier, source, associatedElementType));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::DidInsertAttachmentWithIdentifier(identifier, source, associatedElementType));
 }
 
 void WebEditorClient::didRemoveAttachmentWithIdentifier(const String& identifier)
 {
-    m_page->send(Messages::WebPageProxy::DidRemoveAttachmentWithIdentifier(identifier));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::DidRemoveAttachmentWithIdentifier(identifier));
 }
 
 Vector<SerializedAttachmentData> WebEditorClient::serializedAttachmentDataForIdentifiers(const Vector<String>& identifiers)
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::SerializedAttachmentDataForIdentifiers(identifiers));
+    RefPtr page = m_page.get();
+    if (!page)
+        return { };
+    auto sendResult = page->sendSync(Messages::WebPageProxy::SerializedAttachmentDataForIdentifiers(identifiers));
     auto [serializedData] = sendResult.takeReplyOr(Vector<WebCore::SerializedAttachmentData> { });
     return serializedData;
 }
@@ -194,7 +208,8 @@ Vector<SerializedAttachmentData> WebEditorClient::serializedAttachmentDataForIde
 
 void WebEditorClient::didApplyStyle()
 {
-    m_page->didApplyStyle();
+    if (RefPtr page = m_page.get())
+        page->didApplyStyle();
 }
 
 bool WebEditorClient::shouldMoveRangeAfterDelete(const SimpleRange&, const SimpleRange&)
@@ -206,24 +221,31 @@ void WebEditorClient::didBeginEditing()
 {
     // FIXME: What good is a notification name, if it's always the same?
     static NeverDestroyed<String> WebViewDidBeginEditingNotification(MAKE_STATIC_STRING_IMPL("WebViewDidBeginEditingNotification"));
-    m_page->injectedBundleEditorClient().didBeginEditing(m_page.get(), WebViewDidBeginEditingNotification.get().impl());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleEditorClient().didBeginEditing(*page, WebViewDidBeginEditingNotification.get().impl());
 }
 
 void WebEditorClient::respondToChangedContents()
 {
     static NeverDestroyed<String> WebViewDidChangeNotification(MAKE_STATIC_STRING_IMPL("WebViewDidChangeNotification"));
-    m_page->injectedBundleEditorClient().didChange(m_page.get(), WebViewDidChangeNotification.get().impl());
-    m_page->didChangeContents();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    page->injectedBundleEditorClient().didChange(*page, WebViewDidChangeNotification.get().impl());
+    page->didChangeContents();
 }
 
 void WebEditorClient::respondToChangedSelection(LocalFrame* frame)
 {
     static NeverDestroyed<String> WebViewDidChangeSelectionNotification(MAKE_STATIC_STRING_IMPL("WebViewDidChangeSelectionNotification"));
-    m_page->injectedBundleEditorClient().didChangeSelection(m_page.get(), WebViewDidChangeSelectionNotification.get().impl());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    page->injectedBundleEditorClient().didChangeSelection(*page, WebViewDidChangeSelectionNotification.get().impl());
     if (!frame)
         return;
 
-    m_page->didChangeSelection(*frame);
+    page->didChangeSelection(*frame);
 
 #if PLATFORM(GTK)
     updateGlobalSelection(frame);
@@ -232,43 +254,51 @@ void WebEditorClient::respondToChangedSelection(LocalFrame* frame)
 
 void WebEditorClient::didEndUserTriggeredSelectionChanges()
 {
-    m_page->didEndUserTriggeredSelectionChanges();
+    if (RefPtr page = m_page.get())
+        page->didEndUserTriggeredSelectionChanges();
 }
 
 void WebEditorClient::updateEditorStateAfterLayoutIfEditabilityChanged()
 {
-    m_page->updateEditorStateAfterLayoutIfEditabilityChanged();
+    if (RefPtr page = m_page.get())
+        page->updateEditorStateAfterLayoutIfEditabilityChanged();
 }
 
 void WebEditorClient::didUpdateComposition()
 {
-    m_page->didUpdateComposition();
+    if (RefPtr page = m_page.get())
+        page->didUpdateComposition();
 }
 
 void WebEditorClient::discardedComposition(const Document& document)
 {
-    m_page->discardedComposition(document);
+    if (RefPtr page = m_page.get())
+        page->discardedComposition(document);
 }
 
 void WebEditorClient::canceledComposition()
 {
-    m_page->canceledComposition();
+    if (RefPtr page = m_page.get())
+        page->canceledComposition();
 }
 
 void WebEditorClient::didEndEditing()
 {
     static NeverDestroyed<String> WebViewDidEndEditingNotification(MAKE_STATIC_STRING_IMPL("WebViewDidEndEditingNotification"));
-    m_page->injectedBundleEditorClient().didEndEditing(m_page.get(), WebViewDidEndEditingNotification.get().impl());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleEditorClient().didEndEditing(*page, WebViewDidEndEditingNotification.get().impl());
 }
 
 void WebEditorClient::didWriteSelectionToPasteboard()
 {
-    m_page->injectedBundleEditorClient().didWriteToPasteboard(m_page.get());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleEditorClient().didWriteToPasteboard(*page);
 }
 
 void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<SimpleRange>& range)
 {
-    m_page->injectedBundleEditorClient().willWriteToPasteboard(m_page.get(), range);
+    if (RefPtr page = m_page.get())
+        page->injectedBundleEditorClient().willWriteToPasteboard(*page, range);
 }
 
 void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& range, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData)
@@ -280,7 +310,8 @@ void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& 
         pasteboardData.append(pasteboardTypesAndData[i].second);
     }
 
-    m_page->injectedBundleEditorClient().getPasteboardDataForRange(m_page.get(), range, pasteboardTypes, pasteboardData);
+    if (RefPtr page = m_page.get())
+        page->injectedBundleEditorClient().getPasteboardDataForRange(*page, range, pasteboardTypes, pasteboardData);
 
     ASSERT(pasteboardTypes.size() == pasteboardData.size());
     pasteboardTypesAndData.clear();
@@ -290,21 +321,23 @@ void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& 
 
 bool WebEditorClient::performTwoStepDrop(DocumentFragment& fragment, const SimpleRange& destination, bool isMove)
 {
-    return m_page->injectedBundleEditorClient().performTwoStepDrop(m_page.get(), fragment, destination, isMove);
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleEditorClient().performTwoStepDrop(*page, fragment, destination, isMove) : false;
 }
 
 void WebEditorClient::registerUndoStep(UndoStep& step)
 {
     // FIXME: Add assertion that the command being reapplied is the same command that is
     // being passed to us.
-    if (m_page->isInRedo())
+    RefPtr page = m_page.get();
+    if (!page || page->isInRedo())
         return;
 
     auto webStep = WebUndoStep::create(step);
     auto stepID = webStep->stepID();
 
-    m_page->addWebUndoStep(stepID, WTFMove(webStep));
-    m_page->send(Messages::WebPageProxy::RegisterEditCommandForUndo(stepID, step.label()), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
+    page->addWebUndoStep(stepID, WTFMove(webStep));
+    page->send(Messages::WebPageProxy::RegisterEditCommandForUndo(stepID, step.label()), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 }
 
 void WebEditorClient::registerRedoStep(UndoStep&)
@@ -313,7 +346,8 @@ void WebEditorClient::registerRedoStep(UndoStep&)
 
 void WebEditorClient::clearUndoRedoOperations()
 {
-    m_page->send(Messages::WebPageProxy::ClearAllEditCommands());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::ClearAllEditCommands());
 }
 
 bool WebEditorClient::canCopyCut(LocalFrame*, bool defaultValue) const
@@ -328,38 +362,48 @@ bool WebEditorClient::canPaste(LocalFrame*, bool defaultValue) const
 
 bool WebEditorClient::canUndo() const
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::CanUndoRedo(UndoOrRedo::Undo));
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+    auto sendResult = page->sendSync(Messages::WebPageProxy::CanUndoRedo(UndoOrRedo::Undo));
     auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
 
 bool WebEditorClient::canRedo() const
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::CanUndoRedo(UndoOrRedo::Redo));
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+    auto sendResult = page->sendSync(Messages::WebPageProxy::CanUndoRedo(UndoOrRedo::Redo));
     auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
 
 void WebEditorClient::undo()
 {
-    m_page->sendSync(Messages::WebPageProxy::ExecuteUndoRedo(UndoOrRedo::Undo));
+    if (RefPtr page = m_page.get())
+        page->sendSync(Messages::WebPageProxy::ExecuteUndoRedo(UndoOrRedo::Undo));
 }
 
 void WebEditorClient::redo()
 {
-    m_page->sendSync(Messages::WebPageProxy::ExecuteUndoRedo(UndoOrRedo::Redo));
+    if (RefPtr page = m_page.get())
+        page->sendSync(Messages::WebPageProxy::ExecuteUndoRedo(UndoOrRedo::Redo));
 }
 
 WebCore::DOMPasteAccessResponse WebEditorClient::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, WebCore::FrameIdentifier frameID, const String& originIdentifier)
 {
-    return m_page->requestDOMPasteAccess(pasteAccessCategory, frameID, originIdentifier);
+    RefPtr page = m_page.get();
+    return page ? page->requestDOMPasteAccess(pasteAccessCategory, frameID, originIdentifier) : WebCore::DOMPasteAccessResponse::DeniedForGesture;
 }
 
 #if !PLATFORM(COCOA) && !USE(GLIB)
 
 void WebEditorClient::handleKeyboardEvent(KeyboardEvent& event)
 {
-    if (m_page->handleEditingKeyboardEvent(event))
+    RefPtr page = m_page.get();
+    if (page && page->handleEditingKeyboardEvent(event))
         event.setDefaultHandled();
 }
 
@@ -380,7 +424,8 @@ void WebEditorClient::textFieldDidBeginEditing(Element& element)
     RefPtr webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidBeginEditing(m_page.ptr(), *inputElement, webFrame.get());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleFormClient().textFieldDidBeginEditing(page.get(), *inputElement, webFrame.get());
 }
 
 void WebEditorClient::textFieldDidEndEditing(Element& element)
@@ -392,7 +437,8 @@ void WebEditorClient::textFieldDidEndEditing(Element& element)
     auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidEndEditing(m_page.ptr(), *inputElement, webFrame.get());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleFormClient().textFieldDidEndEditing(page.get(), *inputElement, webFrame.get());
 }
 
 void WebEditorClient::textDidChangeInTextField(Element& element)
@@ -406,7 +452,8 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
     auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextField(m_page.ptr(), *inputElement, webFrame.get(), initiatedByUserTyping);
+    if (RefPtr page = m_page.get())
+        page->injectedBundleFormClient().textDidChangeInTextField(page.get(), *inputElement, webFrame.get(), initiatedByUserTyping);
 }
 
 void WebEditorClient::textDidChangeInTextArea(Element& element)
@@ -418,7 +465,8 @@ void WebEditorClient::textDidChangeInTextArea(Element& element)
     auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextArea(m_page.ptr(), *textAreaElement, webFrame.get());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleFormClient().textDidChangeInTextArea(page.get(), *textAreaElement, webFrame.get());
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -491,7 +539,8 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    return m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.ptr(), *inputElement, toInputFieldAction(actionType), webFrame.get());
+    RefPtr page = m_page.get();
+    return page ? page->injectedBundleFormClient().shouldPerformActionInTextField(page.get(), *inputElement, toInputFieldAction(actionType), webFrame.get()) : false;
 }
 
 void WebEditorClient::textWillBeDeletedInTextField(Element& element)
@@ -503,7 +552,8 @@ void WebEditorClient::textWillBeDeletedInTextField(Element& element)
     auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.ptr(), *inputElement, toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame.get());
+    if (RefPtr page = m_page.get())
+        page->injectedBundleFormClient().shouldPerformActionInTextField(page.get(), *inputElement, toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame.get());
 }
 
 bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(WebCore::TextCheckingType type) const
@@ -519,17 +569,22 @@ bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(WebCore::TextChecki
 
 void WebEditorClient::ignoreWordInSpellDocument(const String& word)
 {
-    m_page->send(Messages::WebPageProxy::IgnoreWord(word));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::IgnoreWord(word));
 }
 
 void WebEditorClient::learnWord(const String& word)
 {
-    m_page->send(Messages::WebPageProxy::LearnWord(word));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::LearnWord(word));
 }
 
 void WebEditorClient::checkSpellingOfString(StringView text, int* misspellingLocation, int* misspellingLength)
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::CheckSpellingOfString(text.toStringWithoutCopying()));
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    auto sendResult = page->sendSync(Messages::WebPageProxy::CheckSpellingOfString(text.toStringWithoutCopying()));
     auto [resultLocation, resultLength] = sendResult.takeReplyOr(-1, 0);
     *misspellingLocation = resultLocation;
     *misspellingLength = resultLength;
@@ -537,7 +592,10 @@ void WebEditorClient::checkSpellingOfString(StringView text, int* misspellingLoc
 
 void WebEditorClient::checkGrammarOfString(StringView text, Vector<WebCore::GrammarDetail>& grammarDetails, int* badGrammarLocation, int* badGrammarLength)
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::CheckGrammarOfString(text.toStringWithoutCopying()));
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    auto sendResult = page->sendSync(Messages::WebPageProxy::CheckGrammarOfString(text.toStringWithoutCopying()));
     int32_t resultLocation = -1;
     int32_t resultLength = 0;
     if (sendResult.succeeded())
@@ -557,7 +615,10 @@ static uint64_t insertionPointFromCurrentSelection(const VisibleSelection& curre
 
 Vector<TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView stringView, OptionSet<WebCore::TextCheckingType> checkingTypes, const VisibleSelection& currentSelection)
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::CheckTextOfParagraph(stringView.toStringWithoutCopying(), checkingTypes, insertionPointFromCurrentSelection(currentSelection)));
+    RefPtr page = m_page.get();
+    if (!page)
+        return { };
+    auto sendResult = page->sendSync(Messages::WebPageProxy::CheckTextOfParagraph(stringView.toStringWithoutCopying(), checkingTypes, insertionPointFromCurrentSelection(currentSelection)));
     auto [results] = sendResult.takeReplyOr(Vector<TextCheckingResult> { });
     return results;
 }
@@ -566,12 +627,14 @@ Vector<TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView stri
 
 void WebEditorClient::updateSpellingUIWithGrammarString(const String& badGrammarPhrase, const GrammarDetail& grammarDetail)
 {
-    m_page->send(Messages::WebPageProxy::UpdateSpellingUIWithGrammarString(badGrammarPhrase, grammarDetail));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::UpdateSpellingUIWithGrammarString(badGrammarPhrase, grammarDetail));
 }
 
 void WebEditorClient::updateSpellingUIWithMisspelledWord(const String& misspelledWord)
 {
-    m_page->send(Messages::WebPageProxy::UpdateSpellingUIWithMisspelledWord(misspelledWord));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::UpdateSpellingUIWithMisspelledWord(misspelledWord));
 }
 
 void WebEditorClient::showSpellingUI(bool)
@@ -581,14 +644,20 @@ void WebEditorClient::showSpellingUI(bool)
 
 bool WebEditorClient::spellingUIIsShowing()
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::SpellingUIIsShowing());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+    auto sendResult = page->sendSync(Messages::WebPageProxy::SpellingUIIsShowing());
     auto [isShowing] = sendResult.takeReplyOr(false);
     return isShowing;
 }
 
 void WebEditorClient::getGuessesForWord(const String& word, const String& context, const VisibleSelection& currentSelection, Vector<String>& guesses)
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::GetGuessesForWord(word, context, insertionPointFromCurrentSelection(currentSelection)));
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    auto sendResult = page->sendSync(Messages::WebPageProxy::GetGuessesForWord(word, context, insertionPointFromCurrentSelection(currentSelection)));
     if (sendResult.succeeded())
         std::tie(guesses) = sendResult.takeReply();
 }
@@ -596,25 +665,31 @@ void WebEditorClient::getGuessesForWord(const String& word, const String& contex
 void WebEditorClient::requestCheckingOfString(TextCheckingRequest& request, const WebCore::VisibleSelection& currentSelection)
 {
     auto requestID = TextCheckerRequestID::generate();
-    m_page->addTextCheckingRequest(requestID, request);
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    page->addTextCheckingRequest(requestID, request);
 
-    m_page->send(Messages::WebPageProxy::RequestCheckingOfString(requestID, request.data(), insertionPointFromCurrentSelection(currentSelection)));
+    page->send(Messages::WebPageProxy::RequestCheckingOfString(requestID, request.data(), insertionPointFromCurrentSelection(currentSelection)));
 }
 
 void WebEditorClient::willChangeSelectionForAccessibility()
 {
-    m_page->willChangeSelectionForAccessibility();
+    if (RefPtr page = m_page.get())
+        page->willChangeSelectionForAccessibility();
 }
 
 void WebEditorClient::didChangeSelectionForAccessibility()
 {
-    m_page->didChangeSelectionForAccessibility();
+    if (RefPtr page = m_page.get())
+        page->didChangeSelectionForAccessibility();
 }
 
 void WebEditorClient::setInputMethodState(Element* element)
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    m_page->setInputMethodState(element);
+    if (RefPtr page = m_page.get())
+        page->setInputMethodState(element);
 #else
     UNUSED_PARAM(element);
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -208,9 +208,7 @@ private:
     bool shouldDrawVisuallyContiguousBidiSelection() const final;
 #endif
 
-    Ref<WebPage> protectedPage() const;
-
-    const WeakRef<WebPage> m_page;
+    const WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
@@ -41,7 +41,8 @@ bool WebEditorClient::handleGtkEditorCommand(LocalFrame& frame, const String& co
     if (command == "GtkInsertEmoji"_s) {
         if (!allowTextInsertion)
             return false;
-        m_page->showEmojiPicker(frame);
+        if (RefPtr page = m_page.get())
+            page->showEmojiPicker(frame);
         return true;
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
@@ -38,7 +38,7 @@ using namespace WebCore;
     
 void WebEditorClient::handleKeyboardEvent(KeyboardEvent& event)
 {
-    if (m_page->handleEditingKeyboardEvent(event))
+    if (RefPtr page = m_page.get(); page && page->handleEditingKeyboardEvent(event))
         event.setDefaultHandled();
 }
 
@@ -66,7 +66,8 @@ void WebEditorClient::stopDelayingAndCoalescingContentChangeNotifications()
 
 bool WebEditorClient::hasRichlyEditableSelection()
 {
-    return m_page->hasRichlyEditableSelection();
+    RefPtr page = m_page.get();
+    return page ? page->hasRichlyEditableSelection() : false;
 }
 
 int WebEditorClient::getPasteboardItemsCount()
@@ -89,42 +90,50 @@ bool WebEditorClient::performsTwoStepPaste(WebCore::DocumentFragment*)
 
 void WebEditorClient::updateStringForFind(const String& findString)
 {
-    m_page->updateStringForFind(findString);
+    if (RefPtr page = m_page.get())
+        page->updateStringForFind(findString);
 }
 
 void WebEditorClient::overflowScrollPositionChanged()
 {
-    m_page->didScrollSelection();
+    if (RefPtr page = m_page.get())
+        page->didScrollSelection();
 }
 
 void WebEditorClient::subFrameScrollPositionChanged()
 {
-    m_page->didScrollSelection();
+    if (RefPtr page = m_page.get())
+        page->didScrollSelection();
 }
 
 bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
 {
-    return m_page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection);
+    RefPtr page = m_page.get();
+    return page ? page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection) : false;
 }
 
 bool WebEditorClient::shouldRevealCurrentSelectionAfterInsertion() const
 {
-    return m_page->shouldRevealCurrentSelectionAfterInsertion();
+    RefPtr page = m_page.get();
+    return page ? page->shouldRevealCurrentSelectionAfterInsertion() : false;
 }
 
 bool WebEditorClient::shouldSuppressPasswordEcho() const
 {
-    return m_page->screenIsBeingCaptured() || m_page->hardwareKeyboardIsAttached();
+    RefPtr page = m_page.get();
+    return page ? (page->screenIsBeingCaptured() || page->hardwareKeyboardIsAttached()) : false;
 }
 
 bool WebEditorClient::shouldRemoveDictationAlternativesAfterEditing() const
 {
-    return m_page->shouldRemoveDictationAlternativesAfterEditing();
+    RefPtr page = m_page.get();
+    return page ? page->shouldRemoveDictationAlternativesAfterEditing() : false;
 }
 
 bool WebEditorClient::shouldDrawVisuallyContiguousBidiSelection() const
 {
-    return m_page->shouldDrawVisuallyContiguousBidiSelection();
+    RefPtr page = m_page.get();
+    return page ? page->shouldDrawVisuallyContiguousBidiSelection() : false;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -50,7 +50,7 @@ using namespace WebCore;
 
 void WebEditorClient::handleKeyboardEvent(KeyboardEvent& event)
 {
-    if (protectedPage()->handleEditingKeyboardEvent(event))
+    if (RefPtr page = m_page.get(); page && page->handleEditingKeyboardEvent(event))
         event.setDefaultHandled();
 }
 
@@ -62,7 +62,8 @@ void WebEditorClient::handleInputMethodKeydown(KeyboardEvent& event)
 
 void WebEditorClient::didDispatchInputMethodKeydown(KeyboardEvent& event)
 {
-    protectedPage()->handleEditingKeyboardEvent(event);
+    if (RefPtr page = m_page.get())
+        page->handleEditingKeyboardEvent(event);
 }
 
 void WebEditorClient::setInsertionPasteboard(const String&)
@@ -89,21 +90,30 @@ static void changeWordCase(WebPage& page, NSString *(*changeCase)(NSString *))
 
 void WebEditorClient::uppercaseWord()
 {
-    changeWordCase(protectedPage().get(), [] (NSString *string) {
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    changeWordCase(*page, [] (NSString *string) {
         return [string uppercaseString];
     });
 }
 
 void WebEditorClient::lowercaseWord()
 {
-    changeWordCase(protectedPage().get(), [] (NSString *string) {
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    changeWordCase(*page, [] (NSString *string) {
         return [string lowercaseString];
     });
 }
 
 void WebEditorClient::capitalizeWord()
 {
-    changeWordCase(protectedPage().get(), [] (NSString *string) {
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+    changeWordCase(*page, [] (NSString *string) {
         return [string capitalizedString];
     });
 }
@@ -117,19 +127,23 @@ void WebEditorClient::showSubstitutionsPanel(bool)
 
 bool WebEditorClient::substitutionsPanelIsShowing()
 {
-    auto sendResult = protectedPage()->sendSync(Messages::WebPageProxy::SubstitutionsPanelIsShowing());
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+    auto sendResult = page->sendSync(Messages::WebPageProxy::SubstitutionsPanelIsShowing());
     auto [isShowing] = sendResult.takeReplyOr(false);
     return isShowing;
 }
 
 void WebEditorClient::toggleSmartInsertDelete()
 {
-    protectedPage()->send(Messages::WebPageProxy::toggleSmartInsertDelete());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::toggleSmartInsertDelete());
 }
 
 bool WebEditorClient::isAutomaticQuoteSubstitutionEnabled()
 {
-    if (protectedPage()->isControlledByAutomation())
+    if (RefPtr page = m_page.get(); page && page->isControlledByAutomation())
         return false;
 
     return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled);
@@ -137,7 +151,8 @@ bool WebEditorClient::isAutomaticQuoteSubstitutionEnabled()
 
 void WebEditorClient::toggleAutomaticQuoteSubstitution()
 {
-    protectedPage()->send(Messages::WebPageProxy::toggleAutomaticQuoteSubstitution());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::toggleAutomaticQuoteSubstitution());
 }
 
 bool WebEditorClient::isAutomaticLinkDetectionEnabled()
@@ -147,12 +162,13 @@ bool WebEditorClient::isAutomaticLinkDetectionEnabled()
 
 void WebEditorClient::toggleAutomaticLinkDetection()
 {
-    protectedPage()->send(Messages::WebPageProxy::toggleAutomaticLinkDetection());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::toggleAutomaticLinkDetection());
 }
 
 bool WebEditorClient::isAutomaticDashSubstitutionEnabled()
 {
-    if (protectedPage()->isControlledByAutomation())
+    if (RefPtr page = m_page.get(); page && page->isControlledByAutomation())
         return false;
 
     return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticDashSubstitutionEnabled);
@@ -160,12 +176,13 @@ bool WebEditorClient::isAutomaticDashSubstitutionEnabled()
 
 void WebEditorClient::toggleAutomaticDashSubstitution()
 {
-    protectedPage()->send(Messages::WebPageProxy::toggleAutomaticDashSubstitution());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::toggleAutomaticDashSubstitution());
 }
 
 bool WebEditorClient::isAutomaticTextReplacementEnabled()
 {
-    if (protectedPage()->isControlledByAutomation())
+    if (RefPtr page = m_page.get(); page && page->isControlledByAutomation())
         return false;
 
     return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticTextReplacementEnabled);
@@ -173,12 +190,13 @@ bool WebEditorClient::isAutomaticTextReplacementEnabled()
 
 void WebEditorClient::toggleAutomaticTextReplacement()
 {
-    protectedPage()->send(Messages::WebPageProxy::toggleAutomaticTextReplacement());
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::toggleAutomaticTextReplacement());
 }
 
 bool WebEditorClient::isAutomaticSpellingCorrectionEnabled()
 {
-    if (protectedPage()->isControlledByAutomation())
+    if (RefPtr page = m_page.get(); page && page->isControlledByAutomation())
         return false;
 
     return WebProcess::singleton().textCheckerState().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled);


### PR DESCRIPTION
#### 2b99f707d57eedadef4838e4806bd6899646c4f0
<pre>
Crash in `WebEditorClient::clearUndoRedoOperations`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298570">https://bugs.webkit.org/show_bug.cgi?id=298570</a>
<a href="https://rdar.apple.com/153031714">rdar://153031714</a>

Reviewed by Pascoe.

Make m_page in WebEditorClient a WeakPtr, since it can be null. WebEditorClient is owned by
WebCore::Page, which may outlive WebKit::WebPage.

* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::protectedPage const): Deleted.
(WebKit::WebEditorClient::shouldDeleteRange):
(WebKit::WebEditorClient::smartInsertDeleteEnabled):
(WebKit::WebEditorClient::isSelectTrailingWhitespaceEnabled const):
(WebKit::WebEditorClient::shouldBeginEditing):
(WebKit::WebEditorClient::shouldEndEditing):
(WebKit::WebEditorClient::shouldInsertNode):
(WebKit::WebEditorClient::shouldInsertText):
(WebKit::WebEditorClient::shouldChangeSelectedRange):
(WebKit::WebEditorClient::shouldApplyStyle):
(WebKit::WebEditorClient::registerAttachmentIdentifier):
(WebKit::WebEditorClient::registerAttachments):
(WebKit::WebEditorClient::cloneAttachmentData):
(WebKit::WebEditorClient::didInsertAttachmentWithIdentifier):
(WebKit::WebEditorClient::didRemoveAttachmentWithIdentifier):
(WebKit::WebEditorClient::serializedAttachmentDataForIdentifiers):
(WebKit::WebEditorClient::didApplyStyle):
(WebKit::WebEditorClient::didBeginEditing):
(WebKit::WebEditorClient::respondToChangedContents):
(WebKit::WebEditorClient::respondToChangedSelection):
(WebKit::WebEditorClient::didEndUserTriggeredSelectionChanges):
(WebKit::WebEditorClient::updateEditorStateAfterLayoutIfEditabilityChanged):
(WebKit::WebEditorClient::didUpdateComposition):
(WebKit::WebEditorClient::discardedComposition):
(WebKit::WebEditorClient::canceledComposition):
(WebKit::WebEditorClient::didEndEditing):
(WebKit::WebEditorClient::didWriteSelectionToPasteboard):
(WebKit::WebEditorClient::willWriteSelectionToPasteboard):
(WebKit::WebEditorClient::getClientPasteboardData):
(WebKit::WebEditorClient::performTwoStepDrop):
(WebKit::WebEditorClient::registerUndoStep):
(WebKit::WebEditorClient::clearUndoRedoOperations):
(WebKit::WebEditorClient::canUndo const):
(WebKit::WebEditorClient::canRedo const):
(WebKit::WebEditorClient::undo):
(WebKit::WebEditorClient::redo):
(WebKit::WebEditorClient::requestDOMPasteAccess):
(WebKit::WebEditorClient::handleKeyboardEvent):
(WebKit::WebEditorClient::textFieldDidBeginEditing):
(WebKit::WebEditorClient::textFieldDidEndEditing):
(WebKit::WebEditorClient::textDidChangeInTextField):
(WebKit::WebEditorClient::textDidChangeInTextArea):
(WebKit::WebEditorClient::doTextFieldCommandFromEvent):
(WebKit::WebEditorClient::textWillBeDeletedInTextField):
(WebKit::WebEditorClient::ignoreWordInSpellDocument):
(WebKit::WebEditorClient::learnWord):
(WebKit::WebEditorClient::checkSpellingOfString):
(WebKit::WebEditorClient::checkGrammarOfString):
(WebKit::WebEditorClient::checkTextOfParagraph):
(WebKit::WebEditorClient::updateSpellingUIWithGrammarString):
(WebKit::WebEditorClient::updateSpellingUIWithMisspelledWord):
(WebKit::WebEditorClient::spellingUIIsShowing):
(WebKit::WebEditorClient::getGuessesForWord):
(WebKit::WebEditorClient::requestCheckingOfString):
(WebKit::WebEditorClient::willChangeSelectionForAccessibility):
(WebKit::WebEditorClient::didChangeSelectionForAccessibility):
(WebKit::WebEditorClient::setInputMethodState):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp:
(WebKit::WebEditorClient::handleGtkEditorCommand):
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm:
(WebKit::WebEditorClient::handleKeyboardEvent):
(WebKit::WebEditorClient::hasRichlyEditableSelection):
(WebKit::WebEditorClient::updateStringForFind):
(WebKit::WebEditorClient::overflowScrollPositionChanged):
(WebKit::WebEditorClient::subFrameScrollPositionChanged):
(WebKit::WebEditorClient::shouldAllowSingleClickToChangeSelection const):
(WebKit::WebEditorClient::shouldRevealCurrentSelectionAfterInsertion const):
(WebKit::WebEditorClient::shouldSuppressPasswordEcho const):
(WebKit::WebEditorClient::shouldRemoveDictationAlternativesAfterEditing const):
(WebKit::WebEditorClient::shouldDrawVisuallyContiguousBidiSelection const):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::handleKeyboardEvent):
(WebKit::WebEditorClient::didDispatchInputMethodKeydown):
(WebKit::WebEditorClient::uppercaseWord):
(WebKit::WebEditorClient::lowercaseWord):
(WebKit::WebEditorClient::capitalizeWord):
(WebKit::WebEditorClient::substitutionsPanelIsShowing):
(WebKit::WebEditorClient::toggleSmartInsertDelete):
(WebKit::WebEditorClient::isAutomaticQuoteSubstitutionEnabled):
(WebKit::WebEditorClient::toggleAutomaticQuoteSubstitution):
(WebKit::WebEditorClient::toggleAutomaticLinkDetection):
(WebKit::WebEditorClient::isAutomaticDashSubstitutionEnabled):
(WebKit::WebEditorClient::toggleAutomaticDashSubstitution):
(WebKit::WebEditorClient::isAutomaticTextReplacementEnabled):
(WebKit::WebEditorClient::toggleAutomaticTextReplacement):
(WebKit::WebEditorClient::isAutomaticSpellingCorrectionEnabled):

Canonical link: <a href="https://commits.webkit.org/299768@main">https://commits.webkit.org/299768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/437eea7320f38449a1a6da6ffc34dc799251dfbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72104 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09b6d683-0e5f-4296-af70-7e81f64b9741) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91149 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60461 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d0c4cea-1d85-4770-a834-9331adf23d93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71704 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76272952-bb2c-49a8-8893-1212c8cc73db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31321 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70000 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129281 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99766 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99610 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45071 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23092 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43572 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19092 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52519 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46279 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49628 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->