### PR TITLE
Support Custom Web Format in Clipboard APIs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https-expected.txt
@@ -16,15 +16,23 @@ PASS supports(text/html) returns true
 PASS supports(image/png) returns true
 PASS supports(text/uri-list) returns true
 FAIL supports(image/svg+xml) returns true assert_equals: expected true but got false
-FAIL supports(web foo/bar) returns true assert_equals: expected true but got false
-FAIL supports(web text/html) returns true assert_equals: expected true but got false
+PASS supports(web foo/bar) returns true
+PASS supports(web text/html) returns true
 PASS supports(web ) returns false
 PASS supports(web) returns false
+PASS supports(w eb) returns false
 PASS supports(web foo) returns false
+PASS supports(web foo/) returns false
+PASS supports(web /bar) returns false
 PASS supports(foo/bar) returns false
 PASS supports(weB text/html) returns false
 PASS supports( web text/html) returns false
 PASS supports(not a/real type) returns false
 PASS supports() returns false
 PASS supports( ) returns false
+PASS supports(web foo//bar) returns false
+PASS supports(web foo/bar/baz) returns false
+PASS supports(web foo/ bar) returns false
+PASS supports(web f oo/bar) returns false
+PASS supports(web f oo/ bar) returns false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https.html
@@ -109,13 +109,21 @@ promise_test(async () => {
   // invalid types
   ['web ',            false],
   ['web',             false],
+  ['w eb',            false],
   ['web foo',         false],
+  ['web foo/',        false],
+  ['web /bar',        false],
   ['foo/bar',         false],
   ['weB text/html',   false],
   [' web text/html',  false],
   ['not a/real type', false],
   ['',                false],
   [' ',               false],
+  ['web foo//bar',    false],
+  ['web foo/bar/baz', false],
+  ['web foo/ bar',    false],
+  ['web f oo/bar',    false],
+  ['web f oo/ bar',   false],
 ].forEach(([type, result]) => {
   promise_test(async () => {
     assert_equals(ClipboardItem.supports(type), result);


### PR DESCRIPTION
#### c782873055ae28dade2b3de54663e90fd512b6de
<pre>
Support Custom Web Format in Clipboard APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=280664">https://bugs.webkit.org/show_bug.cgi?id=280664</a>
<a href="https://rdar.apple.com/137026208">rdar://137026208</a>

Reviewed by NOBODY (OOPS!).

This patch adds support for Custom Web Format in Clipboard APIs as per web
specification [1]:

[1] <a href="https://w3c.github.io/clipboard-apis/#optional-data-types-x">https://w3c.github.io/clipboard-apis/#optional-data-types-x</a>

&gt; Custom format starts with `&quot;web &quot;`(&quot;web&quot; followed by U+0020 SPACE) prefix
  and suffix (after stripping out `&quot;web &quot;`) passes the parsing a MIME type check.

* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
(WebCore::ClipboardItem::supports):
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https.html: Add more tests
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c782873055ae28dade2b3de54663e90fd512b6de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72135 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b448cb7c-870e-4e7f-a3f9-27b50eefe96f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60485 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1888be2-b8d0-4b67-9e27-f2a09e7071bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2fb4f1bc-8052-46e6-bad5-d22cd2b3d320) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25754 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70032 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129312 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99791 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99635 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45091 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43611 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52550 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46311 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49659 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47996 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->