### PR TITLE
Rename `*Instance()` soft-linking functions to `*InstanceSingleton()`

### DIFF
--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -244,7 +244,7 @@ static void* lib##Library() \
     } \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Wunused-function\"") \
-    static className *alloc##className##Instance() NS_RETURNS_RETAINED \
+    static className *alloc##className##InstanceSingleton() NS_RETURNS_RETAINED \
     { \
         return [get##className##Class() alloc]; \
     } \
@@ -272,7 +272,7 @@ static void* lib##Library() \
     } \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Wunused-function\"") \
-    static className *alloc##className##Instance() NS_RETURNS_RETAINED \
+    static className *alloc##className##InstanceSingleton() NS_RETURNS_RETAINED \
     { \
         return [get##className##Class() alloc]; \
     } \
@@ -455,8 +455,8 @@ static void* lib##Library() \
     @class className; \
     namespace functionNamespace { \
     extern Class (*get##className##Class)(); \
-    className *alloc##className##Instance() NS_RETURNS_RETAINED; \
-    inline className *alloc##className##Instance() NS_RETURNS_RETAINED \
+    className *alloc##className##InstanceSingleton() NS_RETURNS_RETAINED; \
+    inline className *alloc##className##InstanceSingleton() NS_RETURNS_RETAINED \
     { \
         return [get##className##Class() alloc]; \
     } \
@@ -466,7 +466,7 @@ static void* lib##Library() \
     @class className; \
     namespace functionNamespace { \
     extern Class (*get##className##Class)(); \
-    className *alloc##className##Instance() availability; \
+    className *alloc##className##InstanceSingleton() availability; \
     }
 
 #define SOFT_LINK_CLASS_FOR_SOURCE_INTERNAL(functionNamespace, framework, className, export, isOptional, availability) \
@@ -516,8 +516,8 @@ static void* lib##Library() \
     SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT_AND_IS_OPTIONAL(functionNamespace, framework, className, , SOFT_LINK_IS_OPTIONAL)
 
 #define SOFT_LINK_CLASS_ALLOC_FUNCTION(className, availability) \
-    NS_RETURNS_RETAINED className *alloc##className##Instance() availability; \
-    NS_RETURNS_RETAINED className *alloc##className##Instance() availability \
+    NS_RETURNS_RETAINED className *alloc##className##InstanceSingleton() availability; \
+    NS_RETURNS_RETAINED className *alloc##className##InstanceSingleton() availability \
     { \
         return [get##className##Class() alloc]; \
     } \

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
@@ -152,8 +152,7 @@ static RetainPtr<VNDetectBarcodesRequest> request()
     // configured the same way. This function is intended to make sure both VNDetectBarcodesRequests are
     // configured accordingly.
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto result = adoptNS([PAL::allocVNDetectBarcodesRequestInstance() init]);
+    auto result = adoptNS([PAL::allocVNDetectBarcodesRequestInstanceSingleton() init]);
     configureRequestToUseCPUOrGPU(result.get());
     return result;
 }
@@ -199,8 +198,7 @@ void BarcodeDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandl
         request.get().symbologies = requestedSymbologies.allObjects;
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstanceSingleton() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
@@ -87,12 +87,10 @@ void FaceDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<
         return;
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto request = adoptNS([PAL::allocVNDetectFaceLandmarksRequestInstance() init]);
+    auto request = adoptNS([PAL::allocVNDetectFaceLandmarksRequestInstanceSingleton() init]);
     configureRequestToUseCPUOrGPU(request.get());
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstanceSingleton() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
@@ -57,12 +57,10 @@ void TextDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<
         return;
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto request = adoptNS([PAL::allocVNRecognizeTextRequestInstance() init]);
+    auto request = adoptNS([PAL::allocVNRecognizeTextRequestInstanceSingleton() init]);
     configureRequestToUseCPUOrGPU(request.get());
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstanceSingleton() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -138,7 +138,7 @@ static PKInstallmentRetailChannel platformRetailChannel(ApplePayInstallmentRetai
 static RetainPtr<id> makeNSArrayElement(const ApplePayInstallmentItem& item)
 {
     ASSERT(PAL::getPKPaymentInstallmentItemClass());
-    auto installmentItem = adoptNS([PAL::allocPKPaymentInstallmentItemInstance() init]);
+    auto installmentItem = adoptNS([PAL::allocPKPaymentInstallmentItemInstanceSingleton() init]);
     [installmentItem setInstallmentItemType:platformItemType(item.type)];
     [installmentItem setAmount:toDecimalNumber(item.amount)];
     [installmentItem setCurrencyCode:item.currencyCode.createNSString().get()];
@@ -183,7 +183,7 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
     if (!PAL::getPKPaymentInstallmentConfigurationClass())
         return nil;
 
-    auto configuration = adoptNS([PAL::allocPKPaymentInstallmentConfigurationInstance() init]);
+    auto configuration = adoptNS([PAL::allocPKPaymentInstallmentConfigurationInstanceSingleton() init]);
 
     [configuration setFeature:platformFeatureType(coreConfiguration.featureType)];
 

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
@@ -42,7 +42,7 @@ namespace WebCore {
 
 static RetainPtr<PKContact> convert(unsigned version, const ApplePayPaymentContact& contact)
 {
-    auto result = adoptNS([PAL::allocPKContactInstance() init]);
+    auto result = adoptNS([PAL::allocPKContactInstanceSingleton() init]);
 
     RetainPtr<NSString> familyName;
     RetainPtr<NSString> phoneticFamilyName;
@@ -77,10 +77,10 @@ static RetainPtr<PKContact> convert(unsigned version, const ApplePayPaymentConta
         [result setEmailAddress:contact.emailAddress.createNSString().get()];
 
     if (!contact.phoneNumber.isEmpty())
-        [result setPhoneNumber:adoptNS([allocCNPhoneNumberInstance() initWithStringValue:contact.phoneNumber.createNSString().get()]).get()];
+        [result setPhoneNumber:adoptNS([allocCNPhoneNumberInstanceSingleton() initWithStringValue:contact.phoneNumber.createNSString().get()]).get()];
 
     if (contact.addressLines && !contact.addressLines->isEmpty()) {
-        auto address = adoptNS([allocCNMutablePostalAddressInstance() init]);
+        auto address = adoptNS([allocCNMutablePostalAddressInstanceSingleton() init]);
 
         StringBuilder builder;
         for (unsigned i = 0; i < contact.addressLines->size(); ++i) {

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
@@ -46,7 +46,7 @@ std::optional<PaymentMerchantSession> PaymentMerchantSession::fromJS(JSC::JSGlob
     if (!dictionary || ![dictionary isKindOfClass:[NSDictionary class]])
         return std::nullopt;
 
-    RetainPtr pkPaymentMerchantSession = adoptNS([PAL::allocPKPaymentMerchantSessionInstance() initWithDictionary:dictionary.get()]);
+    RetainPtr pkPaymentMerchantSession = adoptNS([PAL::allocPKPaymentMerchantSessionInstanceSingleton() initWithDictionary:dictionary.get()]);
 
     return PaymentMerchantSession(WTFMove(pkPaymentMerchantSession));
 }

--- a/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
+++ b/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
@@ -39,7 +39,7 @@ namespace WebCore {
 void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBuffer>&& buffer)
 {
     if (m_mimeType == "image/png"_s) {
-        auto image = adoptNS([PAL::allocUIImageInstance() initWithData:buffer->createNSData().get()]);
+        auto image = adoptNS([PAL::allocUIImageInstanceSingleton() initWithData:buffer->createNSData().get()]);
         if (auto nsData = UIImagePNGRepresentation(image.get()))
             m_result = Blob::create(m_document.get(), makeVector(nsData), m_mimeType);
     }

--- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
+++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
@@ -81,9 +81,9 @@ NS_ASSUME_NONNULL_BEGIN
     _maxAlternatives = alternatives ? alternatives : 1;
 
     if (![localeIdentifier length])
-        _recognizer = adoptNS([PAL::allocSFSpeechRecognizerInstance() init]);
+        _recognizer = adoptNS([PAL::allocSFSpeechRecognizerInstanceSingleton() init]);
     else
-        _recognizer = adoptNS([PAL::allocSFSpeechRecognizerInstance() initWithLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier]]);
+        _recognizer = adoptNS([PAL::allocSFSpeechRecognizerInstanceSingleton() initWithLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier]]);
     if (!_recognizer) {
         [self release];
         return nil;
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [_recognizer setDelegate:self];
 
-    _request = adoptNS([PAL::allocSFSpeechAudioBufferRecognitionRequestInstance() init]);
+    _request = adoptNS([PAL::allocSFSpeechAudioBufferRecognitionRequestInstanceSingleton() init]);
     if ([_recognizer supportsOnDeviceRecognition])
         [_request setRequiresOnDeviceRecognition:YES];
     [_request setShouldReportPartialResults:interimResults];

--- a/Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.h
+++ b/Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.h
@@ -52,12 +52,12 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, DataDetectors, DDHighlightPointIsOnHighlight,
 
 namespace PAL {
 
-inline WKDDActionContext *allocWKDDActionContextInstance()
+inline WKDDActionContext *allocWKDDActionContextInstanceSingleton()
 {
 #if HAVE(SECURE_ACTION_CONTEXT)
-    return allocDDSecureActionContextInstance();
+    return allocDDSecureActionContextInstanceSingleton();
 #else
-    return allocDDActionContextInstance();
+    return allocDDActionContextInstanceSingleton();
 #endif
 }
 

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -206,7 +206,7 @@ void AXRemoteFrame::initializePlatformElementWithRemoteToken(std::span<const uin
         return;
 
     NSString *uuid = [tokenDictionary objectForKey:@"ax-uuid"];
-    RetainPtr remoteElement = adoptNS([allocAXRemoteElementInstance() initWithUUID:uuid andRemotePid:processIdentifier andContextId:0]);
+    RetainPtr remoteElement = adoptNS([allocAXRemoteElementInstanceSingleton() initWithUUID:uuid andRemotePid:processIdentifier andContextId:0]);
     remoteElement.get().onClientSide = YES;
     RefPtr parent = parentObjectUnignored();
     remoteElement.get().accessibilityContainer = parent ?  parent->wrapper() : nil;

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -118,7 +118,7 @@ static std::optional<DetectedItem> detectItem(const VisiblePosition& position, c
     if (!view)
         return { };
 
-    RetainPtr actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
+    RetainPtr actionContext = adoptNS([PAL::allocWKDDActionContextInstanceSingleton() init]);
 
     [actionContext setAllResults:@[ (__bridge id)mainResult ]];
     [actionContext setMainResult:mainResult];

--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -280,7 +280,7 @@ std::optional<SimpleRange> DictionaryLookup::rangeForSelection(const VisibleSele
 
     auto fullCharacterRange = *makeSimpleRange(paragraphStart, paragraphEnd);
     String itemString = plainText(fullCharacterRange);
-    NSRange highlightRange = adoptNS([PAL::allocRVItemInstance() initWithText:itemString.createNSString().get() selectedRange:rangeToPass]).get().highlightRange;
+    NSRange highlightRange = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:itemString.createNSString().get() selectedRange:rangeToPass]).get().highlightRange;
 
     return { { resolveCharacterRange(fullCharacterRange, highlightRange) } };
 
@@ -351,7 +351,7 @@ std::optional<SimpleRange> DictionaryLookup::rangeAtHitTestResult(const HitTestR
     NSRange selectedRange = [PAL::getRVSelectionClass() revealRangeAtIndex:hitIndex selectedRanges:@[[NSValue valueWithRange:selectionRange]] shouldUpdateSelection:nil];
 
     String itemString = plainText(*fullCharacterRange);
-    auto highlightRange = adoptNS([PAL::allocRVItemInstance() initWithText:itemString.createNSString().get() selectedRange:selectedRange]).get().highlightRange;
+    auto highlightRange = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:itemString.createNSString().get() selectedRange:selectedRange]).get().highlightRange;
 
     if (highlightRange.location == NSNotFound || !highlightRange.length)
         return std::nullopt;
@@ -401,7 +401,7 @@ NSString *DictionaryLookup::stringForPDFSelection(PDFSelection *selection)
     auto fullPlainTextString = [selectionForLookup string];
     auto rangeToPass = NSMakeRange(charactersAddedBeforeStart, 0);
 
-    NSRange extractedRange = adoptNS([PAL::allocRVItemInstance() initWithText:fullPlainTextString selectedRange:rangeToPass]).get().highlightRange;
+    NSRange extractedRange = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:fullPlainTextString selectedRange:rangeToPass]).get().highlightRange;
     if (extractedRange.location == NSNotFound)
         return selection.string;
 
@@ -437,7 +437,7 @@ static WKRevealController showPopupOrCreateAnimationController(bool createAnimat
     if (!textIndicator)
         return nil;
 
-    auto presenter = adoptNS([PAL::allocRVPresenterInstance() init]);
+    auto presenter = adoptNS([PAL::allocRVPresenterInstanceSingleton() init]);
 
     NSRect highlightRect;
     NSPoint pointerLocation;
@@ -466,11 +466,11 @@ static WKRevealController showPopupOrCreateAnimationController(bool createAnimat
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
     auto attributedString = dictionaryPopupInfo.platformData.attributedString.nsAttributedString();
     auto webHighlight = adoptNS([[WebRevealHighlight alloc] initWithHighlightRect:highlightRect useDefaultHighlight:!textIndicator->contentImage() attributedString:attributedString.get() clearTextIndicatorCallback:WTFMove(clearTextIndicator)]);
-    auto item = adoptNS([PAL::allocRVItemInstance() initWithText:attributedString.get().string selectedRange:NSMakeRange(0, attributedString.get().string.length)]);
+    auto item = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:attributedString.get().string selectedRange:NSMakeRange(0, attributedString.get().string.length)]);
 #else
     RetainPtr text = dictionaryPopupInfo.text.createNSString();
     RetainPtr webHighlight = adoptNS([[WebRevealHighlight alloc] initWithHighlightRect:highlightRect useDefaultHighlight:!textIndicator->contentImage() attributedString:adoptNS([[NSAttributedString alloc] initWithString:text.get()]).get() clearTextIndicatorCallback:WTFMove(clearTextIndicator)]);
-    RetainPtr item = adoptNS([PAL::allocRVItemInstance() initWithText:text.get() selectedRange:NSMakeRange(0, text.get().length)]);
+    RetainPtr item = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:text.get() selectedRange:NSMakeRange(0, text.get().length)]);
 #endif
 
     auto context = createRVPresentingContextWithRetainedDelegate(pointerLocation, view, webHighlight.get());
@@ -492,10 +492,10 @@ static WKRevealController showPopupOrCreateAnimationController(bool createAnimat
     auto webHighlight = adoptNS([[WebRevealHighlight alloc] initWithHighlightRect:[view convertRect:textIndicator->selectionRectInRootViewCoordinates() toView:nil] view:view image:textIndicator->contentImage()]);
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
     auto attributedString = dictionaryPopupInfo.platformData.attributedString.nsAttributedString();
-    auto item = adoptNS([PAL::allocRVItemInstance() initWithText:attributedString.get().string selectedRange:NSMakeRange(0, attributedString.get().string.length)]);
+    auto item = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:attributedString.get().string selectedRange:NSMakeRange(0, attributedString.get().string.length)]);
 #else
     RetainPtr text = dictionaryPopupInfo.text.createNSString();
-    RetainPtr item = adoptNS([PAL::allocRVItemInstance() initWithText:text.get() selectedRange:NSMakeRange(0, text.get().length)]);
+    RetainPtr item = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:text.get() selectedRange:NSMakeRange(0, text.get().length)]);
 #endif
 
     [UINSSharedRevealController() revealItem:item.get() locationInWindow:dictionaryPopupInfo.origin window:view.window highlighter:webHighlight.get()];

--- a/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
@@ -57,7 +57,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateUnlinkableToken
         RetainPtr serverPublicKey = toNSData(serverPublicKeyData->span());
 
         NSError* nsError = 0;
-        unlinkableToken.blinder = adoptNS([PAL::allocRSABSSATokenBlinderInstance() initWithPublicKey:serverPublicKey.get() error:&nsError]);
+        unlinkableToken.blinder = adoptNS([PAL::allocRSABSSATokenBlinderInstanceSingleton() initWithPublicKey:serverPublicKey.get() error:&nsError]);
         if (nsError)
             return nsError.localizedDescription;
         if (!unlinkableToken.blinder)

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -471,7 +471,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 
         if (RefPtr callback = _callback.get()) {
             BEGIN_BLOCK_OBJC_EXCEPTIONS
-            _routeDetector = adoptNS([PAL::allocAVRouteDetectorInstance() init]);
+            _routeDetector = adoptNS([PAL::allocAVRouteDetectorInstanceSingleton() init]);
             [_routeDetector setRouteDetectionEnabled:_monitoringAirPlayRoutes];
             [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(wirelessRoutesAvailableDidChange:) name:PAL::AVRouteDetectorMultipleRoutesDetectedDidChangeNotification object:_routeDetector.get()];
 

--- a/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm
+++ b/Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm
@@ -72,12 +72,12 @@ SOFT_LINK_CONSTANT(CoreLocation, kCLLocationAccuracyHundredMeters, double)
 
 #if USE(APPLE_INTERNAL_SDK) && HAVE(CORE_LOCATION_WEBSITE_IDENTIFIERS)
     if (!websiteIdentifier.isEmpty())
-        _locationManager = adoptNS([allocCLLocationManagerInstance() initWithWebsiteIdentifier:websiteIdentifier.createNSString().get()]);
+        _locationManager = adoptNS([allocCLLocationManagerInstanceSingleton() initWithWebsiteIdentifier:websiteIdentifier.createNSString().get()]);
 #else
     UNUSED_PARAM(websiteIdentifier);
 #endif
     if (!_locationManager)
-        _locationManager = adoptNS([allocCLLocationManagerInstance() init]);
+        _locationManager = adoptNS([allocCLLocationManagerInstanceSingleton() init]);
     _client = &client;
     _websiteIdentifier = websiteIdentifier;
     [_locationManager setDelegate:self];

--- a/Source/WebCore/platform/cocoa/NSURLUtilities.mm
+++ b/Source/WebCore/platform/cocoa/NSURLUtilities.mm
@@ -45,7 +45,7 @@
 #if HAVE(LINK_PRESENTATION_CHANGE_FOR_RADAR_115801517)
     // -[LPLinkMetadata setTitle:] additionally sets the `_title` SPI attribute on
     // the NSURL URL in OS versions where this codepath is compiled.
-    auto metadata = adoptNS([PAL::allocLPLinkMetadataInstance() init]);
+    auto metadata = adoptNS([PAL::allocLPLinkMetadataInstanceSingleton() init]);
     [metadata setURL:self];
     [metadata setTitle:title];
 #else
@@ -58,7 +58,7 @@
 #if HAVE(LINK_PRESENTATION_CHANGE_FOR_RADAR_115801517)
     // -[LPLinkMetadata title] falls back to the `_title` SPI attribute on the NSURL
     // in OS versions where this codepath is compiled.
-    auto metadata = adoptNS([PAL::allocLPLinkMetadataInstance() init]);
+    auto metadata = adoptNS([PAL::allocLPLinkMetadataInstanceSingleton() init]);
     [metadata setURL:self];
     return [metadata title];
 #else

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -127,7 +127,7 @@ void ParentalControlsContentFilter::responseReceived(const ResourceResponse& res
 #if HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
     ASSERT(!m_webFilterEvaluator);
 
-    m_webFilterEvaluator = adoptNS([allocWebFilterEvaluatorInstance() initWithResponse:response.nsURLResponse()]);
+    m_webFilterEvaluator = adoptNS([allocWebFilterEvaluatorInstanceSingleton() initWithResponse:response.nsURLResponse()]);
 #if HAVE(WEBFILTEREVALUATOR_AUDIT_TOKEN)
     if (m_hostProcessAuditToken)
         m_webFilterEvaluator.get().browserAuditToken = *m_hostProcessAuditToken;

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -197,11 +197,11 @@ WCRBrowserEngineClient* ParentalControlsURLFilter::effectiveWCRBrowserEngineClie
 
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     if (!m_wcrBrowserEngineClient && !m_configurationPath.isEmpty())
-        lazyInitialize(m_wcrBrowserEngineClient, adoptNS([PAL::allocWCRBrowserEngineClientInstance() initWithConfigurationAtPath:m_configurationPath.createNSString().get()]));
+        lazyInitialize(m_wcrBrowserEngineClient, adoptNS([PAL::allocWCRBrowserEngineClientInstanceSingleton() initWithConfigurationAtPath:m_configurationPath.createNSString().get()]));
 #endif
 
     if (!m_wcrBrowserEngineClient)
-        lazyInitialize(m_wcrBrowserEngineClient, adoptNS([PAL::allocWCRBrowserEngineClientInstance() init]));
+        lazyInitialize(m_wcrBrowserEngineClient, adoptNS([PAL::allocWCRBrowserEngineClientInstanceSingleton() init]));
 
     return m_wcrBrowserEngineClient.get();
 }

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -127,7 +127,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (!m_synthesizer) {
-        lazyInitialize(m_synthesizer, adoptNS([PAL::allocAVSpeechSynthesizerInstance() init]));
+        lazyInitialize(m_synthesizer, adoptNS([PAL::allocAVSpeechSynthesizerInstanceSingleton() init]));
         [m_synthesizer setDelegate:self];
     }
     

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h
@@ -45,7 +45,7 @@ namespace WebCore {
 WEBCORE_EXPORT WebAVPlayerLayerView *allocWebAVPlayerLayerViewInstance();
 
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
-WEBCORE_EXPORT WebAVPictureInPicturePlayerLayerView *allocWebAVPictureInPicturePlayerLayerViewInstance();
+WEBCORE_EXPORT WebAVPictureInPicturePlayerLayerView *allocWebAVPictureInPicturePlayerLayerViewInstanceSingleton();
 #endif
 
 }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -148,7 +148,7 @@ static WebAVPictureInPicturePlayerLayerView *WebAVPlayerLayerView_pictureInPictu
     if (WebAVPictureInPicturePlayerLayerView *pipView = [playerLayerView valueForKey:pictureInPicturePlayerLayerViewKey])
         return pipView;
 
-    auto pipView = adoptNS([allocWebAVPictureInPicturePlayerLayerViewInstance() initWithFrame:CGRectZero]);
+    auto pipView = adoptNS([allocWebAVPictureInPicturePlayerLayerViewInstanceSingleton() initWithFrame:CGRectZero]);
     [playerLayerView setValue:pipView.get() forKey:pictureInPicturePlayerLayerViewKey];
     return pipView.get();
 }
@@ -168,7 +168,7 @@ static void WebAVPlayerLayerView_dealloc(id aSelf, SEL)
 
 #pragma mark - Methods
 
-WebAVPlayerLayerView *allocWebAVPlayerLayerViewInstance()
+WebAVPlayerLayerView *allocWebAVPlayerLayerViewInstanceSingleton()
 {
     static Class theClass = nil;
     static dispatch_once_t onceToken;
@@ -203,7 +203,7 @@ static Class WebAVPictureInPicturePlayerLayerView_layerClass(id, SEL)
     return [WebAVPlayerLayer class];
 }
 
-WebAVPictureInPicturePlayerLayerView *allocWebAVPictureInPicturePlayerLayerViewInstance()
+WebAVPictureInPicturePlayerLayerView *allocWebAVPictureInPicturePlayerLayerViewInstanceSingleton()
 {
     static Class theClass = nil;
     static dispatch_once_t onceToken;

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -70,7 +70,7 @@ RefPtr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameContro
         };
 
         NSError* error;
-        auto pattern = adoptNS([allocCHHapticPatternInstance() initWithDictionary:hapticDict error:&error]);
+        auto pattern = adoptNS([allocCHHapticPatternInstanceSingleton() initWithDictionary:hapticDict error:&error]);
         if (!pattern) {
             RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect: Failed to create a CHHapticPattern");
             return nullptr;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -237,9 +237,9 @@ void AudioSourceProviderAVFObjC::createMixIfNeeded()
     }
     m_tap = adoptCF(tap);
     m_tapStorage = WTFMove(tapStorage);
-    m_avAudioMix = adoptNS([PAL::allocAVMutableAudioMixInstance() init]);
+    m_avAudioMix = adoptNS([PAL::allocAVMutableAudioMixInstanceSingleton() init]);
 
-    RetainPtr<AVMutableAudioMixInputParameters> parameters = adoptNS([PAL::allocAVMutableAudioMixInputParametersInstance() init]);
+    RetainPtr<AVMutableAudioMixInputParameters> parameters = adoptNS([PAL::allocAVMutableAudioMixInputParametersInstanceSingleton() init]);
     [parameters setAudioTapProcessor:m_tap.get()];
 
     CMPersistentTrackID trackID = m_avAssetTrack.get().trackID;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -68,7 +68,7 @@ AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogge
     : m_logger(originalLogger)
     , m_logIdentifier(logSiteIdentifier)
     , m_videoLayerManager(makeUniqueRef<VideoLayerManagerObjC>(originalLogger, logSiteIdentifier))
-    , m_synchronizer([adoptNS(PAL::allocAVSampleBufferRenderSynchronizerInstance()) init])
+    , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstanceSingleton() init]))
     , m_listener(WebAVSampleBufferListener::create(*this))
 {
     // addPeriodicTimeObserverForInterval: throws an exception if you pass a non-numeric CMTime, so just use
@@ -697,7 +697,7 @@ void AudioVideoRendererAVFObjC::addAudioRenderer(TrackIdentifier trackId)
 {
     ASSERT(!m_audioRenderers.contains(trackId));
 
-    RetainPtr renderer = [adoptNS(PAL::allocAVSampleBufferAudioRendererInstance()) init];
+    RetainPtr renderer = adoptNS([PAL::allocAVSampleBufferAudioRendererInstanceSingleton() init]);
 
     if (!renderer) {
         ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferAudioRenderer init] returned nil! bailing!");
@@ -880,7 +880,7 @@ void AudioVideoRendererAVFObjC::ensureLayer()
 
     destroyVideoLayerIfNeeded();
 
-    m_sampleBufferDisplayLayer = [adoptNS(PAL::allocAVSampleBufferDisplayLayerInstance()) init];
+    m_sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstanceSingleton() init]);
     if (!m_sampleBufferDisplayLayer) {
         ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferDisplayLayer init] returned nil! bailing!");
         return;
@@ -931,7 +931,7 @@ void AudioVideoRendererAVFObjC::ensureVideoRenderer()
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_sampleBufferVideoRenderer = [adoptNS(PAL::allocAVSampleBufferVideoRendererInstance()) init];
+    m_sampleBufferVideoRenderer = adoptNS([PAL::allocAVSampleBufferVideoRendererInstanceSingleton() init]);
     if (!m_sampleBufferVideoRenderer) {
         ERROR_LOG(LOGIDENTIFIER, "-[VSampleBufferVideoRenderer init] returned nil! bailing!");
         return;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
@@ -77,8 +77,8 @@ AVOutputDeviceMenuController *AVOutputDeviceMenuControllerTargetPicker::devicePi
         return nullptr;
 
     if (!m_outputDeviceMenuController) {
-        RetainPtr<AVOutputContext> context = adoptNS([PAL::allocAVOutputContextInstance() init]);
-        m_outputDeviceMenuController = adoptNS([allocAVOutputDeviceMenuControllerInstance() initWithOutputContext:context.get()]);
+        RetainPtr<AVOutputContext> context = adoptNS([PAL::allocAVOutputContextInstanceSingleton() init]);
+        m_outputDeviceMenuController = adoptNS([allocAVOutputDeviceMenuControllerInstanceSingleton() initWithOutputContext:context.get()]);
 
         [m_outputDeviceMenuController addObserver:m_outputDeviceMenuControllerDelegate.get() forKeyPath:externalOutputDeviceAvailableKeyName options:NSKeyValueObservingOptionNew context:nullptr];
         [m_outputDeviceMenuController addObserver:m_outputDeviceMenuControllerDelegate.get() forKeyPath:externalOutputDevicePickedKeyName options:NSKeyValueObservingOptionNew context:nullptr];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
@@ -66,7 +66,7 @@ bool AVRoutePickerViewTargetPicker::isAvailable()
         if (!getAVRoutePickerViewClass())
             return;
 
-        if (auto picker = adoptNS([allocAVRoutePickerViewInstance() init]))
+        if (auto picker = adoptNS([allocAVRoutePickerViewInstanceSingleton() init]))
             available = [picker respondsToSelector:@selector(showRoutePickingControlsForOutputContext:relativeToRect:ofView:)];
     });
 
@@ -100,7 +100,7 @@ AVOutputContext * AVRoutePickerViewTargetPicker::outputContextInternal()
 AVRoutePickerView *AVRoutePickerViewTargetPicker::devicePicker()
 {
     if (!m_routePickerView) {
-        m_routePickerView = adoptNS([allocAVRoutePickerViewInstance() init]);
+        m_routePickerView = adoptNS([allocAVRoutePickerViewInstanceSingleton() init]);
         [m_routePickerView setDelegate:m_routePickerViewDelegate.get()];
     }
 
@@ -110,7 +110,7 @@ AVRoutePickerView *AVRoutePickerViewTargetPicker::devicePicker()
 AVRouteDetector *AVRoutePickerViewTargetPicker::routeDetector()
 {
     if (!m_routeDetector) {
-        m_routeDetector = adoptNS([PAL::allocAVRouteDetectorInstance() init]);
+        m_routeDetector = adoptNS([PAL::allocAVRouteDetectorInstanceSingleton() init]);
         [[NSNotificationCenter defaultCenter] addObserver:m_routePickerViewDelegate.get() selector:@selector(notificationHandler:) name:PAL::AVRouteDetectorMultipleRoutesDetectedDidChangeNotification object:m_routeDetector.get()];
         if ([m_routeDetector multipleRoutesDetected])
             availableDevicesDidChange();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -485,7 +485,7 @@ AVContentKeySession* CDMSessionAVContentKeySession::contentKeySession()
     if ([PAL::getAVContentKeySessionClass() respondsToSelector:@selector(contentKeySessionWithKeySystem:storageDirectoryAtURL:)])
         m_contentKeySession = [PAL::getAVContentKeySessionClass() contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming storageDirectoryAtURL:storageURL];
     else
-        m_contentKeySession = adoptNS([PAL::allocAVContentKeySessionInstance() initWithStorageDirectoryAtURL:storageURL]);
+        m_contentKeySession = adoptNS([PAL::allocAVContentKeySessionInstanceSingleton() initWithStorageDirectoryAtURL:storageURL]);
 
     [m_contentKeySession setDelegate:m_contentKeySessionDelegate.get() queue:m_delegateQueue->dispatchQueue()];
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -348,7 +348,7 @@ ImageDecoderAVFObjC::ImageDecoderAVFObjC(const FragmentedSharedBuffer& data, con
     : ImageDecoder()
     , m_mimeType(mimeType)
     , m_uti(WebCore::UTIFromMIMEType(mimeType))
-    , m_asset(adoptNS([PAL::allocAVURLAssetInstance() initWithURL:customSchemeURL() options:imageDecoderAssetOptions()]))
+    , m_asset(adoptNS([PAL::allocAVURLAssetInstanceSingleton() initWithURL:customSchemeURL() options:imageDecoderAssetOptions()]))
     , m_loader(adoptNS([[WebCoreSharedBufferResourceLoaderDelegate alloc] initWithParent:this]))
     , m_decompressionSession(WebCoreDecompressionSession::createRGB())
     , m_resourceOwner(WTFMove(resourceOwner))
@@ -403,8 +403,8 @@ void ImageDecoderAVFObjC::readSamples()
     if (!m_sampleData.empty())
         return;
 
-    auto assetReader = adoptNS([PAL::allocAVAssetReaderInstance() initWithAsset:m_asset.get() error:nil]);
-    auto referenceOutput = adoptNS([PAL::allocAVAssetReaderSampleReferenceOutputInstance() initWithTrack:m_track.get()]);
+    auto assetReader = adoptNS([PAL::allocAVAssetReaderInstanceSingleton() initWithAsset:m_asset.get() error:nil]);
+    auto referenceOutput = adoptNS([PAL::allocAVAssetReaderSampleReferenceOutputInstanceSingleton() initWithTrack:m_track.get()]);
 
     referenceOutput.get().alwaysCopiesSampleData = NO;
     [assetReader addOutput:referenceOutput.get()];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -146,7 +146,7 @@ RefPtr<LocalSampleBufferDisplayLayer> LocalSampleBufferDisplayLayer::create(Samp
 {
     RetainPtr<AVSampleBufferDisplayLayer> sampleBufferDisplayLayer;
     @try {
-        sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
+        sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstanceSingleton() init]);
     } @catch(id exception) {
         RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::create failed to allocate display layer");
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -642,7 +642,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_videoLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);
+    m_videoLayer = adoptNS([PAL::allocAVPlayerLayerInstanceSingleton() init]);
     [m_videoLayer setPlayer:m_avPlayer.get()];
 
     [m_videoLayer setName:@"MediaPlayerPrivate AVPlayerLayer"];
@@ -984,13 +984,13 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     RetainPtr nsURL = canonicalURL(url);
 
     @try {
-        m_avAsset = adoptNS([PAL::allocAVURLAssetInstance() initWithURL:nsURL.get() options:options.get()]);
+        m_avAsset = adoptNS([PAL::allocAVURLAssetInstanceSingleton() initWithURL:nsURL.get() options:options.get()]);
     } @catch(NSException *exception) {
         ERROR_LOG(LOGIDENTIFIER, "-[AVURLAssetInstance initWithURL:nsURL.get() options:] threw an exception: ", exception.name, ", reason : ", exception.reason);
         nsURL = canonicalURL(conformFragmentIdentifierForURL(url));
 
         @try {
-            m_avAsset = adoptNS([PAL::allocAVURLAssetInstance() initWithURL:nsURL.get() options:options.get()]);
+            m_avAsset = adoptNS([PAL::allocAVURLAssetInstanceSingleton() initWithURL:nsURL.get() options:options.get()]);
         } @catch(NSException *exception) {
             ASSERT_NOT_REACHED();
             ERROR_LOG(LOGIDENTIFIER, "-[AVURLAssetInstance initWithURL:nsURL.get() options:] threw a second exception, bailing: ", exception.name, ", reason : ", exception.reason);
@@ -1064,7 +1064,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_avPlayer = adoptNS([PAL::allocAVPlayerInstance() init]);
+    m_avPlayer = adoptNS([PAL::allocAVPlayerInstanceSingleton() init]);
     for (NSString *keyName in playerKVOProperties())
         [m_avPlayer addObserver:m_objcObserver.get() forKeyPath:keyName options:NSKeyValueObservingOptionNew context:(void *)MediaPlayerAVFoundationObservationContextPlayer];
     m_automaticallyWaitsToMinimizeStalling = [m_avPlayer automaticallyWaitsToMinimizeStalling];
@@ -1168,7 +1168,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     // Create the player item so we can load media data.
-    m_avPlayerItem = adoptNS([PAL::allocAVPlayerItemInstance() initWithAsset:m_avAsset.get()]);
+    m_avPlayerItem = adoptNS([PAL::allocAVPlayerItemInstanceSingleton() initWithAsset:m_avAsset.get()]);
 
     [[NSNotificationCenter defaultCenter] addObserver:m_objcObserver.get() selector:@selector(didEnd:) name:AVPlayerItemDidPlayToEndTimeNotification object:m_avPlayerItem.get()];
 
@@ -1195,7 +1195,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     const NSTimeInterval avPlayerOutputAdvanceInterval = 2;
 
     RetainPtr<NSArray> subtypes = adoptNS([[NSArray alloc] initWithObjects:@(kCMSubtitleFormatType_WebVTT), nil]);
-    m_legibleOutput = adoptNS([PAL::allocAVPlayerItemLegibleOutputInstance() initWithMediaSubtypesForNativeRepresentation:subtypes.get()]);
+    m_legibleOutput = adoptNS([PAL::allocAVPlayerItemLegibleOutputInstanceSingleton() initWithMediaSubtypesForNativeRepresentation:subtypes.get()]);
     [m_legibleOutput setSuppressesPlayerRendering:YES];
 
     [m_legibleOutput setDelegate:m_objcObserver.get() queue:dispatch_get_main_queue()];
@@ -1210,11 +1210,11 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     }
 #endif
 
-    m_metadataCollector = adoptNS([PAL::allocAVPlayerItemMetadataCollectorInstance() initWithIdentifiers:nil classifyingLabels:nil]);
+    m_metadataCollector = adoptNS([PAL::allocAVPlayerItemMetadataCollectorInstanceSingleton() initWithIdentifiers:nil classifyingLabels:nil]);
     [m_metadataCollector setDelegate:m_objcObserver.get() queue:dispatch_get_main_queue()];
     [m_avPlayerItem addMediaDataCollector:m_metadataCollector.get()];
 
-    m_metadataOutput = adoptNS([PAL::allocAVPlayerItemMetadataOutputInstance() initWithIdentifiers:nil]);
+    m_metadataOutput = adoptNS([PAL::allocAVPlayerItemMetadataOutputInstanceSingleton() initWithIdentifiers:nil]);
     [m_metadataOutput setDelegate:m_objcObserver.get() queue:dispatch_get_main_queue()];
     [m_metadataOutput setAdvanceIntervalForDelegateInvocation:avPlayerOutputAdvanceInterval];
     [m_avPlayerItem addOutput:m_metadataOutput.get()];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -103,7 +103,7 @@ String convertEnumerationToString(MediaPlayerPrivateMediaSourceAVFObjC::SeekStat
 
 MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(MediaPlayer* player)
     : m_player(player)
-    , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstance() init]))
+    , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstanceSingleton() init]))
     , m_seekTimer(*this, &MediaPlayerPrivateMediaSourceAVFObjC::seekInternal)
     , m_networkState(MediaPlayer::NetworkState::Empty)
     , m_readyState(MediaPlayer::ReadyState::HaveNothing)
@@ -906,7 +906,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer()
 
     destroyVideoLayerIfNeeded();
 
-    m_sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
+    m_sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstanceSingleton() init]);
     if (!m_sampleBufferDisplayLayer)
         return;
 
@@ -952,7 +952,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureVideoRenderer()
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_sampleBufferVideoRenderer = adoptNS([PAL::allocAVSampleBufferVideoRendererInstance() init]);
+    m_sampleBufferVideoRenderer = adoptNS([PAL::allocAVSampleBufferVideoRendererInstanceSingleton() init]);
     if (!m_sampleBufferVideoRenderer)
         return;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -139,7 +139,7 @@ QueuedVideoOutput::QueuedVideoOutput(AVPlayerItem* item, AVPlayer* player)
     , m_player(player)
     , m_delegate(adoptNS([[WebQueuedVideoOutputDelegate alloc] initWithParent:this]))
 {
-    m_videoOutput = adoptNS([PAL::allocAVPlayerItemVideoOutputInstance() initWithPixelBufferAttributes:nil]);
+    m_videoOutput = adoptNS([PAL::allocAVPlayerItemVideoOutputInstanceSingleton() initWithPixelBufferAttributes:nil]);
     if (!m_videoOutput) {
         // When bailing out early, also release these following objects
         // to avoid doing unnecessary work in ::invalidate(). Failure to

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -201,7 +201,7 @@ private:
 MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported(const ContentType& type)
 {
     // Check that AVStreamDataParser is in a functional state.
-    if (!PAL::getAVStreamDataParserClass() || !adoptNS([PAL::allocAVStreamDataParserInstance() init]))
+    if (!PAL::getAVStreamDataParserClass() || !adoptNS([PAL::allocAVStreamDataParserInstanceSingleton() init]))
         return MediaPlayerEnums::SupportsType::IsNotSupported;
 
     String extendedType = type.raw();
@@ -215,7 +215,7 @@ MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported
 }
 
 SourceBufferParserAVFObjC::SourceBufferParserAVFObjC(const MediaSourceConfiguration& configuration)
-    : m_parser(adoptNS([PAL::allocAVStreamDataParserInstance() init]))
+    : m_parser(adoptNS([PAL::allocAVStreamDataParserInstanceSingleton() init]))
     , m_configuration(configuration)
 {
     m_delegate = adoptNS([[WebAVStreamDataParserWithKeySpecifierListener alloc] initWithParser:m_parser.get() parent:this]);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -602,7 +602,7 @@ void SourceBufferPrivateAVFObjC::trackDidChangeEnabled(AudioTrackPrivate& track,
     } else {
         RetainPtr renderer = audioRendererForTrackID(trackID);
         if (!renderer) {
-            renderer = adoptNS([PAL::allocAVSampleBufferAudioRendererInstance() init]);
+            renderer = adoptNS([PAL::allocAVSampleBufferAudioRendererInstanceSingleton() init]);
 
             if (!renderer) {
                 ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferAudioRenderer init] returned nil! bailing!");

--- a/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
@@ -59,7 +59,7 @@ RefPtr<Icon> Icon::create(PlatformImagePtr&& platformImage)
 #if USE(APPKIT)
     auto image = adoptNS([[NSImage alloc] initWithCGImage:platformImage.get() size:NSZeroSize]);
 #else
-    auto image = adoptNS([PAL::allocUIImageInstance() initWithCGImage:platformImage.get()]);
+    auto image = adoptNS([PAL::allocUIImageInstanceSingleton() initWithCGImage:platformImage.get()]);
 #endif
     return adoptRef(new Icon(image.get()));
 }

--- a/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
+++ b/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
@@ -48,7 +48,7 @@ namespace WebCore {
 
 void PDFDocumentImage::createPDFDocument()
 {
-    m_document = adoptNS([allocPDFDocumentInstance() initWithData:data()->makeContiguous()->createNSData().get()]);
+    m_document = adoptNS([allocPDFDocumentInstanceSingleton() initWithData:data()->makeContiguous()->createNSData().get()]);
 }
 
 void PDFDocumentImage::computeBoundsForCurrentPage()

--- a/Source/WebCore/platform/ios/DragImageIOS.mm
+++ b/Source/WebCore/platform/ios/DragImageIOS.mm
@@ -198,7 +198,7 @@ DragImageRef createDragImageForRange(LocalFrame& frame, const SimpleRange& range
         return nil;
 
     auto& image = *textIndicator->contentImage();
-    auto render = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:image.size()]);
+    auto render = adoptNS([PAL::allocUIGraphicsImageRendererInstanceSingleton() initWithSize:image.size()]);
     UIImage *finalImage = [render imageWithActions:[&image](UIGraphicsImageRendererContext *rendererContext) {
         GraphicsContextCG context(rendererContext.CGContext);
         context.drawImage(image, FloatPoint());
@@ -212,7 +212,7 @@ DragImageRef createDragImageForColor(const Color& color, const FloatRect& elemen
     FloatRect imageRect { 0, 0, elementRect.width() * pageScaleFactor, elementRect.height() * pageScaleFactor };
     FloatRoundedRect swatch { imageRect, FloatRoundedRect::Radii(ColorSwatchCornerRadius * pageScaleFactor) };
 
-    auto render = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:imageRect.size()]);
+    auto render = adoptNS([PAL::allocUIGraphicsImageRendererInstanceSingleton() initWithSize:imageRect.size()]);
     UIImage *image = [render imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
         GraphicsContextCG context { rendererContext.CGContext };
         context.translate(0, CGRectGetHeight(imageRect));

--- a/Source/WebCore/platform/ios/PreviewConverterIOS.mm
+++ b/Source/WebCore/platform/ios/PreviewConverterIOS.mm
@@ -88,7 +88,7 @@ PreviewConverter::PreviewConverter(const ResourceResponse& response, PreviewConv
     , m_originalResponse { response }
     , m_provider { provider }
     , m_platformDelegate { adoptNS([[WebPreviewConverterDelegate alloc] initWithDelegate:*this]) }
-    , m_platformConverter { adoptNS([PAL::allocQLPreviewConverterInstance() initWithConnection:nil delegate:m_platformDelegate.get() response:m_originalResponse.nsURLResponse() options:nil]) }
+    , m_platformConverter { adoptNS([PAL::allocQLPreviewConverterInstanceSingleton() initWithConnection:nil delegate:m_platformDelegate.get() response:m_originalResponse.nsURLResponse() options:nil]) }
 {
 }
 
@@ -152,7 +152,7 @@ static NSDictionary *optionsWithPassword(const String& password)
 
 void PreviewConverter::platformUnlockWithPassword(const String& password)
 {
-    m_platformConverter = adoptNS([PAL::allocQLPreviewConverterInstance() initWithConnection:nil delegate:m_platformDelegate.get() response:m_originalResponse.nsURLResponse() options:optionsWithPassword(password)]);
+    m_platformConverter = adoptNS([PAL::allocQLPreviewConverterInstanceSingleton() initWithConnection:nil delegate:m_platformDelegate.get() response:m_originalResponse.nsURLResponse() options:optionsWithPassword(password)]);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/QuickLook.mm
+++ b/Source/WebCore/platform/ios/QuickLook.mm
@@ -81,7 +81,7 @@ RetainPtr<NSURLRequest> registerQLPreviewConverterIfNeeded(NSURL *url, NSString 
     if ([QLPreviewGetSupportedMIMETypesSet() containsObject:updatedMIMEType.get()]) {
         RetainPtr<NSString> uti = adoptNS(PAL::softLink_QuickLook_QLTypeCopyUTIForURLAndMimeType(url, updatedMIMEType.get()));
 
-        auto converter = adoptNS([PAL::allocQLPreviewConverterInstance() initWithData:data name:nil uti:uti.get() options:nil]);
+        auto converter = adoptNS([PAL::allocQLPreviewConverterInstanceSingleton() initWithData:data name:nil uti:uti.get() options:nil]);
         ResourceRequest previewRequest = [converter previewRequest];
 
         // We use [request URL] here instead of url since it will be

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -80,7 +80,7 @@ static void WebValidationBubbleViewController_viewDidLoad(WebValidationBubbleVie
 {
     callSuper(instance, @selector(viewDidLoad));
 
-    auto label = adoptNS([PAL::allocUILabelInstance() init]);
+    auto label = adoptNS([PAL::allocUILabelInstanceSingleton() init]);
     [label setFont:[PAL::getUIFontClass() preferredFontForTextStyle:PAL::get_UIKit_UIFontTextStyleCallout()]];
     [label setLineBreakMode:NSLineBreakByTruncatingTail];
     [label setNumberOfLines:validationBubbleMaxNumberOfLines];
@@ -100,7 +100,7 @@ static void WebValidationBubbleViewController_viewSafeAreaInsetsDidChange(WebVal
     updateLabelFrame(instance);
 }
 
-static WebValidationBubbleViewController *allocWebValidationBubbleViewControllerInstance()
+static WebValidationBubbleViewController *allocWebValidationBubbleViewControllerInstanceSingleton()
 {
     static Class theClass = nil;
     static dispatch_once_t onceToken;
@@ -129,7 +129,7 @@ static WebValidationBubbleViewController *allocWebValidationBubbleViewController
         return nil;
 
     _popoverController = popoverController;
-    _tapGestureRecognizer = adoptNS([PAL::allocUITapGestureRecognizerInstance() initWithTarget:self action:@selector(dismissPopover)]);
+    _tapGestureRecognizer = adoptNS([PAL::allocUITapGestureRecognizerInstanceSingleton() initWithTarget:self action:@selector(dismissPopover)]);
     [[_popoverController view] addGestureRecognizer:_tapGestureRecognizer.get()];
 
     return self;
@@ -170,7 +170,7 @@ ValidationBubble::ValidationBubble(UIView *view, String&& message, const Setting
     : m_view(view)
     , m_message(WTFMove(message))
 {
-    m_popoverController = adoptNS([allocWebValidationBubbleViewControllerInstance() init]);
+    m_popoverController = adoptNS([allocWebValidationBubbleViewControllerInstanceSingleton() init]);
     [m_popoverController setModalPresentationStyle:UIModalPresentationPopover];
     m_tapRecognizer = adoptNS([[WebValidationBubbleTapRecognizer alloc] initWithPopoverController:m_popoverController.get()]);
 

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -325,7 +325,7 @@ static void WebAVPictureInPictureContentViewController_dealloc(id aSelf, SEL)
     super_dealloc(&superClass, @selector(dealloc));
 }
 
-static WebAVPictureInPictureContentViewController *allocWebAVPictureInPictureContentViewControllerInstance()
+static WebAVPictureInPictureContentViewController *allocWebAVPictureInPictureContentViewControllerInstanceSingleton()
 {
     static Class theClass = nil;
     static dispatch_once_t onceToken;
@@ -392,7 +392,7 @@ NS_ASSUME_NONNULL_END
 
     _fullscreenInterface = ThreadSafeWeakPtr { *interface };
 
-    _playerLayerView = adoptNS([WebCore::allocWebAVPlayerLayerViewInstance() init]);
+    _playerLayerView = adoptNS([WebCore::allocWebAVPlayerLayerViewInstanceSingleton() init]);
     RetainPtr playerLayer = (WebAVPlayerLayer *)[_playerLayerView playerLayer];
     if (interface)
         [playerLayer setPresentationModel:interface->videoPresentationModel().get()];
@@ -400,10 +400,10 @@ NS_ASSUME_NONNULL_END
     OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
 
 #if PLATFORM(APPLETV)
-    _avPlayerViewController = adoptNS([allocAVPlayerViewControllerInstance() init]);
+    _avPlayerViewController = adoptNS([allocAVPlayerViewControllerInstanceSingleton() init]);
     [self configurePlayerViewControllerWithFullscreenInterface:interface];
 #else
-    _avPlayerViewController = adoptNS([allocAVPlayerViewControllerInstance() initWithPlayerLayerView:_playerLayerView.get()]);
+    _avPlayerViewController = adoptNS([allocAVPlayerViewControllerInstanceSingleton() initWithPlayerLayerView:_playerLayerView.get()]);
 #endif
     [_avPlayerViewController setModalPresentationStyle:UIModalPresentationOverFullScreen];
 #if PLATFORM(WATCHOS)
@@ -417,11 +417,11 @@ NS_ASSUME_NONNULL_END
 
 #if HAVE(PIP_CONTROLLER)
     auto *playerController = static_cast<AVPlayerController *>(interface->playerController());
-    _pipContentViewController = adoptNS([allocWebAVPictureInPictureContentViewControllerInstance() initWithController:playerController]);
+    _pipContentViewController = adoptNS([allocWebAVPictureInPictureContentViewControllerInstanceSingleton() initWithController:playerController]);
 
-    auto source = adoptNS([allocAVPictureInPictureControllerContentSourceInstance() initWithSourceView:static_cast<UIView *>(interface->playerLayerView()) contentViewController:_pipContentViewController.get() playerController:playerController]);
+    auto source = adoptNS([allocAVPictureInPictureControllerContentSourceInstanceSingleton() initWithSourceView:static_cast<UIView *>(interface->playerLayerView()) contentViewController:_pipContentViewController.get() playerController:playerController]);
 
-    _pipController = adoptNS([allocAVPictureInPictureControllerInstance() initWithContentSource:source.get()]);
+    _pipController = adoptNS([allocAVPictureInPictureControllerInstanceSingleton() initWithContentSource:source.get()]);
 #endif
 
     return self;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -159,19 +159,19 @@ void VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing()
     }
 
     @try {
-        RetainPtr pipPlacard = adoptNS([PAL::allocUIViewInstance() initWithFrame:[layerHostView() bounds]]);
+        RetainPtr pipPlacard = adoptNS([PAL::allocUIViewInstanceSingleton() initWithFrame:[layerHostView() bounds]]);
         [pipPlacard setBackgroundColor:blackUIColor()];
         [pipPlacard setTranslatesAutoresizingMaskIntoConstraints:NO];
 
         RetainPtr image = [[[PAL::getUIImageClass() systemImageNamed:@"pip"] imageWithTintColor:greyUIColor() renderingMode:UIImageRenderingModeAlwaysOriginal] imageWithConfiguration:[PAL::getUIImageSymbolConfigurationClass() configurationWithWeight:UIImageSymbolWeightThin]];
 
-        RetainPtr imageView = adoptNS([PAL::allocUIImageViewInstance() initWithImage:image.get()]);
+        RetainPtr imageView = adoptNS([PAL::allocUIImageViewInstanceSingleton() initWithImage:image.get()]);
         [imageView setContentMode:UIViewContentModeScaleAspectFit];
         [imageView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
         [pipPlacard addSubview:imageView.get()];
 
-        auto pipLabel = adoptNS([PAL::allocUILabelInstance() init]);
+        auto pipLabel = adoptNS([PAL::allocUILabelInstanceSingleton() init]);
         [pipLabel setText:@"This video is playing in picture in picture."];
         [pipLabel setTextAlignment:NSTextAlignmentCenter];
         [pipLabel setTextColor:greyUIColor()];
@@ -319,10 +319,10 @@ void VideoPresentationInterfaceIOS::doSetup()
 
 #if !PLATFORM(WATCHOS)
     if (![[m_parentView window] _isHostedInAnotherProcess] && !m_window && !PAL::currentUserInterfaceIdiomIsVision()) {
-        m_window = adoptNS([PAL::allocUIWindowInstance() initWithWindowScene:[[m_parentView window] windowScene]]);
+        m_window = adoptNS([PAL::allocUIWindowInstanceSingleton() initWithWindowScene:[[m_parentView window] windowScene]]);
         [m_window setBackgroundColor:clearUIColor()];
         if (!m_viewController)
-            m_viewController = adoptNS([PAL::allocUIViewControllerInstance() init]);
+            m_viewController = adoptNS([PAL::allocUIViewControllerInstanceSingleton() init]);
         [[m_viewController view] setFrame:[m_window bounds]];
         [m_viewController _setIgnoreAppSupportedOrientations:YES];
         [m_window setRootViewController:m_viewController.get()];

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -216,12 +216,12 @@ Class webAVPlayerControllerClass()
     // FIXME (116592344): Create a phony AVPlayer to satisfy AVPlayerViewController's requirements on tvOS.
     // This can be removed once AVPlayerController API is available on tvOS.
     AVAsset *asset = [PAL::getAVAssetClass() assetWithURL:[NSURL URLWithString:@"about:blank"]];
-    RetainPtr playerItem = adoptNS([PAL::allocAVPlayerItemInstance() initWithAsset:asset]);
-    _player = adoptNS([PAL::allocAVPlayerInstance() initWithPlayerItem:playerItem.get()]);
+    RetainPtr playerItem = adoptNS([PAL::allocAVPlayerItemInstanceSingleton() initWithAsset:asset]);
+    _player = adoptNS([PAL::allocAVPlayerInstanceSingleton() initWithPlayerItem:playerItem.get()]);
 #endif
 
     initAVPlayerController();
-    self.playerControllerProxy = adoptNS([allocAVPlayerControllerInstance() init]).get();
+    self.playerControllerProxy = adoptNS([allocAVPlayerControllerInstanceSingleton() init]).get();
     _liveStreamEventModePossible = YES;
 
     [self addObserver:self forKeyPath:@"seekableTimeRanges" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial) context:WebAVPlayerControllerSeekableTimeRangesObserverContext];
@@ -969,7 +969,7 @@ Class webAVPlayerControllerClass()
     CMTime minSeekable = [seekableTimeRanges.firstObject CMTimeRangeValue].start;
     CMTime maxSeekable = PAL::CMTimeRangeGetEnd([seekableTimeRanges.lastObject CMTimeRangeValue]);
     CMTime duration = PAL::CMTimeSubtract(maxSeekable, minSeekable);
-    return [[allocAVTimeRangeInstance() initWithCMTimeRange:PAL::CMTimeRangeMake(minSeekable, duration)] autorelease];
+    return [[allocAVTimeRangeInstanceSingleton() initWithCMTimeRange:PAL::CMTimeRangeMake(minSeekable, duration)] autorelease];
 }
 
 - (BOOL)hasItem
@@ -1065,7 +1065,7 @@ Class webAVPlayerControllerClass()
 
 - (AVTimeRange *)timeRangeForNavigation
 {
-    return [[allocAVTimeRangeInstance() initWithStartTime:self.minTime endTime:self.maxTime] autorelease];
+    return [[allocAVTimeRangeInstanceSingleton() initWithStartTime:self.minTime endTime:self.maxTime] autorelease];
 }
 
 - (NSTimeInterval)timeFromDisplayTime:(NSTimeInterval)displayTime

--- a/Source/WebCore/platform/ios/WebCoreMotionManager.mm
+++ b/Source/WebCore/platform/ios/WebCoreMotionManager.mm
@@ -141,7 +141,7 @@ static const double kGravity = 9.80665;
 {
     ASSERT(!WebThreadIsCurrent());
 
-    m_motionManager = adoptNS([allocCMMotionManagerInstance() init]);
+    m_motionManager = adoptNS([allocCMMotionManagerInstanceSingleton() init]);
 
     m_gyroAvailable = m_motionManager.get().deviceMotionAvailable;
 
@@ -150,7 +150,7 @@ static const double kGravity = 9.80665;
     else
         [m_motionManager setAccelerometerUpdateInterval:kMotionUpdateInterval];
 
-    m_locationManager = adoptNS([allocCLLocationManagerInstance() init]);
+    m_locationManager = adoptNS([allocCLLocationManagerInstanceSingleton() init]);
     m_headingAvailable = [getCLLocationManagerClass() headingAvailable];
 
     m_initialized = YES;

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -1046,7 +1046,7 @@ void VideoFullscreenControllerContext::setUpFullscreen(HTMLVideoElement& videoEl
         m_interface = VideoPresentationInterfaceAVKitLegacy::create(sessionInterface.get());
         m_interface->setVideoPresentationModel(this);
 
-        m_videoFullscreenView = adoptNS([PAL::allocUIViewInstance() init]);
+        m_videoFullscreenView = adoptNS([PAL::allocUIViewInstanceSingleton() init]);
 
         m_interface->setupFullscreen(videoElementClientRect, videoDimensions, viewRef.get(), mode, allowsPictureInPicture, false, false);
     });

--- a/Source/WebCore/platform/mac/RevealUtilities.mm
+++ b/Source/WebCore/platform/mac/RevealUtilities.mm
@@ -35,7 +35,7 @@ namespace WebCore {
 
 RetainPtr<RVPresentingContext> createRVPresentingContextWithRetainedDelegate(NSPoint point, NSView *view, id<RVPresenterHighlightDelegate> delegate)
 {
-    auto context = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:point inView:view highlightDelegate:delegate]);
+    auto context = adoptNS([PAL::allocRVPresentingContextInstanceSingleton() initWithPointerLocationInView:point inView:view highlightDelegate:delegate]);
     static char retainedDelegateKey;
     objc_setAssociatedObject(context.get(), &retainedDelegateKey, delegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     return context;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -308,7 +308,7 @@ enum class PIPState {
     ASSERT(!_videoViewContainer);
     ASSERT(!_playerLayer);
 
-    _pipViewController = adoptNS([allocPIPViewControllerInstance() init]);
+    _pipViewController = adoptNS([allocPIPViewControllerInstanceSingleton() init]);
     [_pipViewController setDelegate:self];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [_pipViewController setUserCanResize:YES];

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -264,7 +264,7 @@ static AVTouchBarMediaSelectionOptionType toAVTouchBarMediaSelectionOptionType(M
 static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOption>& options)
 {
     return createNSArray(options, [] (auto& option) {
-        return adoptNS([allocAVTouchBarMediaSelectionOptionInstance() initWithTitle:option.displayName.createNSString().get() type:toAVTouchBarMediaSelectionOptionType(option.legibleType)]);
+        return adoptNS([allocAVTouchBarMediaSelectionOptionInstanceSingleton() initWithTitle:option.displayName.createNSString().get() type:toAVTouchBarMediaSelectionOptionType(option.legibleType)]);
     });
 }
 

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
@@ -83,7 +83,7 @@ std::unique_ptr<MediaRecorderPrivateWriter> MediaRecorderPrivateWriterAVFObjC::c
 {
     NSError *error = nil;
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr writer = adoptNS([PAL::allocAVAssetWriterInstance() initWithFileType:AVFileTypeMPEG4 error:&error]);
+    RetainPtr writer = adoptNS([PAL::allocAVAssetWriterInstanceSingleton() initWithFileType:AVFileTypeMPEG4 error:&error]);
     ALLOW_DEPRECATED_DECLARATIONS_END
     if (error) {
         RELEASE_LOG_ERROR(MediaStream, "create AVAssetWriter instance failed with error code %ld", (long)error.code);
@@ -106,7 +106,7 @@ MediaRecorderPrivateWriterAVFObjC::~MediaRecorderPrivateWriterAVFObjC() = defaul
 std::optional<uint8_t> MediaRecorderPrivateWriterAVFObjC::addAudioTrack(const AudioInfo& info)
 {
     m_audioDescription = createFormatDescriptionFromTrackInfo(info);
-    m_audioAssetWriterInput = adoptNS([PAL::allocAVAssetWriterInputInstance() initWithMediaType:AVMediaTypeAudio outputSettings:nil sourceFormatHint:m_audioDescription.get()]);
+    m_audioAssetWriterInput = adoptNS([PAL::allocAVAssetWriterInputInstanceSingleton() initWithMediaType:AVMediaTypeAudio outputSettings:nil sourceFormatHint:m_audioDescription.get()]);
     [m_audioAssetWriterInput setExpectsMediaDataInRealTime:true];
     if (![m_writer canAddInput:m_audioAssetWriterInput.get()]) {
         RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPrivateWriterAVFObjC::addAudioTrack failed canAddInput for audio with %ld", static_cast<long>([m_writer error].code));
@@ -122,7 +122,7 @@ std::optional<uint8_t> MediaRecorderPrivateWriterAVFObjC::addAudioTrack(const Au
 std::optional<uint8_t> MediaRecorderPrivateWriterAVFObjC::addVideoTrack(const VideoInfo& info, const std::optional<CGAffineTransform>& transform)
 {
     m_videoDescription = createFormatDescriptionFromTrackInfo(info);
-    m_videoAssetWriterInput = adoptNS([PAL::allocAVAssetWriterInputInstance() initWithMediaType:AVMediaTypeVideo outputSettings:nil sourceFormatHint:m_videoDescription.get()]);
+    m_videoAssetWriterInput = adoptNS([PAL::allocAVAssetWriterInputInstanceSingleton() initWithMediaType:AVMediaTypeVideo outputSettings:nil sourceFormatHint:m_videoDescription.get()]);
     [m_videoAssetWriterInput setExpectsMediaDataInRealTime:true];
     if (transform)
         [m_videoAssetWriterInput setTransform:*transform];

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -596,7 +596,7 @@ AVCapturePhotoOutput* AVVideoCaptureSource::photoOutput()
     assertIsCurrent(RunLoop::mainSingleton());
 
     if (!m_photoOutput) {
-        m_photoOutput = adoptNS([PAL::allocAVCapturePhotoOutputInstance() init]);
+        m_photoOutput = adoptNS([PAL::allocAVCapturePhotoOutputInstanceSingleton() init]);
 
         if (!m_photoOutput) {
             ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to allocate AVCapturePhotoOutput");
@@ -1090,7 +1090,7 @@ bool AVVideoCaptureSource::setupSession()
     WARNING_LOG_IF(loggerPtr() && mediaEnvironment.isEmpty(), "Media environment is empty");
     // FIXME (119325252): Remove staging code for -[AVCaptureSession initWithMediaEnvironment:]
     if (!mediaEnvironment.isEmpty() && [PAL::getAVCaptureSessionClass() instancesRespondToSelector:@selector(initWithMediaEnvironment:)])
-        m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithMediaEnvironment:mediaEnvironment.createNSString().get()]);
+        m_session = adoptNS([PAL::allocAVCaptureSessionInstanceSingleton() initWithMediaEnvironment:mediaEnvironment.createNSString().get()]);
 #endif
 
 #if ENABLE(APP_PRIVACY_REPORT)
@@ -1099,7 +1099,7 @@ bool AVVideoCaptureSource::setupSession()
         ERROR_LOG_IF(loggerPtr() && !identity, LOGIDENTIFIER, "RealtimeMediaSourceCenter::identity() returned null!");
 
         if (identity && [PAL::getAVCaptureSessionClass() instancesRespondToSelector:@selector(initWithAssumedIdentity:)])
-            m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithAssumedIdentity:identity.get()]);
+            m_session = adoptNS([PAL::allocAVCaptureSessionInstanceSingleton() initWithAssumedIdentity:identity.get()]);
     }
 #endif
 
@@ -1107,7 +1107,7 @@ bool AVVideoCaptureSource::setupSession()
 #if ENABLE(EXTENSION_CAPABILITIES)
         ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "allocating AVCaptureSession without media environment nor identity");
 #endif
-        m_session = adoptNS([PAL::allocAVCaptureSessionInstance() init]);
+        m_session = adoptNS([PAL::allocAVCaptureSessionInstanceSingleton() init]);
     }
 
     if (!m_session) {
@@ -1158,7 +1158,7 @@ bool AVVideoCaptureSource::setupCaptureSession()
     });
 
     NSError *error = nil;
-    RetainPtr<AVCaptureDeviceInput> videoIn = adoptNS([PAL::allocAVCaptureDeviceInputInstance() initWithDevice:device() error:&error]);
+    RetainPtr<AVCaptureDeviceInput> videoIn = adoptNS([PAL::allocAVCaptureDeviceInputInstanceSingleton() initWithDevice:device() error:&error]);
     if (error) {
         ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "failed to allocate AVCaptureDeviceInput ", error);
         return false;
@@ -1170,7 +1170,7 @@ bool AVVideoCaptureSource::setupCaptureSession()
     }
     [session() addInput:videoIn.get()];
 
-    m_videoOutput = adoptNS([PAL::allocAVCaptureVideoDataOutputInstance() init]);
+    m_videoOutput = adoptNS([PAL::allocAVCaptureVideoDataOutputInstanceSingleton() init]);
     auto settingsDictionary = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys: @(preferedPixelBufferFormat()), kCVPixelBufferPixelFormatTypeKey, nil]);
 
     [m_videoOutput setVideoSettings:settingsDictionary.get()];

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -360,7 +360,7 @@ RetainPtr<SCStreamConfiguration> ScreenCaptureKitCaptureSource::streamConfigurat
     if (m_streamConfiguration)
         return m_streamConfiguration;
 
-    m_streamConfiguration = adoptNS([PAL::allocSCStreamConfigurationInstance() init]);
+    m_streamConfiguration = adoptNS([PAL::allocSCStreamConfigurationInstanceSingleton() init]);
     [m_streamConfiguration setPixelFormat:preferedPixelBufferFormat()];
     [m_streamConfiguration setShowsCursor:YES];
     [m_streamConfiguration setQueueDepth:6];

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -433,7 +433,7 @@ void ScreenCaptureKitSharingSessionManager::promptForGetDisplayMedia(DisplayCapt
 
 bool ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingSession(DisplayCapturePromptType promptType)
 {
-    m_pendingSession = adoptNS([PAL::allocSCContentSharingSessionInstance() initWithTitle:@"WebKit getDisplayMedia Prompt"]);
+    m_pendingSession = adoptNS([PAL::allocSCContentSharingSessionInstanceSingleton() initWithTitle:@"WebKit getDisplayMedia Prompt"]);
     if (!m_pendingSession) {
         RELEASE_LOG_ERROR(WebRTC, "ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingSession unable to create sharing session");
         return false;
@@ -450,7 +450,7 @@ bool ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker(Dis
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     ASSERT(useSCContentSharingPicker());
 
-    auto configuration = adoptNS([PAL::allocSCContentSharingPickerConfigurationInstance() init]);
+    auto configuration = adoptNS([PAL::allocSCContentSharingPickerConfigurationInstanceSingleton() init]);
     SCShareableContentStyle shareableContentStyle = SCShareableContentStyleWindow;
     switch (promptType) {
     case DisplayCapturePromptType::Window:
@@ -561,10 +561,10 @@ RefPtr<ScreenCaptureSessionSource> ScreenCaptureKitSharingSessionManager::create
     RetainPtr<SCStream> stream;
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     if (useSCContentSharingPicker())
-        stream = adoptNS([PAL::allocSCStreamInstance() initWithFilter:contentFilter configuration:configuration delegate:(id<SCStreamDelegate> _Nullable)delegate]);
+        stream = adoptNS([PAL::allocSCStreamInstanceSingleton() initWithFilter:contentFilter configuration:configuration delegate:(id<SCStreamDelegate> _Nullable)delegate]);
     else
 #endif
-        stream = adoptNS([PAL::allocSCStreamInstance() initWithSharingSession:sharingSession captureOutputProperties:configuration delegate:(id<SCStreamDelegate> _Nullable)delegate]);
+        stream = adoptNS([PAL::allocSCStreamInstanceSingleton() initWithSharingSession:sharingSession captureOutputProperties:configuration delegate:(id<SCStreamDelegate> _Nullable)delegate]);
 
     if (!stream) {
         RELEASE_LOG_ERROR(WebRTC, "ScreenCaptureKitSharingSessionManager::createSessionSourceForDevice - unable to create SCStream.");

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1257,7 +1257,7 @@ Color RenderThemeIOS::pictureFrameColor(const RenderObject& buttonRenderer)
 RenderThemeCocoa::IconAndSize RenderThemeIOS::iconForAttachment(const String& fileName, const String& attachmentType, const String& title)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    auto documentInteractionController = adoptNS([PAL::allocUIDocumentInteractionControllerInstance() init]);
+    auto documentInteractionController = adoptNS([PAL::allocUIDocumentInteractionControllerInstanceSingleton() init]);
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     [documentInteractionController setName:fileName.isEmpty() ? title.createNSString().get() : fileName.createNSString().get()];

--- a/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
+++ b/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
@@ -81,7 +81,7 @@ const void* const webViewVisualIdentificationOverlayKey = &webViewVisualIdentifi
     [_view setWantsLayer:YES];
     [_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
 #else
-    _view = adoptNS([PAL::allocUIViewInstance() initWithFrame:webView.bounds]);
+    _view = adoptNS([PAL::allocUIViewInstanceSingleton() initWithFrame:webView.bounds]);
     [_view setUserInteractionEnabled:NO];
     [_view setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -591,7 +591,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     if (canLoadWithRealityKit)
         m_modelRKEntity = model->rootRKEntity();
     else if (model->rootEntity())
-        m_modelRKEntity = adoptNS([allocWKRKEntityInstance() initWithCoreEntity:model->rootEntity()]);
+        m_modelRKEntity = adoptNS([allocWKRKEntityInstanceSingleton() initWithCoreEntity:model->rootEntity()]);
     [m_modelRKEntity setDelegate:m_objCAdapter.get()];
 
     m_originalBoundingBoxExtents = [m_modelRKEntity boundingBoxExtents];
@@ -622,7 +622,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
         REEntitySetParent(model->rootEntity(), clientComponentEntity);
     }
 
-    m_stageModeInteractionDriver = adoptNS([allocWKStageModeInteractionDriverInstance() initWithModel:m_modelRKEntity.get() container:clientComponentEntity delegate:m_objCAdapter.get()]);
+    m_stageModeInteractionDriver = adoptNS([allocWKStageModeInteractionDriverInstanceSingleton() initWithModel:m_modelRKEntity.get() container:clientComponentEntity delegate:m_objCAdapter.get()]);
 
     REEntitySubtreeAddNetworkComponentRecursive([m_stageModeInteractionDriver interactionContainerRef]);
     RENetworkMarkEntityMetadataDirty([m_stageModeInteractionDriver interactionContainerRef]);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1910,7 +1910,7 @@ DMFWebsitePolicyMonitor *NetworkSessionCocoa::deviceManagementPolicyMonitor()
 #if HAVE(DEVICE_MANAGEMENT)
     ASSERT(m_deviceManagementRestrictionsEnabled);
     if (!m_deviceManagementPolicyMonitor)
-        m_deviceManagementPolicyMonitor = adoptNS([allocDMFWebsitePolicyMonitorInstance() initWithPolicyChangeHandler:nil]);
+        m_deviceManagementPolicyMonitor = adoptNS([allocDMFWebsitePolicyMonitorInstanceSingleton() initWithPolicyChangeHandler:nil]);
     return m_deviceManagementPolicyMonitor.get();
 #else
     RELEASE_ASSERT_NOT_REACHED();
@@ -2439,8 +2439,8 @@ void NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTime> modif
         return;
     }
 
-    RetainPtr<AnalyticsWorkspace> workspace = adoptNS([allocAnalyticsWorkspaceInstance() initWorkspaceWithService:getkSymptomAnalyticsServiceEndpoint()]);
-    RetainPtr<UsageFeed> usageFeed = adoptNS([allocUsageFeedInstance() initWithWorkspace:workspace.get()]);
+    RetainPtr<AnalyticsWorkspace> workspace = adoptNS([allocAnalyticsWorkspaceInstanceSingleton() initWorkspaceWithService:getkSymptomAnalyticsServiceEndpoint()]);
+    RetainPtr<UsageFeed> usageFeed = adoptNS([allocUsageFeedInstanceSingleton() initWithWorkspace:workspace.get()]);
 
     if (![usageFeed.get() respondsToSelector:@selector(performNetworkDomainsActionWithOptions:reply:)]
         || !canLoadkSymptomAnalyticsServiceDomainTrackingClearHistoryKey()

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -49,18 +49,18 @@ using namespace WebCore;
 RetainPtr<CocoaImageAnalyzer> createImageAnalyzer()
 {
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    return adoptNS([PAL::allocVKCImageAnalyzerInstance() init]);
+    return adoptNS([PAL::allocVKCImageAnalyzerInstanceSingleton() init]);
 #else
-    return adoptNS([PAL::allocVKImageAnalyzerInstance() init]);
+    return adoptNS([PAL::allocVKImageAnalyzerInstanceSingleton() init]);
 #endif
 }
 
 RetainPtr<CocoaImageAnalyzerRequest> createImageAnalyzerRequest(CGImageRef image, VKAnalysisTypes types)
 {
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    return adoptNS([(PAL::allocVKCImageAnalyzerRequestInstance()) initWithCGImage:image orientation:VKImageOrientationUp requestType:types]);
+    return adoptNS([PAL::allocVKCImageAnalyzerRequestInstanceSingleton() initWithCGImage:image orientation:VKImageOrientationUp requestType:types]);
 #else
-    return adoptNS([PAL::allocVKImageAnalyzerRequestInstance() initWithCGImage:image orientation:VKImageOrientationUp requestType:types]);
+    return adoptNS([PAL::allocVKImageAnalyzerRequestInstanceSingleton() initWithCGImage:image orientation:VKImageOrientationUp requestType:types]);
 #endif
 }
 
@@ -426,11 +426,11 @@ void requestPayloadForQRCode(CGImageRef image, CompletionHandler<void(NSString *
             callCompletionOnMainRunLoopWithResult(nil);
         });
 
-        auto request = adoptNS([PAL::allocVNDetectBarcodesRequestInstance() initWithCompletionHandler:completionHandler.get()]);
+        auto request = adoptNS([PAL::allocVNDetectBarcodesRequestInstanceSingleton() initWithCompletionHandler:completionHandler.get()]);
         [request setSymbologies:@[ PAL::get_Vision_VNBarcodeSymbologyQR() ]];
 
         NSError *error = nil;
-        auto handler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:adjustedImage.get() options:@{ }]);
+        auto handler = adoptNS([PAL::allocVNImageRequestHandlerInstanceSingleton() initWithCGImage:adjustedImage.get() options:@{ }]);
         [handler performRequests:@[ request.get() ] error:&error];
 
         if (error)

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -287,10 +287,10 @@ void PaymentAuthorizationPresenter::completePaymentMethodSelection(std::optional
 #if HAVE(PASSKIT_DISBURSEMENTS)
     bool isDisbursementRequestBasedOnSummaryItems = update->newLineItems.isEmpty() ? NO : update->newLineItems.last().disbursementLineItemType == WebCore::ApplePayLineItem::DisbursementLineItemType::Disbursement;
     if (isDisbursementRequestBasedOnSummaryItems)
-        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTFMove(update->newLineItems))]);
+        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstanceSingleton() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTFMove(update->newLineItems))]);
     else
 #endif
-        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
+        paymentMethodUpdate = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstanceSingleton() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
 #if HAVE(PASSKIT_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_SUMMARY_ITEMS)
     [paymentMethodUpdate setErrors:toNSErrors(WTFMove(update->errors)).get()];
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
@@ -334,7 +334,7 @@ void PaymentAuthorizationPresenter::completePaymentSession(WebCore::ApplePayPaym
 
 #if HAVE(PASSKIT_PAYMENT_ORDER_DETAILS)
     if (auto orderDetails = WTFMove(result.orderDetails)) {
-        auto platformOrderDetails = adoptNS([PAL::allocPKPaymentOrderDetailsInstance() initWithOrderTypeIdentifier:orderDetails->orderTypeIdentifier.createNSString().get() orderIdentifier:orderDetails->orderIdentifier.createNSString().get() webServiceURL:adoptNS([[NSURL alloc] initWithString:orderDetails->webServiceURL.createNSString().get()]).get() authenticationToken:orderDetails->authenticationToken.createNSString().get()]);
+        auto platformOrderDetails = adoptNS([PAL::allocPKPaymentOrderDetailsInstanceSingleton() initWithOrderTypeIdentifier:orderDetails->orderTypeIdentifier.createNSString().get() orderIdentifier:orderDetails->orderIdentifier.createNSString().get() webServiceURL:adoptNS([[NSURL alloc] initWithString:orderDetails->webServiceURL.createNSString().get()]).get() authenticationToken:orderDetails->authenticationToken.createNSString().get()]);
         [platformDelegate() completePaymentSession:status errors:errors.get() orderDetails:platformOrderDetails.get()];
         return;
     }
@@ -354,10 +354,10 @@ void PaymentAuthorizationPresenter::completeShippingContactSelection(std::option
     RetainPtr<PKPaymentRequestShippingContactUpdate> shippingContactUpdate;
 #if HAVE(PASSKIT_DISBURSEMENTS)
     if (update->newDisbursementRequest)
-        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTFMove(update->newLineItems))]);
+        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstanceSingleton() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTFMove(update->newLineItems))]);
     else
 #endif // HAVE(PASSKIT_DISBURSEMENTS)
-        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
+        shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstanceSingleton() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
     [shippingContactUpdate setErrors:toNSErrors(WTFMove(update->errors)).get()];
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
     [shippingContactUpdate setAvailableShippingMethods:toPKShippingMethods(WTFMove(update->newShippingMethods)).get()];
@@ -393,7 +393,7 @@ void PaymentAuthorizationPresenter::completeShippingMethodSelection(std::optiona
         return;
     }
 
-    auto shippingMethodUpdate = adoptNS([PAL::allocPKPaymentRequestShippingMethodUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
+    auto shippingMethodUpdate = adoptNS([PAL::allocPKPaymentRequestShippingMethodUpdateInstanceSingleton() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
     [shippingMethodUpdate setAvailableShippingMethods:toPKShippingMethods(WTFMove(update->newShippingMethods)).get()];
 #elif HAVE(PASSKIT_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_SUMMARY_ITEMS)
@@ -430,7 +430,7 @@ void PaymentAuthorizationPresenter::completeCouponCodeChange(std::optional<WebCo
         return;
     }
 
-    auto couponCodeUpdate = adoptNS([PAL::allocPKPaymentRequestCouponCodeUpdateInstance() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
+    auto couponCodeUpdate = adoptNS([PAL::allocPKPaymentRequestCouponCodeUpdateInstanceSingleton() initWithPaymentSummaryItems:WebCore::platformSummaryItems(WTFMove(update->newTotal), WTFMove(update->newLineItems))]);
     [couponCodeUpdate setErrors:toNSErrors(WTFMove(update->errors)).get()];
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
     [couponCodeUpdate setAvailableShippingMethods:toPKShippingMethods(WTFMove(update->newShippingMethods)).get()];

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
@@ -112,7 +112,7 @@ static RetainPtr<PKPaymentAuthorizationViewController> platformViewController(PK
 {
 #if PLATFORM(IOS_FAMILY)
     ASSERT(!viewController);
-    return adoptNS([PAL::allocPKPaymentAuthorizationViewControllerInstance() initWithPaymentRequest:request]);
+    return adoptNS([PAL::allocPKPaymentAuthorizationViewControllerInstanceSingleton() initWithPaymentRequest:request]);
 #else
     return viewController;
 #endif

--- a/Source/WebKit/Platform/cocoa/WKPaymentAuthorizationDelegate.mm
+++ b/Source/WebKit/Platform/cocoa/WKPaymentAuthorizationDelegate.mm
@@ -72,7 +72,7 @@
         _shippingMethods = adoptNS([[update shippingMethods] copy]);
 #endif
     } else {
-        update = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstance() initWithPaymentSummaryItems:_summaryItems.get()]);
+        update = adoptNS([PAL::allocPKPaymentRequestPaymentMethodUpdateInstanceSingleton() initWithPaymentSummaryItems:_summaryItems.get()]);
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
         [update setAvailableShippingMethods:_availableShippingMethods.get()];
 #elif HAVE(PASSKIT_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_SUMMARY_ITEMS)
@@ -85,7 +85,7 @@
 
 - (void)completePaymentSession:(PKPaymentAuthorizationStatus)status errors:(NSArray<NSError *> *)errors
 {
-    auto result = adoptNS([PAL::allocPKPaymentAuthorizationResultInstance() initWithStatus:status errors:errors]);
+    auto result = adoptNS([PAL::allocPKPaymentAuthorizationResultInstanceSingleton() initWithStatus:status errors:errors]);
     std::exchange(_didAuthorizePaymentCompletion, nil)(result.get());
 }
 
@@ -93,7 +93,7 @@
 
 - (void)completePaymentSession:(PKPaymentAuthorizationStatus)status errors:(NSArray<NSError *> *)errors orderDetails:(PKPaymentOrderDetails *)orderDetails
 {
-    auto result = adoptNS([PAL::allocPKPaymentAuthorizationResultInstance() initWithStatus:status errors:errors]);
+    auto result = adoptNS([PAL::allocPKPaymentAuthorizationResultInstanceSingleton() initWithStatus:status errors:errors]);
     [result setOrderDetails:orderDetails];
     std::exchange(_didAuthorizePaymentCompletion, nil)(result.get());
 }
@@ -111,7 +111,7 @@
         _shippingMethods = adoptNS([[update shippingMethods] copy]);
 #endif
     } else {
-        update = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:_summaryItems.get()]);
+        update = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstanceSingleton() initWithPaymentSummaryItems:_summaryItems.get()]);
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
         [update setAvailableShippingMethods:_availableShippingMethods.get()];
 #else
@@ -133,7 +133,7 @@
         _shippingMethods = adoptNS([[update shippingMethods] copy]);
 #endif
     } else {
-        update = adoptNS([PAL::allocPKPaymentRequestShippingMethodUpdateInstance() initWithPaymentSummaryItems:_summaryItems.get()]);
+        update = adoptNS([PAL::allocPKPaymentRequestShippingMethodUpdateInstanceSingleton() initWithPaymentSummaryItems:_summaryItems.get()]);
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
         [update setAvailableShippingMethods:_availableShippingMethods.get()];
 #elif HAVE(PASSKIT_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_SUMMARY_ITEMS)
@@ -157,7 +157,7 @@
         _shippingMethods = adoptNS([[update shippingMethods] copy]);
 #endif
     } else {
-        update = adoptNS([PAL::allocPKPaymentRequestCouponCodeUpdateInstance() initWithPaymentSummaryItems:_summaryItems.get()]);
+        update = adoptNS([PAL::allocPKPaymentRequestCouponCodeUpdateInstanceSingleton() initWithPaymentSummaryItems:_summaryItems.get()]);
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
         [update setAvailableShippingMethods:_availableShippingMethods.get()];
 #else

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -156,7 +156,7 @@ void LinkDecorationFilteringController::updateList(CompletionHandler<void()>&& c
     if (lookupCompletionHandlers->size() > 1)
         return;
 
-    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
     [options setAfterUpdates:NO];
 
     [[PAL::getWPResourcesClass() sharedInstance] requestLinkFilteringData:options.get() completionHandler:^(WPLinkFilteringData *data, NSError *error) {
@@ -200,7 +200,7 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
     if (lookupCallbacks->size() > 1)
         return;
 
-    auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
     [options setAfterUpdates:NO];
 
     [[PAL::getWPResourcesClass() sharedInstance] requestAllowedLinkFilteringData:options.get() completionHandler:^(WPLinkFilteringData *data, NSError *error) {
@@ -273,7 +273,7 @@ void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& 
     if (lookupCompletionHandlers->size() > 1)
         return;
 
-    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
     [options setAfterUpdates:NO];
 
     [[PAL::getWPResourcesClass() sharedInstance] requestStorageAccessPromptQuirksData:options.get() completionHandler:^(WPStorageAccessPromptQuirksData *data, NSError *error) {
@@ -315,7 +315,7 @@ void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<v
     if (lookupCompletionHandlers->size() > 1)
         return;
 
-    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
     [options setAfterUpdates:NO];
 
     [[PAL::getWPResourcesClass() sharedInstance] requestStorageAccessUserAgentStringQuirksData:options.get() completionHandler:^(WPStorageAccessUserAgentStringQuirksData *data, NSError *error) {
@@ -372,7 +372,7 @@ void RestrictedOpenerDomainsController::update()
     if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestRestrictedOpenerDomains:completionHandler:)])
         return;
 
-    auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
     [options setAfterUpdates:NO];
 
     [[PAL::getWPResourcesClass() sharedInstance] requestRestrictedOpenerDomains:options.get() completionHandler:^(NSArray<WPRestrictedOpenerDomain *> *domains, NSError *error) {
@@ -530,7 +530,7 @@ public:
             if (!PAL::isWebPrivacyFrameworkAvailable())
                 return;
 
-            auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+            auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
             [options setAfterUpdates:YES];
 
             [[PAL::getWPResourcesClass() sharedInstance] requestTrackerNetworkAddresses:options.get() completionHandler:^(NSArray<WPNetworkAddressRange *> *ranges, NSError *error) {
@@ -665,7 +665,7 @@ public:
             if (!canRequestTrackerDomainNames)
                 return;
 
-            auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+            auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
             [options setAfterUpdates:YES];
             [[PAL::getWPResourcesClass() sharedInstance] requestTrackerDomainNamesData:options.get() completionHandler:^(NSArray<WPTrackingDomain *> * domains, NSError *error) {
                 if (error) {
@@ -809,7 +809,7 @@ void ScriptTrackingPrivacyController::updateList(CompletionHandler<void()>&& com
     if (pendingCompletionHandlers->size() > 1)
         return;
 
-    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstanceSingleton() init]);
     [options setAfterUpdates:NO];
 
     [[PAL::getWPResourcesClass() sharedInstance] requestFingerprintingScripts:options.get() completionHandler:^(NSArray<WPFingerprintingScript *> *scripts, NSError *error) {

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -146,7 +146,7 @@ Ref<PaymentAuthorizationController> PaymentAuthorizationController::create(Payme
 
 PaymentAuthorizationController::PaymentAuthorizationController(PaymentAuthorizationPresenter::Client& client, PKPaymentRequest *request)
     : PaymentAuthorizationPresenter(client)
-    , m_controller(adoptNS([PAL::allocPKPaymentAuthorizationControllerInstance() initWithPaymentRequest:request]))
+    , m_controller(adoptNS([PAL::allocPKPaymentAuthorizationControllerInstanceSingleton() initWithPaymentRequest:request]))
     , m_delegate(adoptNS([[WKPaymentAuthorizationControllerDelegate alloc] initWithRequest:request presenter:*this]))
 {
     [m_controller setDelegate:m_delegate.get()];

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -277,7 +277,7 @@ static WebCore::NowPlayingMetadataObserver nowPlayingMetadataObserver(PlaybackSe
 
 PlaybackSessionInterfaceLMK::PlaybackSessionInterfaceLMK(WebCore::PlaybackSessionModel& model)
     : PlaybackSessionInterfaceIOS { model }
-    , m_player { adoptNS([allocWKSLinearMediaPlayerInstance() init]) }
+    , m_player { adoptNS([allocWKSLinearMediaPlayerInstanceSingleton() init]) }
     , m_playerDelegate { adoptNS([[WKLinearMediaPlayerDelegate alloc] initWithModel:model]) }
     , m_nowPlayingMetadataObserver { nowPlayingMetadataObserver(*this) }
 {
@@ -328,7 +328,7 @@ void PlaybackSessionInterfaceLMK::seekableRangesChanged(const WebCore::PlatformT
 {
     RetainPtr seekableRanges = adoptNS([[NSMutableArray alloc] initWithCapacity:timeRanges.length()]);
     for (unsigned i = 0; i < timeRanges.length(); ++i) {
-        RetainPtr timeRange = adoptNS([allocWKSLinearMediaTimeRangeInstance() initWithLowerBound:timeRanges.start(i).toDouble() upperBound:timeRanges.end(i).toDouble()]);
+        RetainPtr timeRange = adoptNS([allocWKSLinearMediaTimeRangeInstanceSingleton() initWithLowerBound:timeRanges.start(i).toDouble() upperBound:timeRanges.end(i).toDouble()]);
         [seekableRanges addObject:timeRange.get()];
     }
 
@@ -345,7 +345,7 @@ void PlaybackSessionInterfaceLMK::audioMediaSelectionOptionsChanged(const Vector
 {
     RetainPtr audioTracks = adoptNS([[NSMutableArray alloc] initWithCapacity:options.size()]);
     for (auto& option : options) {
-        RetainPtr audioTrack = adoptNS([allocWKSLinearMediaTrackInstance() initWithLocalizedDisplayName:option.displayName.createNSString().get()]);
+        RetainPtr audioTrack = adoptNS([allocWKSLinearMediaTrackInstanceSingleton() initWithLocalizedDisplayName:option.displayName.createNSString().get()]);
         [audioTracks addObject:audioTrack.get()];
     }
 
@@ -357,7 +357,7 @@ void PlaybackSessionInterfaceLMK::legibleMediaSelectionOptionsChanged(const Vect
 {
     RetainPtr legibleTracks = adoptNS([[NSMutableArray alloc] initWithCapacity:options.size()]);
     for (auto& option : options) {
-        RetainPtr legibleTrack = adoptNS([allocWKSLinearMediaTrackInstance() initWithLocalizedDisplayName:option.displayName.createNSString().get()]);
+        RetainPtr legibleTrack = adoptNS([allocWKSLinearMediaTrackInstanceSingleton() initWithLocalizedDisplayName:option.displayName.createNSString().get()]);
         [legibleTracks addObject:legibleTrack.get()];
     }
 
@@ -421,7 +421,7 @@ void PlaybackSessionInterfaceLMK::spatialVideoMetadataChanged(const std::optiona
 {
     RetainPtr<WKSLinearMediaSpatialVideoMetadata> spatialVideoMetadata;
     if (metadata)
-        spatialVideoMetadata = adoptNS([allocWKSLinearMediaSpatialVideoMetadataInstance() initWithWidth:metadata->size.width() height:metadata->size.height() horizontalFOVDegrees:metadata->horizontalFOVDegrees baseline:metadata->baseline disparityAdjustment:metadata->disparityAdjustment]);
+        spatialVideoMetadata = adoptNS([allocWKSLinearMediaSpatialVideoMetadataInstanceSingleton() initWithWidth:metadata->size.width() height:metadata->size.height() horizontalFOVDegrees:metadata->horizontalFOVDegrees baseline:metadata->baseline disparityAdjustment:metadata->disparityAdjustment]);
     [m_player setSpatialVideoMetadata:spatialVideoMetadata.get()];
 }
 
@@ -465,7 +465,7 @@ static RetainPtr<NSData> artworkData(const WebCore::NowPlayingMetadata& metadata
 
 void PlaybackSessionInterfaceLMK::nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata& metadata)
 {
-    RetainPtr contentMetadata = adoptNS([allocWKSLinearMediaContentMetadataInstance() initWithTitle:metadata.title.createNSString().get() subtitle:metadata.artist.createNSString().get()]);
+    RetainPtr contentMetadata = adoptNS([allocWKSLinearMediaContentMetadataInstanceSingleton() initWithTitle:metadata.title.createNSString().get() subtitle:metadata.artist.createNSString().get()]);
     [m_player setContentMetadata:contentMetadata.get()];
     [m_player setArtwork:artworkData(metadata).get()];
 }

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -122,7 +122,7 @@ NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber)
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return nil;
 
-    auto actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
+    auto actionContext = adoptNS([PAL::allocWKDDActionContextInstanceSingleton() init]);
 
     [actionContext setAllowedActionUTIs:@[ @"com.apple.dial" ]];
 
@@ -147,8 +147,8 @@ RetainPtr<NSMenu> menuForTelephoneNumber(const String& telephoneNumber, NSView *
     auto urlComponents = adoptNS([[NSURLComponents alloc] init]);
     [urlComponents setScheme:@"tel"];
     [urlComponents setPath:telephoneNumber.createNSString().get()];
-    auto item = adoptNS([PAL::allocRVItemInstance() initWithURL:[urlComponents URL] rangeInContext:NSMakeRange(0, telephoneNumber.length())]);
-    auto presenter = adoptNS([PAL::allocRVPresenterInstance() init]);
+    auto item = adoptNS([PAL::allocRVItemInstanceSingleton() initWithURL:[urlComponents URL] rangeInContext:NSMakeRange(0, telephoneNumber.length())]);
+    auto presenter = adoptNS([PAL::allocRVPresenterInstanceSingleton() init]);
     auto delegate = adoptNS([[WKEmptyPresenterHighlightDelegate alloc] initWithRect:rect]);
     auto context = WebCore::createRVPresentingContextWithRetainedDelegate(NSZeroPoint, webView, delegate.get());
     NSArray *proposedMenuItems = [presenter menuItemsForItem:item.get() documentContext:nil presentingContext:context.get() options:nil];

--- a/Source/WebKit/Shared/ApplePay/cocoa/AutomaticReloadPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/AutomaticReloadPaymentRequestCocoa.mm
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 RetainPtr<PKAutomaticReloadPaymentRequest> platformAutomaticReloadPaymentRequest(const ApplePayAutomaticReloadPaymentRequest& webAutomaticReloadPaymentRequest)
 {
-    auto pkAutomaticReloadPaymentRequest = adoptNS([PAL::allocPKAutomaticReloadPaymentRequestInstance() initWithPaymentDescription:webAutomaticReloadPaymentRequest.paymentDescription.createNSString().get() automaticReloadBilling:platformAutomaticReloadSummaryItem(webAutomaticReloadPaymentRequest.automaticReloadBilling) managementURL:adoptNS([[NSURL alloc] initWithString:webAutomaticReloadPaymentRequest.managementURL.createNSString().get()]).get()]);
+    auto pkAutomaticReloadPaymentRequest = adoptNS([PAL::allocPKAutomaticReloadPaymentRequestInstanceSingleton() initWithPaymentDescription:webAutomaticReloadPaymentRequest.paymentDescription.createNSString().get() automaticReloadBilling:platformAutomaticReloadSummaryItem(webAutomaticReloadPaymentRequest.automaticReloadBilling) managementURL:adoptNS([[NSURL alloc] initWithString:webAutomaticReloadPaymentRequest.managementURL.createNSString().get()]).get()]);
     if (auto& billingAgreement = webAutomaticReloadPaymentRequest.billingAgreement; !billingAgreement.isNull())
         [pkAutomaticReloadPaymentRequest setBillingAgreement:billingAgreement.createNSString().get()];
     if (auto& tokenNotificationURL = webAutomaticReloadPaymentRequest.tokenNotificationURL; !tokenNotificationURL.isNull())

--- a/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 RetainPtr<PKDeferredPaymentRequest> platformDeferredPaymentRequest(const ApplePayDeferredPaymentRequest& webDeferredPaymentRequest)
 {
-    auto pkDeferredPaymentRequest = adoptNS([PAL::allocPKDeferredPaymentRequestInstance()
+    auto pkDeferredPaymentRequest = adoptNS([PAL::allocPKDeferredPaymentRequestInstanceSingleton()
         initWithPaymentDescription:webDeferredPaymentRequest.paymentDescription.createNSString().get()
         deferredBilling:platformDeferredSummaryItem(webDeferredPaymentRequest.deferredBilling)
         managementURL:adoptNS([[NSURL alloc] initWithString:webDeferredPaymentRequest.managementURL.createNSString().get()]).get()]);

--- a/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
@@ -67,13 +67,13 @@ static PKContactField platformContactField(ApplePayContactField contactField)
 RetainPtr<PKDisbursementPaymentRequest> platformDisbursementRequest(const ApplePaySessionPaymentRequest& request, const URL& originatingURL, const std::optional<Vector<ApplePayContactField>>& requiredRecipientContactFields)
 {
     // This merchantID is not actually used for web payments, passing an empty string here is fine
-    auto disbursementRequest = adoptNS([PAL::allocPKDisbursementRequestInstance() initWithMerchantIdentifier:@"" currencyCode:request.currencyCode().createNSString().get() regionCode:request.countryCode().createNSString().get() supportedNetworks:createNSArray(request.supportedNetworks()).get() merchantCapabilities:toPKMerchantCapabilities(request.merchantCapabilities()) summaryItems:WebCore::platformDisbursementSummaryItems(request.lineItems())]);
+    auto disbursementRequest = adoptNS([PAL::allocPKDisbursementRequestInstanceSingleton() initWithMerchantIdentifier:@"" currencyCode:request.currencyCode().createNSString().get() regionCode:request.countryCode().createNSString().get() supportedNetworks:createNSArray(request.supportedNetworks()).get() merchantCapabilities:toPKMerchantCapabilities(request.merchantCapabilities()) summaryItems:WebCore::platformDisbursementSummaryItems(request.lineItems())]);
 
     // FIXME: we should consolidate the types for various contact fields in the system(WebCore::ApplePayContactField, WebCore::ApplePaySessionPaymentRequest::ContactFields etc.)
     if (requiredRecipientContactFields)
         [disbursementRequest setRequiredRecipientContactFields:createNSArray(WTFMove(*requiredRecipientContactFields), platformContactField).get()];
 
-    auto disbursementPaymentRequest = adoptNS([PAL::allocPKDisbursementPaymentRequestInstance() initWithDisbursementRequest:disbursementRequest.get()]);
+    auto disbursementPaymentRequest = adoptNS([PAL::allocPKDisbursementPaymentRequestInstanceSingleton() initWithDisbursementRequest:disbursementRequest.get()]);
     [disbursementPaymentRequest setOriginatingURL:originatingURL.createNSURL().get()];
     [disbursementPaymentRequest setAPIType:PKPaymentRequestAPITypeWebPaymentRequest];
     return disbursementPaymentRequest;

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
@@ -49,7 +49,7 @@ static RetainPtr<PKPaymentSetupConfiguration> toPlatformConfiguration(const WebC
         return nil;
 #endif
 
-    auto configuration = adoptNS([PAL::allocPKPaymentSetupConfigurationInstance() init]);
+    auto configuration = adoptNS([PAL::allocPKPaymentSetupConfigurationInstanceSingleton() init]);
     [configuration setMerchantIdentifier:coreConfiguration.merchantIdentifier.createNSString().get()];
     [configuration setOriginatingURL:url.createNSURL().get()];
     [configuration setReferrerIdentifier:coreConfiguration.referrerIdentifier.createNSString().get()];

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
@@ -45,7 +45,7 @@ RetainPtr<PKPaymentTokenContext> platformPaymentTokenContext(const ApplePayPayme
     RetainPtr<NSString> merchantDomain;
     if (!webTokenContext.merchantDomain.isNull())
         merchantDomain = webTokenContext.merchantDomain.createNSString();
-    return adoptNS([PAL::allocPKPaymentTokenContextInstance() initWithMerchantIdentifier:webTokenContext.merchantIdentifier.createNSString().get() externalIdentifier:webTokenContext.externalIdentifier.createNSString().get() merchantName:webTokenContext.merchantName.createNSString().get() merchantDomain:merchantDomain.get() amount:WebCore::toDecimalNumber(webTokenContext.amount)]);
+    return adoptNS([PAL::allocPKPaymentTokenContextInstanceSingleton() initWithMerchantIdentifier:webTokenContext.merchantIdentifier.createNSString().get() externalIdentifier:webTokenContext.externalIdentifier.createNSString().get() merchantName:webTokenContext.merchantName.createNSString().get() merchantDomain:merchantDomain.get() amount:WebCore::toDecimalNumber(webTokenContext.amount)]);
 }
 
 RetainPtr<NSArray<PKPaymentTokenContext *>> platformPaymentTokenContexts(const Vector<ApplePayPaymentTokenContext>& webTokenContexts)

--- a/Source/WebKit/Shared/ApplePay/cocoa/RecurringPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/RecurringPaymentRequestCocoa.mm
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 RetainPtr<PKRecurringPaymentRequest> platformRecurringPaymentRequest(const ApplePayRecurringPaymentRequest& webRecurringPaymentRequest)
 {
-    auto pkRecurringPaymentRequest = adoptNS([PAL::allocPKRecurringPaymentRequestInstance() initWithPaymentDescription:webRecurringPaymentRequest.paymentDescription.createNSString().get() regularBilling:platformRecurringSummaryItem(webRecurringPaymentRequest.regularBilling) managementURL:adoptNS([[NSURL alloc] initWithString:webRecurringPaymentRequest.managementURL.createNSString().get()]).get()]);
+    auto pkRecurringPaymentRequest = adoptNS([PAL::allocPKRecurringPaymentRequestInstanceSingleton() initWithPaymentDescription:webRecurringPaymentRequest.paymentDescription.createNSString().get() regularBilling:platformRecurringSummaryItem(webRecurringPaymentRequest.regularBilling) managementURL:adoptNS([[NSURL alloc] initWithString:webRecurringPaymentRequest.managementURL.createNSString().get()]).get()]);
     if (auto& trialBilling = webRecurringPaymentRequest.trialBilling)
         [pkRecurringPaymentRequest setTrialBilling:platformRecurringSummaryItem(*trialBilling)];
     if (auto& billingAgreement = webRecurringPaymentRequest.billingAgreement; !billingAgreement.isNull())

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -102,7 +102,7 @@ void WebPaymentCoordinatorProxy::platformOpenPaymentSetup(const String& merchant
         return completionHandler(false);
 #endif
 
-    auto passLibrary = adoptNS([PAL::allocPKPassLibraryInstance() init]);
+    auto passLibrary = adoptNS([PAL::allocPKPassLibraryInstanceSingleton() init]);
     [passLibrary openPaymentSetupForMerchantIdentifier:merchantIdentifier.createNSString().get() domain:domainName.createNSString().get() completion:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL result) mutable {
         RunLoop::mainSingleton().dispatch([completionHandler = WTFMove(completionHandler), result] {
             completionHandler(result);
@@ -183,7 +183,7 @@ static RetainPtr<NSDateComponents> toNSDateComponents(const WebCore::ApplePayDat
 
 static RetainPtr<PKDateComponentsRange> toPKDateComponentsRange(const WebCore::ApplePayDateComponentsRange& dateComponentsRange)
 {
-    return adoptNS([PAL::allocPKDateComponentsRangeInstance() initWithStartDateComponents:toNSDateComponents(dateComponentsRange.startDateComponents).get() endDateComponents:toNSDateComponents(dateComponentsRange.endDateComponents).get()]);
+    return adoptNS([PAL::allocPKDateComponentsRangeInstanceSingleton() initWithStartDateComponents:toNSDateComponents(dateComponentsRange.startDateComponents).get() endDateComponents:toNSDateComponents(dateComponentsRange.endDateComponents).get()]);
 }
 
 #endif // HAVE(PASSKIT_SHIPPING_METHOD_DATE_COMPONENTS_RANGE)
@@ -211,7 +211,7 @@ RetainPtr<PKShippingMethods> toPKShippingMethods(const Vector<WebCore::ApplePayS
             defaultMethod = pkShippingMethod;
         return pkShippingMethod;
     });
-    return adoptNS([PAL::allocPKShippingMethodsInstance() initWithMethods:methods.get() defaultMethod:defaultMethod.get()]);
+    return adoptNS([PAL::allocPKShippingMethodsInstanceSingleton() initWithMethods:methods.get() defaultMethod:defaultMethod.get()]);
 }
 
 #endif // HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
@@ -298,7 +298,7 @@ static PKPaymentRequestAPIType toAPIType(WebCore::ApplePaySessionPaymentRequest:
 
 RetainPtr<PKPaymentRequest> WebPaymentCoordinatorProxy::platformPaymentRequest(const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest)
 {
-    auto result = adoptNS([PAL::allocPKPaymentRequestInstance() init]);
+    auto result = adoptNS([PAL::allocPKPaymentRequestInstanceSingleton() init]);
 
     [result setOriginatingURL:originatingURL.createNSURL().get()];
 
@@ -498,7 +498,7 @@ void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupCo
         return;
     }
 
-    auto request = adoptNS([PAL::allocPKPaymentSetupRequestInstance() init]);
+    auto request = adoptNS([PAL::allocPKPaymentSetupRequestInstanceSingleton() init]);
     [request setConfiguration:configuration.platformConfiguration().get()];
     [request setPaymentSetupFeatures:features.platformFeatures()];
 
@@ -508,7 +508,7 @@ void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupCo
         });
     });
 
-    auto paymentSetupController = adoptNS([PAL::allocPKPaymentSetupControllerInstance() init]);
+    auto paymentSetupController = adoptNS([PAL::allocPKPaymentSetupControllerInstanceSingleton() init]);
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     [paymentSetupController presentPaymentSetupRequest:request.get() completion:completion.get()];
@@ -529,11 +529,11 @@ void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupCo
         return;
     }
 
-    auto request = adoptNS([PAL::allocPKPaymentSetupRequestInstance() init]);
+    auto request = adoptNS([PAL::allocPKPaymentSetupRequestInstanceSingleton() init]);
     [request setConfiguration:configuration.platformConfiguration().get()];
     [request setPaymentSetupFeatures:features.platformFeatures()];
 
-    auto paymentSetupViewController = adoptNS([PAL::allocPKPaymentSetupViewControllerInstance() initWithPaymentSetupRequest:request.get()]);
+    auto paymentSetupViewController = adoptNS([PAL::allocPKPaymentSetupViewControllerInstanceSingleton() initWithPaymentSetupRequest:request.get()]);
     if (!paymentSetupViewController) {
         reply(false);
         return;

--- a/Source/WebKit/Shared/Cocoa/RevealItem.mm
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.mm
@@ -53,7 +53,7 @@ NSRange RevealItem::highlightRange() const
 RVItem *RevealItem::item() const
 {
     if (!m_item)
-        m_item = adoptNS([PAL::allocRVItemInstance() initWithText:m_text.createNSString().get() selectedRange:NSMakeRange(m_selectedRange.location, m_selectedRange.length)]);
+        m_item = adoptNS([PAL::allocRVItemInstanceSingleton() initWithText:m_text.createNSString().get() selectedRange:NSMakeRange(m_selectedRange.location, m_selectedRange.length)]);
     return m_item.get();
 }
 

--- a/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
@@ -151,8 +151,8 @@ RetainPtr<CocoaImage> iconForVideoFile(NSURL *file)
 {
     ASSERT_ARG(file, [file isFileURL]);
 
-    RetainPtr<AVURLAsset> asset = adoptNS([PAL::allocAVURLAssetInstance() initWithURL:file options:nil]);
-    RetainPtr<AVAssetImageGenerator> generator = adoptNS([PAL::allocAVAssetImageGeneratorInstance() initWithAsset:asset.get()]);
+    RetainPtr<AVURLAsset> asset = adoptNS([PAL::allocAVURLAssetInstanceSingleton() initWithURL:file options:nil]);
+    RetainPtr<AVAssetImageGenerator> generator = adoptNS([PAL::allocAVAssetImageGeneratorInstanceSingleton() initWithAsset:asset.get()]);
     [generator setAppliesPreferredTrackTransform:YES];
 
     NSError *error = nil;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -427,7 +427,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     if (!_page->preferences().screenTimeEnabled() || !_page->mainFrame()->url().protocolIsInHTTPFamily())
         return;
 
-    _screenTimeWebpageController = adoptNS([PAL::allocSTWebpageControllerInstance() init]);
+    _screenTimeWebpageController = adoptNS([PAL::allocSTWebpageControllerInstanceSingleton() init]);
     [_screenTimeWebpageController addObserver:self forKeyPath:@"URLIsBlocked" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:&screenTimeWebpageControllerBlockedKVOContext];
     _isBlockedByScreenTime = NO;
 
@@ -2466,9 +2466,9 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     _page->didBeginWritingToolsSession(*webSession, contextData);
 
     if (session.type == WTSessionTypeProofreading)
-        _intelligenceTextEffectCoordinator = adoptNS([WebKit::allocWKIntelligenceReplacementTextEffectCoordinatorInstance() initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)self]);
+        _intelligenceTextEffectCoordinator = adoptNS([WebKit::allocWKIntelligenceReplacementTextEffectCoordinatorInstanceSingleton() initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)self]);
     else if (session.type == WTSessionTypeComposition && session.compositionSessionType == WTCompositionSessionTypeSmartReply)
-        _intelligenceTextEffectCoordinator = adoptNS([WebKit::allocWKIntelligenceSmartReplyTextEffectCoordinatorInstance() initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)self]);
+        _intelligenceTextEffectCoordinator = adoptNS([WebKit::allocWKIntelligenceSmartReplyTextEffectCoordinatorInstanceSingleton() initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)self]);
     else
         _intelligenceTextEffectCoordinator = nil;
 

--- a/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
@@ -81,7 +81,7 @@ bool shouldAllowAutoFillForCellularIdentifiers(const URL& topURL)
 #if HAVE(DELAY_INIT_LINKING)
     static NeverDestroyed cachedClient = adoptNS([[CoreTelephonyClient alloc] initWithQueue:dispatch_get_main_queue()]);
 #else
-    static NeverDestroyed cachedClient = adoptNS([PAL::allocCoreTelephonyClientInstance() initWithQueue:dispatch_get_main_queue()]);
+    static NeverDestroyed cachedClient = adoptNS([PAL::allocCoreTelephonyClientInstanceSingleton() initWithQueue:dispatch_get_main_queue()]);
 #endif
     auto client = cachedClient->get();
 

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -133,7 +133,7 @@ Ref<GroupActivitiesCoordinator> GroupActivitiesCoordinator::create(GroupActiviti
 GroupActivitiesCoordinator::GroupActivitiesCoordinator(GroupActivitiesSession& session)
     : m_session(session)
     , m_delegate(adoptNS([[WKGroupActivitiesCoordinatorDelegate alloc] initWithParent:*this]))
-    , m_playbackCoordinator(adoptNS([PAL::allocAVDelegatingPlaybackCoordinatorInstance() initWithPlaybackControlDelegate:m_delegate.get()]))
+    , m_playbackCoordinator(adoptNS([PAL::allocAVDelegatingPlaybackCoordinatorInstanceSingleton() initWithPlaybackControlDelegate:m_delegate.get()]))
     , m_stateChangeObserver([this] (auto& session, auto state) { sessionStateChanged(session, state); })
 {
     [session.groupSession() coordinateWithCoordinator:m_playbackCoordinator.get()];

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
@@ -51,7 +51,7 @@ GroupActivitiesSessionNotifier& GroupActivitiesSessionNotifier::singleton()
 }
 
 GroupActivitiesSessionNotifier::GroupActivitiesSessionNotifier()
-    : m_sessionObserver(adoptNS([allocWKGroupSessionObserverInstance() init]))
+    : m_sessionObserver(adoptNS([allocWKGroupSessionObserverInstanceSingleton() init]))
     , m_stateChangeObserver([this] (auto& session, auto state) { sessionStateChanged(session, state); })
 {
     m_sessionObserver.get().newSessionCallback = [weakThis = WeakPtr { *this }] (WKGroupSession *groupSession) {

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -312,7 +312,7 @@ IGNORE_WARNINGS_END
 
 bool checkSpeechRecognitionServiceAvailability(const String& localeIdentifier)
 {
-    auto recognizer = localeIdentifier.isEmpty() ? adoptNS([PAL::allocSFSpeechRecognizerInstance() init]) : adoptNS([PAL::allocSFSpeechRecognizerInstance() initWithLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier.createNSString().get()]]);
+    auto recognizer = localeIdentifier.isEmpty() ? adoptNS([PAL::allocSFSpeechRecognizerInstanceSingleton() init]) : adoptNS([PAL::allocSFSpeechRecognizerInstanceSingleton() initWithLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier.createNSString().get()]]);
     return recognizer && [recognizer isAvailable];
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -170,7 +170,7 @@ void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCor
     }
 
     auto nsUUID = adoptNS([[NSUUID alloc] initWithUUIDString:uuid.createNSString().get()]);
-    auto preview = adoptNS([allocASVInlinePreviewInstance() initWithFrame:CGRectMake(0, 0, size.width(), size.height()) UUID:nsUUID.get()]);
+    auto preview = adoptNS([allocASVInlinePreviewInstanceSingleton() initWithFrame:CGRectMake(0, 0, size.width(), size.height()) UUID:nsUUID.get()]);
 
     LOG(ModelElement, "Created remote preview with UUID %s.", uuid.utf8().data());
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -88,7 +88,7 @@ public:
     void didInsertAttachment(API::Attachment&, const String& source) final;
     void didRemoveAttachment(API::Attachment&) final;
     void didInvalidateDataForAttachment(API::Attachment&) final;
-    NSFileWrapper *allocFileWrapperInstance() const final;
+    NSFileWrapper *allocFileWrapperInstanceSingleton() const final;
     NSSet *serializableFileWrapperClasses() const final;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -141,7 +141,7 @@ void PageClientImplCocoa::didInvalidateDataForAttachment(API::Attachment& attach
     [m_webView _didInvalidateDataForAttachment:attachment];
 }
 
-NSFileWrapper *PageClientImplCocoa::allocFileWrapperInstance() const
+NSFileWrapper *PageClientImplCocoa::allocFileWrapperInstanceSingleton() const
 {
     RetainPtr cls = [m_webView configuration]._attachmentFileWrapperClass ?: [NSFileWrapper class];
     return [cls.get() alloc];

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -95,7 +95,7 @@ static bool isSameOrigin(const WebCore::ResourceRequest& request, const WebCore:
 } // namespace
 
 SOAuthorizationSession::SOAuthorizationSession(RetainPtr<WKSOAuthorizationDelegate> delegate, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, InitiatingAction action)
-    : m_soAuthorization(adoptNS([PAL::allocSOAuthorizationInstance() init]))
+    : m_soAuthorization(adoptNS([PAL::allocSOAuthorizationInstanceSingleton() init]))
     , m_navigationAction(WTFMove(navigationAction))
     , m_page(page)
     , m_action(action)

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -133,10 +133,10 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     RetainPtr contentType = WebCore::UTIFromMIMEType("model/vnd.usdz+zip"_s).createNSString();
 
 #if HAVE(ARKIT_QUICK_LOOK_PREVIEW_ITEM)
-    RetainPtr previewItem = adoptNS([WebKit::allocARQuickLookPreviewItemInstance() initWithFileAtURL:_downloadedURL.createNSURL().get()]);
+    RetainPtr previewItem = adoptNS([WebKit::allocARQuickLookPreviewItemInstanceSingleton() initWithFileAtURL:_downloadedURL.createNSURL().get()]);
     [previewItem setCanonicalWebPageURL:_originatingPageURL.createNSURL().get()];
 
-    _item = adoptNS([allocARQuickLookWebKitItemInstance() initWithPreviewItemProvider:_itemProvider.get() contentType:contentType.get() previewTitle:@"Preview" fileSize:@(0) previewItem:previewItem.get()]);
+    _item = adoptNS([allocARQuickLookWebKitItemInstanceSingleton() initWithPreviewItemProvider:_itemProvider.get() contentType:contentType.get() previewTitle:@"Preview" fileSize:@(0) previewItem:previewItem.get()]);
     [_item setDelegate:self];
 
     if ([_item respondsToSelector:(@selector(setAdditionalParameters:))]) {
@@ -145,7 +145,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     }
 
 #else
-    _item = adoptNS([PAL::allocQLItemInstance() initWithPreviewItemProvider:_itemProvider.get() contentType:contentType previewTitle:@"Preview" fileSize:@(0)]);
+    _item = adoptNS([PAL::allocQLItemInstanceSingleton() initWithPreviewItemProvider:_itemProvider.get() contentType:contentType previewTitle:@"Preview" fileSize:@(0)]);
 #endif
     [_item setUseLoadingTimeout:NO];
 
@@ -455,7 +455,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
         protectedThis->m_fragmentIdentifier = url.fragmentIdentifier().toString();
 
 #if !PLATFORM(VISION)
-        protectedThis->m_qlPreviewController = adoptNS([PAL::allocQLPreviewControllerInstance() init]);
+        protectedThis->m_qlPreviewController = adoptNS([PAL::allocQLPreviewControllerInstanceSingleton() init]);
 
         protectedThis->m_qlPreviewControllerDelegate = adoptNS([[_WKPreviewControllerDelegate alloc] initWithSystemPreviewController:protectedThis]);
         [protectedThis->m_qlPreviewController setDelegate:protectedThis->m_qlPreviewControllerDelegate.get()];

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
@@ -116,7 +116,7 @@ static WebCore::VideoFrameRotation computeVideoFrameRotation(int rotation)
         if (!avDevice)
             return { };
 
-        RetainPtr coordinator = adoptNS([PAL::allocAVCaptureDeviceRotationCoordinatorInstance() initWithDevice:avDevice.get() previewLayer:layer]);
+        RetainPtr coordinator = adoptNS([PAL::allocAVCaptureDeviceRotationCoordinatorInstanceSingleton() initWithDevice:avDevice.get() previewLayer:layer]);
         [coordinator addObserver:self forKeyPath:@"videoRotationAngleForHorizonLevelPreview" options:NSKeyValueObservingOptionNew context:(void *)nil];
 
         iterator->value = WTFMove(coordinator);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -965,7 +965,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
     if (!interface->videoView()) {
         ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayerView");
         auto initialFrame = CGRectMake(0, 0, initialSize.width(), initialSize.height());
-        auto playerView = adoptNS([allocWebAVPlayerLayerViewInstance() initWithFrame:initialFrame]);
+        auto playerView = adoptNS([allocWebAVPlayerLayerViewInstanceSingleton() initWithFrame:initialFrame]);
 
         model->setVideoDimensions(nativeSize);
 

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -164,7 +164,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
         _contactPickerDelegate = adoptNS([[WKCNContactPickerSingleSelectDelegate alloc] initWithContactPickerDelegate:self]);
 
 #if HAVE(CNCONTACTPICKERVIEWCONTROLLER)
-    _contactPickerViewController = adoptNS([allocCNContactPickerViewControllerInstance() init]);
+    _contactPickerViewController = adoptNS([allocCNContactPickerViewControllerInstanceSingleton() init]);
     [_contactPickerViewController setDelegate:_contactPickerDelegate.get()];
     [_contactPickerViewController setPrompt:requestData.url.createNSString().get()];
 
@@ -285,7 +285,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
         if (![jsContact isKindOfClass:[NSDictionary class]])
             continue;
 
-        auto contact = adoptNS([allocCNMutableContactInstance() init]);
+        auto contact = adoptNS([allocCNMutableContactInstanceSingleton() init]);
 
         RetainPtr<id> names = [(NSDictionary *)jsContact objectForKey:@"name"];
         if ([names isKindOfClass:[NSArray class]]) {

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -74,7 +74,7 @@ static NSString *typeIdentifierForFileURL(NSURL *url)
 
 static RetainPtr<LPLinkMetadata> placeholderMetadataWithURLAndTitle(NSURL *url, NSString *title)
 {
-    RetainPtr metadata = adoptNS([PAL::allocLPLinkMetadataInstance() init]);
+    RetainPtr metadata = adoptNS([PAL::allocLPLinkMetadataInstanceSingleton() init]);
     [metadata setOriginalURL:url];
     [metadata setURL:url];
     [metadata setTitle:title];
@@ -116,13 +116,13 @@ static RetainPtr<NSString> nameForFileURLWithTypeIdentifier(NSURL *url, NSString
 
 static RetainPtr<LPLinkMetadata> placeholderMetadataWithFileURL(NSURL *url)
 {
-    RetainPtr metadata = adoptNS([PAL::allocLPLinkMetadataInstance() init]);
+    RetainPtr metadata = adoptNS([PAL::allocLPLinkMetadataInstanceSingleton() init]);
     [metadata setOriginalURL:url];
     [metadata setURL:url];
 
     RetainPtr typeIdentifier = typeIdentifierForFileURL(url);
 
-    RetainPtr fileMetadata = adoptNS([PAL::allocLPFileMetadataInstance() init]);
+    RetainPtr fileMetadata = adoptNS([PAL::allocLPFileMetadataInstanceSingleton() init]);
     [fileMetadata setType:typeIdentifier.get()];
     [fileMetadata setName:nameForFileURLWithTypeIdentifier(url, typeIdentifier.get()).get()];
     [fileMetadata setSize:sizeForFileURL(url)];
@@ -151,7 +151,7 @@ static RetainPtr<LPLinkMetadata> placeholderMetadataWithFileURL(NSURL *url)
 
     _url = url;
 
-    auto provider = adoptNS([PAL::allocLPMetadataProviderInstance() init]);
+    auto provider = adoptNS([PAL::allocLPMetadataProviderInstanceSingleton() init]);
     [provider setShouldFetchSubresources:NO];
 
     _headerMetadata = [provider _startFetchingMetadataForURL:url completionHandler:^(NSError *) { }];

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -373,7 +373,7 @@ void WebPageProxy::platformRegisterAttachment(Ref<API::Attachment>&& attachment,
     if (!pageClient)
         return;
 
-    RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstance() initRegularFileWithContents:bufferCopy.unsafeBuffer()->createNSData().get()]);
+    RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstanceSingleton() initRegularFileWithContents:bufferCopy.unsafeBuffer()->createNSData().get()]);
     [fileWrapper setPreferredFilename:preferredFileName.createNSString().get()];
     attachment->setFileWrapper(fileWrapper.get());
 }
@@ -387,7 +387,7 @@ void WebPageProxy::platformRegisterAttachment(Ref<API::Attachment>&& attachment,
     if (!pageClient)
         return;
 
-    RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstance() initWithURL:adoptNS([[NSURL alloc] initFileURLWithPath:filePath.createNSString().get()]).get() options:0 error:nil]);
+    RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstanceSingleton() initWithURL:adoptNS([[NSURL alloc] initFileURLWithPath:filePath.createNSString().get()]).get() options:0 error:nil]);
     attachment->setFileWrapper(fileWrapper.get());
 }
 
@@ -905,7 +905,7 @@ void WebPageProxy::setUpHighlightsObserver()
         });
     };
     
-    m_appHighlightsObserver = adoptNS([allocSYNotesActivationObserverInstance() initWithHandler:updateAppHighlightsVisibility]);
+    m_appHighlightsObserver = adoptNS([allocSYNotesActivationObserverInstanceSingleton() initWithHandler:updateAppHighlightsVisibility]);
 }
 
 #endif
@@ -928,12 +928,12 @@ void WebPageProxy::startApplePayAMSUISession(URL&& originatingURL, ApplePayAMSUI
         return;
     }
 
-    RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstance() initWithRequestDictionary:dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[request.engagementRequest.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil])]);
+    RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstanceSingleton() initWithRequestDictionary:dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[request.engagementRequest.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil])]);
     [amsRequest setOriginatingURL:originatingURL.createNSURL().get()];
 
     auto amsBag = retainPtr([getAMSUIEngagementTaskClass() createBagForSubProfile]);
 
-    m_applePayAMSUISession = adoptNS([allocAMSUIEngagementTaskInstance() initWithRequest:amsRequest.get() bag:amsBag.get() presentingViewController:presentingViewController.get()]);
+    m_applePayAMSUISession = adoptNS([allocAMSUIEngagementTaskInstanceSingleton() initWithRequest:amsRequest.get() bag:amsBag.get() presentingViewController:presentingViewController.get()]);
     [m_applePayAMSUISession setRemotePresentation:YES];
 
     auto amsResult = retainPtr([m_applePayAMSUISession presentEngagement]);

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -134,7 +134,7 @@ static RetainPtr<NSArray<WKIdentityDocumentPresentmentMobileDocumentIndividualDo
 
             for (auto&& elementPair : elements) {
                 RetainPtr mappedElementIdentifier = elementPair.first.createNSString();
-                RetainPtr mappedElementValue = adoptNS([WebKit::allocWKIdentityDocumentPresentmentMobileDocumentElementInfoInstance() initWithIsRetaining:elementPair.second.isRetaining]);
+                RetainPtr mappedElementValue = adoptNS([WebKit::allocWKIdentityDocumentPresentmentMobileDocumentElementInfoInstanceSingleton() initWithIsRetaining:elementPair.second.isRetaining]);
 
                 [namespaceDictionary setObject:mappedElementValue.get() forKey:mappedElementIdentifier.get()];
             }
@@ -144,7 +144,7 @@ static RetainPtr<NSArray<WKIdentityDocumentPresentmentMobileDocumentIndividualDo
         }
 
         RetainPtr documentType = validatedDocumentRequest.documentType.createNSString();
-        RetainPtr mappedDocumentRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequestInstance() initWithDocumentType:documentType.get() namespaces:namespaces.get()]);
+        RetainPtr mappedDocumentRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequestInstanceSingleton() initWithDocumentType:documentType.get() namespaces:namespaces.get()]);
         [mappedDocumentRequests addObject:mappedDocumentRequest.get()];
     }
 
@@ -166,7 +166,7 @@ static RetainPtr<NSArray<WKIdentityDocumentPresentmentMobileDocumentPresentmentR
     RetainPtr<NSMutableArray<WKIdentityDocumentPresentmentMobileDocumentPresentmentRequest *>> mappedPresentmentRequests = adoptNS([[NSMutableArray alloc] init]);
     for (auto&& validatedPresentmentRequest : presentmentRequests) {
         RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequest *> *>> mappedDocumentSets = mapDocumentRequestSets(validatedPresentmentRequest.documentRequestSets);
-        RetainPtr mappedPresentmentRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentMobileDocumentPresentmentRequestInstance() initWithDocumentSets:mappedDocumentSets.get() isMandatory:validatedPresentmentRequest.isMandatory]);
+        RetainPtr mappedPresentmentRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentMobileDocumentPresentmentRequestInstanceSingleton() initWithDocumentSets:mappedDocumentSets.get() isMandatory:validatedPresentmentRequest.isMandatory]);
         [mappedPresentmentRequests addObject:mappedPresentmentRequest.get()];
     }
     return mappedPresentmentRequests;
@@ -183,7 +183,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
         CFIndex count = CFArrayGetCount(certificateChain.get());
         for (CFIndex i = 0; i < count; ++i) {
             auto certificate = checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(certificateChain.get(), i));
-            RetainPtr mappedCertificate = adoptNS([WebKit::allocWKIdentityDocumentPresentmentRequestAuthenticationCertificateInstance() initWithCertificate:certificate]);
+            RetainPtr mappedCertificate = adoptNS([WebKit::allocWKIdentityDocumentPresentmentRequestAuthenticationCertificateInstanceSingleton() initWithCertificate:certificate]);
             [mappedCertificateChain addObject:mappedCertificate.get()];
         }
         [mappedRequestAuthenticationCertificates addObject:mappedCertificateChain.get()];
@@ -258,7 +258,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
                 continue;
             }
 
-            RetainPtr rawRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentRawRequestInstance() initWithRequestProtocol:@"org.iso.mdoc" requestData:requestDataBytes.get()]);
+            RetainPtr rawRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentRawRequestInstanceSingleton() initWithRequestProtocol:@"org.iso.mdoc" requestData:requestDataBytes.get()]);
             [rawRequests addObject:rawRequest.get()];
         }
 
@@ -307,12 +307,12 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
         RetainPtr<NSArray<WKIdentityDocumentPresentmentMobileDocumentPresentmentRequest *>> presentmentRequests = mapPresentmentRequests(validatedRequest.presentmentRequests);
         RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticationCertificate *> *>> authenticationCertificates = mapRequestAuthentications(validatedRequest.requestAuthentications);
 
-        RetainPtr mobileDocumentRequest = [WebKit::allocWKIdentityDocumentPresentmentMobileDocumentRequestInstance() initWithPresentmentRequests:presentmentRequests.get() authenticationCertificates:authenticationCertificates.get()];
+        RetainPtr mobileDocumentRequest = [WebKit::allocWKIdentityDocumentPresentmentMobileDocumentRequestInstanceSingleton() initWithPresentmentRequests:presentmentRequests.get() authenticationCertificates:authenticationCertificates.get()];
         [mobileDocumentRequests addObject:mobileDocumentRequest.get()];
     }
 
     RetainPtr mappedOrigin = requestData.topOrigin.toURL().createNSURL();
-    RetainPtr mappedRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentRequestInstance() initWithOrigin:mappedOrigin.get() mobileDocumentRequests:mobileDocumentRequests.get()]);
+    RetainPtr mappedRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentRequestInstanceSingleton() initWithOrigin:mappedOrigin.get() mobileDocumentRequests:mobileDocumentRequests.get()]);
 
     if (![mobileDocumentRequests count]) {
         LOG(DigitalCredentials, "No supported mobile document requests to present.");
@@ -332,7 +332,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
 
 - (void)setupPresentmentController
 {
-    _presentmentController = adoptNS([WebKit::allocWKIdentityDocumentPresentmentControllerInstance() init]);
+    _presentmentController = adoptNS([WebKit::allocWKIdentityDocumentPresentmentControllerInstanceSingleton() init]);
     [_presentmentController.get() setDelegate:self];
 }
 

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -184,7 +184,7 @@ void MediaUsageManagerCocoa::updateMediaUsage(WebCore::MediaSessionIdentifier id
             if (!mediaUsageInfo.isPlaying)
                 return;
 
-            session->usageTracker = adoptNS([PAL::allocUSVideoUsageInstance() initWithBundleIdentifier:session->bundleIdentifier.createNSString().get() URL:session->pageURL.createNSURL().get()
+            session->usageTracker = adoptNS([PAL::allocUSVideoUsageInstanceSingleton() initWithBundleIdentifier:session->bundleIdentifier.createNSString().get() URL:session->pageURL.createNSURL().get()
                 mediaURL:mediaUsageInfo.mediaURL.createNSURL().get() videoMetadata:metadata]);
             ASSERT(session->usageTracker);
             if (!session->usageTracker)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -740,7 +740,7 @@ public:
     virtual void writePromisedAttachmentToPasteboard(WebCore::PromisedAttachmentInfo&&) { }
 #endif
 #if PLATFORM(COCOA)
-    virtual NSFileWrapper *allocFileWrapperInstance() const { return nullptr; }
+    virtual NSFileWrapper *allocFileWrapperInstanceSingleton() const { return nullptr; }
     virtual NSSet *serializableFileWrapperClasses() const { return nullptr; }
 #endif
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -448,7 +448,7 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
 
 #if HAVE(CORE_MATERIAL)
     case PlatformCALayer::LayerType::LayerTypeMaterialLayer:
-        return makeWithLayer(adoptNS([PAL::allocMTMaterialLayerInstance() init]));
+        return makeWithLayer(adoptNS([PAL::allocMTMaterialLayerInstanceSingleton() init]));
 #endif
 
 #if HAVE(MATERIAL_HOSTING)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -50,29 +50,29 @@ AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator(const Authe
     : m_manager(manager)
 {
 #if HAVE(ASC_AUTH_UI)
-    m_context = adoptNS([allocASCAuthorizationPresentationContextInstance() initWithRequestContext:nullptr appIdentifier:nullptr]);
+    m_context = adoptNS([allocASCAuthorizationPresentationContextInstanceSingleton() initWithRequestContext:nullptr appIdentifier:nullptr]);
     if ([getASCAuthorizationPresentationContextClass() instancesRespondToSelector:@selector(setServiceName:)])
         [m_context setServiceName:rpId.createNSString().get()];
 
     switch (type) {
     case ClientDataType::Create: {
-        auto options = adoptNS([allocASCPublicKeyCredentialCreationOptionsInstance() init]);
+        auto options = adoptNS([allocASCPublicKeyCredentialCreationOptionsInstanceSingleton() init]);
         [options setUserName:username.createNSString().get()];
 
         if (transports.contains(AuthenticatorTransport::Internal))
-            [m_context addLoginChoice:adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstance() initRegistrationChoiceWithOptions:options.get()]).get()];
+            [m_context addLoginChoice:adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstanceSingleton() initRegistrationChoiceWithOptions:options.get()]).get()];
         if (transports.contains(AuthenticatorTransport::Usb) || transports.contains(AuthenticatorTransport::Nfc))
-            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initRegistrationChoiceWithOptions:options.get()]).get()];
+            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstanceSingleton() initRegistrationChoiceWithOptions:options.get()]).get()];
         break;
     }
     case ClientDataType::Get:
         if ((transports.contains(AuthenticatorTransport::Usb) || transports.contains(AuthenticatorTransport::Nfc)) && !transports.contains(AuthenticatorTransport::Internal))
-            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initAssertionPlaceholderChoice]).get()];
+            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstanceSingleton() initAssertionPlaceholderChoice]).get()];
         break;
     }
 
     m_presenterDelegate = adoptNS([[WKASCAuthorizationPresenterDelegate alloc] initWithCoordinator:*this]);
-    m_presenter = adoptNS([allocASCAuthorizationPresenterInstance() init]);
+    m_presenter = adoptNS([allocASCAuthorizationPresenterInstanceSingleton() init]);
     [m_presenter setDelegate:m_presenterDelegate.get()];
 
     auto completionHandler = makeBlockPtr([manager = m_manager] (id<ASCCredentialProtocol> credential, NSError *error) mutable {
@@ -145,7 +145,7 @@ void AuthenticatorPresenterCoordinator::updatePresenter(WebAuthenticationStatus 
     }
     case WebAuthenticationStatus::LANoCredential: {
         if (m_delayedPresentationNeedsSecurityKey) {
-            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initAssertionPlaceholderChoice]).get()];
+            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstanceSingleton() initAssertionPlaceholderChoice]).get()];
             m_delayedPresentation();
 
             break;
@@ -229,7 +229,7 @@ void AuthenticatorPresenterCoordinator::selectAssertionResponse(Vector<Ref<Authe
             if (response->userHandle())
                 userHandle = toNSData(response->userHandle()->span());
 
-            auto loginChoice = adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initWithName:response->name().createNSString().get() displayName:response->displayName().createNSString().get() userHandle:userHandle.get()]);
+            auto loginChoice = adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstanceSingleton() initWithName:response->name().createNSString().get() displayName:response->displayName().createNSString().get() userHandle:userHandle.get()]);
             [loginChoices addObject:loginChoice.get()];
 
             m_credentials.add(response->name(), WTFMove(response));
@@ -246,14 +246,14 @@ void AuthenticatorPresenterCoordinator::selectAssertionResponse(Vector<Ref<Authe
             if (response->userHandle())
                 userHandle = toNSData(response->userHandle()->span());
 
-            auto loginChoice = adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstance() initWithName:response->name().createNSString().get() displayName:response->displayName().createNSString().get() userHandle:userHandle.get()]);
+            auto loginChoice = adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstanceSingleton() initWithName:response->name().createNSString().get() displayName:response->displayName().createNSString().get() userHandle:userHandle.get()]);
             [m_context addLoginChoice:loginChoice.get()];
 
             m_credentials.add(response->name(), WTFMove(response));
         }
 
         if (m_delayedPresentationNeedsSecurityKey)
-            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initAssertionPlaceholderChoice]).get()];
+            [m_context addLoginChoice:adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstanceSingleton() initAssertionPlaceholderChoice]).get()];
         m_delayedPresentation();
         return;
     }
@@ -276,7 +276,7 @@ void AuthenticatorPresenterCoordinator::dimissPresenter(WebAuthenticationResult 
     if (result == WebAuthenticationResult::Succeeded && m_credentialRequestHandler) {
         // FIXME(219767): Replace the ASCAppleIDCredential with the upcoming WebAuthn credentials one.
         // This is just a place holder to tell the UI that the ceremony succeeds.
-        m_credentialRequestHandler(adoptNS([WebKit::allocASCAppleIDCredentialInstance() initWithUser:@"" identityToken:adoptNS([[NSData alloc] init]).get() state:nil]).get(), nil);
+        m_credentialRequestHandler(adoptNS([WebKit::allocASCAppleIDCredentialInstanceSingleton() initWithUser:@"" identityToken:adoptNS([[NSData alloc] init]).get() state:nil]).get(), nil);
     }
 
     [m_presenter dismissWithError:nil];

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -87,7 +87,7 @@ void LocalConnection::verifyUser(const String& rpId, ClientDataType type, SecAcc
     }
 #endif
 
-    m_context = adoptNS([allocLAContextInstance() init]);
+    m_context = adoptNS([allocLAContextInstanceSingleton() init]);
 
     auto options = adoptNS([[NSMutableDictionary alloc] init]);
 #if HAVE(UNIFIED_ASC_AUTH_UI)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
@@ -58,7 +58,7 @@ bool LocalService::isAvailable()
 {
 LOCAL_SERVICE_ADDITIONS
 
-    auto context = adoptNS([allocLAContextInstance() init]);
+    auto context = adoptNS([allocLAContextInstanceSingleton() init]);
     NSError *error = nil;
     auto result = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
     if ((!result || error) && error.code != LAErrorBiometryLockout) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -257,7 +257,7 @@ RetainPtr<ASAuthorizationController> WebAuthenticatorCoordinatorProxy::construct
     });
     if (!requests || ![requests count])
         return nullptr;
-    return adoptNS([allocASAuthorizationControllerInstance() initWithAuthorizationRequests:requests.get()]);
+    return adoptNS([allocASAuthorizationControllerInstanceSingleton() initWithAuthorizationRequests:requests.get()]);
 }
 
 #if HAVE(WEB_AUTHN_PRF_API)
@@ -273,8 +273,8 @@ static inline RetainPtr<ASAuthorizationPublicKeyCredentialPRFAssertionInputValue
         second = WebCore::toNSData(*eval->second);
 
     if (eval->second)
-        return adoptNS([WebKit::allocASAuthorizationPublicKeyCredentialPRFAssertionInputValuesInstance() initWithSaltInput1:first.get() saltInput2:WebCore::toNSData(*eval->second).get()]);
-    return adoptNS([WebKit::allocASAuthorizationPublicKeyCredentialPRFAssertionInputValuesInstance() initWithSaltInput1:first.get() saltInput2:nil]);
+        return adoptNS([WebKit::allocASAuthorizationPublicKeyCredentialPRFAssertionInputValuesInstanceSingleton() initWithSaltInput1:first.get() saltInput2:WebCore::toNSData(*eval->second).get()]);
+    return adoptNS([WebKit::allocASAuthorizationPublicKeyCredentialPRFAssertionInputValuesInstanceSingleton() initWithSaltInput1:first.get() saltInput2:nil]);
 }
 #endif
 
@@ -305,20 +305,20 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
     RetainPtr<NSMutableArray<ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor *>> crossPlatformExcludedCredentials = adoptNS([[NSMutableArray alloc] init]);
     for (auto credential : options.excludeCredentials) {
         if (credential.transports.contains(AuthenticatorTransport::Internal) || credential.transports.isEmpty())
-            [platformExcludedCredentials addObject:adoptNS([allocASAuthorizationPlatformPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get()]).get()];
+            [platformExcludedCredentials addObject:adoptNS([allocASAuthorizationPlatformPublicKeyCredentialDescriptorInstanceSingleton() initWithCredentialID:toNSData(credential.id).get()]).get()];
         if (credential.transports.isEmpty() || !credential.transports.contains(AuthenticatorTransport::Internal)) {
             RetainPtr<NSMutableArray<ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport>> transports = adoptNS([[NSMutableArray alloc] init]);
             for (auto transport : credential.transports) {
                 if (auto asTransport = toASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport(transport))
                     [transports addObject:asTransport.get()];
             }
-            [crossPlatformExcludedCredentials addObject:adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get() transports:transports.get()]).get()];
+            [crossPlatformExcludedCredentials addObject:adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialDescriptorInstanceSingleton() initWithCredentialID:toNSData(credential.id).get() transports:transports.get()]).get()];
         }
     }
 
-    RetainPtr<ASPublicKeyCredentialClientData> clientData = adoptNS([allocASPublicKeyCredentialClientDataInstance() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString().createNSString().get()]);
+    RetainPtr<ASPublicKeyCredentialClientData> clientData = adoptNS([allocASPublicKeyCredentialClientDataInstanceSingleton() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString().createNSString().get()]);
     if (includePlatformRequest) {
-        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rp.id.createNSString().get()]);
+        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstanceSingleton() initWithRelyingPartyIdentifier:options.rp.id.createNSString().get()]);
         RetainPtr request = adoptNS([provider createCredentialRegistrationRequestWithClientData:clientData.get() name:options.user.name.createNSString().get() userID:toNSData(options.user.id).get()]);
 
         if (m_isConditionalMediation && [request respondsToSelector:@selector(setRequestStyle:)])
@@ -327,7 +327,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
         if (options.extensions && options.extensions->prf) {
             auto prf = options.extensions->prf;
             if (prf->eval)
-                request.get().prf = adoptNS([allocASAuthorizationPublicKeyCredentialPRFRegistrationInputInstance() initWithInputValues:toASAssertionPRFInputValue(prf->eval).get()]).get();
+                request.get().prf = adoptNS([allocASAuthorizationPublicKeyCredentialPRFRegistrationInputInstanceSingleton() initWithInputValues:toASAssertionPRFInputValue(prf->eval).get()]).get();
             else
                 request.get().prf = [getASAuthorizationPublicKeyCredentialPRFRegistrationInputClass() checkForSupport];
         }
@@ -341,14 +341,14 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
         if (options.extensions && options.extensions->largeBlob) {
             // These are satisfied by validation in AuthenticatorCoordinator.
             ASSERT(!options.extensions->largeBlob->read && !options.extensions->largeBlob->write);
-            request.get().largeBlob = adoptNS([allocASAuthorizationPublicKeyCredentialLargeBlobRegistrationInputInstance() initWithSupportRequirement:toASAuthorizationPublicKeyCredentialLargeBlobSupportRequirement(options.extensions->largeBlob->support)]).get();
+            request.get().largeBlob = adoptNS([allocASAuthorizationPublicKeyCredentialLargeBlobRegistrationInputInstanceSingleton() initWithSupportRequirement:toASAuthorizationPublicKeyCredentialLargeBlobSupportRequirement(options.extensions->largeBlob->support)]).get();
         }
         request.get().excludedCredentials = platformExcludedCredentials.get();
         [requests addObject:request.leakRef()];
     }
 #if HAVE(SECURITY_KEY_API)
     if (includeSecurityKeyRequest) {
-        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rp.id.createNSString().get()]);
+        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstanceSingleton() initWithRelyingPartyIdentifier:options.rp.id.createNSString().get()]);
         RetainPtr<ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequest> request;
         if ([provider respondsToSelector:@selector(createCredentialRegistrationRequestWithClientData:displayName:name:userID:)])
             request = adoptNS([provider createCredentialRegistrationRequestWithClientData:clientData.get() displayName:options.user.displayName.createNSString().get() name:options.user.name.createNSString().get() userID:toNSData(options.user.id).get()]);
@@ -357,7 +357,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
         request.get().attestationPreference = toAttestationConveyancePreference(options.attestation).get();
         RetainPtr<NSMutableArray<ASAuthorizationPublicKeyCredentialParameters *>> parameters = adoptNS([[NSMutableArray alloc] init]);
         for (auto alg : options.pubKeyCredParams)
-            [parameters addObject:adoptNS([allocASAuthorizationPublicKeyCredentialParametersInstance() initWithAlgorithm:alg.alg]).get()];
+            [parameters addObject:adoptNS([allocASAuthorizationPublicKeyCredentialParametersInstanceSingleton() initWithAlgorithm:alg.alg]).get()];
         request.get().credentialParameters = parameters.get();
         if (options.authenticatorSelection) {
             request.get().userVerificationPreference = toASUserVerificationPreference(options.authenticatorSelection->userVerification).get();
@@ -400,26 +400,26 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
     bool allowHybrid = options.allowCredentials.isEmpty();
     for (auto credential : options.allowCredentials) {
         if (isPlatformRequest(credential.transports))
-            [platformAllowedCredentials addObject:adoptNS([allocASAuthorizationPlatformPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get()]).get()];
+            [platformAllowedCredentials addObject:adoptNS([allocASAuthorizationPlatformPublicKeyCredentialDescriptorInstanceSingleton() initWithCredentialID:toNSData(credential.id).get()]).get()];
         if (isCrossPlatformRequest(credential.transports)) {
             RetainPtr<NSMutableArray<ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport>> transports = adoptNS([[NSMutableArray alloc] init]);
             for (auto transport : credential.transports) {
                 if (auto asTransport = toASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport(transport))
                     [transports addObject:asTransport.get()];
             }
-            [crossPlatformAllowedCredentials addObject:adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialDescriptorInstance() initWithCredentialID:toNSData(credential.id).get() transports:transports.get()]).get()];
+            [crossPlatformAllowedCredentials addObject:adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialDescriptorInstanceSingleton() initWithCredentialID:toNSData(credential.id).get() transports:transports.get()]).get()];
         }
 
         if (!allowHybrid && allowsHybrid(credential.transports))
             allowHybrid = true;
     }
-    RetainPtr clientData = adoptNS([allocASPublicKeyCredentialClientDataInstance() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString().createNSString().get()]);
+    RetainPtr clientData = adoptNS([allocASPublicKeyCredentialClientDataInstanceSingleton() initWithChallenge:toNSData(options.challenge).get() origin:callerOrigin.toString().createNSString().get()]);
     if (parentOrigin) {
         clientData.get().crossOrigin = ASPublicKeyCredentialClientDataCrossOriginValueCrossOrigin;
         clientData.get().topOrigin = parentOrigin->toString().createNSString().get();
     }
     if ([platformAllowedCredentials count] || ![crossPlatformAllowedCredentials count]) {
-        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rpId.createNSString().get()]);
+        RetainPtr provider = adoptNS([allocASAuthorizationPlatformPublicKeyCredentialProviderInstanceSingleton() initWithRelyingPartyIdentifier:options.rpId.createNSString().get()]);
         RetainPtr request = adoptNS([provider createCredentialAssertionRequestWithClientData:clientData.get()]);
         if (platformAllowedCredentials)
             request.get().allowedCredentials = platformAllowedCredentials.get();
@@ -428,7 +428,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
             ASSERT(!options.extensions->largeBlob->support);
             ASSERT(!(options.extensions->largeBlob->read && options.extensions->largeBlob->write));
             auto largeBlob = options.extensions->largeBlob;
-            RetainPtr asLargeBlob = adoptNS([allocASAuthorizationPublicKeyCredentialLargeBlobAssertionInputInstance() initWithOperation:(largeBlob->read && *largeBlob->read) ? ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationRead : ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationWrite]);
+            RetainPtr asLargeBlob = adoptNS([allocASAuthorizationPublicKeyCredentialLargeBlobAssertionInputInstanceSingleton() initWithOperation:(largeBlob->read && *largeBlob->read) ? ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationRead : ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationWrite]);
             if (largeBlob->write)
                 asLargeBlob.get().dataToWrite = WebCore::toNSData(*largeBlob->write).get();
             request.get().largeBlob = asLargeBlob.get();
@@ -453,7 +453,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
                     [perCredentialInputValues setObject:toASAssertionPRFInputValue(credentialIDAndInputValues.value).get() forKey: toNSData(*key).get()];
                 }
             }
-            request.get().prf = adoptNS([allocASAuthorizationPublicKeyCredentialPRFAssertionInputInstance() initWithInputValues:inputValues.get() perCredentialInputValues:perCredentialInputValues.get()]).get();
+            request.get().prf = adoptNS([allocASAuthorizationPublicKeyCredentialPRFAssertionInputInstanceSingleton() initWithInputValues:inputValues.get() perCredentialInputValues:perCredentialInputValues.get()]).get();
         }
 #endif
 
@@ -462,7 +462,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
 
 #if HAVE(SECURITY_KEY_API)
     if (!m_isConditionalMediation && ([crossPlatformAllowedCredentials count] || ![platformAllowedCredentials count])) {
-        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstance() initWithRelyingPartyIdentifier:options.rpId.createNSString().get()]);
+        RetainPtr provider = adoptNS([allocASAuthorizationSecurityKeyPublicKeyCredentialProviderInstanceSingleton() initWithRelyingPartyIdentifier:options.rpId.createNSString().get()]);
         RetainPtr<ASAuthorizationSecurityKeyPublicKeyCredentialAssertionRequest> request;
         if ([provider respondsToSelector:@selector(createCredentialAssertionRequestWithClientData:)])
             request = adoptNS([provider createCredentialAssertionRequestWithClientData:clientData.get()]);
@@ -780,13 +780,13 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
         }
     }
 
-    return adoptNS([allocASCPublicKeyCredentialDescriptorInstance() initWithCredentialID:WebCore::toNSData(descriptor.id).get() transports:transports.get()]);
+    return adoptNS([allocASCPublicKeyCredentialDescriptorInstanceSingleton() initWithCredentialID:WebCore::toNSData(descriptor.id).get() transports:transports.get()]);
 }
 
 static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensions(const AuthenticationExtensionsClientInputs& extensions)
 {
     if ([getASCWebAuthenticationExtensionsClientInputsClass() instancesRespondToSelector:@selector(initWithAppID:)])
-        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid.createNSString().get()]);
+        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstanceSingleton() initWithAppID:extensions.appid.createNSString().get()]);
 
     return nil;
 }
@@ -794,7 +794,7 @@ static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensi
 static inline void setGlobalFrameIDForContext(RetainPtr<ASCCredentialRequestContext> requestContext, std::optional<WebCore::GlobalFrameIdentifier> globalFrameID)
 {
     if (globalFrameID && [requestContext respondsToSelector:@selector(setGlobalFrameID:)]) {
-        auto asGlobalFrameID = adoptNS([allocASGlobalFrameIdentifierInstance() initWithPageID:[NSNumber numberWithUnsignedLong:globalFrameID->pageID.toUInt64()] frameID:[NSNumber numberWithUnsignedLong:globalFrameID->frameID.toUInt64()]]);
+        auto asGlobalFrameID = adoptNS([allocASGlobalFrameIdentifierInstanceSingleton() initWithPageID:[NSNumber numberWithUnsignedLong:globalFrameID->pageID.toUInt64()] frameID:[NSNumber numberWithUnsignedLong:globalFrameID->frameID.toUInt64()]]);
         requestContext.get().globalFrameID = asGlobalFrameID.get();
     }
 }
@@ -838,12 +838,12 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
     if (!LocalService::isAvailable())
         requestTypes &= ~ASCCredentialRequestTypePlatformPublicKeyRegistration;
 
-    auto requestContext = adoptNS([allocASCCredentialRequestContextInstance() initWithRequestTypes:requestTypes]);
+    auto requestContext = adoptNS([allocASCCredentialRequestContextInstanceSingleton() initWithRequestTypes:requestTypes]);
     ASSERT(options.rp.id);
     [requestContext setRelyingPartyIdentifier:options.rp.id.createNSString().get()];
     setGlobalFrameIDForContext(requestContext, globalFrameID);
 
-    auto credentialCreationOptions = adoptNS([allocASCPublicKeyCredentialCreationOptionsInstance() init]);
+    auto credentialCreationOptions = adoptNS([allocASCPublicKeyCredentialCreationOptionsInstanceSingleton() init]);
 
     auto clientDataJson = WebCore::buildClientDataJson(ClientDataType::Create, options.challenge, callerOrigin.securityOrigin(), WebAuthn::Scope::SameOrigin);
     RetainPtr nsClientDataJSON = toNSData(clientDataJson->span());
@@ -907,9 +907,9 @@ static inline RetainPtr<ASCPublicKeyCredentialAssertionOptions> configureAsserti
     RetainPtr nsClientDataJSON = toNSData(clientDataJson->span());
     RetainPtr<ASCPublicKeyCredentialAssertionOptions> assertionOptions;
     if ([getASCPublicKeyCredentialAssertionOptionsClass() instancesRespondToSelector:@selector(initWithKind:relyingPartyIdentifier:clientDataJSON:userVerificationPreference:allowedCredentials:origin:)])
-        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get() origin:callerOrigin.toString().createNSString().get()]);
+        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstanceSingleton() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get() origin:callerOrigin.toString().createNSString().get()]);
     else
-        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get()]);
+        assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstanceSingleton() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get()]);
     if (options.extensions) {
         if ([assertionOptions respondsToSelector:@selector(setExtensionsCBOR:)])
             [assertionOptions setExtensionsCBOR:toNSData(options.extensions->toCBOR()).get()];
@@ -947,7 +947,7 @@ static RetainPtr<ASCCredentialRequestContext> configurationAssertionRequestConte
             [allowedCredentials addObject:toASCDescriptor(descriptor).get()];
     }
 
-    auto requestContext = adoptNS([allocASCCredentialRequestContextInstance() initWithRequestTypes:requestTypes]);
+    auto requestContext = adoptNS([allocASCCredentialRequestContextInstanceSingleton() initWithRequestTypes:requestTypes]);
     [requestContext setRelyingPartyIdentifier:options.rpId.createNSString().get()];
     if (mediation == MediationRequirement::Conditional) {
         if (![requestContext respondsToSelector:@selector(setRequestStyle:)])
@@ -1113,7 +1113,7 @@ void WebAuthenticatorCoordinatorProxy::performRequestLegacy(RetainPtr<ASCCredent
         RELEASE_LOG_ERROR(WebAuthn, "Request cancelled due to none requestTypes.");
         return;
     }
-    m_proxy = adoptNS([allocASCAgentProxyInstance() init]);
+    m_proxy = adoptNS([allocASCAgentProxyInstanceSingleton() init]);
 
     if (requestContext.get().requestStyle == ASCredentialRequestStyleSilent) {
         [m_proxy performSilentAuthorizationRequestsForContext:requestContext.get() withCompletionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, handler = WTFMove(handler)](id<ASCCredentialProtocol> credential, NSError *error) mutable {
@@ -1173,7 +1173,7 @@ void WebAuthenticatorCoordinatorProxy::performRequestLegacy(RetainPtr<ASCCredent
                 return;
             }
 
-            weakThis->m_presenter = adoptNS([allocASCAuthorizationRemotePresenterInstance() init]);
+            weakThis->m_presenter = adoptNS([allocASCAuthorizationRemotePresenterInstanceSingleton() init]);
             [weakThis->m_presenter presentWithWindow:window.get() daemonEndpoint:daemonEndpoint.get() completionHandler:makeBlockPtr([weakThis, handler = WTFMove(handler)](id<ASCCredentialProtocol> credentialNotRetain, NSError *errorNotRetain) mutable {
                 auto credential = retainPtr(credentialNotRetain);
                 auto error = retainPtr(errorNotRetain);

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
@@ -78,7 +78,7 @@ void MockLocalConnection::verifyUser(const String&, ClientDataType, SecAccessCon
             break;
         }
 
-        callback(userVerification, adoptNS([allocLAContextInstance() init]).get());
+        callback(userVerification, adoptNS([allocLAContextInstanceSingleton() init]).get());
     });
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -245,7 +245,7 @@ void MockNfcService::platformStartDiscovery()
         Method methodToSwizzle5 = class_getInstanceMethod(getNFReaderSessionClass(), @selector(startPollingWithError:));
         method_setImplementation(methodToSwizzle5, (IMP)NFReaderSessionStartPollingWithError);
 
-        auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
+        auto readerSession = adoptNS([allocNFReaderSessionInstanceSingleton() initWithUIType:NFReaderSessionUINone]);
         setConnection(NfcConnection::create(readerSession.get(), *this));
     }
     LOG_ERROR("No nfc authenticators is available.");
@@ -271,7 +271,7 @@ void MockNfcService::detectTags() const
         if (configuration.nfc->multiplePhysicalTags)
             [tags addObject:adoptNS([[WKMockNFTag alloc] initWithType:NFTagTypeGeneric4A tagID:toNSDataNoCopy(std::span { tagID2 }, FreeWhenDone::No).get()]).get()];
 
-        auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
+        auto readerSession = adoptNS([allocNFReaderSessionInstanceSingleton() initWithUIType:NFReaderSessionUINone]);
         [globalNFReaderSessionDelegate readerSession:readerSession.get() didDetectTags:tags.get()];
     });
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), callback.get());

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm
@@ -63,14 +63,14 @@ void VirtualLocalConnection::verifyUser(const String&, ClientDataType, SecAccess
     RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, callback = WTFMove(callback)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
-            callback(UserVerification::No, adoptNS([allocLAContextInstance() init]).get());
+            callback(UserVerification::No, adoptNS([allocLAContextInstanceSingleton() init]).get());
             return;
         }
         ASSERT(protectedThis->m_configuration.transport == AuthenticatorTransport::Internal);
 
         UserVerification userVerification = protectedThis->m_configuration.isUserVerified ? UserVerification::Yes : UserVerification::Presence;
 
-        callback(userVerification, adoptNS([allocLAContextInstance() init]).get());
+        callback(userVerification, adoptNS([allocLAContextInstanceSingleton() init]).get());
     });
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
@@ -46,7 +46,7 @@ void getScreenTimeURLs(std::optional<WTF::UUID> identifier, CompletionHandler<vo
     if (identifier)
         profileIdentifier = [identifier->createNSUUID() UUIDString];
 
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstanceSingleton() initWithProfileIdentifier:profileIdentifier.get()]);
 
     [webHistory fetchAllHistoryWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSSet<NSURL *> *urls, NSError *error) mutable {
         ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), urls = retainPtr(urls), error = retainPtr(error)] mutable {
@@ -73,7 +73,7 @@ void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDat
     if (configuration.identifier())
         profileIdentifier = [configuration.identifier()->createNSUUID() UUIDString];
 
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstanceSingleton() initWithProfileIdentifier:profileIdentifier.get()]);
 
     RetainPtr<NSMutableSet<NSString *>> websitesToRemoveDomains = [NSMutableSet set];
     for (auto& url : websitesToRemove)
@@ -99,7 +99,7 @@ void removeScreenTimeDataWithInterval(WallTime modifiedSince, const WebsiteDataS
     if (configuration.identifier())
         profileIdentifier = [configuration.identifier()->createNSUUID() UUIDString];
 
-    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
+    RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstanceSingleton() initWithProfileIdentifier:profileIdentifier.get()]);
 
     if (!modifiedSince.isNaN()) {
         NSTimeInterval timeInterval = modifiedSince.secondsSinceEpoch().seconds();

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -246,7 +246,7 @@ void ARKitCoordinator::createSessionIfNeeded()
     if (m_session)
         return;
 
-    m_session = adoptNS([WebKit::allocARSessionInstance() init]);
+    m_session = adoptNS([WebKit::allocARSessionInstanceSingleton() init]);
 }
 
 void ARKitCoordinator::renderLoop(Box<RenderState> active)

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -305,7 +305,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RELEASE_LOG(XR, "%s", __FUNCTION__);
     [super viewWillAppear:animated];
 
-    RetainPtr configuration = adoptNS([WebKit::allocARWorldTrackingConfigurationInstance() init]);
+    RetainPtr configuration = adoptNS([WebKit::allocARWorldTrackingConfigurationInstanceSingleton() init]);
     [_session runWithConfiguration:configuration.get()];
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12811,7 +12811,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
     ASSERT(self.hasSelectableTextForImageContextMenu || self.hasVisualSearchResultsForImageContextMenu);
 
     ASSERT(!_visualSearchPreviewController);
-    _visualSearchPreviewController = adoptNS([PAL::allocQLPreviewControllerInstance() init]);
+    _visualSearchPreviewController = adoptNS([PAL::allocQLPreviewControllerInstanceSingleton() init]);
     [_visualSearchPreviewController setDelegate:self];
     [_visualSearchPreviewController setDataSource:self];
     [_visualSearchPreviewController setAppearanceActions:appearanceActions];
@@ -12872,7 +12872,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 {
     ASSERT(controller == _visualSearchPreviewController);
     ASSERT(!index);
-    auto item = adoptNS([PAL::allocQLItemInstance() initWithDataProvider:self contentType:UTTypeTIFF.identifier previewTitle:_visualSearchPreviewTitle.get()]);
+    auto item = adoptNS([PAL::allocQLItemInstanceSingleton() initWithDataProvider:self contentType:UTTypeTIFF.identifier previewTitle:_visualSearchPreviewTitle.get()]);
     if ([item respondsToSelector:@selector(setPreviewOptions:)]) {
         auto previewOptions = adoptNS([[NSMutableDictionary alloc] initWithCapacity:2]);
         if (_visualSearchPreviewImageURL)
@@ -13435,7 +13435,7 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
 {
     if (!_imageAnalysisInteraction) {
         _imageAnalysisActionButtons = adoptNS([[NSMutableSet alloc] initWithCapacity:1]);
-        _imageAnalysisInteraction = adoptNS([PAL::allocVKCImageAnalysisInteractionInstance() init]);
+        _imageAnalysisInteraction = adoptNS([PAL::allocVKCImageAnalysisInteractionInstanceSingleton() init]);
         [_imageAnalysisInteraction setDelegate:self];
         [_imageAnalysisInteraction setAnalysisButtonRequiresVisibleContentGating:YES];
         [_imageAnalysisInteraction setQuickActionConfigurationUpdateHandler:[weakSelf = WeakObjCPtr<WKContentView>(self)] (UIButton *button) {
@@ -14151,7 +14151,7 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
         [_sourceAnimationIDtoDestinationAnimationID setObject:uuid forKey:data.sourceAnimationUUID.value_or(WTF::UUID(WTF::UUID::emptyValue)).createNSUUID().get()];
 
     if (!_textAnimationManager)
-        _textAnimationManager = adoptNS([WebKit::allocWKTextAnimationManagerInstance() initWithDelegate:self]);
+        _textAnimationManager = adoptNS([WebKit::allocWKTextAnimationManagerInstanceSingleton() initWithDelegate:self]);
 
     [_textAnimationManager addTextAnimationForAnimationID:uuid withStyleType:toWKTextAnimationType(data.style)];
 }

--- a/Source/WebKit/UIProcess/ios/WKModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKModelView.mm
@@ -125,7 +125,7 @@ SOFT_LINK_CLASS(AssetViewer, ASVInlinePreview);
     auto bounds = self.bounds;
     ASSERT(!CGRectEqualToRect(bounds, CGRectZero));
 
-    _preview = adoptNS([allocASVInlinePreviewInstance() initWithFrame:bounds]);
+    _preview = adoptNS([allocASVInlinePreviewInstanceSingleton() initWithFrame:bounds]);
     [self.layer addSublayer:[_preview layer]];
 
     RetainPtr url = adoptNS([[NSURL alloc] initFileURLWithPath:_filePath.createNSString().get()]);

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
@@ -94,10 +94,10 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
 
     RetainPtr contentType = getUTIForUSDMIMEType(_mimeType.get());
 
-    _item = adoptNS([PAL::allocQLItemInstance() initWithDataProvider:self contentType:contentType.get() previewTitle:_suggestedFilename.get()]);
+    _item = adoptNS([PAL::allocQLItemInstanceSingleton() initWithDataProvider:self contentType:contentType.get() previewTitle:_suggestedFilename.get()]);
     [_item setUseLoadingTimeout:NO];
 
-    _thumbnailView = adoptNS([allocASVThumbnailViewInstance() init]);
+    _thumbnailView = adoptNS([allocASVThumbnailViewInstanceSingleton() init]);
     [_thumbnailView setDelegate:self];
     [self setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
 

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -57,7 +57,7 @@ static void clearGeolocationCache(CFNotificationCenterRef center, void *observer
 
 static bool appHasPreciseLocationPermission()
 {
-    auto locationManager = adoptNS([allocCLLocationManagerInstance() init]);
+    auto locationManager = adoptNS([allocCLLocationManagerInstanceSingleton() init]);
 
     CLAuthorizationStatus authStatus = [locationManager authorizationStatus];
     return (authStatus == kCLAuthorizationStatusAuthorizedAlways || authStatus == kCLAuthorizationStatusAuthorizedWhenInUse)

--- a/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
@@ -78,15 +78,15 @@ typedef NSInteger WKAirPlayRoutePickerRouteSharingPolicy;
     if (_actionSheet)
         return;
 
-    __block RetainPtr<MPAVRoutingController> routingController = adoptNS([allocMPAVRoutingControllerInstance() initWithName:@"WebKit - HTML media element showing AirPlay route picker"]);
+    __block RetainPtr<MPAVRoutingController> routingController = adoptNS([allocMPAVRoutingControllerInstanceSingleton() initWithName:@"WebKit - HTML media element showing AirPlay route picker"]);
     [routingController setDiscoveryMode:MPRouteDiscoveryModeDetailed];
 
     RetainPtr<MPMediaControlsConfiguration> configuration;
     if ([getMPMediaControlsConfigurationClass() instancesRespondToSelector:@selector(setSortByIsVideoRoute:)]) {
-        configuration = adoptNS([allocMPMediaControlsConfigurationInstance() init]);
+        configuration = adoptNS([allocMPMediaControlsConfigurationInstanceSingleton() init]);
         configuration.get().sortByIsVideoRoute = hasVideo;
     }
-    _actionSheet = adoptNS([allocMPMediaControlsViewControllerInstance() initWithConfiguration:configuration.get()]);
+    _actionSheet = adoptNS([allocMPMediaControlsViewControllerInstanceSingleton() initWithConfiguration:configuration.get()]);
 
     if ([_actionSheet respondsToSelector:@selector(setOverrideRouteSharingPolicy:routingContextUID:)])
         [_actionSheet setOverrideRouteSharingPolicy:static_cast<WKAirPlayRoutePickerRouteSharingPolicy>(routeSharingPolicy) routingContextUID:routingContextUID];

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -240,9 +240,9 @@ static NSString * firstUTIThatConformsTo(NSArray<NSString *> *typeIdentifiers, U
 - (void)start
 {
 #if HAVE(PX_ACTIVITY_PROGRESS_CONTROLLER)
-    _progressController = adoptNS([allocPXActivityProgressControllerInstance() init]);
+    _progressController = adoptNS([allocPXActivityProgressControllerInstanceSingleton() init]);
 #else
-    _progressController = adoptNS([allocPUActivityProgressControllerInstance() init]);
+    _progressController = adoptNS([allocPUActivityProgressControllerInstanceSingleton() init]);
 #endif
     [_progressController setTitle:WEB_UI_STRING_KEY("Preparing…", "Preparing (file upload)", "Title for file upload progress view").createNSString().get()];
     [_progressController showAnimated:YES allowDelay:YES];
@@ -295,8 +295,8 @@ static NSString * firstUTIThatConformsTo(NSArray<NSString *> *typeIdentifiers, U
     NSString *filePath = [temporaryDirectory stringByAppendingPathComponent:fileName];
     NSURL *outputURL = [NSURL fileURLWithPath:filePath isDirectory:NO];
 
-    RetainPtr<AVURLAsset> asset = adoptNS([PAL::allocAVURLAssetInstance() initWithURL:item.fileURL options:nil]);
-    _exportSession = adoptNS([PAL::allocAVAssetExportSessionInstance() initWithAsset:asset.get() presetName:AVAssetExportPresetHighestQuality]);
+    RetainPtr<AVURLAsset> asset = adoptNS([PAL::allocAVURLAssetInstanceSingleton() initWithURL:item.fileURL options:nil]);
+    _exportSession = adoptNS([PAL::allocAVAssetExportSessionInstanceSingleton() initWithAsset:asset.get() presetName:AVAssetExportPresetHighestQuality]);
     [_exportSession setOutputURL:outputURL];
     [_exportSession setOutputFileType:AVFileTypeQuickTimeMovie];
 
@@ -916,7 +916,7 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
 - (void)_showPhotoPicker
 {
 #if HAVE(PHOTOS_UI)
-    auto configuration = adoptNS([allocPHPickerConfigurationInstance() init]);
+    auto configuration = adoptNS([allocPHPickerConfigurationInstanceSingleton() init]);
     [configuration setSelectionLimit:_allowMultipleFiles ? 0 : 1];
     [configuration setPreferredAssetRepresentationMode:[self _preferredAssetRepresentationMode]];
     [configuration _setAllowsDownscaling:YES];
@@ -931,7 +931,7 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
     _uploadFileManager = adoptNS([[NSFileManager alloc] init]);
     _uploadFileCoordinator = adoptNS([[NSFileCoordinator alloc] init]);
 
-    _photoPicker = adoptNS([allocPHPickerViewControllerInstance() initWithConfiguration:configuration.get()]);
+    _photoPicker = adoptNS([allocPHPickerViewControllerInstanceSingleton() initWithConfiguration:configuration.get()]);
     [_photoPicker setDelegate:self];
     [_photoPicker presentationController].delegate = self;
 

--- a/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
@@ -111,7 +111,7 @@ static NSString *timePickerDateFormat = @"HH:mm";
 
     self.headerView.hidden = YES;
 
-    _timePicker = adoptNS([allocCLKUIWheelsOfTimeViewInstance() initWithFrame:self.view.bounds style:CLKUIWheelsOfTimeStyleAlarm12]);
+    _timePicker = adoptNS([allocCLKUIWheelsOfTimeViewInstanceSingleton() initWithFrame:self.view.bounds style:CLKUIWheelsOfTimeStyleAlarm12]);
     [_timePicker setDelegate:self];
 
     NSDateComponents *components = self.dateComponentsFromInitialValue;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -969,7 +969,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self, window = retainPtr([webView window]), completionHandler = WTFMove(completionHandler), logIdentifier = OBJC_LOGIDENTIFIER] (URL&& url) mutable {
             UIWindowScene *scene = [window windowScene];
-            _previewWindowController = adoptNS([WebKit::allocWKPreviewWindowControllerInstance() initWithURL:url.createNSURL().get() sceneID:scene._sceneIdentifier]);
+            _previewWindowController = adoptNS([WebKit::allocWKPreviewWindowControllerInstanceSingleton() initWithURL:url.createNSURL().get() sceneID:scene._sceneIdentifier]);
             [_previewWindowController setDelegate:self];
             [_previewWindowController presentWindowWithCompletionHandler:^{ }];
             _fullScreenState = WebKit::InFullScreen;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm
@@ -62,7 +62,7 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVBackgroundView)
 
     [self setClipsToBounds:YES];
 #if !PLATFORM(APPLETV)
-    _backgroundView = adoptNS([allocAVBackgroundViewInstance() initWithFrame:frame]);
+    _backgroundView = adoptNS([allocAVBackgroundViewInstanceSingleton() initWithFrame:frame]);
     // FIXME: remove this once AVBackgroundView handles this. https://bugs.webkit.org/show_bug.cgi?id=188022
     [_backgroundView setClipsToBounds:YES];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -454,7 +454,7 @@
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return nil;
 
-    RetainPtr actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
+    RetainPtr actionContext = adoptNS([PAL::allocWKDDActionContextInstanceSingleton() init]);
     if (!actionContext)
         return nil;
 

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -590,7 +590,7 @@ static RetainPtr<NSString> linkDestinationName(PDFDocument *document, PDFDestina
 
     if (!_printedPagesPDFDocument) {
         RetainPtr pdfData = toNSData(_printedPagesData.span());
-        _printedPagesPDFDocument = adoptNS([WebKit::allocPDFDocumentInstance() initWithData:pdfData.get()]);
+        _printedPagesPDFDocument = adoptNS([WebKit::allocPDFDocumentInstanceSingleton() initWithData:pdfData.get()]);
 
         unsigned pageCount = [_printedPagesPDFDocument pageCount];
         _linkDestinationsPerPage.clear();

--- a/Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm
+++ b/Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm
@@ -49,7 +49,7 @@
 
     _activity = activity;
     _imageData = imageData;
-    _item = adoptNS([PAL::allocQLItemInstance() initWithDataProvider:(id)self contentType:UTTypePNG previewTitle:title]);
+    _item = adoptNS([PAL::allocQLItemInstanceSingleton() initWithDataProvider:(id)self contentType:UTTypePNG previewTitle:title]);
     if ([_item respondsToSelector:@selector(setPreviewOptions:)]) {
         auto previewOptions = adoptNS([[NSMutableDictionary alloc] initWithCapacity:2]);
         if (imageURL)

--- a/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
+++ b/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
@@ -55,8 +55,8 @@
         return nil;
 
     _impl = impl;
-    _presenter = adoptNS([PAL::allocRVPresenterInstance() init]);
-    _presentingContext = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:menuLocationInView inView:impl.view() highlightDelegate:self]);
+    _presenter = adoptNS([PAL::allocRVPresenterInstanceSingleton() init]);
+    _presentingContext = adoptNS([PAL::allocRVPresentingContextInstanceSingleton() initWithPointerLocationInView:menuLocationInView inView:impl.view() highlightDelegate:self]);
     _item = item;
     _frameInView = frameInView;
     _menuLocationInView = menuLocationInView;

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
@@ -81,7 +81,7 @@
     _webView = webView;
     _chunkToEffect = adoptNS([[NSMutableDictionary alloc] init]);
 
-    _effectView = adoptNS([PAL::alloc_WTTextEffectViewInstance() initWithAsyncSource:self]);
+    _effectView = adoptNS([PAL::alloc_WTTextEffectViewInstanceSingleton() initWithAsyncSource:self]);
     [_effectView setClipsToBounds:YES];
     [_effectView setFrame:webView.view().bounds];
 
@@ -99,15 +99,15 @@
     }
 
     RetainPtr<id<_WTTextEffect>> effect;
-    RetainPtr chunk = adoptNS([PAL::alloc_WTTextChunkInstance() initChunkWithIdentifier:uuid.UUIDString]);
+    RetainPtr chunk = adoptNS([PAL::alloc_WTTextChunkInstanceSingleton() initChunkWithIdentifier:uuid.UUIDString]);
 
     switch (data.style) {
     case WebCore::TextAnimationType::Initial:
-        effect = adoptNS([PAL::alloc_WTSweepTextEffectInstance() initWithChunk:chunk.get() effectView:_effectView.get()]);
+        effect = adoptNS([PAL::alloc_WTSweepTextEffectInstanceSingleton() initWithChunk:chunk.get() effectView:_effectView.get()]);
         break;
 
     case WebCore::TextAnimationType::Source:
-        effect = adoptNS([PAL::alloc_WTReplaceSourceTextEffectInstance() initWithChunk:chunk.get() effectView:_effectView.get()]);
+        effect = adoptNS([PAL::alloc_WTReplaceSourceTextEffectInstanceSingleton() initWithChunk:chunk.get() effectView:_effectView.get()]);
 
         effect.get().preCompletion = makeBlockPtr([weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), uuid = RetainPtr(uuid), runMode = data.runMode] {
             CheckedPtr webView = weakWebView.get();
@@ -130,7 +130,7 @@
         break;
 
     case WebCore::TextAnimationType::Final:
-        effect = adoptNS([PAL::alloc_WTReplaceDestinationTextEffectInstance() initWithChunk:chunk.get() effectView:_effectView.get()]);
+        effect = adoptNS([PAL::alloc_WTReplaceDestinationTextEffectInstanceSingleton() initWithChunk:chunk.get() effectView:_effectView.get()]);
 
         effect.get().preCompletion = makeBlockPtr([weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), remainingID = *data.unanimatedRangeUUID] {
             if (CheckedPtr webView = weakWebView.get())
@@ -253,7 +253,7 @@
         for (auto textRectInSnapshotCoordinates : textIndicator->textRectsInBoundingRectCoordinates()) {
             CGRect textLineFrameInBoundingRectCoordinates = CGRectOffset(textRectInSnapshotCoordinates, snapshotRectInBoundingRectCoordinates.origin.x, snapshotRectInBoundingRectCoordinates.origin.y);
             textRectInSnapshotCoordinates.scale(textIndicator->contentImageScaleFactor());
-            [textPreviews addObject:adoptNS([PAL::alloc_WTTextPreviewInstance() initWithSnapshotImage:adoptCF(CGImageCreateWithImageInRect(snapshotPlatformImage.get(), textRectInSnapshotCoordinates)).get() presentationFrame:textLineFrameInBoundingRectCoordinates]).get()];
+            [textPreviews addObject:adoptNS([PAL::alloc_WTTextPreviewInstanceSingleton() initWithSnapshotImage:adoptCF(CGImageCreateWithImageInRect(snapshotPlatformImage.get(), textRectInSnapshotCoordinates)).get() presentationFrame:textLineFrameInBoundingRectCoordinates]).get()];
         }
 
         completionHandler(textPreviews.get());
@@ -272,7 +272,7 @@
             return;
         }
 
-        RetainPtr textPreview = adoptNS([PAL::alloc_WTTextPreviewInstance() initWithSnapshotImage:image presentationFrame:rect]);
+        RetainPtr textPreview = adoptNS([PAL::alloc_WTTextPreviewInstanceSingleton() initWithSnapshotImage:image presentationFrame:rect]);
         completionHandler(textPreview.get());
     });
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6613,11 +6613,11 @@ void WebViewImpl::updateMediaTouchBar()
 {
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER) && ENABLE(VIDEO_PRESENTATION_MODE)
     if (!m_mediaTouchBarProvider) {
-        m_mediaTouchBarProvider = adoptNS([allocAVTouchBarPlaybackControlsProviderInstance() init]);
+        m_mediaTouchBarProvider = adoptNS([allocAVTouchBarPlaybackControlsProviderInstanceSingleton() init]);
     }
 
     if (!m_mediaPlaybackControlsView) {
-        m_mediaPlaybackControlsView = adoptNS([allocAVTouchBarScrubberInstance() init]);
+        m_mediaPlaybackControlsView = adoptNS([allocAVTouchBarScrubberInstanceSingleton() init]);
         // FIXME: Remove this once setCanShowMediaSelectionButton: is declared in an SDK used by Apple's buildbot.
         if ([m_mediaPlaybackControlsView respondsToSelector:@selector(setCanShowMediaSelectionButton:)])
             [m_mediaPlaybackControlsView setCanShowMediaSelectionButton:YES];
@@ -6781,7 +6781,7 @@ void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContext
     }
 
     auto view = m_view.get();
-    auto translationViewController = adoptNS([PAL::allocLTUITranslationViewControllerInstance() init]);
+    auto translationViewController = adoptNS([PAL::allocLTUITranslationViewControllerInstanceSingleton() init]);
     [translationViewController setText:adoptNS([[NSAttributedString alloc] initWithString:info.text.createNSString().get()]).get()];
     if (info.mode == WebCore::TranslationContextMenuMode::Editable) {
         [translationViewController setIsSourceEditable:YES];
@@ -6791,7 +6791,7 @@ void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContext
         }];
     }
 
-    auto sourceMetadata = adoptNS([PAL::allocLTUISourceMetaInstance() init]);
+    auto sourceMetadata = adoptNS([PAL::allocLTUISourceMetaInstanceSingleton() init]);
     [sourceMetadata setOrigin:info.source == WebCore::TranslationContextMenuSource::Image ? LTUISourceMetaOriginImage : LTUISourceMetaOriginUnspecified];
     [translationViewController setSourceMeta:sourceMetadata.get()];
 
@@ -6852,7 +6852,7 @@ void WebViewImpl::endPreviewPanelControl(QLPreviewPanel *panel)
 void WebViewImpl::handleClickForDataDetectionResult(const WebCore::DataDetectorElementInfo& info, const WebCore::IntPoint& clickLocation)
 {
 #if ENABLE(REVEAL)
-    m_revealItemPresenter = adoptNS([[WKRevealItemPresenter alloc] initWithWebViewImpl:*this item:adoptNS([PAL::allocRVItemInstance() initWithDDResult:info.result.get()]).get() frame:info.elementBounds menuLocation:clickLocation]);
+    m_revealItemPresenter = adoptNS([[WKRevealItemPresenter alloc] initWithWebViewImpl:*this item:adoptNS([PAL::allocRVItemInstanceSingleton() initWithDDResult:info.result.get()]).get() frame:info.elementBounds menuLocation:clickLocation]);
     [m_revealItemPresenter setShouldUseDefaultHighlight:NO];
     [m_revealItemPresenter showContextMenu];
 #else
@@ -7016,7 +7016,7 @@ void WebViewImpl::installImageAnalysisOverlayView(RetainPtr<VKCImageAnalysis>&& 
             return;
 
         if (!checkedThis->m_imageAnalysisOverlayView) {
-            checkedThis->m_imageAnalysisOverlayView = adoptNS([PAL::allocVKCImageAnalysisOverlayViewInstance() initWithFrame:[checkedThis->m_view bounds]]);
+            checkedThis->m_imageAnalysisOverlayView = adoptNS([PAL::allocVKCImageAnalysisOverlayViewInstanceSingleton() initWithFrame:[checkedThis->m_view bounds]]);
             checkedThis->m_imageAnalysisOverlayViewDelegate = adoptNS([[WKImageAnalysisOverlayViewDelegate alloc] initWithWebViewImpl:*checkedThis.get()]);
             [checkedThis->m_imageAnalysisOverlayView setDelegate:checkedThis->m_imageAnalysisOverlayViewDelegate.get()];
             prepareImageAnalysisForOverlayView(checkedThis->m_imageAnalysisOverlayView.get());

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -153,7 +153,7 @@ void ARKitInlinePreviewModelPlayerMac::load(WebCore::Model& modelSource, WebCore
 void ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL(const URL& url)
 {
     // First, create the WebProcess preview.
-    m_inlinePreview = adoptNS([allocASVInlinePreviewInstance() initWithFrame:CGRectMake(0, 0, m_size.width(), m_size.height())]);
+    m_inlinePreview = adoptNS([allocASVInlinePreviewInstanceSingleton() initWithFrame:CGRectMake(0, 0, m_size.width(), m_size.height())]);
     LOG(ModelElement, "ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL() created preview with UUID %s and size %f x %f.", ((String)[m_inlinePreview uuid].UUIDString).utf8().data(), m_size.width().toDouble(), m_size.height().toDouble());
 
     auto* client = this->client();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -786,7 +786,7 @@ void PDFIncrementalLoader::threadEntry(Ref<PDFIncrementalLoader>&& protectedLoad
 
     RetainPtr dataProvider = adoptCF(CGDataProviderCreateMultiRangeDirectAccess(this, kCGDataProviderIndeterminateSize, &dataProviderCallbacks));
     CGDataProviderSetProperty(dataProvider.get(), kCGDataProviderHasHighLatency, kCFBooleanTrue);
-    m_backgroundThreadDocument = adoptNS([allocPDFDocumentInstance() initWithProvider:dataProvider.get()]);
+    m_backgroundThreadDocument = adoptNS([allocPDFDocumentInstanceSingleton() initWithProvider:dataProvider.get()]);
 
     // [PDFDocument initWithProvider:] will return nil in cases where the PDF is non-linearized.
     // In those cases we'll just keep buffering the entire PDF on the main thread.

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -524,7 +524,7 @@ PDFPlugin::PDFPlugin(HTMLPlugInElement& element)
     , m_containerLayer(adoptNS([[CALayer alloc] init]))
     , m_contentLayer(adoptNS([[CALayer alloc] init]))
     , m_scrollCornerLayer(adoptNS([[WKPDFPluginScrollbarLayer alloc] initWithPDFPlugin:this shouldFlip:NO]))
-    , m_pdfLayerController(adoptNS([allocPDFLayerControllerInstance() init]))
+    , m_pdfLayerController(adoptNS([allocPDFLayerControllerInstanceSingleton() init]))
     , m_pdfLayerControllerDelegate(adoptNS([[WKPDFLayerControllerDelegate alloc] initWithPDFPlugin:this]))
 {
     Ref document = element.document();
@@ -1325,7 +1325,7 @@ PDFSelection *PDFPlugin::nextMatchForString(const String& target, bool searchFor
         foundSelection = [m_pdfDocument findString:nsTarget.get() fromSelection:initialSelection withOptions:options];
 
     if (!foundSelection && wrapSearch) {
-        auto emptySelection = adoptNS([allocPDFSelectionInstance() initWithDocument:m_pdfDocument.get()]);
+        auto emptySelection = adoptNS([allocPDFSelectionInstanceSingleton() initWithDocument:m_pdfDocument.get()]);
         foundSelection = [m_pdfDocument findString:nsTarget.get() fromSelection:emptySelection.get() withOptions:options];
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -241,7 +241,7 @@ void PDFPluginBase::destroy()
 
 void PDFPluginBase::createPDFDocument()
 {
-    m_pdfDocument = adoptNS([allocPDFDocumentInstance() initWithData:RetainPtr { originalData() }.get()]);
+    m_pdfDocument = adoptNS([allocPDFDocumentInstanceSingleton() initWithData:RetainPtr { originalData() }.get()]);
 }
 
 bool PDFPluginBase::isFullFramePlugin() const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -3320,7 +3320,7 @@ bool UnifiedPDFPlugin::findString(const String& target, WebCore::FindOptions opt
         RetainPtr nsTarget = target.createNSString();
         RetainPtr foundSelection = [m_pdfDocument findString:nsTarget.get() fromSelection:m_currentSelection.get() withOptions:compareOptions];
         if (!foundSelection && wrapSearch) {
-            RetainPtr emptySelection = adoptNS([allocPDFSelectionInstance() initWithDocument:m_pdfDocument.get()]);
+            RetainPtr emptySelection = adoptNS([allocPDFSelectionInstanceSingleton() initWithDocument:m_pdfDocument.get()]);
             foundSelection = [m_pdfDocument findString:nsTarget.get() fromSelection:emptySelection.get() withOptions:compareOptions];
         }
         return foundSelection;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -155,7 +155,7 @@ Ref<WebCore::PlatformCALayer> PlatformCALayerRemoteCustom::clone(PlatformCALayer
     if (layerType() == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
         
         if (PAL::isAVFoundationFrameworkAvailable() && [platformLayer() isKindOfClass:PAL::getAVPlayerLayerClass()]) {
-            clonedLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);
+            clonedLayer = adoptNS([PAL::allocAVPlayerLayerInstanceSingleton() init]);
 
             RetainPtr destinationPlayerLayer = static_cast<AVPlayerLayer *>(clonedLayer.get());
             RetainPtr sourcePlayerLayer = static_cast<AVPlayerLayer *>(platformLayer());

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -148,7 +148,7 @@ static WebCore::ValidatedMobileDocumentRequest buildValidatedRequest(WKIdentityD
 Vector<WebCore::ValidatedDigitalCredentialRequest> DigitalCredentials::validateRequests(const SecurityOrigin &topOrigin, const Document &document, const Vector<UnvalidatedDigitalCredentialRequest> &unvalidatedRequests)
 {
     RetainPtr convertedTopOrigin = topOrigin.toURL().createNSURL().get();
-    RetainPtr validator = adoptNS([WebKit::allocWKIdentityDocumentRawRequestValidatorInstance() init]);
+    RetainPtr validator = adoptNS([WebKit::allocWKIdentityDocumentRawRequestValidatorInstanceSingleton() init]);
 
     Vector<WebCore::ValidatedDigitalCredentialRequest> validatedRequests;
 
@@ -171,7 +171,7 @@ Vector<WebCore::ValidatedDigitalCredentialRequest> DigitalCredentials::validateR
         RetainPtr convertedEncryptionInfo = mobileDocumentRequest.encryptionInfo.createNSString();
         RetainPtr convertedDeviceRequest = mobileDocumentRequest.deviceRequest.createNSString();
 
-        RetainPtr iso18013Request = adoptNS([WebKit::allocWKISO18013RequestInstance() initWithEncryptionInfo:convertedEncryptionInfo.get() deviceRequest:convertedDeviceRequest.get()]);
+        RetainPtr iso18013Request = adoptNS([WebKit::allocWKISO18013RequestInstanceSingleton() initWithEncryptionInfo:convertedEncryptionInfo.get() deviceRequest:convertedDeviceRequest.get()]);
 
         NSError *error = nil;
         auto validatedISORequest = [validator validateISO18013Request:iso18013Request.get() origin:convertedTopOrigin.get() error:&error];

--- a/Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm
@@ -65,7 +65,7 @@ using namespace WebCore;
 {
     ASSERT(!_locationManager);
 
-    _locationManager = adoptNS([allocCLLocationManagerInstance() init]);
+    _locationManager = adoptNS([allocCLLocationManagerInstanceSingleton() init]);
     _lastAuthorizationStatus = [getCLLocationManagerClass() authorizationStatus];
 
     [ _locationManager setDelegate:self];

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -477,7 +477,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return nil;
 
-    auto actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
+    auto actionContext = adoptNS([PAL::allocWKDDActionContextInstanceSingleton() init]);
 
     if (!actionContext)
         return nil;

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -104,7 +104,7 @@ static void WebAVPlayerView_exitFullScreen(id aSelf, SEL, id sender)
     [playerView.webDelegate playerViewRequestExitFullscreen:playerView];
 }
 
-static WebAVPlayerView *allocWebAVPlayerViewInstance()
+static WebAVPlayerView *allocWebAVPlayerViewInstanceSingleton()
 {
     static Class theClass = nil;
     static dispatch_once_t onceToken;
@@ -184,7 +184,7 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     [window setHasShadow:YES]; // This is nicer with a shadow.
     [window setLevel:NSPopUpMenuWindowLevel-1];
 
-    _playerView = adoptNS([allocWebAVPlayerViewInstance() initWithFrame:window.contentLayoutRect]);
+    _playerView = adoptNS([allocWebAVPlayerViewInstanceSingleton() initWithFrame:window.contentLayoutRect]);
     _playerView.get().controlsStyle = AVPlayerViewControlsStyleNone;
     _playerView.get().showsFullScreenToggleButton = YES;
     _playerView.get().showsAudioOnlyIndicatorView = NO;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -832,20 +832,20 @@ static WebCore::StorageBlockingPolicy core(WebStorageBlockingPolicy storageBlock
     if (!(self = [super init]))
         return nil;
 
-    _dataInteractionImage = [PAL::allocUIImageInstance() initWithCGImage:image scale:scale orientation:UIImageOrientationDownMirrored];
+    _dataInteractionImage = [PAL::allocUIImageInstanceSingleton() initWithCGImage:image scale:scale orientation:UIImageOrientationDownMirrored];
     _selectionRectInRootViewCoordinates = indicator->selectionRectInRootViewCoordinates();
     _textBoundingRectInRootViewCoordinates = indicator->textBoundingRectInRootViewCoordinates();
     _textRectsInBoundingRectCoordinates = createNSArray(indicator->textRectsInBoundingRectCoordinates()).leakRef();
     _contentImageScaleFactor = indicator->contentImageScaleFactor();
     if (indicator->contentImageWithHighlight())
-        _contentImageWithHighlight = [PAL::allocUIImageInstance() initWithCGImage:indicator->contentImageWithHighlight()->nativeImage()->platformImage().get() scale:scale orientation:UIImageOrientationDownMirrored];
+        _contentImageWithHighlight = [PAL::allocUIImageInstanceSingleton() initWithCGImage:indicator->contentImageWithHighlight()->nativeImage()->platformImage().get() scale:scale orientation:UIImageOrientationDownMirrored];
     if (indicator->contentImage())
-        _contentImage = [PAL::allocUIImageInstance() initWithCGImage:indicator->contentImage()->nativeImage()->platformImage().get() scale:scale orientation:UIImageOrientationUp];
+        _contentImage = [PAL::allocUIImageInstanceSingleton() initWithCGImage:indicator->contentImage()->nativeImage()->platformImage().get() scale:scale orientation:UIImageOrientationUp];
 
     if (indicator->contentImageWithoutSelection()) {
         auto nativeImage = indicator->contentImageWithoutSelection()->nativeImage();
         if (nativeImage) {
-            _contentImageWithoutSelection = [PAL::allocUIImageInstance() initWithCGImage:nativeImage->platformImage().get() scale:scale orientation:UIImageOrientationUp];
+            _contentImageWithoutSelection = [PAL::allocUIImageInstanceSingleton() initWithCGImage:nativeImage->platformImage().get() scale:scale orientation:UIImageOrientationUp];
             _contentImageWithoutSelectionRectInRootViewCoordinates = indicator->contentImageWithoutSelectionRectInRootViewCoordinates();
         }
     }
@@ -861,7 +861,7 @@ static WebCore::StorageBlockingPolicy core(WebStorageBlockingPolicy storageBlock
     if (!(self = [super init]))
         return nil;
 
-    _dataInteractionImage = [PAL::allocUIImageInstance() initWithCGImage:image scale:scale orientation:UIImageOrientationDownMirrored];
+    _dataInteractionImage = [PAL::allocUIImageInstanceSingleton() initWithCGImage:image scale:scale orientation:UIImageOrientationDownMirrored];
 
     return self;
 }
@@ -9476,7 +9476,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 {
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER) && ENABLE(VIDEO_PRESENTATION_MODE)
     if (!_private->mediaTouchBarProvider)
-        _private->mediaTouchBarProvider = adoptNS([allocAVTouchBarPlaybackControlsProviderInstance() init]);
+        _private->mediaTouchBarProvider = adoptNS([allocAVTouchBarPlaybackControlsProviderInstanceSingleton() init]);
 
     if (![_private->mediaTouchBarProvider playbackControlsController]) {
         ASSERT(_private->playbackSessionInterface);
@@ -9598,7 +9598,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
         return;
     }
 
-    auto translationViewController = adoptNS([PAL::allocLTUITranslationViewControllerInstance() init]);
+    auto translationViewController = adoptNS([PAL::allocLTUITranslationViewControllerInstanceSingleton() init]);
     [translationViewController setText:adoptNS([[NSAttributedString alloc] initWithString:info.text.createNSString().get()]).get()];
     if (info.mode == WebCore::TranslationContextMenuMode::Editable) {
         [translationViewController setIsSourceEditable:YES];

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1761,7 +1761,7 @@ TEST(IPCSerialization, SecureCoding)
     runTestNS({ scannerResult.get() });
 
     // DDActionContext/DDSecureActionContext
-    auto actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
+    auto actionContext = adoptNS([PAL::allocWKDDActionContextInstanceSingleton() init]);
     [actionContext setAllResults:@[ (__bridge id)scannerResult.get().coreResult ]];
     [actionContext setMainResult:scannerResult.get().coreResult];
     auto components = personNameComponentsForTesting();

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -109,7 +109,7 @@ static IMP makeQueryParameterRequestHandler(NSArray<NSString *> *parameters, NSA
 {
     return imp_implementationWithBlock([&didHandleRequest, parameters = RetainPtr { parameters }, domains = RetainPtr { domains }, paths = RetainPtr { paths }](WPResources *, WPResourceRequestOptions *, void(^completion)(WPLinkFilteringData *, NSError *)) mutable {
         RunLoop::mainSingleton().dispatch([&didHandleRequest, parameters = WTFMove(parameters), domains = WTFMove(domains), paths = WTFMove(paths), completion = makeBlockPtr(completion)]() mutable {
-            auto data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()
+            auto data = adoptNS([PAL::allocWPLinkFilteringDataInstanceSingleton() initWithQueryParameters:parameters.get()
 #if defined(HAS_WEB_PRIVACY_LINK_FILTERING_RULE_PATH)
                 domains:domains.get() paths:paths.get()
 #endif
@@ -124,7 +124,7 @@ static IMP makeAllowedLinkFilteringDataRequestHandler(NSArray<NSString *> *param
 {
     return imp_implementationWithBlock([parameters = RetainPtr { parameters }](WPResources *, WPResourceRequestOptions *, void(^completion)(WPLinkFilteringData *, NSError *)) mutable {
         RunLoop::mainSingleton().dispatch([parameters = WTFMove(parameters), completion = makeBlockPtr(completion)]() mutable {
-            auto data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()]);
+            auto data = adoptNS([PAL::allocWPLinkFilteringDataInstanceSingleton() initWithQueryParameters:parameters.get()]);
             completion(data.get(), nil);
         });
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -388,8 +388,8 @@ using GetAuthorizationHintsCallback = void (^)(SOAuthorizationHints *authorizati
 static void overrideGetAuthorizationHintsWithURL(id, SEL, NSURL *url, NSInteger responseCode, GetAuthorizationHintsCallback completion)
 {
     EXPECT_EQ(responseCode, 0l);
-    auto soAuthorizationHintsCore = adoptNS([PAL::allocSOAuthorizationHintsCoreInstance() initWithLocalizedExtensionBundleDisplayName:@"Test"]);
-    auto soAuthorizationHints = adoptNS([PAL::allocSOAuthorizationHintsInstance() initWithAuthorizationHintsCore:soAuthorizationHintsCore.get()]);
+    auto soAuthorizationHintsCore = adoptNS([PAL::allocSOAuthorizationHintsCoreInstanceSingleton() initWithLocalizedExtensionBundleDisplayName:@"Test"]);
+    auto soAuthorizationHints = adoptNS([PAL::allocSOAuthorizationHintsInstanceSingleton() initWithAuthorizationHintsCore:soAuthorizationHintsCore.get()]);
     completion(soAuthorizationHints.get(), nullptr);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -2493,8 +2493,8 @@ TEST(WKAttachmentTestsIOS, DragAttachmentInsertedAsData)
 
 static RetainPtr<NSItemProvider> mapItemForTesting()
 {
-    auto placemark = adoptNS([allocMKPlacemarkInstance() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
-    auto mapItem = adoptNS([allocMKMapItemInstance() initWithPlacemark:placemark.get()]);
+    auto placemark = adoptNS([allocMKPlacemarkInstanceSingleton() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
+    auto mapItem = adoptNS([allocMKMapItemInstanceSingleton() initWithPlacemark:placemark.get()]);
     [mapItem setName:@"Apple Park.vcf"];
 
     auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
@@ -2517,7 +2517,7 @@ static RetainPtr<NSItemProvider> calendarInviteForTesting()
 
 static RetainPtr<NSItemProvider> contactItemForTesting()
 {
-    auto contact = adoptNS([allocCNMutableContactInstance() init]);
+    auto contact = adoptNS([allocCNMutableContactInstanceSingleton() init]);
     [contact setGivenName:@"Foo"];
     [contact setFamilyName:@"Bar"];
 

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -1094,8 +1094,8 @@ TEST(DragAndDropTests, ExternalSourceOverrideDropFileUpload)
 
 static RetainPtr<NSItemProvider> createMapItemForTesting()
 {
-    auto placemark = adoptNS([allocMKPlacemarkInstance() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
-    auto item = adoptNS([allocMKMapItemInstance() initWithPlacemark:placemark.get()]);
+    auto placemark = adoptNS([allocMKPlacemarkInstanceSingleton() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
+    auto item = adoptNS([allocMKMapItemInstanceSingleton() initWithPlacemark:placemark.get()]);
     [item setName:@"Apple Park"];
 
     auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
@@ -1107,7 +1107,7 @@ static RetainPtr<NSItemProvider> createMapItemForTesting()
 
 static RetainPtr<NSItemProvider> createContactItemForTesting()
 {
-    auto contact = adoptNS([allocCNMutableContactInstance() init]);
+    auto contact = adoptNS([allocCNMutableContactInstanceSingleton() init]);
     [contact setGivenName:@"Foo"];
     [contact setFamilyName:@"Bar"];
 

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -436,7 +436,7 @@ static NSString *overrideBundleIdentifier(id, SEL)
 
 static RetainPtr<BEKeyEntry> wrap(WebEvent *webEvent)
 {
-    auto uiKeyEvent = adoptNS([allocUIKeyEventInstance() initWithWebEvent:webEvent]);
+    auto uiKeyEvent = adoptNS([allocUIKeyEventInstanceSingleton() initWithWebEvent:webEvent]);
     return adoptNS([[BEKeyEntry alloc] _initWithUIKitKeyEvent:uiKeyEvent.get()]);
 }
 


### PR DESCRIPTION
#### 5d701665610748bc816a50d95c702c32f65ee740
<pre>
Rename `*Instance()` soft-linking functions to `*InstanceSingleton()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298576">https://bugs.webkit.org/show_bug.cgi?id=298576</a>

Reviewed by NOBODY (OOPS!).

Rename `*Instance()` soft-linking functions to `*InstanceSingleton()` to silence Safer CPP static
analysis false positives.

* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm:
(WebCore::ShapeDetection::request):
(WebCore::ShapeDetection::BarcodeDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm:
(WebCore::ShapeDetection::FaceDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm:
(WebCore::ShapeDetection::TextDetectorImpl::detect):
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::makeNSArrayElement):
(WebCore::createPlatformConfiguration):
* Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm:
(WebCore::convert):
* Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm:
(WebCore::PaymentMerchantSession::fromJS):
* Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm:
(-[WebSpeechRecognizerTaskImpl initWithIdentifier:locale:doMultipleRecognitions:reportInterimResults:maxAlternatives:delegateCallback:]):
* Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.h:
(PAL::allocWKDDActionContextInstanceSingleton):
(PAL::allocWKDDActionContextInstance): Deleted.
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AXRemoteFrame::initializePlatformElementWithRemoteToken):
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::detectItem):
* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
(WebCore::DictionaryLookup::rangeForSelection):
(WebCore::DictionaryLookup::rangeAtHitTestResult):
(WebCore::DictionaryLookup::stringForPDFSelection):
(WebCore::showPopupOrCreateAnimationController):
* Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm:
(WebCore::PrivateClickMeasurement::calculateAndUpdateUnlinkableToken):
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(-[WebMediaSessionHelper startMonitoringAirPlayRoutes]):
* Source/WebCore/platform/cocoa/CoreLocationGeolocationProvider.mm:
(-[WebCLLocationManager initWithWebsiteIdentifier:client:mode:]):
* Source/WebCore/platform/cocoa/NSURLUtilities.mm:
(-[NSURL _web_setTitle:]):
(-[NSURL _web_title]):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::responseReceived):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::effectiveWCRBrowserEngineClient):
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper speakUtterance:]):
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_pictureInPicturePlayerLayerView):
(WebCore::allocWebAVPlayerLayerViewInstanceSingleton):
(WebCore::allocWebAVPictureInPicturePlayerLayerViewInstanceSingleton):
(WebCore::allocWebAVPlayerLayerViewInstance): Deleted.
(WebCore::allocWebAVPictureInPicturePlayerLayerViewInstance): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::GameControllerHapticEffect::create):
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::createMixIfNeeded):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::addAudioRenderer):
(WebCore::AudioVideoRendererAVFObjC::ensureLayer):
(WebCore::AudioVideoRendererAVFObjC::ensureVideoRenderer):
* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm:
(WebCore::AVOutputDeviceMenuControllerTargetPicker::devicePicker):
* Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm:
(WebCore::AVRoutePickerViewTargetPicker::isAvailable):
(WebCore::AVRoutePickerViewTargetPicker::devicePicker):
(WebCore::AVRoutePickerViewTargetPicker::routeDetector):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::contentKeySession):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::ImageDecoderAVFObjC):
(WebCore::ImageDecoderAVFObjC::readSamples):
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::create):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureVideoRenderer):
* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm:
(WebCore::QueuedVideoOutput::QueuedVideoOutput):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::isContentTypeSupported):
(WebCore::SourceBufferParserAVFObjC::SourceBufferParserAVFObjC):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
* Source/WebCore/platform/graphics/cocoa/IconCocoa.mm:
(WebCore::Icon::create):
* Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm:
(WebCore::PDFDocumentImage::createPDFDocument):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::createDragImageForRange):
(WebCore::createDragImageForColor):
* Source/WebCore/platform/ios/PreviewConverterIOS.mm:
(WebCore::PreviewConverter::platformUnlockWithPassword):
* Source/WebCore/platform/ios/QuickLook.mm:
(WebCore::registerQLPreviewConverterIfNeeded):
* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(WebValidationBubbleViewController_viewDidLoad):
(allocWebValidationBubbleViewControllerInstanceSingleton):
(-[WebValidationBubbleTapRecognizer initWithPopoverController:]):
(WebCore::ValidationBubble::ValidationBubble):
(allocWebValidationBubbleViewControllerInstance): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(allocWebAVPictureInPictureContentViewControllerInstanceSingleton):
(-[WebAVPlayerViewController initWithFullscreenInterface:]):
(allocWebAVPictureInPictureContentViewControllerInstance): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing):
(WebCore::VideoPresentationInterfaceIOS::doSetup):
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVPlayerController init]):
(-[WebAVPlayerController timeRangeSeekable]):
(-[WebAVPlayerController timeRangeForNavigation]):
* Source/WebCore/platform/ios/WebCoreMotionManager.mm:
(-[WebCoreMotionManager initializeOnMainThread]):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::setUpFullscreen):
* Source/WebCore/platform/mac/RevealUtilities.mm:
(WebCore::createRVPresentingContextWithRetainedDelegate):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC setUpPIPForVideoView:withFrame:inWindow:]):
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm:
(mediaSelectionOptions):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
(WebCore::MediaRecorderPrivateWriterAVFObjC::create):
(WebCore::MediaRecorderPrivateWriterAVFObjC::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterAVFObjC::addVideoTrack):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::photoOutput):
(WebCore::AVVideoCaptureSource::setupSession):
(WebCore::AVVideoCaptureSource::setupCaptureSession):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamConfiguration):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingSession):
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker):
(WebCore::ScreenCaptureKitSharingSessionManager::createSessionSourceForDevice):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::iconForAttachment):
* Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm:
(-[WebViewVisualIdentificationOverlay initWithWebView:kind:deprecated:]):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::deviceManagementPolicyMonitor):
(WebKit::NetworkSessionCocoa::removeNetworkWebsiteData):
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::createImageAnalyzer):
(WebKit::createImageAnalyzerRequest):
(WebKit::requestPayloadForQRCode):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
(WebKit::PaymentAuthorizationPresenter::completePaymentMethodSelection):
(WebKit::PaymentAuthorizationPresenter::completePaymentSession):
(WebKit::PaymentAuthorizationPresenter::completeShippingContactSelection):
(WebKit::PaymentAuthorizationPresenter::completeShippingMethodSelection):
(WebKit::PaymentAuthorizationPresenter::completeCouponCodeChange):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm:
(WebKit::platformViewController):
* Source/WebKit/Platform/cocoa/WKPaymentAuthorizationDelegate.mm:
(-[WKPaymentAuthorizationDelegate completePaymentMethodSelection:]):
(-[WKPaymentAuthorizationDelegate completePaymentSession:errors:]):
(-[WKPaymentAuthorizationDelegate completePaymentSession:errors:orderDetails:]):
(-[WKPaymentAuthorizationDelegate completeShippingContactSelection:]):
(-[WKPaymentAuthorizationDelegate completeShippingMethodSelection:]):
(-[WKPaymentAuthorizationDelegate completeCouponCodeChange:]):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::LinkDecorationFilteringController::updateList):
(WebKit::requestLinkDecorationFilteringData):
(WebKit::StorageAccessPromptQuirkController::updateList):
(WebKit::StorageAccessUserAgentStringQuirkController::updateList):
(WebKit::RestrictedOpenerDomainsController::update):
(WebKit::TrackerAddressLookupInfo::populateIfNeeded):
(WebKit::TrackerDomainLookupInfo::populateIfNeeded):
(WebKit::ScriptTrackingPrivacyController::updateList):
* Source/WebKit/Platform/ios/PaymentAuthorizationController.mm:
(WebKit::PaymentAuthorizationController::PaymentAuthorizationController):
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::seekableRangesChanged):
(WebKit::PlaybackSessionInterfaceLMK::audioMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionInterfaceLMK::legibleMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionInterfaceLMK::spatialVideoMetadataChanged):
(WebKit::PlaybackSessionInterfaceLMK::nowPlayingMetadataChanged):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::menuItemForTelephoneNumber):
(WebKit::menuForTelephoneNumber):
* Source/WebKit/Shared/ApplePay/cocoa/AutomaticReloadPaymentRequestCocoa.mm:
(WebKit::platformAutomaticReloadPaymentRequest):
* Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm:
(WebKit::platformDeferredPaymentRequest):
* Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm:
(WebKit::platformDisbursementRequest):
* Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm:
(WebKit::toPlatformConfiguration):
* Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm:
(WebKit::platformPaymentTokenContext):
* Source/WebKit/Shared/ApplePay/cocoa/RecurringPaymentRequestCocoa.mm:
(WebKit::platformRecurringPaymentRequest):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformOpenPaymentSetup):
(WebKit::toPKDateComponentsRange):
(WebKit::toPKShippingMethods):
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
(WebKit::WebPaymentCoordinatorProxy::platformBeginApplePaySetup):
* Source/WebKit/Shared/Cocoa/RevealItem.mm:
(WebKit::RevealItem::item const):
* Source/WebKit/Shared/Cocoa/WebIconUtilities.mm:
(WebKit::iconForVideoFile):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageControllerIfNeeded]):
(-[WKWebView didBeginWritingToolsSession:contexts:]):
* Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm:
(WebKit::shouldAllowAutoFillForCellularIdentifiers):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(WebKit::GroupActivitiesCoordinator::GroupActivitiesCoordinator):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm:
(WebKit::GroupActivitiesSessionNotifier::GroupActivitiesSessionNotifier):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::checkSpeechRecognitionServiceAvailability):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelElementCreateRemotePreview):
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::allocFileWrapperInstanceSingleton const):
(WebKit::PageClientImplCocoa::allocFileWrapperInstance const): Deleted.
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::SOAuthorizationSession):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm:
(-[WKRotationCoordinatorObserver start:layer:]):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createViewWithID):
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker presentWithRequestData:completionHandler:]):
(-[WKContactPicker _contactsFromJSContacts:]):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(placeholderMetadataWithURLAndTitle):
(placeholderMetadataWithFileURL):
(-[WKShareSheetFileItemProvider initWithURL:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::platformRegisterAttachment):
(WebKit::WebPageProxy::setUpHighlightsObserver):
(WebKit::WebPageProxy::startApplePayAMSUISession):
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(mapDocumentRequests):
(mapPresentmentRequests):
(-[WKDigitalCredentialsPicker fetchRawRequestsWithCompletionHandler:]):
(-[WKDigitalCredentialsPicker performRequest:]):
(-[WKDigitalCredentialsPicker setupPresentmentController]):
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
(WebKit::MediaUsageManagerCocoa::updateMediaUsage):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::allocFileWrapperInstanceSingleton const):
(WebKit::PageClient::allocFileWrapperInstance const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator):
(WebKit::AuthenticatorPresenterCoordinator::updatePresenter):
(WebKit::AuthenticatorPresenterCoordinator::selectAssertionResponse):
(WebKit::AuthenticatorPresenterCoordinator::dimissPresenter):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
(WebKit::LocalConnection::verifyUser):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm:
(WebKit::LocalService::isAvailable):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::constructASController):
(WebKit::toASAssertionPRFInputValue):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForRegistration):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):
(WebKit::toASCDescriptor):
(WebKit::toASCExtensions):
(WebKit::setGlobalFrameIDForContext):
(WebKit::configureRegistrationRequestContext):
(WebKit::configureAssertionOptions):
(WebKit::configurationAssertionRequestContext):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm:
(WebKit::MockLocalConnection::verifyUser):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(WebKit::MockNfcService::platformStartDiscovery):
(WebKit::MockNfcService::detectTags const):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm:
(WebKit::VirtualLocalConnection::verifyUser):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm:
(WebKit::ScreenTimeWebsiteDataSupport::getScreenTimeURLs):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeData):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeDataWithInterval):
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::createSessionIfNeeded):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[_WKARPresentationSession viewWillAppear:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView presentVisualSearchPreviewControllerForImage:imageURL:title:imageBounds:appearanceActions:]):
(-[WKContentView previewController:previewItemAtIndex:]):
(-[WKContentView installImageAnalysisInteraction:]):
(-[WKContentView addTextAnimationForAnimationID:withData:]):
* Source/WebKit/UIProcess/ios/WKModelView.mm:
(-[WKModelView createPreview]):
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:]):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(appHasPreciseLocationPermission):
* Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm:
(-[WKAirPlayRoutePicker showFromView:routeSharingPolicy:routingContextUID:hasVideo:]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadMediaTranscoder start]):
(-[WKFileUploadMediaTranscoder _processItemAtIndex:]):
* Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm:
(-[WKTimePickerViewController viewDidLoad]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm:
(-[WKFullscreenStackView init]):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _animationControllerForDataDetectedLink]):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView drawRect:]):
* Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm:
(-[WKQuickLookPreviewController initWithPage:imageData:title:imageURL:activity:]):
* Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm:
(-[WKRevealItemPresenter initWithWebViewImpl:item:frame:menuLocation:]):
* Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm:
(-[WKTextAnimationManager initWithWebViewImpl:]):
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
(-[WKTextAnimationManager textPreviewsForChunk:completion:]):
(-[WKTextAnimationManager textPreviewForRect:completion:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateMediaTouchBar):
(WebKit::WebViewImpl::handleContextMenuTranslation):
(WebKit::WebViewImpl::handleClickForDataDetectionResult):
(WebKit::WebViewImpl::installImageAnalysisOverlayView):
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm:
(WebKit::ARKitInlinePreviewModelPlayerMac::createPreviewsForModelWithURL):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::threadEntry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::PDFPlugin):
(WebKit::PDFPlugin::nextMatchForString):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::createPDFDocument):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::findString):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::clone const):
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm:
(WebKit::DigitalCredentials::validateRequests):
* Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm:
(-[WebGeolocationCoreLocationProvider createLocationManager]):
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
(-[WebImmediateActionController _animationControllerForDataDetectedLink]):
* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm:
(allocWebAVPlayerViewInstanceSingleton):
(-[WebVideoFullscreenController windowDidLoad]):
(allocWebAVPlayerViewInstance): Deleted.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebUITextIndicatorData initWithImage:textIndicator:scale:]):
(-[WebUITextIndicatorData initWithImage:scale:]):
(-[WebView updateMediaTouchBar]):
(-[WebView _handleContextMenuTranslation:]):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, SecureCoding)):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::makeQueryParameterRequestHandler):
(TestWebKitAPI::makeAllowedLinkFilteringDataRequestHandler):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(overrideGetAuthorizationHintsWithURL):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::mapItemForTesting):
(TestWebKitAPI::contactItemForTesting):
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::createMapItemForTesting):
(TestWebKitAPI::createContactItemForTesting):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(wrap):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d701665610748bc816a50d95c702c32f65ee740

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120021 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39714 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72094 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd758bec-a5a5-443e-9a88-ba86271780aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121897 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40411 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91143 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a3929e7-236a-4d1d-b5c2-e8dbb86cb2aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122973 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/40411 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71698 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02ae17ca-7a8a-414a-a6db-85f9db1006ff) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/40411 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69990 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112146 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/40411 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129271 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118537 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46941 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99759 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47307 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99603 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23087 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46803 "Hash 5d701665 for PR 50479 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52509 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147236 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46269 "Hash 5d701665 for PR 50479 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37834 "Found 1 new JSC binary failure: testapi, Found 18652 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49618 "Hash 5d701665 for PR 50479 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47955 "Hash 5d701665 for PR 50479 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->