### PR TITLE
[JSC] Add callee-save registers to BBQ

### DIFF
--- a/Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp
+++ b/Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp
@@ -121,6 +121,16 @@ const RegisterAtOffsetList& RegisterAtOffsetList::ipintCalleeSaveRegisters()
     });
     return result.get();
 }
+
+const RegisterAtOffsetList& RegisterAtOffsetList::bbqCalleeSaveRegisters()
+{
+    static std::once_flag onceKey;
+    static LazyNeverDestroyed<RegisterAtOffsetList> result;
+    std::call_once(onceKey, [] {
+        result.construct(RegisterSetBuilder::bbqCalleeSaveRegisters());
+    });
+    return result.get();
+}
 #endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/RegisterAtOffsetList.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffsetList.h
@@ -71,6 +71,7 @@ public:
 #if ENABLE(WEBASSEMBLY)
     static const RegisterAtOffsetList& wasmPinnedRegisters();
     static const RegisterAtOffsetList& ipintCalleeSaveRegisters(); // Registers and Offsets saved and used by IPInt.
+    static const RegisterAtOffsetList& bbqCalleeSaveRegisters(); // Registers and Offsets saved and used by BBQ.
 #endif
 
 private:

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -443,6 +443,14 @@ RegisterSet RegisterSetBuilder::ipintCalleeSaveRegisters()
 #endif
     return registers;
 }
+
+RegisterSet RegisterSetBuilder::bbqCalleeSaveRegisters()
+{
+    RegisterSet registers;
+    registers.add(GPRInfo::jitDataRegister, IgnoreVectors);
+    ASSERT(!wasmPinnedRegisters().contains(GPRInfo::jitDataRegister, IgnoreVectors));
+    return registers;
+}
 #endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -210,6 +210,7 @@ public:
 #if ENABLE(WEBASSEMBLY)
     JS_EXPORT_PRIVATE static RegisterSet wasmPinnedRegisters();
     JS_EXPORT_PRIVATE static RegisterSet ipintCalleeSaveRegisters(); // Registers saved and used by the IPInt.
+    JS_EXPORT_PRIVATE static RegisterSet bbqCalleeSaveRegisters(); // Registers saved and used by the BBQ JIT.
 #endif
     JS_EXPORT_PRIVATE static RegisterSetBuilder registersToSaveForJSCall(RegisterSetBuilder live);
     JS_EXPORT_PRIVATE static RegisterSetBuilder registersToSaveForCCall(RegisterSetBuilder live);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -330,6 +330,15 @@ public:
             return val;
         }
 
+        ALWAYS_INLINE static Value fromPointer(void* pointer)
+        {
+#if USE(JSVALUE64)
+            return fromI64(std::bit_cast<uintptr_t>(pointer));
+#else
+            return fromI32(std::bit_cast<uintptr_t>(pointer));
+#endif
+        }
+
         ALWAYS_INLINE static Value fromRef(TypeKind refType, EncodedJSValue ref)
         {
             Value val;
@@ -2218,6 +2227,9 @@ private:
 
     void emitIncrementCallSlotCount(unsigned callSlotIndex);
 
+    void emitSaveCalleeSaves();
+    void emitRestoreCalleeSaves();
+
     CCallHelpers& m_jit;
     CalleeGroup& m_calleeGroup;
     IPIntCallee& m_profiledCallee;
@@ -2249,7 +2261,7 @@ private:
     Vector<DataLabelPtr, 1> m_frameSizeLabels;
     int m_frameSize { 0 };
     int m_maxCalleeStackSize { 0 };
-    int m_localStorage { 0 }; // Stack offset pointing to the local with the lowest address.
+    int m_localAndCalleeSaveStorage { 0 }; // Stack offset pointing to the local and callee save with the lowest address.
     bool m_usesSIMD { false }; // Whether the function we are compiling uses SIMD instructions or not.
     bool m_usesExceptions { false };
     Checked<unsigned> m_tryCatchDepth { 0 };

--- a/Source/JavaScriptCore/wasm/WasmCallSlot.h
+++ b/Source/JavaScriptCore/wasm/WasmCallSlot.h
@@ -43,6 +43,7 @@ public:
     }
 
     uint32_t* addressOfCount() { return &m_count; }
+    static constexpr ptrdiff_t offsetOfCount() { return OBJECT_OFFSETOF(CallSlot, m_count); }
 
 private:
     uint32_t m_count { 0 };

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -460,6 +460,12 @@ BBQCallee::~BBQCallee()
     }
 }
 
+
+const RegisterAtOffsetList* BBQCallee::calleeSaveRegistersImpl()
+{
+    return &RegisterAtOffsetList::bbqCalleeSaveRegisters();
+}
+
 #endif
 
 WasmBuiltinCallee::WasmBuiltinCallee(const WebAssemblyBuiltin* builtin, std::pair<const Name*, RefPtr<NameSection>>&& name)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -345,6 +345,7 @@ private:
 
 class BBQCallee final : public OptimizingJITCallee {
     WTF_MAKE_COMPACT_TZONE_ALLOCATED(BBQCallee);
+    friend class Callee;
 public:
     static constexpr unsigned extraOSRValuesForLoopIndex = 1;
 
@@ -406,6 +407,8 @@ private:
     {
     }
 
+    JS_EXPORT_PRIVATE const RegisterAtOffsetList* calleeSaveRegistersImpl();
+
     RefPtr<OMGOSREntryCallee> m_osrEntryCallee;
     TierUpCount m_tierUpCounter;
     std::optional<CodeLocationLabel<WasmEntryPtrTag>> m_sharedLoopEntrypoint;
@@ -440,6 +443,8 @@ public:
 
     FixedVector<CallSlot>& callSlots() { return m_callSlots; }
     const FixedVector<CallSlot>& callSlots() const { return m_callSlots; }
+
+    bool needsProfiling() const { return !m_callSlots.isEmpty(); }
 
     IPIntTierUpCounter& tierUpCounter() { return m_tierUpCounter; }
 


### PR DESCRIPTION
#### 33a0faaaeb62c517d91aeddf897a0c1f4a559cca
<pre>
[JSC] Add callee-save registers to BBQ
<a href="https://bugs.webkit.org/show_bug.cgi?id=298582">https://bugs.webkit.org/show_bug.cgi?id=298582</a>
<a href="https://rdar.apple.com/160168754">rdar://160168754</a>

Reviewed by Yijia Huang and Justin Michaud.

This patch adds GPRInfo::jitDataRegister to Wasm::BBQJIT&apos;s callee-save.
This register will be used for per-instance Function data in BBQJIT so
that we can quickly store interesting information like callsite
profiling (or later, we can put more and more interesting information
and/or support information for BBQJIT).

* Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp:
(JSC::RegisterAtOffsetList::bbqCalleeSaveRegisters):
* Source/JavaScriptCore/jit/RegisterAtOffsetList.h:
* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSetBuilder::bbqCalleeSaveRegisters):
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIncrementCallSlotCount):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoopOSREntrypoint):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitLoopTierUpCheckAndOSREntryData):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReturn):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitTailCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIndirectTailCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::canonicalSlot):
(JSC::Wasm::BBQJIT::emitSaveCalleeSaves):
(JSC::Wasm::BBQJIT::emitRestoreCalleeSaves):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::Value::fromPointer):
* Source/JavaScriptCore/wasm/WasmCallSlot.h:
(JSC::Wasm::CallSlot::offsetOfCount):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::BBQCallee::calleeSaveRegistersImpl):
* Source/JavaScriptCore/wasm/WasmCallee.h:

Canonical link: <a href="https://commits.webkit.org/299759@main">https://commits.webkit.org/299759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95a42d2eb5f0776e2f5d829b52ce69beb522c7a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72099 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a3671892-d7d4-4772-bf47-cfeef85b5529) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91146 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60458 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bec1f5a-71b6-48be-af27-2bfd5ea7561c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71701 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3804903-b3dd-4216-bd91-acf2b828ae80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25730 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69995 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112151 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129276 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118542 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99608 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43567 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19086 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52514 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147241 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46274 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37836 "Found 1 new JSC binary failure: testapi, Found 18650 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push1.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47960 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->