### PR TITLE
[Build Speed] Remove DocumentInlines.h from all non-Inlines.h headers

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1388,6 +1388,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/MouseRelatedEvent.h
     dom/MutationEvent.h
     dom/MutationObserver.h
+    dom/MutationObserverOptions.h
     dom/NameNodeList.h
     dom/NamedNodeMap.h
     dom/NativeNodeFilter.h

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -33,6 +33,7 @@
 #include "DOMWrapperWorld.h"
 #include "ElementRareData.h"
 #include "EventLoop.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLFormElement.h"
 #include "HTMLMaybeFormAssociatedCustomElement.h"
 #include "HTMLUnknownElement.h"

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -31,6 +31,7 @@
 
 #include "CommonVM.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "Frame.h"
 #include "FrameLoaderTypes.h"
 #include "GarbageCollectionController.h"

--- a/Source/WebCore/dom/ChildListMutationScope.h
+++ b/Source/WebCore/dom/ChildListMutationScope.h
@@ -31,8 +31,8 @@
 #pragma once
 
 #include "ContainerNode.h"
-#include "DocumentInlines.h"
-#include "MutationObserver.h"
+#include "Document.h"
+#include "MutationObserverOptions.h"
 #include <memory>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -38,6 +38,7 @@
 #include <WebCore/FrameDestructionObserver.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/HitTestSource.h>
+#include <WebCore/MutationObserverOptions.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PlaybackTargetClientContextIdentifier.h>
 #include <WebCore/PseudoElementIdentifier.h>
@@ -1084,7 +1085,7 @@ public:
     void didConnectPluginElement() { ++m_connectedPluginElementCount; }
     void didDisconnectPluginElement() { ASSERT(m_connectedPluginElementCount); --m_connectedPluginElementCount; }
 
-    inline bool hasMutationObserversOfType(MutationObserverOptionType) const;
+    bool hasMutationObserversOfType(MutationObserverOptionType type) const { return m_mutationObserverTypes.containsAny(type); }
     bool hasMutationObservers() const { return !m_mutationObserverTypes.isEmpty(); }
     void addMutationObserverTypes(MutationObserverOptions types) { m_mutationObserverTypes.add(types); }
 

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -67,6 +67,22 @@
 
 namespace WebCore {
 
+class DocumentFullscreen::CompletionHandlerScope final {
+public:
+    CompletionHandlerScope(CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
+        : m_completionHandler(WTFMove(completionHandler)) { }
+    CompletionHandlerScope(CompletionHandlerScope&&) = default;
+    CompletionHandlerScope& operator=(CompletionHandlerScope&&) = default;
+    ~CompletionHandlerScope()
+    {
+        if (m_completionHandler)
+            m_completionHandler({ });
+    }
+    CompletionHandler<void(ExceptionOr<void>)> release() { return WTFMove(m_completionHandler); }
+private:
+    CompletionHandler<void(ExceptionOr<void>)> m_completionHandler;
+};
+
 // MARK: - Constructor.
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentFullscreen);
@@ -423,6 +439,11 @@ bool DocumentFullscreen::isSimpleFullscreenDocument() const
         }
     }
     return foundFullscreenFlag;
+}
+
+Page* DocumentFullscreen::page() const
+{
+    return document().page();
 }
 
 // MARK: - Simple helper to get document frame

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(FULLSCREEN_API)
 
-#include <WebCore/DocumentInlines.h>
+#include <WebCore/Document.h>
 #include <WebCore/GCReachableRef.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
@@ -64,7 +64,6 @@ public:
     Document& document() { return m_document.get(); }
     const Document& document() const { return m_document.get(); }
     Ref<Document> protectedDocument() const { return m_document.get(); }
-    Page* page() const { return document().page(); }
     LocalFrame* frame() const;
     Element* documentElement() const { return document().documentElement(); }
     bool isSimpleFullscreenDocument() const;
@@ -117,6 +116,7 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
+    Page* page() const;
     Document* mainFrameDocument() { return protectedDocument()->mainFrameDocument(); }
 
     RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }
@@ -142,21 +142,7 @@ private:
     const uint64_t m_logIdentifier;
 #endif
 
-    class CompletionHandlerScope final {
-    public:
-        CompletionHandlerScope(CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
-            : m_completionHandler(WTFMove(completionHandler)) { }
-        CompletionHandlerScope(CompletionHandlerScope&&) = default;
-        CompletionHandlerScope& operator=(CompletionHandlerScope&&) = default;
-        ~CompletionHandlerScope()
-        {
-            if (m_completionHandler)
-                m_completionHandler({ });
-        }
-        CompletionHandler<void(ExceptionOr<void>)> release() { return WTFMove(m_completionHandler); }
-    private:
-        CompletionHandler<void(ExceptionOr<void>)> m_completionHandler;
-    };
+    class CompletionHandlerScope;
 };
 
 }

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -166,11 +166,6 @@ inline void Document::invalidateAccessKeyCache()
         invalidateAccessKeyCacheSlowCase();
 }
 
-inline bool Document::hasMutationObserversOfType(MutationObserverOptionType type) const
-{
-    return m_mutationObserverTypes.containsAny(type);
-}
-
 inline ClientOrigin Document::clientOrigin() const { return { topOrigin().data(), securityOrigin().data() }; }
 
 inline bool Document::isSameOriginAsTopDocument() const { return protectedSecurityOrigin()->isSameOriginAs(protectedTopOrigin()); }

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -32,9 +32,9 @@
 #pragma once
 
 #include <WebCore/GCReachableRef.h>
+#include <WebCore/MutationObserverOptions.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
-#include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
@@ -53,24 +53,6 @@ class MutationRecord;
 class Node;
 class WindowEventLoop;
 template<typename> class ExceptionOr;
-
-enum class MutationObserverOptionType : uint8_t {
-    // MutationType
-    ChildList = 1 << 0,
-    Attributes = 1 << 1,
-    CharacterData = 1 << 2,
-
-    // ObservationFlags
-    Subtree = 1 << 3,
-    AttributeFilter = 1 << 4,
-
-    // DeliveryFlags
-    AttributeOldValue = 1 << 5,
-    CharacterDataOldValue = 1 << 6,
-};
-
-using MutationObserverOptions = OptionSet<MutationObserverOptionType>;
-using MutationRecordDeliveryOptions = OptionSet<MutationObserverOptionType>;
 
 class MutationObserver final : public RefCounted<MutationObserver> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MutationObserver);

--- a/Source/WebCore/dom/MutationObserverInterestGroup.h
+++ b/Source/WebCore/dom/MutationObserverInterestGroup.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "DocumentInlines.h"
+#include "Document.h"
 #include "MutationObserver.h"
 #include <memory>
 #include <wtf/HashMap.h>

--- a/Source/WebCore/dom/MutationObserverOptions.h
+++ b/Source/WebCore/dom/MutationObserverOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,37 +25,26 @@
 
 #pragma once
 
-#include <WebCore/Document.h>
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 
-class XMLDocument : public Document {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(XMLDocument);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XMLDocument);
-public:
-    static Ref<XMLDocument> create(LocalFrame* frame, const Settings& settings, const URL& url)
-    {
-        auto document = adoptRef(*new XMLDocument(frame, settings, url, { DocumentClass::XML }));
-        document->addToContextsMap();
-        return document;
-    }
+enum class MutationObserverOptionType : uint8_t {
+    // MutationType
+    ChildList = 1 << 0,
+    Attributes = 1 << 1,
+    CharacterData = 1 << 2,
 
-    WEBCORE_EXPORT static Ref<XMLDocument> createXHTML(LocalFrame*, const Settings&, const URL&);
+    // ObservationFlags
+    Subtree = 1 << 3,
+    AttributeFilter = 1 << 4,
 
-protected:
-    XMLDocument(LocalFrame* frame, const Settings& settings, const URL& url, DocumentClasses documentClasses = { })
-        : Document(frame, settings, url, documentClasses | DocumentClasses(DocumentClass::XML))
-    {
-    }
+    // DeliveryFlags
+    AttributeOldValue = 1 << 5,
+    CharacterDataOldValue = 1 << 6,
 };
 
-} // namespace WebCore
+using MutationObserverOptions = OptionSet<MutationObserverOptionType>;
+using MutationRecordDeliveryOptions = OptionSet<MutationObserverOptionType>;
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::XMLDocument)
-    static bool isType(const WebCore::Document& document) { return document.isXMLDocument(); }
-    static bool isType(const WebCore::Node& node)
-    {
-        auto* document = dynamicDowncast<WebCore::Document>(node);
-        return document && isType(*document);
-    }
-SPECIALIZE_TYPE_TRAITS_END()
+}

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <WebCore/Document.h>
-#include <WebCore/DocumentInlines.h>
 #include <WebCore/TreeScopeOrderedMap.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -61,6 +61,7 @@
 #include "OffscreenCanvas.h"
 #include "RenderBox.h"
 #include "ScriptExecutionContextInlines.h"
+#include "Settings.h"
 #include "WebCodecsVideoFrame.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include "WebGLActiveInfo.h"

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -68,6 +68,7 @@
 #include "OESTextureHalfFloatLinear.h"
 #include "OESVertexArrayObject.h"
 #include "RenderBox.h"
+#include "Settings.h"
 #include "WebCodecsVideoFrame.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include "WebGLBlendFuncExtended.h"

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1335,6 +1335,24 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(ServiceWorker
     return globalScope.inspectorController().m_instrumentingAgents;
 }
 
+InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const LocalFrameView& frameView)
+{
+    return instrumentingAgents(frameView.frame());
+}
+
+InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const Frame& frame)
+{
+    return instrumentingAgents(frame.page());
+}
+
+InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Document& document)
+{
+    Page* page = document.page();
+    if (!page && document.templateDocumentHost())
+        page = document.templateDocumentHost()->page();
+    return instrumentingAgents(page);
+}
+
 InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -415,7 +415,7 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
         }
     }
 
-    InspectorInstrumentation::didReceiveThreadableLoaderResponse(*this, identifier);
+    InspectorInstrumentation::didReceiveThreadableLoaderResponse(document(), *this, identifier);
 
     if (m_delayCallbacksForIntegrityCheck)
         return;

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -62,7 +62,6 @@
 #include "CSSValuePool.h"
 #include "CSSViewValue.h"
 #include "ContainerNodeInlines.h"
-#include "DocumentInlines.h"
 #include "FontCascade.h"
 #include "FontSelectionValueInlines.h"
 #include "HTMLFrameOwnerElement.h"

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -20,6 +20,7 @@
 #include "DOMParser.h"
 
 #include "CommonAtomStrings.h"
+#include "DocumentInlines.h"
 #include "ExceptionOr.h"
 #include "HTMLDocument.h"
 #include "NodeInlines.h"

--- a/Source/WebKitLegacy/mac/DOM/DOMUtility.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUtility.mm
@@ -47,6 +47,7 @@
 #import "DOMTreeWalkerInternal.h"
 #import "DOMXPathExpressionInternal.h"
 #import "DOMXPathResultInternal.h"
+#import <WebCore/DocumentInlines.h>
 #import <WebCore/JSCSSRule.h>
 #import <WebCore/JSCSSRuleList.h>
 #import <WebCore/JSCSSStyleDeclaration.h>


### PR DESCRIPTION
#### 8062f3de28baf85ae278ce06232a7c7a2aac7c80
<pre>
[Build Speed] Remove DocumentInlines.h from all non-Inlines.h headers
<a href="https://rdar.apple.com/160166530">rdar://160166530</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298578">https://bugs.webkit.org/show_bug.cgi?id=298578</a>

Reviewed by Chris Dumez.

Prior to this patch, there were 7 instances of including Document.h in non-Inlines.h headers, the
third largest such header in the WebCore project.

Many of the uses of DocumentInlines.h was to enable using MutationObserverOptions, so this enum
and OptionSet were pulled into its own (inexpensive) header so it could be used directly in Document.h.

Other uses included going from Document to Frame to Page in InspectorInstrumentation, but since the
entry points passing Page were non-inline, there was no benefit to inlining these functions.

DocumentFullscreen.h needed DocumentInlines.h to implement a private, inline nested class; the entire class
was moved into the implementation file. A private page() accessor was moved to the implementation file as well.

Other files included DocumentInlines.h but did not need to, including HTMLDocument.h and XMLDocument.h.

After this patch, no uses of Document.h in non-Inlines.h headers remain.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
* Source/WebCore/bindings/js/JSWindowProxy.cpp:
* Source/WebCore/dom/ChildListMutationScope.h:
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasMutationObserversOfType const):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::page const):
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::hasMutationObserversOfType const): Deleted.
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/MutationObserverInterestGroup.h:
* Source/WebCore/dom/MutationObserverOptions.h:
* Source/WebCore/dom/XMLDocument.h:
* Source/WebCore/html/HTMLDocument.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didAddOrRemoveScrollbars):
(WebCore::InspectorInstrumentation::didReceiveThreadableLoaderResponse):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::didReceiveResponse):
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/xml/DOMParser.cpp:
* Source/WebKitLegacy/mac/DOM/DOMUtility.mm:

Canonical link: <a href="https://commits.webkit.org/299782@main">https://commits.webkit.org/299782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f3ca24b47192ece9bdb61eca984dd8aea4fa8e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/439dd8f6-a18c-4e2d-9a95-a8e81494169a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91248 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60557 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9a717e2-8e7a-480e-86b0-e17d91fa8533) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f619481-2336-4c2b-bb81-8407687d23ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25834 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70126 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129404 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47071 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/35709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99713 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25317 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43702 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46933 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52639 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46401 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->