### PR TITLE
Rename `*Class()` soft-linking functions to `*ClassSingleton()`

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
@@ -80,7 +80,8 @@ void configureRequestToUseCPUOrGPU(VNRequest *request)
     for (VNComputeStage computeStage in supportedComputeStageDevices) {
         bool set = false;
         for (id<MLComputeDeviceProtocol> device in supportedComputeStageDevices[computeStage]) {
-            if ([device isKindOfClass:RetainPtr { PAL::getMLGPUComputeDeviceClass() }.get()]) {
+            // FIXME: This is a safer cpp false positive (rdar://160259918).
+            SUPPRESS_UNRETAINED_ARG if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClassSingleton()]) {
                 [request setComputeDevice:device forComputeStage:computeStage];
                 set = true;
                 break;
@@ -88,7 +89,8 @@ void configureRequestToUseCPUOrGPU(VNRequest *request)
         }
         if (!set) {
             for (id<MLComputeDeviceProtocol> device in supportedComputeStageDevices[computeStage]) {
-                if ([device isKindOfClass:RetainPtr { PAL::getMLGPUComputeDeviceClass() }.get()]) {
+                // FIXME: This is a safer cpp false positive (rdar://160259918).
+                SUPPRESS_UNRETAINED_ARG if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClassSingleton()]) {
                     [request setComputeDevice:device forComputeStage:computeStage];
                     break;
                 }

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentAPIVersionCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentAPIVersionCocoa.mm
@@ -49,8 +49,8 @@ unsigned PaymentAPIVersion::current()
 #elif HAVE(PASSKIT_NEW_BUTTON_TYPES)
         return 10;
 #elif HAVE(PASSKIT_INSTALLMENTS)
-        if (PAL::getPKPaymentInstallmentConfigurationClass()) {
-            if (PAL::getPKPaymentInstallmentItemClass())
+        if (PAL::getPKPaymentInstallmentConfigurationClassSingleton()) {
+            if (PAL::getPKPaymentInstallmentItemClassSingleton())
                 return 9;
             return 8;
         }

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -98,8 +98,8 @@ static NSCalendarUnit toCalendarUnit(ApplePayRecurringPaymentDateUnit unit)
 PKRecurringPaymentSummaryItem *platformRecurringSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Recurring);
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKRecurringPaymentSummaryItem> summaryItem = [PAL::getPKRecurringPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    // FIXME: This is a static analysis false positive (rdar://160259918).
+    SUPPRESS_UNRETAINED_ARG RetainPtr<PKRecurringPaymentSummaryItem> summaryItem = [PAL::getPKRecurringPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.recurringPaymentStartDate.isNaN())
         summaryItem.get().startDate = toProtectedDate(lineItem.recurringPaymentStartDate).get();
     summaryItem.get().intervalUnit = toCalendarUnit(lineItem.recurringPaymentIntervalUnit);
@@ -116,8 +116,8 @@ PKRecurringPaymentSummaryItem *platformRecurringSummaryItem(const ApplePayLineIt
 PKDeferredPaymentSummaryItem *platformDeferredSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Deferred);
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKDeferredPaymentSummaryItem> summaryItem = [PAL::getPKDeferredPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    // FIXME: This is a static analysis false positive (rdar://160259918).
+    SUPPRESS_UNRETAINED_ARG RetainPtr<PKDeferredPaymentSummaryItem> summaryItem = [PAL::getPKDeferredPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.deferredPaymentDate.isNaN())
         summaryItem.get().deferredDate = toProtectedDate(lineItem.deferredPaymentDate).get();
     return summaryItem.get();
@@ -130,8 +130,8 @@ PKDeferredPaymentSummaryItem *platformDeferredSummaryItem(const ApplePayLineItem
 PKAutomaticReloadPaymentSummaryItem *platformAutomaticReloadSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::AutomaticReload);
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKAutomaticReloadPaymentSummaryItem> summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    // FIXME: This is a static analysis false positive (rdar://160259918).
+    SUPPRESS_UNRETAINED_ARG RetainPtr<PKAutomaticReloadPaymentSummaryItem> summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     summaryItem.get().thresholdAmount = toProtectedDecimalNumber(lineItem.automaticReloadPaymentThresholdAmount).get();
     return summaryItem.get();
 }
@@ -143,15 +143,15 @@ PKAutomaticReloadPaymentSummaryItem *platformAutomaticReloadSummaryItem(const Ap
 PKDisbursementSummaryItem *platformDisbursementSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::Disbursement);
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKDisbursementSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get()];
+    // FIXME: This is a static analysis false positive (rdar://160259918).
+    SUPPRESS_UNRETAINED_ARG return [PAL::getPKDisbursementSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get()];
 }
 
 PKInstantFundsOutFeeSummaryItem *platformInstantFundsOutFeeSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::InstantFundsOutFee);
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKInstantFundsOutFeeSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get()];
+    // FIXME: This is a static analysis false positive (rdar://160259918).
+    SUPPRESS_UNRETAINED_ARG return [PAL::getPKInstantFundsOutFeeSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get()];
 }
 
 #endif // HAVE(PASSKIT_DISBURSEMENTS)
@@ -189,8 +189,8 @@ PKPaymentSummaryItem *platformSummaryItem(const ApplePayLineItem& lineItem)
 #endif
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    // FIXME: This is a static analysis false positive (rdar://160259918).
+    SUPPRESS_UNRETAINED_ARG return [PAL::getPKPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
 }
 
 #if HAVE(PASSKIT_DISBURSEMENTS)

--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
@@ -48,9 +48,9 @@ std::optional<OutputContext>& OutputContext::sharedAudioPresentationOutputContex
 {
     static NeverDestroyed<std::optional<OutputContext>> sharedAudioPresentationOutputContext = [] () -> std::optional<OutputContext> {
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-        AVOutputContext* context = [getAVOutputContextClass() sharedSystemAudioContext];
+        AVOutputContext* context = [getAVOutputContextClassSingleton() sharedSystemAudioContext];
 #else
-        auto context = [getAVOutputContextClass() sharedAudioPresentationOutputContext];
+        auto context = [getAVOutputContextClassSingleton() sharedAudioPresentationOutputContext];
 #endif
         if (!context)
             return std::nullopt;

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -34,7 +34,7 @@
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, AVFoundation)
 
 // Note: We don't define accessor macros for classes (e.g.
-//    #define AVAssetCache PAL::getAVAssetCacheClass()
+//    #define AVAssetCache PAL::getAVAssetCacheClassSingleton()
 // because they make it difficult to use the class name in source code.
 
 SOFT_LINK_CLASS_FOR_HEADER(PAL, AVAsset)
@@ -443,9 +443,9 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVContentKeyRequestSho
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVContentKeyRequestRandomDeviceIdentifierSeedKey, NSString *)
 #define AVContentKeyRequestRandomDeviceIdentifierSeedKey PAL::get_AVFoundation_AVContentKeyRequestRandomDeviceIdentifierSeedKey()
 
-SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferAudioRenderer, PAL::getAVSampleBufferAudioRendererClass())
-SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferDisplayLayer, PAL::getAVSampleBufferDisplayLayerClass())
-SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferVideoRenderer, PAL::getAVSampleBufferVideoRendererClass())
-SPECIALIZE_OBJC_TYPE_TRAITS(AVOutputContext, PAL::getAVOutputContextClass())
+SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferAudioRenderer, PAL::getAVSampleBufferAudioRendererClassSingleton())
+SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferDisplayLayer, PAL::getAVSampleBufferDisplayLayerClassSingleton())
+SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferVideoRenderer, PAL::getAVSampleBufferVideoRendererClassSingleton())
+SPECIALIZE_OBJC_TYPE_TRAITS(AVOutputContext, PAL::getAVOutputContextClassSingleton())
 
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
@@ -60,6 +60,6 @@ SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleSepara
 
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMaterial, MTVisualStylingCreateDictionaryRepresentation, NSDictionary *, (MTCoreMaterialRecipe recipe, MTCoreMaterialVisualStyleCategory category, MTCoreMaterialVisualStyle style, NSDictionary *options), (recipe, category, style, options))
 
-SPECIALIZE_OBJC_TYPE_TRAITS(MTMaterialLayer, PAL::getMTMaterialLayerClass())
+SPECIALIZE_OBJC_TYPE_TRAITS(MTMaterialLayer, PAL::getMTMaterialLayerClassSingleton())
 
 #endif // HAVE(CORE_MATERIAL)

--- a/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.mm
+++ b/Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.mm
@@ -49,7 +49,7 @@ bool isLockdownModeEnabled()
 {
 #if HAVE(LOCKDOWN_MODE_FRAMEWORK)
     if (LockdownModeLibrary())
-        return [(LockdownModeManager *)[getLockdownModeManagerClass() shared] enabled];
+        return [(LockdownModeManager *)[getLockdownModeManagerClassSingleton() shared] enabled];
 #endif
 
     // FIXME(<rdar://108208100>): Remove this fallback once recoveryOS includes the framework.

--- a/Source/WebCore/PAL/pal/cocoa/RevealSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/RevealSoftLink.mm
@@ -28,7 +28,7 @@
 #if ENABLE(REVEAL)
 
 #import <pal/spi/cocoa/RevealSPI.h>
-#import <wtf/SoftLinking.h>
+#import <wtf/cocoa/SoftLinking.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, Reveal, PAL_EXPORT)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(PAL, Reveal, RVPresenter, PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.h
+++ b/Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.h
@@ -62,12 +62,12 @@ inline WKDDActionContext *allocWKDDActionContextInstance()
 }
 
 #ifdef __OBJC__
-inline Class getWKDDActionContextClass()
+inline Class getWKDDActionContextClassSingleton()
 {
 #if HAVE(SECURE_ACTION_CONTEXT)
-    return getDDSecureActionContextClass();
+    return getDDSecureActionContextClassSingleton();
 #else
-    return getDDActionContextClass();
+    return getDDActionContextClassSingleton();
 #endif
 }
 #endif

--- a/Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.mm
+++ b/Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.mm
@@ -28,7 +28,7 @@
 
 #import <AppKit/AppKit.h>
 #import <pal/spi/mac/DataDetectorsSPI.h>
-#import <wtf/SoftLinking.h>
+#import <wtf/cocoa/SoftLinking.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, DataDetectors, PAL_EXPORT)
 

--- a/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
+++ b/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
@@ -70,7 +70,7 @@ private:
         ensureOnMainRunLoop([this, shouldKeepScreenAwake] {
             if (m_screenWakeLockHandler && m_screenWakeLockHandler(shouldKeepScreenAwake))
                 return;
-            [[PAL::getUIApplicationClass() sharedApplication] _setIdleTimerDisabled:shouldKeepScreenAwake forReason:@"WebKit SleepDisabler"];
+            [[PAL::getUIApplicationClassSingleton() sharedApplication] _setIdleTimerDisabled:shouldKeepScreenAwake forReason:@"WebKit SleepDisabler"];
         });
     }
     ScreenSleepDisablerCounter m_screenSleepDisablerCount;

--- a/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm
+++ b/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm
@@ -93,7 +93,7 @@ bool updateCurrentUserInterfaceIdiom()
     // Since daemons don't ever run in an iPhone-app-on-iPad jail, this will be accurate in the daemon case,
     // but is not sufficient in the application case.
     UserInterfaceIdiom newIdiom = [&] {
-        if (![PAL::getUIApplicationClass() sharedApplication]) {
+        if (![PAL::getUIApplicationClassSingleton() sharedApplication]) {
             if (PAL::deviceClassIsDesktop())
                 return UserInterfaceIdiom::Desktop;
             if (PAL::deviceClassIsSmallScreen() || shouldForceUserInterfaceIdiomSmallScreen())
@@ -101,7 +101,7 @@ bool updateCurrentUserInterfaceIdiom()
             if (PAL::deviceClassIsVision())
                 return UserInterfaceIdiom::Vision;
         } else {
-            auto idiom = [[PAL::getUIDeviceClass() currentDevice] userInterfaceIdiom];
+            auto idiom = [[PAL::getUIDeviceClassSingleton() currentDevice] userInterfaceIdiom];
             if (idiom == UIUserInterfaceIdiomPad || idiom == UIUserInterfaceIdiomMac)
                 return UserInterfaceIdiom::Desktop;
             if (idiom == UIUserInterfaceIdiomPhone || idiom == UIUserInterfaceIdiomWatch || shouldForceUserInterfaceIdiomSmallScreen(idiom))

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -145,7 +145,6 @@ platform/graphics/cocoa/GraphicsContextGLCocoa.mm
 platform/graphics/cocoa/IOSurface.mm
 platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
-platform/graphics/cocoa/SystemFontDatabaseCocoa.mm
 platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
 platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -175,7 +174,6 @@ platform/graphics/mac/controls/WebControlView.mm
 platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
 platform/ios/WebAVPlayerController.mm
 platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
-platform/mac/CursorMac.mm
 platform/mac/DataDetectorHighlight.mm
 platform/mac/HIDDevice.cpp
 platform/mac/PasteboardMac.mm

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -428,7 +428,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     auto extendedDescription = backingObject->extendedDescription();
     if (extendedDescription.length()) {
         accessibilityCustomContent = adoptNS([[NSMutableArray alloc] init]);
-        Class customContentClass = PAL::getAXCustomContentClass();
+        Class customContentClass = PAL::getAXCustomContentClassSingleton();
         AXCustomContent *contentItem = [customContentClass customContentWithLabel:WEB_UI_STRING("description", "description detail").createNSString().get() value:extendedDescription.createNSString().get()];
         // Set this to high, so that it's always spoken.
         [contentItem setImportance:AXCustomContentImportanceHigh];

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -50,19 +50,19 @@
 #define PlatformNSTextTableBlock        NSTextTableBlock.class
 #else
 #define PlatformColor                   UIColor
-#define PlatformColorClass              PAL::getUIColorClass()
+#define PlatformColorClass              PAL::getUIColorClassSingleton()
 #define PlatformFont                    UIFont
-#define PlatformFontClass               PAL::getUIFontClass()
-#define PlatformImageClass              PAL::getUIImageClass()
-#define PlatformNSColorClass            getNSColorClass()
-#define PlatformNSParagraphStyle        PAL::getNSParagraphStyleClass()
-#define PlatformNSPresentationIntent    PAL::getNSPresentationIntentClass()
-#define PlatformNSShadow                PAL::getNSShadowClass()
-#define PlatformNSTextAttachment        getNSTextAttachmentClass()
-#define PlatformNSTextList              getNSTextListClass()
-#define PlatformNSTextTab               getNSTextTabClass()
-#define PlatformNSTextTable             getNSTextTableClass()
-#define PlatformNSTextTableBlock        getNSTextTableBlockClass()
+#define PlatformFontClass               PAL::getUIFontClassSingleton()
+#define PlatformImageClass              PAL::getUIImageClassSingleton()
+#define PlatformNSColorClass            getNSColorClassSingleton()
+#define PlatformNSParagraphStyle        PAL::getNSParagraphStyleClassSingleton()
+#define PlatformNSPresentationIntent    PAL::getNSPresentationIntentClassSingleton()
+#define PlatformNSShadow                PAL::getNSShadowClassSingleton()
+#define PlatformNSTextAttachment        getNSTextAttachmentClassSingleton()
+#define PlatformNSTextList              getNSTextListClassSingleton()
+#define PlatformNSTextTab               getNSTextTabClassSingleton()
+#define PlatformNSTextTable             getNSTextTableClassSingleton()
+#define PlatformNSTextTableBlock        getNSTextTableBlockClassSingleton()
 #endif
 
 OBJC_CLASS NSAttributedString;

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -704,7 +704,7 @@ static NSArray * processDataDetectorScannerResults(DDScannerRef scanner, OptionS
     if (lastTextNodeToUpdate)
         lastTextNodeToUpdate->setData(lastNodeContent);
 
-    return [PAL::getDDScannerResultClass() resultsFromCoreResults:scannerResults.get()];
+    return [PAL::getDDScannerResultClassSingleton() resultsFromCoreResults:scannerResults.get()];
 }
 
 // This is the async version of `detectContentInRange` and should be preferred.

--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -225,7 +225,7 @@ SOFT_LINK(UIKitMacHelper, UINSSharedRevealController, id<UINSRevealController>, 
     WebCore::CGContextStateSaver saveState(context);
     CGAffineTransform contextTransform = CGContextGetCTM(context);
     CGFloat backingScale = contextTransform.a;
-    CGFloat macCatalystScaleFactor = [PAL::getUIApplicationClass() sharedApplication]._iOSMacScale;
+    CGFloat macCatalystScaleFactor = [PAL::getUIApplicationClassSingleton() sharedApplication]._iOSMacScale;
     CGAffineTransform transform = CGAffineTransformMakeScale(macCatalystScaleFactor * backingScale, macCatalystScaleFactor * backingScale);
     CGContextSetCTM(context, transform);
     
@@ -252,7 +252,7 @@ static bool canCreateRevealItems()
     static bool result;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] {
-        result = PAL::isRevealCoreFrameworkAvailable() && PAL::getRVItemClass();
+        result = PAL::isRevealCoreFrameworkAvailable() && PAL::getRVItemClassSingleton();
     });
     return result;
 }
@@ -348,7 +348,7 @@ std::optional<SimpleRange> DictionaryLookup::rangeAtHitTestResult(const HitTestR
         hitIndex = characterCount(*makeSimpleRange(fullCharacterRange->start, position));
     }
 
-    NSRange selectedRange = [PAL::getRVSelectionClass() revealRangeAtIndex:hitIndex selectedRanges:@[[NSValue valueWithRange:selectionRange]] shouldUpdateSelection:nil];
+    NSRange selectedRange = [PAL::getRVSelectionClassSingleton() revealRangeAtIndex:hitIndex selectedRanges:@[[NSValue valueWithRange:selectionRange]] shouldUpdateSelection:nil];
 
     String itemString = plainText(*fullCharacterRange);
     auto highlightRange = adoptNS([PAL::allocRVItemInstance() initWithText:itemString.createNSString().get() selectedRange:selectedRange]).get().highlightRange;
@@ -430,7 +430,7 @@ static WKRevealController showPopupOrCreateAnimationController(bool createAnimat
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     
 #if PLATFORM(MAC)
-    if (!PAL::isRevealFrameworkAvailable() || !canCreateRevealItems() || !PAL::getRVPresenterClass())
+    if (!PAL::isRevealFrameworkAvailable() || !canCreateRevealItems() || !PAL::getRVPresenterClassSingleton())
         return nil;
 
     auto textIndicator = dictionaryPopupInfo.textIndicator;

--- a/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
@@ -105,7 +105,7 @@ RetainPtr<NSTextList> TextList::createTextList() const
 #if PLATFORM(MAC)
     Class textListClass = NSTextList.class;
 #else
-    Class textListClass = PAL::getNSTextListClass();
+    Class textListClass = PAL::getNSTextListClassSingleton();
 #endif
     auto result = adoptNS([[textListClass alloc] initWithMarkerFormat:cocoaTextListMarkerName(styleType, ordered) options:0]);
     [result setStartingItemNumber:startingItemNumber];
@@ -135,7 +135,7 @@ RetainPtr<NSDictionary> FontAttributes::createDictionary() const
 #if PLATFORM(MAC)
     Class paragraphStyleClass = NSParagraphStyle.class;
 #else
-    Class paragraphStyleClass = PAL::getNSParagraphStyleClass();
+    Class paragraphStyleClass = PAL::getNSParagraphStyleClassSingleton();
 #endif
     auto style = adoptNS([[paragraphStyleClass defaultParagraphStyle] mutableCopy]);
 

--- a/Source/WebCore/editing/cocoa/FontShadowCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontShadowCocoa.mm
@@ -40,7 +40,7 @@ RetainPtr<NSShadow> FontShadow::createShadow() const
 #if USE(APPKIT)
     auto shadow = adoptNS([NSShadow new]);
 #elif PLATFORM(IOS_FAMILY)
-    auto shadow = adoptNS([PAL::getNSShadowClass() new]);
+    auto shadow = adoptNS([PAL::getNSShadowClassSingleton() new]);
 #endif
     [shadow setShadowColor:cocoaColor(color).get()];
     [shadow setShadowOffset:offset];

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -1194,7 +1194,7 @@ void HTMLConverter::_newTabForElement(Element& element)
     _flags.isSoft = YES;
 }
 
-static Class _WebMessageDocumentClass()
+static Class _WebMessageDocumentClassSingleton()
 {
     static Class _WebMessageDocumentClass = Nil;
     static BOOL lookedUpClass = NO;
@@ -1283,7 +1283,7 @@ BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL 
 #endif
     if (!fileWrapper && !notFound && url) {
         // Special handling for Mail attachments, until WebKit provides a standard way to get the data.
-        Class WebMessageDocumentClass = _WebMessageDocumentClass();
+        Class WebMessageDocumentClass = _WebMessageDocumentClassSingleton();
         if (WebMessageDocumentClass) {
             NSTextAttachment *mimeTextAttachment = nil;
             [WebMessageDocumentClass document:NULL attachment:&mimeTextAttachment forURL:url];

--- a/Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm
+++ b/Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm
@@ -46,7 +46,7 @@ CocoaImage *webCoreTextAttachmentMissingPlatformImage()
     dispatch_once(&once, ^{
         RetainPtr webCoreBundle = [NSBundle bundleWithIdentifier:@"com.apple.WebCore"];
 #if PLATFORM(IOS_FAMILY)
-        RetainPtr image = [PAL::getUIImageClass() imageNamed:@"missingImage" inBundle:webCoreBundle.get() compatibleWithTraitCollection:nil];
+        RetainPtr image = [PAL::getUIImageClassSingleton() imageNamed:@"missingImage" inBundle:webCoreBundle.get() compatibleWithTraitCollection:nil];
 #else
         RetainPtr image = [webCoreBundle imageForResource:@"missingImage"];
 #endif

--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
@@ -52,14 +52,14 @@ void AudioSessionCocoa::setEligibleForSmartRoutingInternal(bool eligible)
     if (!AudioSession::shouldManageAudioSessionCategory())
         return;
 
-    static bool supportsEligibleForBT = [PAL::getAVAudioSessionClass() instancesRespondToSelector:@selector(setEligibleForBTSmartRoutingConsideration:error:)]
-        && [PAL::getAVAudioSessionClass() instancesRespondToSelector:@selector(eligibleForBTSmartRoutingConsideration)];
+    static bool supportsEligibleForBT = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setEligibleForBTSmartRoutingConsideration:error:)]
+        && [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(eligibleForBTSmartRoutingConsideration)];
     if (!supportsEligibleForBT)
         return;
 
     RELEASE_LOG(Media, "AudioSession::setEligibleForSmartRouting() %s", eligible ? "true" : "false");
 
-    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
+    AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     if (session.eligibleForBTSmartRoutingConsideration == eligible)
         return;
 
@@ -95,8 +95,8 @@ void AudioSessionCocoa::setEligibleForSmartRouting(bool isEligible, ForceUpdate 
 bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
 {
 #if HAVE(AVAUDIOSESSION)
-    static bool supportsSharedInstance = [PAL::getAVAudioSessionClass() respondsToSelector:@selector(sharedInstance)];
-    static bool supportsSetActive = [PAL::getAVAudioSessionClass() instancesRespondToSelector:@selector(setActive:withOptions:error:)];
+    static bool supportsSharedInstance = [PAL::getAVAudioSessionClassSingleton() respondsToSelector:@selector(sharedInstance)];
+    static bool supportsSetActive = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setActive:withOptions:error:)];
 
     if (!supportsSharedInstance)
         return true;
@@ -114,7 +114,7 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
         m_workQueue->dispatchSync([&success] {
             NSError *error = nil;
             if (supportsSetActive)
-                [[PAL::getAVAudioSessionClass() sharedInstance] setActive:YES withOptions:0 error:&error];
+                [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:YES withOptions:0 error:&error];
             if (error)
                 RELEASE_LOG_ERROR(Media, "failed to activate audio session, error: %@", error.localizedDescription);
             success = !error;
@@ -125,7 +125,7 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
     m_workQueue->dispatch([] {
         NSError *error = nil;
         if (supportsSetActive)
-            [[PAL::getAVAudioSessionClass() sharedInstance] setActive:NO withOptions:0 error:&error];
+            [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:NO withOptions:0 error:&error];
         if (error)
             RELEASE_LOG_ERROR(Media, "failed to deactivate audio session, error: %@", error.localizedDescription);
     });

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -584,7 +584,7 @@ std::optional<bool> MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForCon
 
 static id<MRNowPlayingActivityUIControllable> nowPlayingActivityController()
 {
-    static id<MRNowPlayingActivityUIControllable> controller = RetainPtr([getMRUIControllerProviderClass() nowPlayingActivityController]).leakRef();
+    static id<MRNowPlayingActivityUIControllable> controller = RetainPtr([getMRUIControllerProviderClassSingleton() nowPlayingActivityController]).leakRef();
     return controller;
 }
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -248,7 +248,7 @@ void MediaSessionHelper::providePresentingApplicationPID(ProcessID)
 void MediaSessionHelper::updateActiveAudioRouteSupportsSpatialPlayback()
 {
 #if HAVE(AVAUDIOSESSION)
-    AVAudioSession* audioSession = [PAL::getAVAudioSessionClass() sharedInstance];
+    AVAudioSession* audioSession = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     for (AVAudioSessionPortDescription* output in audioSession.currentRoute.outputs) {
         if (output.spatialAudioEnabled) {
             setActiveAudioRouteSupportsSpatialPlayback(true);
@@ -295,7 +295,7 @@ void MediaSessionHelperIOS::providePresentingApplicationPID(ProcessID pid)
     m_presentedApplicationPID = pid;
 
     NSError *error = nil;
-    [[getAVSystemControllerClass() sharedAVSystemController] setAttribute:@(pid) forKey:getAVSystemController_PIDToInheritApplicationStateFrom() error:&error];
+    [[getAVSystemControllerClassSingleton() sharedAVSystemController] setAttribute:@(pid) forKey:getAVSystemController_PIDToInheritApplicationStateFrom() error:&error];
     if (error)
         RELEASE_LOG_ERROR(Media, "Failed to set AVSystemController_PIDToInheritApplicationStateFrom: %@", error.localizedDescription);
 #else
@@ -336,7 +336,7 @@ void MediaSessionHelperIOS::mediaServerConnectionDied()
 void MediaSessionHelperIOS::updateCarPlayIsConnected()
 {
 #if HAVE(AVAUDIOSESSION)
-    AVAudioSession *audioSession = [PAL::getAVAudioSessionClass() sharedInstance];
+    AVAudioSession *audioSession = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     for (AVAudioSessionPortDescription *output in audioSession.currentRoute.outputs) {
         if ([output.portType isEqualToString:AVAudioSessionPortCarAudio]) {
             setIsPlayingToAutomotiveHeadUnit(true);
@@ -407,7 +407,7 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     // Now playing won't work unless we turn on the delivery of remote control events.
     RunLoop::mainSingleton().dispatch([] {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        [[PAL::getUIApplicationClass() sharedApplication] beginReceivingRemoteControlEvents];
+        [[PAL::getUIApplicationClassSingleton() sharedApplication] beginReceivingRemoteControlEvents];
         END_BLOCK_OBJC_EXCEPTIONS
     });
 

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
@@ -94,7 +94,7 @@ void SharedRoutingArbitrator::beginRoutingArbitrationForToken(const SharedRoutin
         }
 
         ALWAYS_LOG_IF(m_logger, identifier, "leaving current arbitration");
-        [[PAL::getAVAudioRoutingArbiterClass() sharedRoutingArbiter] leaveArbitration];
+        [[PAL::getAVAudioRoutingArbiterClassSingleton() sharedRoutingArbiter] leaveArbitration];
     }
 
     m_currentCategory = requestedCategory;
@@ -122,7 +122,7 @@ void SharedRoutingArbitrator::beginRoutingArbitrationForToken(const SharedRoutin
         callback(error, routeChanged);
     });
 
-    [[PAL::getAVAudioRoutingArbiterClass() sharedRoutingArbiter] beginArbitrationWithCategory:arbitrationCategory completionHandler:[this, identifier = WTFMove(identifier)](BOOL defaultDeviceChanged, NSError * _Nullable error) mutable {
+    [[PAL::getAVAudioRoutingArbiterClassSingleton() sharedRoutingArbiter] beginArbitrationWithCategory:arbitrationCategory completionHandler:[this, identifier = WTFMove(identifier)](BOOL defaultDeviceChanged, NSError * _Nullable error) mutable {
         callOnMainRunLoop([this, defaultDeviceChanged, error = retainPtr(error), identifier = WTFMove(identifier)] {
             if (error)
                 ERROR_LOG(identifier, error.get(), ", routeChanged = ", !!defaultDeviceChanged);
@@ -154,7 +154,7 @@ void SharedRoutingArbitrator::endRoutingArbitrationForToken(const SharedRoutingA
 
     m_enqueuedCallbacks.clear();
     m_currentCategory.reset();
-    [[PAL::getAVAudioRoutingArbiterClass() sharedRoutingArbiter] leaveArbitration];
+    [[PAL::getAVAudioRoutingArbiterClassSingleton() sharedRoutingArbiter] leaveArbitration];
 }
 
 void SharedRoutingArbitrator::setLogger(const Logger& logger)

--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -116,7 +116,7 @@ Vector<uint8_t> ContentFilterUnblockHandler::webFilterEvaluatorData() const
 static RetainPtr<WebFilterEvaluator> unpackWebFilterEvaluatorData(Vector<uint8_t>&& vector)
 {
     NSError *error { nil };
-    NSSet<Class> *classes = [NSSet setWithObjects:getWebFilterEvaluatorClass(), NSNumber.class, NSURL.class, NSString.class, NSMutableString.class, nil];
+    NSSet<Class> *classes = [NSSet setWithObjects:getWebFilterEvaluatorClassSingleton(), NSNumber.class, NSURL.class, NSString.class, NSMutableString.class, nil];
     RetainPtr data = toNSDataNoCopy(vector.span(), FreeWhenDone::No);
     return [NSKeyedUnarchiver _strictlyUnarchivedObjectOfClasses:classes fromData:data.get() error:&error];
 }

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -69,7 +69,7 @@ bool ParentalControlsContentFilter::enabled() const
 #endif // HAVE(WEBCONTENTRESTRICTIONS)
 
 #if HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
-    bool enabled = [getWebFilterEvaluatorClass() isManagedSession];
+    bool enabled = [getWebFilterEvaluatorClassSingleton() isManagedSession];
     LOG(ContentFiltering, "ParentalControlsContentFilter is %s.\n", enabled ? "enabled" : "not enabled");
     return enabled;
 #else

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -46,9 +46,9 @@ namespace WebCore {
 static bool wcrBrowserEngineClientEnabled(const String& path)
 {
     if (!path.isEmpty())
-        return [PAL::getWCRBrowserEngineClientClass() shouldEvaluateURLsForConfigurationAtPath:path.createNSString().get()];
+        return [PAL::getWCRBrowserEngineClientClassSingleton() shouldEvaluateURLsForConfigurationAtPath:path.createNSString().get()];
 
-    return [PAL::getWCRBrowserEngineClientClass() shouldEvaluateURLs];
+    return [PAL::getWCRBrowserEngineClientClassSingleton() shouldEvaluateURLs];
 }
 
 static HashMap<String, UniqueRef<ParentalControlsURLFilter>>& allFiltersWithConfigurationPath()
@@ -79,7 +79,7 @@ ParentalControlsURLFilter::ParentalControlsURLFilter(const String& configuration
 
 static bool wcrBrowserEngineClientEnabled()
 {
-    return [PAL::getWCRBrowserEngineClientClass() shouldEvaluateURLs];
+    return [PAL::getWCRBrowserEngineClientClassSingleton() shouldEvaluateURLs];
 }
 
 ParentalControlsURLFilter& ParentalControlsURLFilter::singleton()

--- a/Source/WebCore/platform/cocoa/PlatformNSAdaptiveImageGlyph.h
+++ b/Source/WebCore/platform/cocoa/PlatformNSAdaptiveImageGlyph.h
@@ -37,7 +37,7 @@
 
 #import <UIKit/NSAdaptiveImageGlyph.h>
 
-#define PlatformNSAdaptiveImageGlyph getNSAdaptiveImageGlyphClass()
+#define PlatformNSAdaptiveImageGlyph getNSAdaptiveImageGlyphClassSingleton()
 
 #endif
 

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -137,7 +137,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     RetainPtr<NSString> voiceLanguage;
     if (!utteranceVoice || utteranceVoice->voiceURI().isEmpty()) {
         if (utterance->lang().isEmpty())
-            voiceLanguage = [PAL::getAVSpeechSynthesisVoiceClass() currentLanguageCode];
+            voiceLanguage = [PAL::getAVSpeechSynthesisVoiceClassSingleton() currentLanguageCode];
         else
             voiceLanguage = utterance->lang().createNSString();
     } else
@@ -145,12 +145,12 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
 
     AVSpeechSynthesisVoice *avVoice = nil;
     if (utteranceVoice)
-        avVoice = [PAL::getAVSpeechSynthesisVoiceClass() voiceWithIdentifier:utteranceVoice->voiceURI().createNSString().get()];
+        avVoice = [PAL::getAVSpeechSynthesisVoiceClassSingleton() voiceWithIdentifier:utteranceVoice->voiceURI().createNSString().get()];
 
     if (!avVoice)
-        avVoice = [PAL::getAVSpeechSynthesisVoiceClass() voiceWithLanguage:voiceLanguage.get()];
+        avVoice = [PAL::getAVSpeechSynthesisVoiceClassSingleton() voiceWithLanguage:voiceLanguage.get()];
 
-    AVSpeechUtterance *avUtterance = [PAL::getAVSpeechUtteranceClass() speechUtteranceWithString:utterance->text().createNSString().get()];
+    AVSpeechUtterance *avUtterance = [PAL::getAVSpeechUtteranceClassSingleton() speechUtteranceWithString:utterance->text().createNSString().get()];
 
     [avUtterance setRate:[self mapSpeechRateToPlatformRate:utterance->rate()]];
     [avUtterance setVolume:utterance->volume()];
@@ -296,7 +296,7 @@ void PlatformSpeechSynthesizer::initializeVoiceList()
     // SpeechSynthesis replaces on-device compact with higher quality compact voices. These
     // are not available to WebKit so we're losing these default voices for WebSpeech.
     // Only show built-in voices when requesting through WebKit to reduce fingerprinting surface area.
-    for (AVSpeechSynthesisVoice *voice in [PAL::getAVSpeechSynthesisVoiceClass() speechVoicesIncludingSuperCompact]) {
+    for (AVSpeechSynthesisVoice *voice in [PAL::getAVSpeechSynthesisVoiceClassSingleton() speechVoicesIncludingSuperCompact]) {
         if (voice.isSystemVoice)
             m_voiceList.append(PlatformSpeechSynthesisVoice::create(voice.identifier, voice.name, voice.language, true, true));
     }

--- a/Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm
+++ b/Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm
@@ -56,7 +56,7 @@ RetainPtr<VKCImageAnalysis> TextRecognitionResult::decodeVKCImageAnalysis(Retain
     // be reached from outside the web content process to prevent sandbox escapes.
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(isInWebProcess());
 
-    return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getVKCImageAnalysisClass() fromData:data.get() error:nil];
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getVKCImageAnalysisClassSingleton() fromData:data.get() error:nil];
 }
 
 RetainPtr<NSAttributedString> stringForRange(const TextRecognitionResult& result, const CharacterRange& range)

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -152,7 +152,7 @@ private:
 
 - (void)setPlayerController:(AVPlayerController *)playerController
 {
-    ASSERT(!playerController || [playerController isKindOfClass:webAVPlayerControllerClass()]);
+    ASSERT(!playerController || [playerController isKindOfClass:webAVPlayerControllerClassSingleton()]);
     _playerController = (WebAVPlayerController *)playerController;
 }
 

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -84,8 +84,8 @@ static AVPlayerLayer *WebAVPlayerLayerView_playerLayer(id aSelf, SEL)
 {
     __AVPlayerLayerView *playerLayerView = aSelf;
 
-    if ([get__AVPlayerLayerViewClass() instancesRespondToSelector:@selector(playerLayer)]) {
-        objc_super superClass { playerLayerView, get__AVPlayerLayerViewClass() };
+    if ([get__AVPlayerLayerViewClassSingleton() instancesRespondToSelector:@selector(playerLayer)]) {
+        objc_super superClass { playerLayerView, get__AVPlayerLayerViewClassSingleton() };
         auto superClassMethod = reinterpret_cast<AVPlayerLayer *(*)(objc_super *, SEL)>(objc_msgSendSuper);
         return superClassMethod(&superClass, @selector(playerLayer));
     }
@@ -100,7 +100,7 @@ static UIView *WebAVPlayerLayerView_videoView(id aSelf, SEL)
     CALayer* videoLayer = [webAVPlayerLayer videoSublayer];
     if (!videoLayer || !videoLayer.delegate)
         return nil;
-    ASSERT([[videoLayer delegate] isKindOfClass:PAL::getUIViewClass()]);
+    ASSERT([[videoLayer delegate] isKindOfClass:PAL::getUIViewClassSingleton()]);
     return (UIView *)[videoLayer delegate];
 }
 
@@ -161,7 +161,7 @@ static void WebAVPlayerLayerView_dealloc(id aSelf, SEL)
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
     [playerLayerView setValue:nil forKey:pictureInPicturePlayerLayerViewKey];
 #endif
-    objc_super superClass { playerLayerView, get__AVPlayerLayerViewClass() };
+    objc_super superClass { playerLayerView, get__AVPlayerLayerViewClassSingleton() };
     auto super_dealloc = reinterpret_cast<void(*)(objc_super*, SEL)>(objc_msgSendSuper);
     super_dealloc(&superClass, @selector(dealloc));
 }
@@ -173,8 +173,8 @@ WebAVPlayerLayerView *allocWebAVPlayerLayerViewInstance()
     static Class theClass = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        ASSERT(get__AVPlayerLayerViewClass());
-        theClass = objc_allocateClassPair(get__AVPlayerLayerViewClass(), "WebAVPlayerLayerView", 0);
+        ASSERT(get__AVPlayerLayerViewClassSingleton());
+        theClass = objc_allocateClassPair(get__AVPlayerLayerViewClassSingleton(), "WebAVPlayerLayerView", 0);
         class_addMethod(theClass, @selector(dealloc), (IMP)WebAVPlayerLayerView_dealloc, "v@:");
         class_addMethod(theClass, @selector(transferVideoViewTo:), (IMP)WebAVPlayerLayerView_transferVideoViewTo, "v@:@");
         class_addMethod(theClass, @selector(setPlayerController:), (IMP)WebAVPlayerLayerView_setPlayerController, "v@:@");
@@ -208,7 +208,7 @@ WebAVPictureInPicturePlayerLayerView *allocWebAVPictureInPicturePlayerLayerViewI
     static Class theClass = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        theClass = objc_allocateClassPair(PAL::getUIViewClass(), "WebAVPictureInPicturePlayerLayerView", 0);
+        theClass = objc_allocateClassPair(PAL::getUIViewClassSingleton(), "WebAVPictureInPicturePlayerLayerView", 0);
         objc_registerClassPair(theClass);
         Class metaClass = objc_getMetaClass("WebAVPictureInPicturePlayerLayerView");
         class_addMethod(metaClass, @selector(layerClass), (IMP)WebAVPictureInPicturePlayerLayerView_layerClass, "@@:");

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -183,7 +183,7 @@ void GameControllerGamepadProvider::prewarmGameControllerDevicesIfNecessary()
         return;
 
     LOG(Gamepad, "GameControllerGamepadProvider explicitly starting GameController framework monitoring");
-    [getGCControllerClass() __openXPC_and_CBApplicationDidBecomeActive__];
+    [getGCControllerClassSingleton() __openXPC_and_CBApplicationDidBecomeActive__];
 
     init_GameController_GCInputButtonA();
     init_GameController_GCInputButtonB();
@@ -229,7 +229,7 @@ void GameControllerGamepadProvider::startMonitoringGamepads(GamepadProviderClien
         }];
     }
 
-    auto *controllers = [getGCControllerClass() controllers];
+    auto *controllers = [getGCControllerClassSingleton() controllers];
     if (!controllers || !controllers.count)
         LOG(Gamepad, "GameControllerGamepadProvider has no initial GCControllers attached");
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
@@ -91,7 +91,7 @@ SOFT_LINK_CLASS_FOR_HEADER(WebCore, GCEventInteraction)
 SOFT_LINK_CLASS_FOR_HEADER(WebCore, GCMouse)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, GameController, GCMouseDidStopBeingCurrentNotification, NSString *)
 
-SPECIALIZE_OBJC_TYPE_TRAITS(GCMouse, WebCore::getGCMouseClass())
+SPECIALIZE_OBJC_TYPE_TRAITS(GCMouse, WebCore::getGCMouseClassSingleton())
 #endif
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/GameControllerSoftLinkAdditions.h>)

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
@@ -195,7 +195,7 @@ static GameControllerFrameworkHandlesDevice gameControllerFrameworkWillHandleHID
         return GameControllerFrameworkHandlesDevice::No;
 
 #if HAVE(GCCONTROLLER_HID_DEVICE_CHECK)
-    return [getGCControllerClass() supportsHIDDevice:device] ? GameControllerFrameworkHandlesDevice::Yes : GameControllerFrameworkHandlesDevice::No;
+    return [getGCControllerClassSingleton() supportsHIDDevice:device] ? GameControllerFrameworkHandlesDevice::Yes : GameControllerFrameworkHandlesDevice::No;
 #else
     CFNumberRef cfVendorID = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
     CFNumberRef cfProductID = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey));

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -289,12 +289,12 @@ AtomString AVTrackPrivateAVFObjCImpl::label() const
     if (![commonMetadata count] && m_mediaSelectionOption)
         commonMetadata = [m_mediaSelectionOption->avMediaSelectionOption() commonMetadata];
 
-    NSArray *titles = [PAL::getAVMetadataItemClass() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
+    NSArray *titles = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
     if (![titles count])
         return emptyAtom();
 
     // If possible, return a title in one of the user's preferred languages.
-    NSArray *titlesForPreferredLanguages = [PAL::getAVMetadataItemClass() metadataItemsFromArray:titles filteredAndSortedAccordingToPreferredLanguages:[NSLocale preferredLanguages]];
+    NSArray *titlesForPreferredLanguages = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:titles filteredAndSortedAccordingToPreferredLanguages:[NSLocale preferredLanguages]];
     if ([titlesForPreferredLanguages count])
         return [[titlesForPreferredLanguages objectAtIndex:0] stringValue];
     return [[titles objectAtIndex:0] stringValue];

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -1206,7 +1206,7 @@ void AudioVideoRendererAVFObjC::updateSpatialTrackingLabel()
     // If there is no video renderer, use the default spatial tracking label if available, or
     // the session's spatial tracking label if not, and set the label directly on each audio
     // renderer.
-    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
+    AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     RetainPtr<NSString> defaultLabel;
     if (!m_defaultSpatialTrackingLabel.isNull()) {
         INFO_LOG(LOGIDENTIFIER, "Default STSLabel: ", m_defaultSpatialTrackingLabel);

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
@@ -97,8 +97,8 @@ MediaPlaybackTargetCocoa::MediaPlaybackTargetCocoa(MediaPlaybackTargetContextCoc
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST)
 Ref<MediaPlaybackTargetCocoa> MediaPlaybackTargetCocoa::create()
 {
-    auto *routingContextUID = [[PAL::getAVAudioSessionClass() sharedInstance] routingContextUID];
-    return adoptRef(*new MediaPlaybackTargetCocoa(MediaPlaybackTargetContextCocoa([PAL::getAVOutputContextClass() outputContextForID:routingContextUID])));
+    auto *routingContextUID = [[PAL::getAVAudioSessionClassSingleton() sharedInstance] routingContextUID];
+    return adoptRef(*new MediaPlaybackTargetCocoa(MediaPlaybackTargetContextCocoa([PAL::getAVOutputContextClassSingleton() outputContextForID:routingContextUID])));
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
@@ -129,7 +129,7 @@ MediaSelectionGroupAVFObjC::~MediaSelectionGroupAVFObjC()
 
 void MediaSelectionGroupAVFObjC::updateOptions(const Vector<String>& characteristics)
 {
-    RetainPtr<NSSet> newAVOptions = adoptNS([[NSSet alloc] initWithArray:[PAL::getAVMediaSelectionGroupClass() playableMediaSelectionOptionsFromArray:[m_mediaSelectionGroup options]]]);
+    RetainPtr<NSSet> newAVOptions = adoptNS([[NSSet alloc] initWithArray:[PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[m_mediaSelectionGroup options]]]);
     RetainPtr<NSMutableSet> oldAVOptions = adoptNS([[NSMutableSet alloc] initWithCapacity:m_options.size()]);
     for (auto& avOption : m_options.keys())
         [oldAVOptions addObject:(__bridge AVMediaSelectionOption *)avOption];
@@ -159,7 +159,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!m_shouldSelectOptionAutomatically)
         return;
 
-    NSArray* filteredOptions = [PAL::getAVMediaSelectionGroupClass() mediaSelectionOptionsFromArray:[m_mediaSelectionGroup options]
+    NSArray* filteredOptions = [PAL::getAVMediaSelectionGroupClassSingleton() mediaSelectionOptionsFromArray:[m_mediaSelectionGroup options]
         filteredAndSortedAccordingToPreferredLanguages:createNSArray(userPreferredLanguages(ShouldMinimizeLanguages::No)).get()];
 
     if (![filteredOptions count] && characteristics.isEmpty())
@@ -169,7 +169,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![filteredOptions count])
         filteredOptions = [m_mediaSelectionGroup options];
 
-    NSArray* optionsWithCharacteristics = [PAL::getAVMediaSelectionGroupClass() mediaSelectionOptionsFromArray:filteredOptions withMediaCharacteristics:createNSArray(characteristics).get()];
+    NSArray* optionsWithCharacteristics = [PAL::getAVMediaSelectionGroupClassSingleton() mediaSelectionOptionsFromArray:filteredOptions withMediaCharacteristics:createNSArray(characteristics).get()];
     if (optionsWithCharacteristics && [optionsWithCharacteristics count])
         filteredOptions = optionsWithCharacteristics;
 

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -179,7 +179,7 @@ static bool isSampleBufferVideoRenderer(id object)
             return;
         }
 
-        if ([object isKindOfClass:PAL::getAVSampleBufferAudioRendererClass()]) {
+        if ([object isKindOfClass:PAL::getAVSampleBufferAudioRendererClassSingleton()]) {
             RetainPtr renderer = (AVSampleBufferAudioRenderer *)object;
 
             ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), error = WTFMove(error)] {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
@@ -114,11 +114,11 @@ bool AVAssetMIMETypeCache::canDecodeExtendedType(const ContentType& typeParamete
     ASSERT(isAvailable());
 
     if (PAL::canLoad_AVFoundation_AVURLAssetExtendedMIMETypePlayabilityTreatPlaylistMIMETypesAsISOBMFFMediaDataContainersKey()) {
-        if ([PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:type.raw().createNSString().get() options:@{ AVURLAssetExtendedMIMETypePlayabilityTreatPlaylistMIMETypesAsISOBMFFMediaDataContainersKey: @YES }])
+        if ([PAL::getAVURLAssetClassSingleton() isPlayableExtendedMIMEType:type.raw().createNSString().get() options:@{ AVURLAssetExtendedMIMETypePlayabilityTreatPlaylistMIMETypesAsISOBMFFMediaDataContainersKey: @YES }])
             return true;
     } else
 
-    if ([PAL::getAVURLAssetClass() isPlayableExtendedMIMEType:type.raw().createNSString().get()])
+    if ([PAL::getAVURLAssetClassSingleton() isPlayableExtendedMIMEType:type.raw().createNSString().get()])
         return true;
 
 #endif // ENABLE(VIDEO) && USE(AVFOUNDATION)
@@ -196,7 +196,7 @@ void AVAssetMIMETypeCache::initializeCache(HashSet<String>& cache)
     if (!isAvailable())
         return;
 
-    for (NSString *type in [PAL::getAVURLAssetClass() audiovisualMIMETypes])
+    for (NSString *type in [PAL::getAVURLAssetClassSingleton() audiovisualMIMETypes])
         cache.add(type);
 
     if (m_cacheTypeCallback)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
@@ -73,7 +73,7 @@ AVOutputDeviceMenuControllerTargetPicker::~AVOutputDeviceMenuControllerTargetPic
 
 AVOutputDeviceMenuController *AVOutputDeviceMenuControllerTargetPicker::devicePicker()
 {
-    if (!getAVOutputDeviceMenuControllerClass())
+    if (!getAVOutputDeviceMenuControllerClassSingleton())
         return nullptr;
 
     if (!m_outputDeviceMenuController) {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
@@ -63,7 +63,7 @@ bool AVRoutePickerViewTargetPicker::isAvailable()
     static bool available;
     static std::once_flag flag;
     std::call_once(flag, [] () {
-        if (!getAVRoutePickerViewClass())
+        if (!getAVRoutePickerViewClassSingleton())
             return;
 
         if (auto picker = adoptNS([allocAVRoutePickerViewInstance() init]))
@@ -88,7 +88,7 @@ AVRoutePickerViewTargetPicker::~AVRoutePickerViewTargetPicker()
 AVOutputContext * AVRoutePickerViewTargetPicker::outputContextInternal()
 {
     if (!m_outputContext) {
-        m_outputContext = [PAL::getAVOutputContextClass() iTunesAudioContext];
+        m_outputContext = [PAL::getAVOutputContextClassSingleton() iTunesAudioContext];
         ASSERT(m_outputContext);
         if (m_outputContext)
             [[NSNotificationCenter defaultCenter] addObserver:m_routePickerViewDelegate.get() selector:@selector(notificationHandler:) name:PAL::AVOutputContextOutputDevicesDidChangeNotification object:m_outputContext.get()];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
@@ -56,7 +56,7 @@ bool AVStreamDataParserMIMETypeCache::isAvailable() const
     if (!PAL::AVFoundationLibrary())
         return false;
 
-    return [PAL::getAVStreamDataParserClass() respondsToSelector:@selector(audiovisualMIMETypes)];
+    return [PAL::getAVStreamDataParserClassSingleton() respondsToSelector:@selector(audiovisualMIMETypes)];
 #else
     return false;
 #endif
@@ -91,8 +91,8 @@ bool AVStreamDataParserMIMETypeCache::canDecodeExtendedType(const ContentType& t
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
     ASSERT(isAvailable());
 
-    if ([PAL::getAVStreamDataParserClass() respondsToSelector:@selector(canParseExtendedMIMEType:)])
-        return [PAL::getAVStreamDataParserClass() canParseExtendedMIMEType:type.raw().createNSString().get()];
+    if ([PAL::getAVStreamDataParserClassSingleton() respondsToSelector:@selector(canParseExtendedMIMEType:)])
+        return [PAL::getAVStreamDataParserClassSingleton() canParseExtendedMIMEType:type.raw().createNSString().get()];
 
     // FIXME(rdar://50502771) AVStreamDataParser does not have an -canParseExtendedMIMEType: method on this system,
     //  so just replace the container type with a valid one from AVAssetMIMETypeCache and ask that cache if it
@@ -114,7 +114,7 @@ void AVStreamDataParserMIMETypeCache::initializeCache(HashSet<String>& cache)
     if (!isAvailable())
         return;
 
-    for (NSString* type in [PAL::getAVStreamDataParserClass() audiovisualMIMETypes])
+    for (NSString* type in [PAL::getAVStreamDataParserClassSingleton() audiovisualMIMETypes])
         cache.add(type);
 #endif
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
@@ -149,10 +149,10 @@ AtomString InbandTextTrackPrivateAVFObjC::label() const
         return emptyAtom();
 
     NSString *title = 0;
-    NSArray *titles = [PAL::getAVMetadataItemClass() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
+    NSArray *titles = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:commonMetadata withKey:AVMetadataCommonKeyTitle keySpace:AVMetadataKeySpaceCommon];
     if ([titles count]) {
         // If possible, return a title in one of the user's preferred languages.
-        NSArray *titlesForPreferredLanguages = [PAL::getAVMetadataItemClass() metadataItemsFromArray:titles filteredAndSortedAccordingToPreferredLanguages:[NSLocale preferredLanguages]];
+        NSArray *titlesForPreferredLanguages = [PAL::getAVMetadataItemClassSingleton() metadataItemsFromArray:titles filteredAndSortedAccordingToPreferredLanguages:[NSLocale preferredLanguages]];
         if ([titlesForPreferredLanguages count])
             title = [[titlesForPreferredLanguages objectAtIndex:0] stringValue];
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -108,7 +108,7 @@ using namespace WebCore;
     UNUSED_PARAM(keyPath);
     UNUSED_PARAM(change);
 
-    if (![object isKindOfClass:PAL::getAVSampleBufferDisplayLayerClass()])
+    if (![object isKindOfClass:PAL::getAVSampleBufferDisplayLayerClassSingleton()])
         return;
 
     if ([keyPath isEqualToString:@"status"]) {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -317,7 +317,7 @@ static AVAssetCache *assetCacheForPath(const String& path)
     if (path.isEmpty())
         return nil;
 
-    return [PAL::getAVAssetCacheClass() assetCacheWithURL:[NSURL fileURLWithPath:path.createNSString().get() isDirectory:YES]];
+    return [PAL::getAVAssetCacheClassSingleton() assetCacheWithURL:[NSURL fileURLWithPath:path.createNSString().get() isDirectory:YES]];
 }
 
 static AVAssetCache *ensureAssetCacheExistsForPath(const String& path)
@@ -581,7 +581,7 @@ void MediaPlayerPrivateAVFoundationObjC::createImageGenerator()
     if (!m_avAsset || m_imageGenerator)
         return;
 
-    m_imageGenerator = [PAL::getAVAssetImageGeneratorClass() assetImageGeneratorWithAsset:m_avAsset.get()];
+    m_imageGenerator = [PAL::getAVAssetImageGeneratorClassSingleton() assetImageGeneratorWithAsset:m_avAsset.get()];
 
     [m_imageGenerator setApertureMode:AVAssetImageGeneratorApertureModeCleanAperture];
     [m_imageGenerator setAppliesPreferredTrackTransform:YES];
@@ -2380,7 +2380,7 @@ void MediaPlayerPrivateAVFoundationObjC::tracksChanged()
 
     AVMediaSelectionGroup *legibleGroup = safeMediaSelectionGroupForLegibleMedia();
     if (legibleGroup && m_cachedTracks) {
-        hasCaptions = [[PAL::getAVMediaSelectionGroupClass() playableMediaSelectionOptionsFromArray:[legibleGroup options]] count];
+        hasCaptions = [[PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[legibleGroup options]] count];
         if (hasCaptions)
             processMediaSelectionOptions();
     }
@@ -3126,7 +3126,7 @@ void MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions()
     }
 
     Vector<RefPtr<InbandTextTrackPrivateAVF>> removedTextTracks = m_textTracks;
-    NSArray *legibleOptions = [PAL::getAVMediaSelectionGroupClass() playableMediaSelectionOptionsFromArray:[legibleGroup options]];
+    NSArray *legibleOptions = [PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[legibleGroup options]];
     for (AVMediaSelectionOption *option in legibleOptions) {
         bool newTrack = true;
         for (unsigned i = removedTextTracks.size(); i > 0; --i) {
@@ -4116,7 +4116,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
     }
 
     // If there is no AVPlayerLayer, and no default spatial tracking label is available, use the session's spatial tracking label.
-    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
+    AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     ALWAYS_LOG(LOGIDENTIFIER, "AVAudioSession label: ", session.spatialTrackingLabel);
     [m_avPlayer _setSTSLabel:session.spatialTrackingLabel];
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -217,10 +217,10 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::isAvailable()
 {
     return PAL::isAVFoundationFrameworkAvailable()
         && PAL::isCoreMediaFrameworkAvailable()
-        && PAL::getAVStreamDataParserClass()
-        && PAL::getAVSampleBufferAudioRendererClass()
-        && PAL::getAVSampleBufferRenderSynchronizerClass()
-        && class_getInstanceMethod(PAL::getAVSampleBufferAudioRendererClass(), @selector(setMuted:));
+        && PAL::getAVStreamDataParserClassSingleton()
+        && PAL::getAVSampleBufferAudioRendererClassSingleton()
+        && PAL::getAVSampleBufferRenderSynchronizerClassSingleton()
+        && class_getInstanceMethod(PAL::getAVSampleBufferAudioRendererClassSingleton(), @selector(setMuted:));
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::getSupportedTypes(HashSet<String>& types)
@@ -2015,7 +2015,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
     // If there is no video renderer, use the default spatial tracking label if available, or
     // the session's spatial tracking label if not, and set the label directly on each audio
     // renderer.
-    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
+    AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     RetainPtr<NSString> defaultLabel;
     if (!m_defaultSpatialTrackingLabel.isNull()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Default STSLabel: ", m_defaultSpatialTrackingLabel);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -220,7 +220,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::registerMediaEngine(MediaEngineRegist
 
 bool MediaPlayerPrivateMediaStreamAVFObjC::isAvailable()
 {
-    return PAL::isAVFoundationFrameworkAvailable() && PAL::isCoreMediaFrameworkAvailable() && PAL::getAVSampleBufferDisplayLayerClass();
+    return PAL::isAVFoundationFrameworkAvailable() && PAL::isCoreMediaFrameworkAvailable() && PAL::getAVSampleBufferDisplayLayerClassSingleton();
 }
 
 void MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes(HashSet<String>& types)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -38,7 +38,7 @@
 #include <wtf/TZoneMallocInlines.h>
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(AVPlayerItemVideoOutput)
-static bool isType(const AVPlayerItemOutput& output) { return [&output isKindOfClass:PAL::getAVPlayerItemVideoOutputClass()]; }
+static bool isType(const AVPlayerItemOutput& output) { return [&output isKindOfClass:PAL::getAVPlayerItemVideoOutputClassSingleton()]; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 @interface WebQueuedVideoOutputDelegate : NSObject<AVPlayerItemOutputPullDelegate> {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -201,13 +201,13 @@ private:
 MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported(const ContentType& type)
 {
     // Check that AVStreamDataParser is in a functional state.
-    if (!PAL::getAVStreamDataParserClass() || !adoptNS([PAL::allocAVStreamDataParserInstance() init]))
+    if (!PAL::getAVStreamDataParserClassSingleton() || !adoptNS([PAL::allocAVStreamDataParserInstance() init]))
         return MediaPlayerEnums::SupportsType::IsNotSupported;
 
     String extendedType = type.raw();
     String outputCodecs = type.parameter(ContentType::codecsParameter());
-    if (!outputCodecs.isEmpty() && [PAL::getAVStreamDataParserClass() respondsToSelector:@selector(outputMIMECodecParameterForInputMIMECodecParameter:)]) {
-        outputCodecs = [PAL::getAVStreamDataParserClass() outputMIMECodecParameterForInputMIMECodecParameter:outputCodecs.createNSString().get()];
+    if (!outputCodecs.isEmpty() && [PAL::getAVStreamDataParserClassSingleton() respondsToSelector:@selector(outputMIMECodecParameterForInputMIMECodecParameter:)]) {
+        outputCodecs = [PAL::getAVStreamDataParserClassSingleton() outputMIMECodecParameterForInputMIMECodecParameter:outputCodecs.createNSString().get()];
         extendedType = makeString(type.containerType(), "; codecs=\""_s, outputCodecs, "\""_s);
     }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -75,7 +75,7 @@ void VideoLayerManagerObjC::setVideoLayer(PlatformLayer *videoLayer, FloatSize c
     [m_videoInlineLayer setName:@"WebVideoContainerLayer"];
     [m_videoInlineLayer setFrame:CGRectMake(0, 0, contentSize.width(), contentSize.height())];
     [m_videoInlineLayer setContentsGravity:kCAGravityResizeAspect];
-    if (PAL::isAVFoundationFrameworkAvailable() && [videoLayer isKindOfClass:PAL::getAVPlayerLayerClass()])
+    if (PAL::isAVFoundationFrameworkAvailable() && [videoLayer isKindOfClass:PAL::getAVPlayerLayerClassSingleton()])
         [m_videoInlineLayer setPlayerLayer:(AVPlayerLayer *)videoLayer];
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
     OBJC_INFO_LOG(OBJC_LOGIDENTIFIER, "keys=", keys.size());
 
     // FIXME (117803793): Remove staging code once -[AVContentKey revoke] is available in SDKs used by WebKit builders
-    if (![PAL::getAVContentKeyClass() instancesRespondToSelector:@selector(revoke)])
+    if (![PAL::getAVContentKeyClassSingleton() instancesRespondToSelector:@selector(revoke)])
         return;
 
     for (auto& key : keys)

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -209,7 +209,7 @@ static NSString *toCAFilterType(PlatformCALayer::FilterType type)
 
 PlatformCALayer::LayerType PlatformCALayerCocoa::layerTypeForPlatformLayer(PlatformLayer* layer)
 {
-    if (PAL::isAVFoundationFrameworkAvailable() && [layer isKindOfClass:PAL::getAVPlayerLayerClass()])
+    if (PAL::isAVFoundationFrameworkAvailable() && [layer isKindOfClass:PAL::getAVPlayerLayerClassSingleton()])
         return LayerType::LayerTypeAVPlayerLayer;
 
     if ([layer isKindOfClass:WebVideoContainerLayer.class]
@@ -247,7 +247,7 @@ PlatformCALayerCocoa::PlatformCALayerCocoa(LayerType layerType, PlatformCALayerC
         break;
 #if HAVE(CORE_MATERIAL)
     case LayerType::LayerTypeMaterialLayer:
-        layerClass = PAL::getMTMaterialLayerClass();
+        layerClass = PAL::getMTMaterialLayerClassSingleton();
         break;
 #endif
 #if HAVE(MATERIAL_HOSTING)
@@ -261,7 +261,7 @@ PlatformCALayerCocoa::PlatformCALayerCocoa(LayerType layerType, PlatformCALayerC
         break;
     case LayerType::LayerTypeAVPlayerLayer:
         if (PAL::isAVFoundationFrameworkAvailable())
-            layerClass = PAL::getAVPlayerLayerClass();
+            layerClass = PAL::getAVPlayerLayerClassSingleton();
         break;
 #if ENABLE(MODEL_ELEMENT)
     case LayerType::LayerTypeModelLayer:
@@ -388,7 +388,7 @@ Ref<PlatformCALayer> PlatformCALayerCocoa::clone(PlatformCALayerClient* owner) c
     newLayer->updateCustomAppearance(customAppearance());
 
     if (type == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
-        ASSERT(PAL::isAVFoundationFrameworkAvailable() && [newLayer->platformLayer() isKindOfClass:PAL::getAVPlayerLayerClass()]);
+        ASSERT(PAL::isAVFoundationFrameworkAvailable() && [newLayer->platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()]);
 
         AVPlayerLayer *destinationPlayerLayer = newLayer->avPlayerLayer();
         AVPlayerLayer *sourcePlayerLayer = avPlayerLayer();
@@ -1369,7 +1369,7 @@ AVPlayerLayer *PlatformCALayerCocoa::avPlayerLayer() const
     if (layerType() != PlatformCALayer::LayerType::LayerTypeAVPlayerLayer)
         return nil;
 
-    if ([platformLayer() isKindOfClass:PAL::getAVPlayerLayerClass()])
+    if ([platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()])
         return static_cast<AVPlayerLayer *>(platformLayer());
 
     if (auto *layer = dynamic_objc_cast<WebVideoContainerLayer>(platformLayer()))

--- a/Source/WebCore/platform/graphics/cocoa/ColorCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/ColorCocoa.mm
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RetainPtr<UIColor> cocoaColor(const Color& color)
 {
-    return [PAL::getUIColorClass() _disambiguated_due_to_CIImage_colorWithCGColor:cachedCGColor(color).get()];
+    return [PAL::getUIColorClassSingleton() _disambiguated_due_to_CIImage_colorWithCGColor:cachedCGColor(color).get()];
 }
 
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm
@@ -54,7 +54,7 @@ CFStringRef contentSizeCategory()
         return bridge_cast(contentSizeCategoryStorage().createNSString().autorelease());
     }
 #if PLATFORM(IOS_FAMILY)
-    return static_cast<CFStringRef>([[PAL::getUIApplicationClass() sharedApplication] preferredContentSizeCategory]);
+    return static_cast<CFStringRef>([[PAL::getUIApplicationClassSingleton() sharedApplication] preferredContentSizeCategory]);
 #else
     return kCTFontContentSizeCategoryL;
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -111,9 +111,9 @@ void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& colo
     focusRingStyle.version = 0;
     focusRingStyle.tint = kCGFocusRingTintBlue;
     focusRingStyle.ordering = kCGFocusRingOrderingNone;
-    focusRingStyle.alpha = [PAL::getUIFocusRingStyleClass() maxAlpha];
-    focusRingStyle.radius = [PAL::getUIFocusRingStyleClass() borderThickness];
-    focusRingStyle.threshold = [PAL::getUIFocusRingStyleClass() alphaThreshold];
+    focusRingStyle.alpha = [PAL::getUIFocusRingStyleClassSingleton() maxAlpha];
+    focusRingStyle.radius = [PAL::getUIFocusRingStyleClassSingleton() borderThickness];
+    focusRingStyle.threshold = [PAL::getUIFocusRingStyleClassSingleton() alphaThreshold];
     focusRingStyle.bounds = CGRectZero;
 #endif
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1322,9 +1322,9 @@ bool MediaPlayerPrivateWebM::isAvailable()
     return SourceBufferParserWebM::isAvailable()
         && PAL::isAVFoundationFrameworkAvailable()
         && PAL::isCoreMediaFrameworkAvailable()
-        && PAL::getAVSampleBufferAudioRendererClass()
-        && PAL::getAVSampleBufferRenderSynchronizerClass()
-        && class_getInstanceMethod(PAL::getAVSampleBufferAudioRendererClass(), @selector(setMuted:));
+        && PAL::getAVSampleBufferAudioRendererClassSingleton()
+        && PAL::getAVSampleBufferRenderSynchronizerClassSingleton()
+        && class_getInstanceMethod(PAL::getAVSampleBufferAudioRendererClassSingleton(), @selector(setMuted:));
 }
 
 bool MediaPlayerPrivateWebM::isEnabledVideoTrackID(TrackID trackID) const

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCocoa.mm
@@ -30,10 +30,10 @@
 
 namespace WebCore {
 
-static auto cocoaFontClass()
+static auto cocoaFontClassSingleton()
 {
 #if PLATFORM(IOS_FAMILY)
-    return PAL::getUIFontClass();
+    return PAL::getUIFontClassSingleton();
 #else
     return NSFont.class;
 #endif
@@ -41,18 +41,18 @@ static auto cocoaFontClass()
 
 RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::smallCaptionFontDescriptor()
 {
-    auto font = [cocoaFontClass() systemFontOfSize:[cocoaFontClass() smallSystemFontSize]];
+    auto font = [cocoaFontClassSingleton() systemFontOfSize:[cocoaFontClassSingleton() smallSystemFontSize]];
     return static_cast<CTFontDescriptorRef>(font.fontDescriptor);
 }
 
 RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::menuFontDescriptor()
 {
-    return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontMenuItem, [cocoaFontClass() systemFontSize], nullptr));
+    return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontMenuItem, [cocoaFontClassSingleton() systemFontSize], nullptr));
 }
 
 RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::statusBarFontDescriptor()
 {
-    return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, [cocoaFontClass() labelFontSize], nullptr));
+    return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, [cocoaFontClassSingleton() labelFontSize], nullptr));
 }
 
 RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::miniControlFontDescriptor()
@@ -60,7 +60,7 @@ RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::miniControlFontDescri
 #if PLATFORM(IOS_FAMILY)
     return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontMiniSystem, 0, nullptr));
 #else
-    auto font = [cocoaFontClass() systemFontOfSize:[cocoaFontClass() systemFontSizeForControlSize:NSControlSizeMini]];
+    auto font = [cocoaFontClassSingleton() systemFontOfSize:[cocoaFontClassSingleton() systemFontSizeForControlSize:NSControlSizeMini]];
     return static_cast<CTFontDescriptorRef>(font.fontDescriptor);
 #endif
 }
@@ -70,7 +70,7 @@ RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::smallControlFontDescr
 #if PLATFORM(IOS_FAMILY)
     return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSmallSystem, 0, nullptr));
 #else
-    auto font = [cocoaFontClass() systemFontOfSize:[cocoaFontClass() systemFontSizeForControlSize:NSControlSizeSmall]];
+    auto font = [cocoaFontClassSingleton() systemFontOfSize:[cocoaFontClassSingleton() systemFontSizeForControlSize:NSControlSizeSmall]];
     return static_cast<CTFontDescriptorRef>(font.fontDescriptor);
 #endif
 }
@@ -80,7 +80,7 @@ RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::controlFontDescriptor
 #if PLATFORM(IOS_FAMILY)
     return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, 0, nullptr));
 #else
-    auto font = [cocoaFontClass() systemFontOfSize:[cocoaFontClass() systemFontSizeForControlSize:NSControlSizeRegular]];
+    auto font = [cocoaFontClassSingleton() systemFontOfSize:[cocoaFontClassSingleton() systemFontSizeForControlSize:NSControlSizeRegular]];
     return static_cast<CTFontDescriptorRef>(font.fontDescriptor);
 #endif
 }

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -929,7 +929,7 @@ void VideoMediaSampleRenderer::resetReadyForMoreMediaData()
 void VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime& time)
 {
     assertIsMainThread();
-    if (isUsingDecompressionSession() || ![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(expectMinimumUpcomingSampleBufferPresentationTime:)])
+    if (isUsingDecompressionSession() || ![PAL::getAVSampleBufferDisplayLayerClassSingleton() instancesRespondToSelector:@selector(expectMinimumUpcomingSampleBufferPresentationTime:)])
         return;
 
     [renderer() expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(time)];

--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
@@ -47,7 +47,7 @@ UITraitCollection *traitCollectionWithAdjustedIdiomForSystemColors(UITraitCollec
 
 LocalCurrentTraitCollection::LocalCurrentTraitCollection(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)
 {
-    m_savedTraitCollection = [PAL::getUITraitCollectionClass() currentTraitCollection];
+    m_savedTraitCollection = [PAL::getUITraitCollectionClassSingleton() currentTraitCollection];
 
     // FIXME: <rdar://problem/96607991> `-[UITraitCollection currentTraitCollection]` is not guaranteed
     // to return a useful set of traits in cases where it has not been explicitly set. Ideally, this
@@ -58,19 +58,19 @@ LocalCurrentTraitCollection::LocalCurrentTraitCollection(bool useDarkAppearance,
         traits.userInterfaceLevel = useElevatedUserInterfaceLevel ? UIUserInterfaceLevelElevated : UIUserInterfaceLevelBase;
     }];
 
-    [PAL::getUITraitCollectionClass() setCurrentTraitCollection:traitCollectionWithAdjustedIdiomForSystemColors(combinedTraits.get())];
+    [PAL::getUITraitCollectionClassSingleton() setCurrentTraitCollection:traitCollectionWithAdjustedIdiomForSystemColors(combinedTraits.get())];
 }
 
 LocalCurrentTraitCollection::LocalCurrentTraitCollection(UITraitCollection *traitCollection)
 {
-    m_savedTraitCollection = [PAL::getUITraitCollectionClass() currentTraitCollection];
+    m_savedTraitCollection = [PAL::getUITraitCollectionClassSingleton() currentTraitCollection];
     auto newTraitCollection = traitCollectionWithAdjustedIdiomForSystemColors(traitCollection);
-    [PAL::getUITraitCollectionClass() setCurrentTraitCollection:newTraitCollection];
+    [PAL::getUITraitCollectionClassSingleton() setCurrentTraitCollection:newTraitCollection];
 }
 
 LocalCurrentTraitCollection::~LocalCurrentTraitCollection()
 {
-    [PAL::getUITraitCollectionClass() setCurrentTraitCollection:m_savedTraitCollection.get()];
+    [PAL::getUITraitCollectionClassSingleton() setCurrentTraitCollection:m_savedTraitCollection.get()];
 }
 
 }

--- a/Source/WebCore/platform/ios/LocalizedDeviceModel.mm
+++ b/Source/WebCore/platform/ios/LocalizedDeviceModel.mm
@@ -42,7 +42,7 @@ String localizedDeviceModel()
 {
     auto& deviceModel = cachedLocalizedDeviceModel();
     if (!deviceModel)
-        deviceModel = String([[PAL::getUIDeviceClass() currentDevice] localizedModel]);
+        deviceModel = String([[PAL::getUIDeviceClassSingleton() currentDevice] localizedModel]);
     return *deviceModel;
 }
 

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -62,7 +62,7 @@ namespace WebCore {
 
 static UIPasteboard *generalUIPasteboard()
 {
-    return static_cast<UIPasteboard *>([PAL::getUIPasteboardClass() generalPasteboard]);
+    return static_cast<UIPasteboard *>([PAL::getUIPasteboardClassSingleton() generalPasteboard]);
 }
 
 PlatformPasteboard::PlatformPasteboard()
@@ -116,7 +116,7 @@ void PlatformPasteboard::performAsDataOwner(DataOwnerType type, NOESCAPE Functio
         break;
     }
 
-    [PAL::getUIPasteboardClass() _performAsDataOwner:dataOwner block:^{
+    [PAL::getUIPasteboardClassSingleton() _performAsDataOwner:dataOwner block:^{
         actions();
     }];
 }
@@ -321,7 +321,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 Color PlatformPasteboard::color()
 {
     NSData *data = [m_pasteboard dataForPasteboardType:UIColorPboardType];
-    UIColor *uiColor = [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getUIColorClass() fromData:data error:nil];
+    UIColor *uiColor = [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getUIColorClassSingleton() fromData:data error:nil];
     return roundAndClampToSRGBALossy(uiColor.CGColor);
 }
 
@@ -393,7 +393,7 @@ static void registerItemsToPasteboard(NSArray<WebItemProviderRegistrationInfoLis
 #if PLATFORM(MACCATALYST)
     // In macCatalyst, -[UIPasteboard setItemProviders:] is not yet supported, so we fall back to setting an item dictionary when
     // populating the pasteboard upon copy.
-    if ([pasteboard isKindOfClass:PAL::getUIPasteboardClass()]) {
+    if ([pasteboard isKindOfClass:PAL::getUIPasteboardClassSingleton()]) {
         auto itemDictionaries = adoptNS([[NSMutableArray alloc] initWithCapacity:itemLists.count]);
         for (WebItemProviderRegistrationInfoList *representationsToRegister in itemLists) {
             auto itemDictionary = adoptNS([[NSMutableDictionary alloc] initWithCapacity:representationsToRegister.numberOfItems]);

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -131,7 +131,7 @@ float currentEDRHeadroomForDisplay(PlatformDisplayID)
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->currentEDRHeadroom;
 
-    return [[PAL::getUIScreenClass() mainScreen] currentEDRHeadroom];
+    return [[PAL::getUIScreenClassSingleton() mainScreen] currentEDRHeadroom];
 }
 
 float maxEDRHeadroomForDisplay(PlatformDisplayID)
@@ -139,7 +139,7 @@ float maxEDRHeadroomForDisplay(PlatformDisplayID)
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->maxEDRHeadroom;
 
-    return [[PAL::getUIScreenClass() mainScreen] potentialEDRHeadroom];
+    return [[PAL::getUIScreenClassSingleton() mainScreen] potentialEDRHeadroom];
 }
 
 bool suppressEDRForDisplay(PlatformDisplayID)
@@ -219,24 +219,24 @@ float screenPPIFactor()
 
 FloatSize screenSize()
 {
-    if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClass() sharedApplication] _isClassic])
+    if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClassSingleton() sharedApplication] _isClassic])
         return { 320, 480 };
 
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->screenRect.size();
 
-    return FloatSize([[PAL::getUIScreenClass() mainScreen] _referenceBounds].size);
+    return FloatSize([[PAL::getUIScreenClassSingleton() mainScreen] _referenceBounds].size);
 }
 
 FloatSize availableScreenSize()
 {
-    if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClass() sharedApplication] _isClassic])
+    if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClassSingleton() sharedApplication] _isClassic])
         return { 320, 480 };
 
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->screenAvailableRect.size();
 
-    return FloatSize([PAL::getUIScreenClass() mainScreen].bounds.size);
+    return FloatSize([PAL::getUIScreenClassSingleton() mainScreen].bounds.size);
 }
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/PlatformScreenIOS.mm>)
@@ -255,7 +255,7 @@ FloatSize overrideAvailableScreenSize()
 float screenScaleFactor(UIScreen *screen)
 {
     if (!screen)
-        screen = [PAL::getUIScreenClass() mainScreen];
+        screen = [PAL::getUIScreenClassSingleton() mainScreen];
 
     return screen.scale;
 }
@@ -267,7 +267,7 @@ ScreenProperties collectScreenProperties()
     // FIXME: This displayID doesn't match the synthetic displayIDs we use in iOS WebKit (see WebPageProxy::generateDisplayIDFromPageID()).
     PlatformDisplayID displayID = 0;
 
-    for (UIScreen *screen in [PAL::getUIScreenClass() screens]) {
+    for (UIScreen *screen in [PAL::getUIScreenClassSingleton() screens]) {
         ScreenData screenData;
 
         auto screenAvailableRect = FloatRect { screen.bounds };
@@ -289,7 +289,7 @@ ScreenProperties collectScreenProperties()
 
         screenProperties.screenDataMap.set(++displayID, WTFMove(screenData));
 
-        if (screen == [PAL::getUIScreenClass() mainScreen])
+        if (screen == [PAL::getUIScreenClassSingleton() mainScreen])
             screenProperties.primaryDisplayID = displayID;
     }
 

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -114,7 +114,7 @@ void PlaybackSessionInterfaceAVKitLegacy::currentTimeChanged(double currentTime,
         return;
 
     NSTimeInterval anchorTimeStamp = ![m_playerController rate] ? NAN : anchorTime;
-    AVValueTiming *timing = [getAVValueTimingClass() valueTimingWithAnchorValue:currentTime
+    AVValueTiming *timing = [getAVValueTimingClassSingleton() valueTimingWithAnchorValue:currentTime
         anchorTimeStamp:anchorTimeStamp rate:0];
 
     [m_playerController setTiming:timing];

--- a/Source/WebCore/platform/ios/UIViewControllerUtilities.mm
+++ b/Source/WebCore/platform/ios/UIViewControllerUtilities.mm
@@ -41,10 +41,10 @@ namespace WebCore {
 UIViewController *viewController(UIView *view)
 {
     if (!WTF::IOSApplication::isMobileSafari())
-        return [PAL::getUIViewControllerClass() viewControllerForView:view];
+        return [PAL::getUIViewControllerClassSingleton() viewControllerForView:view];
 
     auto responder = view.nextResponder;
-    if (![responder isKindOfClass:PAL::getUIViewControllerClass()])
+    if (![responder isKindOfClass:PAL::getUIViewControllerClassSingleton()])
         return nil;
 
     auto controller = static_cast<UIViewController *>(responder);

--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -45,17 +45,17 @@ namespace WebCore {
 
 static inline bool isClassic()
 {
-    return [[PAL::getUIApplicationClass() sharedApplication] _isClassic];
+    return [[PAL::getUIApplicationClassSingleton() sharedApplication] _isClassic];
 }
 
 static inline bool isClassicPad()
 {
-    return [PAL::getUIApplicationClass() _classicMode] == UIApplicationSceneClassicModeOriginalPad;
+    return [PAL::getUIApplicationClassSingleton() _classicMode] == UIApplicationSceneClassicModeOriginalPad;
 }
 
 static inline bool isClassicPhone()
 {
-    return isClassic() && [PAL::getUIApplicationClass() _classicMode] != UIApplicationSceneClassicModeOriginalPad;
+    return isClassic() && [PAL::getUIApplicationClassSingleton() _classicMode] != UIApplicationSceneClassicModeOriginalPad;
 }
 
 ASCIILiteral osNameForUserAgent()

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -71,7 +71,7 @@ static void updateLabelFrame(WebValidationBubbleViewController *controller)
 
 static void callSuper(WebValidationBubbleViewController *instance, SEL selector)
 {
-    objc_super superStructure { instance, PAL::getUIViewControllerClass() };
+    objc_super superStructure { instance, PAL::getUIViewControllerClassSingleton() };
     auto msgSendSuper = reinterpret_cast<void(*)(objc_super*, SEL)>(objc_msgSendSuper);
     msgSendSuper(&superStructure, selector);
 }
@@ -81,7 +81,7 @@ static void WebValidationBubbleViewController_viewDidLoad(WebValidationBubbleVie
     callSuper(instance, @selector(viewDidLoad));
 
     auto label = adoptNS([PAL::allocUILabelInstance() init]);
-    [label setFont:[PAL::getUIFontClass() preferredFontForTextStyle:PAL::get_UIKit_UIFontTextStyleCallout()]];
+    [label setFont:[PAL::getUIFontClassSingleton() preferredFontForTextStyle:PAL::get_UIKit_UIFontTextStyleCallout()]];
     [label setLineBreakMode:NSLineBreakByTruncatingTail];
     [label setNumberOfLines:validationBubbleMaxNumberOfLines];
     [instance.view addSubview:label.get()];
@@ -105,7 +105,7 @@ static WebValidationBubbleViewController *allocWebValidationBubbleViewController
     static Class theClass = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        theClass = objc_allocateClassPair(PAL::getUIViewControllerClass(), "WebValidationBubbleViewController", 0);
+        theClass = objc_allocateClassPair(PAL::getUIViewControllerClassSingleton(), "WebValidationBubbleViewController", 0);
         class_addMethod(theClass, @selector(viewDidLoad), (IMP)WebValidationBubbleViewController_viewDidLoad, "v@:");
         class_addMethod(theClass, @selector(viewWillLayoutSubviews), (IMP)WebValidationBubbleViewController_viewWillLayoutSubviews, "v@:");
         class_addMethod(theClass, @selector(viewSafeAreaInsetsDidChange), (IMP)WebValidationBubbleViewController_viewSafeAreaInsetsDidChange, "v@:");

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -269,7 +269,7 @@ static WebAVPictureInPictureContentViewController* WebAVPictureInPictureContentV
     ASSERT(controller);
 
     WebAVPictureInPictureContentViewController *pipController = aSelf;
-    objc_super superClass { pipController, getAVPictureInPictureContentViewControllerClass() };
+    objc_super superClass { pipController, getAVPictureInPictureContentViewControllerClassSingleton() };
     auto super_init = reinterpret_cast<id(*)(objc_super*, SEL)>(objc_msgSendSuper);
     aSelf = super_init(&superClass, @selector(init));
     if (!aSelf)
@@ -309,7 +309,7 @@ static void WebAVPictureInPictureContentViewController_setPlayerLayer(id aSelf, 
 static void WebAVPictureInPictureContentViewController_viewWillLayoutSubviews(id aSelf, SEL)
 {
     WebAVPictureInPictureContentViewController *pipController = aSelf;
-    objc_super superClass { pipController, getAVPictureInPictureContentViewControllerClass() };
+    objc_super superClass { pipController, getAVPictureInPictureContentViewControllerClassSingleton() };
     auto super_viewWillLayoutSubviews = reinterpret_cast<void(*)(objc_super*, SEL)>(objc_msgSendSuper);
     super_viewWillLayoutSubviews(&superClass, @selector(viewWillLayoutSubviews));
     [[pipController playerLayer] setFrame:[pipController view].bounds];
@@ -320,7 +320,7 @@ static void WebAVPictureInPictureContentViewController_dealloc(id aSelf, SEL)
     WebAVPictureInPictureContentViewController *pipController = aSelf;
     [[pipController controller] release];
     [[pipController playerLayer] release];
-    objc_super superClass { pipController, getAVPictureInPictureContentViewControllerClass() };
+    objc_super superClass { pipController, getAVPictureInPictureContentViewControllerClassSingleton() };
     auto super_dealloc = reinterpret_cast<void(*)(objc_super*, SEL)>(objc_msgSendSuper);
     super_dealloc(&superClass, @selector(dealloc));
 }
@@ -330,7 +330,7 @@ static WebAVPictureInPictureContentViewController *allocWebAVPictureInPictureCon
     static Class theClass = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        theClass = objc_allocateClassPair(getAVPictureInPictureContentViewControllerClass(), "WebAVPictureInPictureContentViewController", 0);
+        theClass = objc_allocateClassPair(getAVPictureInPictureContentViewControllerClassSingleton(), "WebAVPictureInPictureContentViewController", 0);
         class_addMethod(theClass, @selector(initWithController:), (IMP)WebAVPictureInPictureContentViewController_initWithController, "v@:@");
         class_addMethod(theClass, @selector(controller), (IMP)WebAVPictureInPictureContentViewController_controller, "@@:");
         class_addMethod(theClass, @selector(playerController), (IMP)WebAVPictureInPictureContentViewController_controller, "@@:");
@@ -953,7 +953,7 @@ bool supportsPictureInPicture()
 #if ENABLE(VIDEO_PRESENTATION_MODE) && !PLATFORM(WATCHOS)
     if (isPictureInPictureSupported.has_value())
         return *isPictureInPictureSupported;
-    return [getAVPictureInPictureControllerClass() isPictureInPictureSupported];
+    return [getAVPictureInPictureControllerClassSingleton() isPictureInPictureSupported];
 #else
     return false;
 #endif

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -69,17 +69,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoPresentationInterfaceIOS);
 
 static UIColor *clearUIColor()
 {
-    return (UIColor *)[PAL::getUIColorClass() clearColor];
+    return (UIColor *)[PAL::getUIColorClassSingleton() clearColor];
 }
 
 static UIColor *blackUIColor()
 {
-    return (UIColor *)[PAL::getUIColorClass() blackColor];
+    return (UIColor *)[PAL::getUIColorClassSingleton() blackColor];
 }
 
 static UIColor *greyUIColor()
 {
-    return (UIColor *)[PAL::getUIColorClass() colorWithRed:164.0 / 255.0 green:164.0 / 255.0 blue:164.0 / 255.0 alpha:1];
+    return (UIColor *)[PAL::getUIColorClassSingleton() colorWithRed:164.0 / 255.0 green:164.0 / 255.0 blue:164.0 / 255.0 alpha:1];
 }
 
 #if !LOG_DISABLED
@@ -163,7 +163,7 @@ void VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing()
         [pipPlacard setBackgroundColor:blackUIColor()];
         [pipPlacard setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-        RetainPtr image = [[[PAL::getUIImageClass() systemImageNamed:@"pip"] imageWithTintColor:greyUIColor() renderingMode:UIImageRenderingModeAlwaysOriginal] imageWithConfiguration:[PAL::getUIImageSymbolConfigurationClass() configurationWithWeight:UIImageSymbolWeightThin]];
+        RetainPtr image = [[[PAL::getUIImageClassSingleton() systemImageNamed:@"pip"] imageWithTintColor:greyUIColor() renderingMode:UIImageRenderingModeAlwaysOriginal] imageWithConfiguration:[PAL::getUIImageSymbolConfigurationClassSingleton() configurationWithWeight:UIImageSymbolWeightThin]];
 
         RetainPtr imageView = adoptNS([PAL::allocUIImageViewInstance() initWithImage:image.get()]);
         [imageView setContentMode:UIViewContentModeScaleAspectFit];
@@ -175,7 +175,7 @@ void VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing()
         [pipLabel setText:@"This video is playing in picture in picture."];
         [pipLabel setTextAlignment:NSTextAlignmentCenter];
         [pipLabel setTextColor:greyUIColor()];
-        [pipLabel setFont:[PAL::getUIFontClass() systemFontOfSize:16]];
+        [pipLabel setFont:[PAL::getUIFontClassSingleton() systemFontOfSize:16]];
         [pipLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
 
         [pipPlacard addSubview:pipLabel.get()];
@@ -327,7 +327,7 @@ void VideoPresentationInterfaceIOS::doSetup()
         [m_viewController _setIgnoreAppSupportedOrientations:YES];
         [m_window setRootViewController:m_viewController.get()];
         auto textEffectsWindowLevel = [&] {
-            auto *textEffectsWindow = [PAL::getUITextEffectsWindowClass() sharedTextEffectsWindowForWindowScene:[m_window windowScene]];
+            auto *textEffectsWindow = [PAL::getUITextEffectsWindowClassSingleton() sharedTextEffectsWindowForWindowScene:[m_window windowScene]];
             return textEffectsWindow ? textEffectsWindow.windowLevel : PAL::get_UIKit_UITextEffectsBeneathStatusBarWindowLevel();
         }();
         [m_window setWindowLevel:textEffectsWindowLevel - 1];

--- a/Source/WebCore/platform/ios/WebAVPlayerController.h
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.h
@@ -141,7 +141,7 @@ class PlaybackSessionInterfaceIOS;
 
 @end
 
-Class webAVPlayerControllerClass();
+Class webAVPlayerControllerClassSingleton();
 RetainPtr<WebAVPlayerController> createWebAVPlayerController();
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/platform/ios/WebCoreMotionManager.mm
+++ b/Source/WebCore/platform/ios/WebCoreMotionManager.mm
@@ -151,7 +151,7 @@ static const double kGravity = 9.80665;
         [m_motionManager setAccelerometerUpdateInterval:kMotionUpdateInterval];
 
     m_locationManager = adoptNS([allocCLLocationManagerInstance() init]);
-    m_headingAvailable = [getCLLocationManagerClass() headingAvailable];
+    m_headingAvailable = [getCLLocationManagerClassSingleton() headingAvailable];
 
     m_initialized = YES;
 

--- a/Source/WebCore/platform/ios/WebEvent.mm
+++ b/Source/WebCore/platform/ios/WebEvent.mm
@@ -494,7 +494,7 @@ static NSString *normalizedStringWithAppKitCompatibilityMapping(NSString *charac
 
 + (WebEventFlags)modifierFlags
 {
-    return GSEventIsHardwareKeyboardAttached() ? GSKeyboardGetModifierState([PAL::getUIApplicationClass() sharedApplication]._hardwareKeyboard) : 0;
+    return GSEventIsHardwareKeyboardAttached() ? GSKeyboardGetModifierState([PAL::getUIApplicationClassSingleton() sharedApplication]._hardwareKeyboard) : 0;
 }
 
 @end

--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
@@ -599,7 +599,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 static NSArray<Class<NSItemProviderReading>> *allLoadableClasses()
 {
-    return @[ [PAL::getUIColorClass() class], [PAL::getUIImageClass() class], [NSURL class], [NSString class], [NSAttributedString class] ];
+    return @[ [PAL::getUIColorClassSingleton() class], [PAL::getUIImageClassSingleton() class], [NSURL class], [NSString class], [NSAttributedString class] ];
 }
 
 static Class classForTypeIdentifier(NSString *typeIdentifier, NSString *&outTypeIdentifierToLoad)

--- a/Source/WebCore/platform/mac/CursorMac.mm
+++ b/Source/WebCore/platform/mac/CursorMac.mm
@@ -114,7 +114,7 @@ static NSInteger WKCoreCursor_coreCursorType(id self, SEL)
     return NSNotFound;
 }
 
-static Class createCoreCursorClass()
+static Class createCoreCursorClassSingleton()
 {
     Class coreCursorClass = objc_allocateClassPair([NSCursor class], "WKCoreCursor", 0);
     SEL coreCursorType = NSSelectorFromString(@"_coreCursorType");
@@ -123,11 +123,11 @@ static Class createCoreCursorClass()
     return coreCursorClass;
 }
 
-static Class coreCursorClass()
+static Class coreCursorClassSingleton()
 {
     Class coreCursorClass = objc_lookUpClass("WKCoreCursor");
     if (!coreCursorClass)
-        coreCursorClass = createCoreCursorClass();
+        coreCursorClass = createCoreCursorClassSingleton();
     return coreCursorClass;
 }
 
@@ -178,7 +178,7 @@ static NSCursor *cursor(ASCIILiteral name)
         return nil;
     
     if (!*slot)
-        *slot = [[coreCursorClass() alloc] init];
+        *slot = [[coreCursorClassSingleton() alloc] init];
     return *slot;
 }
 

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -132,7 +132,7 @@ ScreenProperties collectScreenProperties()
         bool supportsHighDynamicRange = false;
 #if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
         if (PAL::isAVFoundationFrameworkAvailable()) {
-            dynamicRangeMode = convertAVVideoRangeToEnum([PAL::getAVPlayerClass() preferredVideoRangeForDisplays:@[ @(displayID) ]]);
+            dynamicRangeMode = convertAVVideoRangeToEnum([PAL::getAVPlayerClassSingleton() preferredVideoRangeForDisplays:@[ @(displayID) ]]);
             supportsHighDynamicRange = dynamicRangeMode > DynamicRangeMode::Standard;
         }
 #endif
@@ -460,7 +460,7 @@ DynamicRangeMode preferredDynamicRangeMode(Widget* widget)
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
     if (PAL::isAVFoundationFrameworkAvailable()) {
         auto displayID = WebCore::displayID(screen(widget));
-        return convertAVVideoRangeToEnum([PAL::getAVPlayerClass() preferredVideoRangeForDisplays:@[ @(displayID) ]]);
+        return convertAVVideoRangeToEnum([PAL::getAVPlayerClassSingleton() preferredVideoRangeForDisplays:@[ @(displayID) ]]);
     }
 
     return DynamicRangeMode::Standard;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -249,7 +249,7 @@ void PlaybackSessionInterfaceMac::setPlayBackControlsManager(WebPlaybackControls
         return;
 
     NSTimeInterval anchorTimeStamp = ![manager rate] ? NAN : [[NSProcessInfo processInfo] systemUptime];
-    manager.timing = [getAVValueTimingClass() valueTimingWithAnchorValue:m_playbackSessionModel->currentTime() anchorTimeStamp:anchorTimeStamp rate:0];
+    manager.timing = [getAVValueTimingClassSingleton() valueTimingWithAnchorValue:m_playbackSessionModel->currentTime() anchorTimeStamp:anchorTimeStamp rate:0];
     double duration = m_playbackSessionModel->duration();
     manager.contentDuration = duration;
     manager.hasEnabledAudio = duration > 0;
@@ -294,7 +294,7 @@ void PlaybackSessionInterfaceMac::updatePlaybackControlsManagerTiming(double cur
         || (manager.rate < 0 && model->playbackStartedTime() <= currentTime))
         effectivePlaybackRate = 0;
 
-    manager.timing = [getAVValueTimingClass() valueTimingWithAnchorValue:currentTime anchorTimeStamp:effectiveAnchorTime rate:effectivePlaybackRate];
+    manager.timing = [getAVValueTimingClassSingleton() valueTimingWithAnchorValue:currentTime anchorTimeStamp:effectiveAnchorTime rate:effectivePlaybackRate];
 }
 
 uint32_t PlaybackSessionInterfaceMac::checkedPtrCount() const

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -130,7 +130,7 @@ static JSValue *jsValueWithValueInContext(id value, JSContext *context)
     if ([value isKindOfClass:[NSData class]])
         return jsValueWithDataInContext(value, context);
 
-    if ([value isKindOfClass:PAL::getAVMetadataItemClass()])
+    if ([value isKindOfClass:PAL::getAVMetadataItemClassSingleton()])
         return jsValueWithAVMetadataItemInContext(value, context);
 
     return nil;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -231,7 +231,7 @@ enum class PIPState {
         if (!_canSkipAd)
             playbackState.prerollAttributes = nil;
         else
-            playbackState.prerollAttributes = [getPIPPrerollAttributesClass() prerollAttributesForAdContentWithRequiredLinearPlaybackEndTime:0 preferredTintColor:nil];
+            playbackState.prerollAttributes = [getPIPPrerollAttributesClassSingleton() prerollAttributesForAdContentWithRequiredLinearPlaybackEndTime:0 preferredTintColor:nil];
     }];
 }
 #endif
@@ -865,7 +865,7 @@ WTFLogChannel& VideoPresentationInterfaceMac::logChannel() const
 
 bool supportsPictureInPicture()
 {
-    return PIPLibrary() && getPIPViewControllerClass();
+    return PIPLibrary() && getPIPViewControllerClassSingleton();
 }
 
 }

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm
@@ -104,10 +104,10 @@ AVAudioSessionCaptureDeviceManager::AVAudioSessionCaptureDeviceManager()
 void AVAudioSessionCaptureDeviceManager::createAudioSession()
 {
 #if !PLATFORM(MACCATALYST)
-    m_audioSession = adoptNS([[PAL::getAVAudioSessionClass() alloc] initAuxiliarySession]);
+    m_audioSession = adoptNS([[PAL::getAVAudioSessionClassSingleton() alloc] initAuxiliarySession]);
 #else
     // FIXME: Figure out if this is correct for Catalyst, where auxiliary session isn't available.
-    m_audioSession = [PAL::getAVAudioSessionClass() sharedInstance];
+    m_audioSession = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
 #endif
 
     NSError *error = nil;
@@ -206,7 +206,7 @@ bool AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceIDs()
         RELEASE_LOG_INFO(WebRTC, "AVAudioSessionCaptureDeviceManager setting preferred input to '%{public}s'", m_preferredMicrophoneID.ascii().data());
 
         NSError *error = nil;
-        if (![[PAL::getAVAudioSessionClass() sharedInstance] setPreferredInput:preferredInputPort error:&error]) {
+        if (![[PAL::getAVAudioSessionClassSingleton() sharedInstance] setPreferredInput:preferredInputPort error:&error]) {
             RELEASE_LOG_ERROR(WebRTC, "AVAudioSessionCaptureDeviceManager failed to set preferred input to '%{public}s' with error: %@", m_preferredMicrophoneID.utf8().data(), error.localizedDescription);
             return false;
         }

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
@@ -55,7 +55,7 @@ using namespace WebCore;
     _callback = callback;
 
     NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-    AVAudioSession* session = [PAL::getAVAudioSessionClass() sharedInstance];
+    AVAudioSession* session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
 
     [center addObserver:self selector:@selector(sessionMediaServicesWereReset:) name:AVAudioSessionMediaServicesWereResetNotification object:session];
 

--- a/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
@@ -78,8 +78,8 @@ using namespace WebCore;
     ASSERT(!m_coordinator);
 
     UIStatusBarStyleOverrides overrides = UIStatusBarStyleOverrideWebRTCAudioCapture;
-    m_statusBarStyleOverride = [getSBSStatusBarStyleOverridesAssertionClass() assertionWithStatusBarStyleOverrides:overrides forPID:legacyPresentingApplicationPID() exclusive:YES showsWhenForeground:YES];
-    m_coordinator = adoptNS([[getSBSStatusBarStyleOverridesCoordinatorClass() alloc] init]);
+    m_statusBarStyleOverride = [getSBSStatusBarStyleOverridesAssertionClassSingleton() assertionWithStatusBarStyleOverrides:overrides forPID:legacyPresentingApplicationPID() exclusive:YES showsWhenForeground:YES];
+    m_coordinator = adoptNS([[getSBSStatusBarStyleOverridesCoordinatorClassSingleton() alloc] init]);
     m_coordinator.get().delegate = self;
 
     [m_coordinator setRegisteredStyleOverrides:overrides reply:^(NSError *error) {

--- a/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm
@@ -57,7 +57,7 @@ using namespace WebCore;
         return self;
 
     _capturer = WTFMove(capturer);
-    [[PAL::getRPScreenRecorderClass() sharedRecorder] addObserver:self forKeyPath:@"recording" options:NSKeyValueObservingOptionNew context:(void *)nil];
+    [[PAL::getRPScreenRecorderClassSingleton() sharedRecorder] addObserver:self forKeyPath:@"recording" options:NSKeyValueObservingOptionNew context:(void *)nil];
 
     return self;
 }
@@ -65,7 +65,7 @@ using namespace WebCore;
 - (void)disconnect
 {
     _capturer = nullptr;
-    [[PAL::getRPScreenRecorderClass() sharedRecorder] removeObserver:self forKeyPath:@"recording"];
+    [[PAL::getRPScreenRecorderClassSingleton() sharedRecorder] removeObserver:self forKeyPath:@"recording"];
 }
 
 - (void)observeValueForKeyPath:keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context
@@ -100,7 +100,7 @@ namespace WebCore {
 
 bool ReplayKitCaptureSource::isAvailable()
 {
-    return [PAL::getRPScreenRecorderClass() sharedRecorder].isAvailable;
+    return [PAL::getRPScreenRecorderClassSingleton() sharedRecorder].isAvailable;
 }
 
 ReplayKitCaptureSource::ReplayKitCaptureSource(CapturerObserver& observer)
@@ -123,7 +123,7 @@ bool ReplayKitCaptureSource::start()
     auto identifier = LOGIDENTIFIER;
     ALWAYS_LOG_IF(loggerPtr(), identifier);
 
-    auto *screenRecorder = [PAL::getRPScreenRecorderClass() sharedRecorder];
+    auto *screenRecorder = [PAL::getRPScreenRecorderClassSingleton() sharedRecorder];
     if (screenRecorder.recording)
         return true;
 
@@ -180,7 +180,7 @@ void ReplayKitCaptureSource::captureStateDidChange()
         if (!weakThis)
             return;
 
-        bool isRecording = !![[PAL::getRPScreenRecorderClass() sharedRecorder] isRecording];
+        bool isRecording = !![[PAL::getRPScreenRecorderClassSingleton() sharedRecorder] isRecording];
         if (m_isRunning == (isRecording && !m_interrupted))
             return;
 
@@ -198,7 +198,7 @@ void ReplayKitCaptureSource::stop()
     m_interrupted = false;
     m_isRunning = false;
 
-    auto *screenRecorder = [PAL::getRPScreenRecorderClass() sharedRecorder];
+    auto *screenRecorder = [PAL::getRPScreenRecorderClassSingleton() sharedRecorder];
     if (screenRecorder.recording) {
         [screenRecorder stopCaptureWithHandler:^(NSError * _Nullable error) {
             ERROR_LOG_IF(error && loggerPtr(), identifier, "startCaptureWithHandler failed ", error);

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -221,7 +221,7 @@ void AVVideoCaptureSource::setUseAVCaptureDeviceRotationCoordinatorAPI(bool valu
 
 CaptureSourceOrError AVVideoCaptureSource::create(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
-    auto *avDevice = [PAL::getAVCaptureDeviceClass() deviceWithUniqueID:device.persistentId().createNSString().get()];
+    auto *avDevice = [PAL::getAVCaptureDeviceClassSingleton() deviceWithUniqueID:device.persistentId().createNSString().get()];
     if (!avDevice)
         return CaptureSourceOrError({ "No AVVideoCaptureSource device"_s , MediaAccessDenialReason::PermissionDenied });
 
@@ -676,7 +676,7 @@ RetainPtr<AVCapturePhotoSettings> AVVideoCaptureSource::photoConfiguration(const
     if (photoSettings.imageHeight && photoSettings.imageWidth)
         requestedPhotoDimensions = { static_cast<int>(*photoSettings.imageWidth), static_cast<int>(*photoSettings.imageHeight) };
 
-    AVCapturePhotoSettings* avPhotoSettings = [PAL::getAVCapturePhotoSettingsClass() photoSettingsWithFormat:@{
+    AVCapturePhotoSettings* avPhotoSettings = [PAL::getAVCapturePhotoSettingsClassSingleton() photoSettingsWithFormat:@{
         AVVideoCodecKey : AVVideoCodecTypeJPEG,
         AVVideoCompressionPropertiesKey : @{ AVVideoQualityKey : @(1) }
     }];
@@ -1089,7 +1089,7 @@ bool AVVideoCaptureSource::setupSession()
     String mediaEnvironment = RealtimeMediaSourceCenter::singleton().currentMediaEnvironment();
     WARNING_LOG_IF(loggerPtr() && mediaEnvironment.isEmpty(), "Media environment is empty");
     // FIXME (119325252): Remove staging code for -[AVCaptureSession initWithMediaEnvironment:]
-    if (!mediaEnvironment.isEmpty() && [PAL::getAVCaptureSessionClass() instancesRespondToSelector:@selector(initWithMediaEnvironment:)])
+    if (!mediaEnvironment.isEmpty() && [PAL::getAVCaptureSessionClassSingleton() instancesRespondToSelector:@selector(initWithMediaEnvironment:)])
         m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithMediaEnvironment:mediaEnvironment.createNSString().get()]);
 #endif
 
@@ -1098,7 +1098,7 @@ bool AVVideoCaptureSource::setupSession()
         auto identity = RealtimeMediaSourceCenter::singleton().identity();
         ERROR_LOG_IF(loggerPtr() && !identity, LOGIDENTIFIER, "RealtimeMediaSourceCenter::identity() returned null!");
 
-        if (identity && [PAL::getAVCaptureSessionClass() instancesRespondToSelector:@selector(initWithAssumedIdentity:)])
+        if (identity && [PAL::getAVCaptureSessionClassSingleton() instancesRespondToSelector:@selector(initWithAssumedIdentity:)])
             m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithAssumedIdentity:identity.get()]);
     }
 #endif

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
@@ -82,7 +82,7 @@ namespace WebCore {
 #if HAVE(AVAUDIOAPPLICATION)
 static AVAudioApplication *getSharedAVAudioApplication()
 {
-    return PAL::isAVFAudioFrameworkAvailable() ? (AVAudioApplication *)[PAL::getAVAudioApplicationClass() sharedInstance] : nil;
+    return PAL::isAVFAudioFrameworkAvailable() ? (AVAudioApplication *)[PAL::getAVAudioApplicationClassSingleton() sharedInstance] : nil;
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -197,11 +197,11 @@ namespace WebCore {
 bool ScreenCaptureKitSharingSessionManager::isAvailable()
 {
 #if HAVE(SC_CONTENT_SHARING_PICKER)
-    if (PAL::getSCContentSharingPickerClass() && PAL::getSCContentSharingPickerConfigurationClass())
+    if (PAL::getSCContentSharingPickerClassSingleton() && PAL::getSCContentSharingPickerConfigurationClassSingleton())
         return true;
 #endif
 
-    return PAL::getSCContentSharingSessionClass();
+    return PAL::getSCContentSharingSessionClassSingleton();
 }
 
 bool ScreenCaptureKitSharingSessionManager::useSCContentSharingPicker()
@@ -255,7 +255,7 @@ void ScreenCaptureKitSharingSessionManager::cancelPicking()
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     if (useSCContentSharingPicker()) {
         if (m_activeSources.isEmpty()) {
-            RetainPtr picker = [PAL::getSCContentSharingPickerClass() sharedPicker];
+            RetainPtr picker = [PAL::getSCContentSharingPickerClassSingleton() sharedPicker];
             [m_promptHelper stopObservingPicker:picker.get()];
         }
     }
@@ -467,7 +467,7 @@ bool ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker(Dis
         break;
     }
 
-    RetainPtr picker = [PAL::getSCContentSharingPickerClass() sharedPicker];
+    RetainPtr picker = [PAL::getSCContentSharingPickerClassSingleton() sharedPicker];
     [picker setDefaultConfiguration:configuration.get()];
     [picker setMaximumStreamCount:@(std::numeric_limits<unsigned>::max())];
     [m_promptHelper startObservingPicker:picker.get()];

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
@@ -40,7 +40,7 @@
 #if PLATFORM(MAC)
 #define PlatformNSParagraphStyle NSParagraphStyle.class
 #else
-#define PlatformNSParagraphStyle PAL::getNSParagraphStyleClass()
+#define PlatformNSParagraphStyle PAL::getNSParagraphStyleClassSingleton()
 #endif
 
 OBJC_CLASS NSCalendar;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1001,7 +1001,7 @@ Color RenderThemeIOS::systemFocusRingColor()
 {
     if (!cachedFocusRingColor().has_value()) {
         // FIXME: Should be using +keyboardFocusIndicatorColor. For now, work around <rdar://problem/50838886>.
-        cachedFocusRingColor() = colorFromCocoaColor([PAL::getUIColorClass() systemBlueColor]);
+        cachedFocusRingColor() = colorFromCocoaColor([PAL::getUIColorClassSingleton() systemBlueColor]);
     }
     return *cachedFocusRingColor();
 }
@@ -1144,7 +1144,7 @@ static const Vector<CSSValueSystemColorInformation>& cssValueSystemColorInformat
 
 static inline std::optional<Color> systemColorFromCSSValueSystemColorInformation(CSSValueSystemColorInformation systemColorInformation, bool useDarkAppearance)
 {
-    UIColor *color = wtfObjCMsgSend<UIColor *>(PAL::getUIColorClass(), systemColorInformation.selector);
+    UIColor *color = wtfObjCMsgSend<UIColor *>(PAL::getUIColorClassSingleton(), systemColorInformation.selector);
     if (!color)
         return std::nullopt;
 

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -240,7 +240,7 @@ DDScannerResult *Internals::fakeDataDetectorResultForTesting()
         if (!CFArrayGetCount(results.get()))
             return nil;
 
-        return { [[PAL::getDDScannerResultClass() resultsFromCoreResults:results.get()] firstObject] };
+        return { [[PAL::getDDScannerResultClassSingleton() resultsFromCoreResults:results.get()] firstObject] };
     }();
     return result->get();
 }

--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -50,8 +50,8 @@ namespace WebKit {
 bool GPUConnectionToWebProcess::setCaptureAttributionString()
 {
 #if HAVE(SYSTEM_STATUS)
-    if (![PAL::getSTDynamicActivityAttributionPublisherClass() respondsToSelector:@selector(setCurrentAttributionStringWithFormat:auditToken:)]
-        && ![PAL::getSTDynamicActivityAttributionPublisherClass() respondsToSelector:@selector(setCurrentAttributionWebsiteString:auditToken:)]) {
+    if (![PAL::getSTDynamicActivityAttributionPublisherClassSingleton() respondsToSelector:@selector(setCurrentAttributionStringWithFormat:auditToken:)]
+        && ![PAL::getSTDynamicActivityAttributionPublisherClassSingleton() respondsToSelector:@selector(setCurrentAttributionWebsiteString:auditToken:)]) {
         return true;
     }
 
@@ -63,11 +63,11 @@ bool GPUConnectionToWebProcess::setCaptureAttributionString()
     if (!visibleName)
         visibleName = gpuProcess().applicationVisibleName().createNSString();
 
-    if ([PAL::getSTDynamicActivityAttributionPublisherClass() respondsToSelector:@selector(setCurrentAttributionWebsiteString:auditToken:)])
-        [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionWebsiteString:visibleName.get() auditToken:auditToken.value()];
+    if ([PAL::getSTDynamicActivityAttributionPublisherClassSingleton() respondsToSelector:@selector(setCurrentAttributionWebsiteString:auditToken:)])
+        [PAL::getSTDynamicActivityAttributionPublisherClassSingleton() setCurrentAttributionWebsiteString:visibleName.get() auditToken:auditToken.value()];
     else {
         RetainPtr formatString = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ in %%@", "The domain and application using the camera and/or microphone. The first argument is domain, the second is the application name (iOS only)."), visibleName.get()]);
-        [PAL::getSTDynamicActivityAttributionPublisherClass() setCurrentAttributionStringWithFormat:formatString.get() auditToken:auditToken.value()];
+        [PAL::getSTDynamicActivityAttributionPublisherClassSingleton() setCurrentAttributionStringWithFormat:formatString.get() auditToken:auditToken.value()];
     }
 #endif
 

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -95,7 +95,7 @@ void GPUProcess::ensureAVCaptureServerConnection()
 {
     RELEASE_LOG(WebRTC, "GPUProcess::ensureAVCaptureServerConnection: Entering.");
 #if HAVE(AVCAPTUREDEVICE) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)
-    RetainPtr deviceClass = PAL::getAVCaptureDeviceClass();
+    RetainPtr deviceClass = PAL::getAVCaptureDeviceClassSingleton();
     if ([deviceClass respondsToSelector:@selector(ensureServerConnection)]) {
         RELEASE_LOG(WebRTC, "GPUProcess::ensureAVCaptureServerConnection: Calling [AVCaptureDevice ensureServerConnection]");
         [deviceClass ensureServerConnection];

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -197,7 +197,7 @@ void RKModelLoaderUSD::load(CompletionHandler<void()>&& completionHandler)
     RetainPtr<NSString> attributionID;
     if (m_attributionTaskID.has_value())
         attributionID = m_attributionTaskID.value().createNSString();
-    [getWKRKEntityClass() loadFromData:m_model->data()->createNSData().get() withAttributionTaskID:attributionID.get() entityMemoryLimit:(m_entityMemoryLimit ? *m_entityMemoryLimit : 0) completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (WKRKEntity *entity) mutable {
+    [getWKRKEntityClassSingleton() loadFromData:m_model->data()->createNSData().get() withAttributionTaskID:attributionID.get() entityMemoryLimit:(m_entityMemoryLimit ? *m_entityMemoryLimit : 0) completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (WKRKEntity *entity) mutable {
         completionHandler();
 
         RefPtr protectedThis = weakThis.get();
@@ -585,7 +585,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     dispatch_assert_queue(dispatch_get_main_queue());
     ASSERT(&loader == m_loader.get());
 
-    bool canLoadWithRealityKit = [getWKRKEntityClass() isLoadFromDataAvailable];
+    bool canLoadWithRealityKit = [getWKRKEntityClassSingleton() isLoadFromDataAvailable];
 
     m_loader = nullptr;
     if (canLoadWithRealityKit)
@@ -680,7 +680,7 @@ void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSi
 
     WKREEngine::shared().runWithSharedScene([this, protectedThis = Ref { *this }, model = Ref { model }] (RESceneRef scene) {
         m_scene = scene;
-        if ([getWKRKEntityClass() isLoadFromDataAvailable])
+        if ([getWKRKEntityClassSingleton() isLoadFromDataAvailable])
             m_loader = RKUSDModelLoadScheduler::singleton().scheduleModelLoad(model.get(), m_attributionTaskID, m_debugEntityMemoryLimit ? *m_debugEntityMemoryLimit : defaultEntityMemoryLimit, *this);
         else
             m_loader = WebCore::loadREModel(model.get(), *this);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2432,8 +2432,8 @@ void NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTime> modif
     if (!SymptomAnalyticsLibrary()
         || !SymptomPresentationFeedLibrary()
         || !SymptomPresentationLiteLibrary()
-        || !getAnalyticsWorkspaceClass()
-        || !getUsageFeedClass()
+        || !getAnalyticsWorkspaceClassSingleton()
+        || !getUsageFeedClassSingleton()
         || !canLoadkSymptomAnalyticsServiceEndpoint()) {
         completionHandler();
         return;

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -134,7 +134,7 @@ TextRecognitionResult makeTextRecognitionResult(CocoaImageAnalysis *analysis)
 #endif // ENABLE(DATA_DETECTION)
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    if ([analysis isKindOfClass:PAL::getVKCImageAnalysisClass()])
+    if ([analysis isKindOfClass:PAL::getVKCImageAnalysisClassSingleton()])
         result.imageAnalysisData = TextRecognitionResult::encodeVKCImageAnalysis(analysis);
 #endif
 
@@ -159,7 +159,7 @@ bool languageIdentifierSupportsLiveText(NSString *languageIdentifier)
 
     static NeverDestroyed<MemoryCompactRobinHoodHashSet<String>> supportedLanguages = [] {
         MemoryCompactRobinHoodHashSet<String> set;
-        for (NSString *identifier in [PAL::getVKCImageAnalyzerClass() supportedRecognitionLanguages]) {
+        for (NSString *identifier in [PAL::getVKCImageAnalyzerClassSingleton() supportedRecognitionLanguages]) {
             if (auto code = languageCodeForLocale(identifier); !code.isEmpty())
                 set.add(WTFMove(code));
         }

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -110,7 +110,7 @@ Variant<MediaPlaybackTargetContextCocoa, MediaPlaybackTargetContextMock> MediaPl
     propertyList[@"AVOutputContextSerializationKeyContextID"] = m_contextID.createNSString().get();
     propertyList[@"AVOutputContextSerializationKeyContextType"] = m_contextType.createNSString().get();
     auto unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:propertyList]);
-    auto outputContext = adoptNS([[PAL::getAVOutputContextClass() alloc] initWithCoder:unarchiver.get()]);
+    auto outputContext = adoptNS([[PAL::getAVOutputContextClassSingleton() alloc] initWithCoder:unarchiver.get()]);
     // Variant construction in older clang gives either an error, a vtable linkage error unless we construct it this way.
     Variant<MediaPlaybackTargetContextCocoa, MediaPlaybackTargetContextMock> variant { WTF::InPlaceType<MediaPlaybackTargetContextCocoa>, WTFMove(outputContext) };
     return variant;

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -175,10 +175,10 @@ static NSError *toNSError(const WebCore::ApplePayError& error)
     if (error.domain() == WebCore::ApplePayError::Domain::Disbursement) {
         switch (error.code()) {
         case WebCore::ApplePayErrorCode::UnsupportedCard:
-            return [PAL::getPKDisbursementRequestClass() disbursementCardUnsupportedError];
+            return [PAL::getPKDisbursementRequestClassSingleton() disbursementCardUnsupportedError];
         case WebCore::ApplePayErrorCode::RecipientContactInvalid:
             if (error.contactField())
-                return [PAL::getPKDisbursementRequestClass() disbursementContactInvalidErrorWithContactField:toPKContactField(error.contactField().value()) localizedDescription:error.message().createNSString().get()];
+                return [PAL::getPKDisbursementRequestClassSingleton() disbursementContactInvalidErrorWithContactField:toPKContactField(error.contactField().value()) localizedDescription:error.message().createNSString().get()];
             break;
         default:
             return [NSError errorWithDomain:PAL::get_PassKitCore_PKDisbursementErrorDomain() code:PKDisbursementUnknownError userInfo:userInfo.get()];

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
@@ -51,7 +51,7 @@
 
 - (void)_getPaymentServicesMerchantURL:(void(^)(NSURL *, NSError *))completion
 {
-    [PAL::getPKPaymentAuthorizationViewControllerClass() paymentServicesMerchantURLForAPIType:[_request APIType] completion:completion];
+    [PAL::getPKPaymentAuthorizationViewControllerClassSingleton() paymentServicesMerchantURLForAPIType:[_request APIType] completion:completion];
 }
 
 #pragma mark PKPaymentAuthorizationViewControllerDelegate

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -159,7 +159,7 @@ void LinkDecorationFilteringController::updateList(CompletionHandler<void()>&& c
     RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
     [options setAfterUpdates:NO];
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestLinkFilteringData:options.get() completionHandler:^(WPLinkFilteringData *data, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestLinkFilteringData:options.get() completionHandler:^(WPLinkFilteringData *data, NSError *error) {
         Vector<WebCore::LinkDecorationFilteringData> result;
         if (error)
             RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request query parameters from WebPrivacy.");
@@ -187,7 +187,7 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
     }
 
     static BOOL canRequestAllowedQueryParameters = [] {
-        return [PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestAllowedLinkFilteringData:completionHandler:)];
+        return [PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestAllowedLinkFilteringData:completionHandler:)];
     }();
 
     if (!canRequestAllowedQueryParameters) {
@@ -203,7 +203,7 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
     auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
     [options setAfterUpdates:NO];
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestAllowedLinkFilteringData:options.get() completionHandler:^(WPLinkFilteringData *data, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestAllowedLinkFilteringData:options.get() completionHandler:^(WPLinkFilteringData *data, NSError *error) {
         Vector<WebCore::LinkDecorationFilteringData> result;
         if (error)
             RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request allowed query parameters from WebPrivacy.");
@@ -263,7 +263,7 @@ static Vector<URL> quirkPagesArrayToVector(NSArray<NSString *> *triggerPages)
 void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestStorageAccessPromptQuirksData:completionHandler:)]) {
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestStorageAccessPromptQuirksData:completionHandler:)]) {
         RunLoop::mainSingleton().dispatch(WTFMove(completionHandler));
         return;
     }
@@ -276,13 +276,13 @@ void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& 
     RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
     [options setAfterUpdates:NO];
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestStorageAccessPromptQuirksData:options.get() completionHandler:^(WPStorageAccessPromptQuirksData *data, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestStorageAccessPromptQuirksData:options.get() completionHandler:^(WPStorageAccessPromptQuirksData *data, NSError *error) {
         Vector<WebCore::OrganizationStorageAccessPromptQuirk> result;
         if (error)
             RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request storage access quirks from WebPrivacy.");
         else {
             auto quirks = [data quirks];
-            auto hasQuirkDomainsAndTriggerPages = [PAL::getWPStorageAccessPromptQuirkClass() instancesRespondToSelector:@selector(quirkDomains)] && [PAL::getWPStorageAccessPromptQuirkClass() instancesRespondToSelector:@selector(triggerPages)];
+            auto hasQuirkDomainsAndTriggerPages = [PAL::getWPStorageAccessPromptQuirkClassSingleton() instancesRespondToSelector:@selector(quirkDomains)] && [PAL::getWPStorageAccessPromptQuirkClassSingleton() instancesRespondToSelector:@selector(triggerPages)];
             for (WPStorageAccessPromptQuirk *quirk : quirks) {
                 if (hasQuirkDomainsAndTriggerPages)
                     result.append(WebCore::OrganizationStorageAccessPromptQuirk { quirk.name, quirkDomainsDictToMap(quirk.quirkDomains), quirkPagesArrayToVector(quirk.triggerPages) });
@@ -305,7 +305,7 @@ unsigned StorageAccessUserAgentStringQuirkController::resourceTypeValue() const
 void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestStorageAccessUserAgentStringQuirksData:completionHandler:)]) {
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestStorageAccessUserAgentStringQuirksData:completionHandler:)]) {
         RunLoop::mainSingleton().dispatch(WTFMove(completionHandler));
         return;
     }
@@ -318,7 +318,7 @@ void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<v
     RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
     [options setAfterUpdates:NO];
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestStorageAccessUserAgentStringQuirksData:options.get() completionHandler:^(WPStorageAccessUserAgentStringQuirksData *data, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestStorageAccessUserAgentStringQuirksData:options.get() completionHandler:^(WPStorageAccessUserAgentStringQuirksData *data, NSError *error) {
         HashMap<WebCore::RegistrableDomain, String> result;
         if (error)
             RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request storage access user agent string quirks from WebPrivacy.");
@@ -369,13 +369,13 @@ void RestrictedOpenerDomainsController::scheduleNextUpdate(ContinuousApproximate
 void RestrictedOpenerDomainsController::update()
 {
     ASSERT(RunLoop::isMain());
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestRestrictedOpenerDomains:completionHandler:)])
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestRestrictedOpenerDomains:completionHandler:)])
         return;
 
     auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
     [options setAfterUpdates:NO];
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestRestrictedOpenerDomains:options.get() completionHandler:^(NSArray<WPRestrictedOpenerDomain *> *domains, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestRestrictedOpenerDomains:options.get() completionHandler:^(NSArray<WPRestrictedOpenerDomain *> *domains, NSError *error) {
         if (error) {
             RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request restricted opener domains from WebPrivacy");
             return;
@@ -422,7 +422,7 @@ void ResourceMonitorURLsController::setContentRuleListStore(API::ContentRuleList
 void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRuleList*, bool)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(prepareResourceMonitorRulesForStore:completionHandler:)]) {
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(prepareResourceMonitorRulesForStore:completionHandler:)]) {
         completionHandler(nullptr, false);
         return;
     }
@@ -434,7 +434,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
 
     Ref<API::ContentRuleListStore> store = m_contentRuleListStore ? *m_contentRuleListStore : API::ContentRuleListStore::defaultStoreSingleton();
 
-    [[PAL::getWPResourcesClass() sharedInstance] prepareResourceMonitorRulesForStore:wrapper(store.get()) completionHandler:^(WKContentRuleList *list, bool updated, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] prepareResourceMonitorRulesForStore:wrapper(store.get()) completionHandler:^(WKContentRuleList *list, bool updated, NSError *error) {
         if (error)
             RELEASE_LOG_ERROR(ResourceMonitoring, "Failed to request resource monitor urls from WebPrivacy: %@", error);
 
@@ -446,7 +446,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
 void ResourceMonitorURLsController::getSource(CompletionHandler<void(String&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestResourceMonitorRulesSource:completionHandler:)]) {
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestResourceMonitorRulesSource:completionHandler:)]) {
         completionHandler({ });
         return;
     }
@@ -456,7 +456,7 @@ void ResourceMonitorURLsController::getSource(CompletionHandler<void(String&&)>&
     if (lookupCompletionHandlers->size() > 1)
         return;
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestResourceMonitorRulesSource:nil completionHandler:^(NSString *source, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestResourceMonitorRulesSource:nil completionHandler:^(NSString *source, NSError *error) {
         if (error)
             RELEASE_LOG_ERROR(ResourceMonitoring, "Failed to request resource monitor urls source from WebPrivacy");
 
@@ -533,7 +533,7 @@ public:
             auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
             [options setAfterUpdates:YES];
 
-            [[PAL::getWPResourcesClass() sharedInstance] requestTrackerNetworkAddresses:options.get() completionHandler:^(NSArray<WPNetworkAddressRange *> *ranges, NSError *error) {
+            [[PAL::getWPResourcesClassSingleton() sharedInstance] requestTrackerNetworkAddresses:options.get() completionHandler:^(NSArray<WPNetworkAddressRange *> *ranges, NSError *error) {
                 if (error) {
                     RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request tracking IP addresses from WebPrivacy");
                     return;
@@ -659,7 +659,7 @@ public:
                 return;
 
             static BOOL canRequestTrackerDomainNames = [] {
-                return [PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestTrackerDomainNamesData:completionHandler:)];
+                return [PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestTrackerDomainNamesData:completionHandler:)];
             }();
 
             if (!canRequestTrackerDomainNames)
@@ -667,7 +667,7 @@ public:
 
             auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
             [options setAfterUpdates:YES];
-            [[PAL::getWPResourcesClass() sharedInstance] requestTrackerDomainNamesData:options.get() completionHandler:^(NSArray<WPTrackingDomain *> * domains, NSError *error) {
+            [[PAL::getWPResourcesClassSingleton() sharedInstance] requestTrackerDomainNamesData:options.get() completionHandler:^(NSArray<WPTrackingDomain *> * domains, NSError *error) {
                 if (error) {
                     RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request tracking domains from WebPrivacy");
                     return;
@@ -799,7 +799,7 @@ void ScriptTrackingPrivacyController::updateList(CompletionHandler<void()>&& com
 {
     ASSERT(RunLoop::isMain());
 #if ENABLE(SCRIPT_TRACKING_PRIVACY_PROTECTIONS)
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestFingerprintingScripts:completionHandler:)]) {
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestFingerprintingScripts:completionHandler:)]) {
         RunLoop::mainSingleton().dispatch(WTFMove(completion));
         return;
     }
@@ -812,7 +812,7 @@ void ScriptTrackingPrivacyController::updateList(CompletionHandler<void()>&& com
     RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
     [options setAfterUpdates:NO];
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestFingerprintingScripts:options.get() completionHandler:^(NSArray<WPFingerprintingScript *> *scripts, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestFingerprintingScripts:options.get() completionHandler:^(NSArray<WPFingerprintingScript *> *scripts, NSError *error) {
         auto callCompletionHandlers = makeScopeExit([&] {
             for (auto& completionHandler : std::exchange(pendingCompletionHandlers.get(), { }))
                 completionHandler();

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -60,10 +60,10 @@
 - (void)_getPaymentServicesMerchantURL:(void(^)(NSURL *, NSError *))completion
 {
     // FIXME: This -respondsToSelector: check can be removed once rdar://problem/48771320 is in an iOS SDK.
-    if ([PAL::getPKPaymentAuthorizationControllerClass() respondsToSelector:@selector(paymentServicesMerchantURLForAPIType:completion:)])
-        [PAL::getPKPaymentAuthorizationControllerClass() paymentServicesMerchantURLForAPIType:[_request APIType] completion:completion];
+    if ([PAL::getPKPaymentAuthorizationControllerClassSingleton() respondsToSelector:@selector(paymentServicesMerchantURLForAPIType:completion:)])
+        [PAL::getPKPaymentAuthorizationControllerClassSingleton() paymentServicesMerchantURLForAPIType:[_request APIType] completion:completion];
     else
-        [PAL::getPKPaymentAuthorizationViewControllerClass() paymentServicesMerchantURLForAPIType:[_request APIType] completion:completion];
+        [PAL::getPKPaymentAuthorizationViewControllerClassSingleton() paymentServicesMerchantURLForAPIType:[_request APIType] completion:completion];
 }
 
 #pragma mark PKPaymentAuthorizationControllerDelegate

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -91,7 +91,7 @@ using namespace WebCore;
 
 NSString *menuItemTitleForTelephoneNumberGroup()
 {
-    return [getTUCallClass() supplementalDialTelephonyCallString];
+    return [getTUCallClassSingleton() supplementalDialTelephonyCallString];
 }
 
 #if HAVE(DATA_DETECTORS_MAC_ACTION)
@@ -107,10 +107,10 @@ static DDAction *actionForMenuItem(NSMenuItem *item)
     id action = [representedObject objectForKey:@"DDAction"];
 
 #if HAVE(DATA_DETECTORS_MAC_ACTION)
-    if (![action isKindOfClass:PAL::getDDMacActionClass()])
+    if (![action isKindOfClass:PAL::getDDMacActionClassSingleton()])
         return nil;
 #else
-    if (![action isKindOfClass:PAL::getDDActionClass()])
+    if (![action isKindOfClass:PAL::getDDActionClassSingleton()])
         return nil;
 #endif
 
@@ -126,7 +126,7 @@ NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber)
 
     [actionContext setAllowedActionUTIs:@[ @"com.apple.dial" ]];
 
-    RetainPtr<NSArray> proposedMenuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForValue:telephoneNumber.createNSString().get() type:PAL::get_DataDetectorsCore_DDBinderPhoneNumberKey() service:nil context:actionContext.get()];
+    RetainPtr<NSArray> proposedMenuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForValue:telephoneNumber.createNSString().get() type:PAL::get_DataDetectorsCore_DDBinderPhoneNumberKey() service:nil context:actionContext.get()];
     for (NSMenuItem *item in proposedMenuItems.get()) {
         RetainPtr action = actionForMenuItem(item);
         if ([action.get().actionUTI hasPrefix:@"com.apple.dial"]) {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -16,11 +16,11 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
 [Nested] class Namespace::OtherClass {
     int a
     [BitField] bool b
-    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClass()]] RetainPtr<NSArray> dataDetectorResults;
+    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClassSingleton()]] RetainPtr<NSArray> dataDetectorResults;
 }
 
 [Nested] class Namespace::ClassWithMemberPrecondition {
-    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClass()]] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClassSingleton()]] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
 }
 
 [RefCounted] class Namespace::ReturnRefClass {
@@ -102,8 +102,8 @@ class WTF::Seconds {
 };
 
 struct SoftLinkedMember {
-    [SecureCodingAllowed=[PAL::getDDActionContextClass()]] RetainPtr<DDActionContext> firstMember;
-    [SecureCodingAllowed=[PAL::getDDActionContextClass()]] RetainPtr<DDActionContext> secondMember;
+    [SecureCodingAllowed=[PAL::getDDActionContextClassSingleton()]] RetainPtr<DDActionContext> firstMember;
+    [SecureCodingAllowed=[PAL::getDDActionContextClassSingleton()]] RetainPtr<DDActionContext> secondMember;
 }
 
 [RefCounted] class WebCore::TimingFunction subclasses {
@@ -233,7 +233,7 @@ struct RequestEncodedWithBody {
 
 #if USE(AVFOUNDATION)
 secure_coding_header: <pal/cocoa/AVFoundationSoftLink.h>
-[WebKitSecureCodingClass=PAL::getAVOutputContextClass(), SupportWKKeyedCoder] webkit_secure_coding AVOutputContext {
+[WebKitSecureCodingClass=PAL::getAVOutputContextClassSingleton(), SupportWKKeyedCoder] webkit_secure_coding AVOutputContext {
     AVOutputContextSerializationKeyContextID: String
     AVOutputContextSerializationKeyContextType: String
 }
@@ -256,7 +256,7 @@ webkit_secure_coding NSSomeFoundationType {
 #if ENABLE(DATA_DETECTION)
 # Test a comment
 secure_coding_headers: <pal/cocoa/DataDetectorsCoreSoftLink.h>
-[WebKitSecureCodingClass=PAL::getDDScannerResultClass()] webkit_secure_coding DDScannerResult {
+[WebKitSecureCodingClass=PAL::getDDScannerResultClassSingleton()] webkit_secure_coding DDScannerResult {
     StringKey: String
     NumberKey: Number
     OptionalNumberKey: Number?

--- a/Source/WebKit/Shared/API/c/cf/WKStringCF.mm
+++ b/Source/WebKit/Shared/API/c/cf/WKStringCF.mm
@@ -31,7 +31,7 @@
 #import <objc/runtime.h>
 #import <wtf/text/WTFString.h>
 
-static inline Class wkNSStringClass()
+static inline Class wkNSStringClassSingleton()
 {
     static dispatch_once_t once;
     static Class wkNSStringClass;
@@ -44,7 +44,7 @@ static inline Class wkNSStringClass()
 WKStringRef WKStringCreateWithCFString(CFStringRef cfString)
 {
     // Since WKNSString is an internal class with no subclasses, we can do a simple equality check.
-    if (object_getClass((__bridge NSString *)cfString) == wkNSStringClass())
+    if (object_getClass((__bridge NSString *)cfString) == wkNSStringClassSingleton())
         return WebKit::toAPI(RefPtr { downcast<API::String>(&[(WKNSString *)(__bridge NSString *)CFRetain(cfString) _apiObject]) }.get());
     String string(cfString);
     return WebKit::toCopiedAPI(string);

--- a/Source/WebKit/Shared/API/c/cf/WKURLCF.mm
+++ b/Source/WebKit/Shared/API/c/cf/WKURLCF.mm
@@ -31,7 +31,7 @@
 #import <objc/runtime.h>
 #import <wtf/cf/CFURLExtras.h>
 
-static inline Class wkNSURLClass()
+static inline Class wkNSURLClassSingleton()
 {
     static dispatch_once_t once;
     static Class wkNSURLClass;
@@ -47,7 +47,7 @@ WKURLRef WKURLCreateWithCFURL(CFURLRef cfURL)
         return nullptr;
 
     // Since WKNSURL is an internal class with no subclasses, we can do a simple equality check.
-    if (object_getClass((__bridge NSURL *)cfURL) == wkNSURLClass())
+    if (object_getClass((__bridge NSURL *)cfURL) == wkNSURLClassSingleton())
         return WebKit::toAPI(RefPtr { downcast<API::URL>(&[(WKNSURL *)(__bridge NSURL *)CFRetain(cfURL) _apiObject]) }.get());
 
     // FIXME: Why is it OK to ignore the base URL in the CFURL here?

--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in
@@ -26,7 +26,7 @@ headers: <pal/cocoa/PassKitSoftLink.h>
 
 header: "ApplePayPaymentSetupFeaturesWebKit.h"
 [CustomHeader] class WebKit::PaymentSetupFeatures {
-    [SecureCodingAllowed=[NSArray.class, PAL::getPKPaymentSetupFeatureClass()]] RetainPtr<NSArray> m_platformFeatures;
+    [SecureCodingAllowed=[NSArray.class, PAL::getPKPaymentSetupFeatureClassSingleton()]] RetainPtr<NSArray> m_platformFeatures;
 };
 
 #endif

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
@@ -45,7 +45,7 @@ namespace WebKit {
 static RetainPtr<PKPaymentSetupConfiguration> toPlatformConfiguration(const WebCore::ApplePaySetupConfiguration& coreConfiguration, const URL& url)
 {
 #if PLATFORM(MAC)
-    if (!PAL::getPKPaymentSetupConfigurationClass())
+    if (!PAL::getPKPaymentSetupConfigurationClassSingleton())
         return nil;
 #endif
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -190,7 +190,7 @@ static RetainPtr<PKDateComponentsRange> toPKDateComponentsRange(const WebCore::A
 
 RetainPtr<PKShippingMethod> toPKShippingMethod(const WebCore::ApplePayShippingMethod& shippingMethod)
 {
-    RetainPtr<PKShippingMethod> result = [PAL::getPKShippingMethodClass() summaryItemWithLabel:shippingMethod.label.createNSString().get() amount:WebCore::toDecimalNumber(shippingMethod.amount)];
+    RetainPtr<PKShippingMethod> result = [PAL::getPKShippingMethodClassSingleton() summaryItemWithLabel:shippingMethod.label.createNSString().get() amount:WebCore::toDecimalNumber(shippingMethod.amount)];
     [result setIdentifier:shippingMethod.identifier.createNSString().get()];
     [result setDetail:shippingMethod.detail.createNSString().get()];
 #if HAVE(PASSKIT_SHIPPING_METHOD_DATE_COMPONENTS_RANGE)
@@ -460,7 +460,7 @@ void WebPaymentCoordinatorProxy::platformCompleteCouponCodeChange(std::optional<
 void WebPaymentCoordinatorProxy::getSetupFeatures(const PaymentSetupConfiguration& configuration, CompletionHandler<void(PaymentSetupFeatures&&)>&& reply)
 {
 #if PLATFORM(MAC)
-    if (!PAL::getPKPaymentSetupControllerClass()) {
+    if (!PAL::getPKPaymentSetupControllerClassSingleton()) {
         reply({ });
         return;
     }
@@ -473,7 +473,7 @@ void WebPaymentCoordinatorProxy::getSetupFeatures(const PaymentSetupConfiguratio
     });
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    [PAL::getPKPaymentSetupControllerClass() paymentSetupFeaturesForConfiguration:configuration.platformConfiguration().get() completion:completion.get()];
+    [PAL::getPKPaymentSetupControllerClassSingleton() paymentSetupFeaturesForConfiguration:configuration.platformConfiguration().get() completion:completion.get()];
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 }
 
@@ -493,7 +493,7 @@ void WebPaymentCoordinatorProxy::endApplePaySetup()
 
 void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupConfiguration& configuration, const PaymentSetupFeatures& features, CompletionHandler<void(bool)>&& reply)
 {
-    if (!PAL::getPKPaymentSetupRequestClass()) {
+    if (!PAL::getPKPaymentSetupRequestClassSingleton()) {
         reply(false);
         return;
     }

--- a/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
+++ b/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -38,7 +38,7 @@ namespace WebKit {
 
 void WebPaymentCoordinatorProxy::platformCanMakePayments(CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_canMakePaymentsQueue->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationControllerClass()), completionHandler = WTFMove(completionHandler)]() mutable {
+    m_canMakePaymentsQueue->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationControllerClassSingleton()), completionHandler = WTFMove(completionHandler)]() mutable {
         RunLoop::mainSingleton().dispatch([canMakePayments = [theClass canMakePayments], completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler(canMakePayments);
         });

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -47,7 +47,7 @@ void WebPaymentCoordinatorProxy::platformCanMakePayments(CompletionHandler<void(
 #endif
         return completionHandler(false);
 
-    protectedCanMakePaymentsQueue()->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationViewControllerClass()), completionHandler = WTFMove(completionHandler)]() mutable {
+    protectedCanMakePaymentsQueue()->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationViewControllerClassSingleton()), completionHandler = WTFMove(completionHandler)]() mutable {
         RunLoop::mainSingleton().dispatch([canMakePayments = [theClass canMakePayments], completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler(canMakePayments);
         });
@@ -84,7 +84,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 
         auto showPaymentUIRequestSeed = weakThis->m_showPaymentUIRequestSeed;
 
-        [PAL::getPKPaymentAuthorizationViewControllerClass() requestViewControllerWithPaymentRequest:paymentRequest.get() completion:makeBlockPtr([paymentRequest, showPaymentUIRequestSeed, weakThis = WTFMove(weakThis), completionHandler = WTFMove(completionHandler)](PKPaymentAuthorizationViewController *viewController, NSError *error) mutable {
+        [PAL::getPKPaymentAuthorizationViewControllerClassSingleton() requestViewControllerWithPaymentRequest:paymentRequest.get() completion:makeBlockPtr([paymentRequest, showPaymentUIRequestSeed, weakThis = WTFMove(weakThis), completionHandler = WTFMove(completionHandler)](PKPaymentAuthorizationViewController *viewController, NSError *error) mutable {
             RefPtr paymentCoordinatorProxy = weakThis.get();
             if (!paymentCoordinatorProxy)
                 return completionHandler(false);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -273,70 +273,70 @@ using namespace WebCore;
 #if ENABLE(DATA_DETECTION)
 template<> Class getClass<DDScannerResult>()
 {
-    return PAL::getDDScannerResultClass();
+    return PAL::getDDScannerResultClassSingleton();
 }
 
 #if PLATFORM(MAC)
 template<> Class getClass<WKDDActionContext>()
 {
-    return PAL::getWKDDActionContextClass();
+    return PAL::getWKDDActionContextClassSingleton();
 }
 #endif
 #endif
 #if USE(AVFOUNDATION)
 template<> Class getClass<AVOutputContext>()
 {
-    return PAL::getAVOutputContextClass();
+    return PAL::getAVOutputContextClassSingleton();
 }
 #endif
 #if USE(PASSKIT)
 template<> Class getClass<CNContact>()
 {
-    return PAL::getCNContactClass();
+    return PAL::getCNContactClassSingleton();
 }
 template<> Class getClass<CNPhoneNumber>()
 {
-    return PAL::getCNPhoneNumberClass();
+    return PAL::getCNPhoneNumberClassSingleton();
 }
 template<> Class getClass<CNPostalAddress>()
 {
-    return PAL::getCNPostalAddressClass();
+    return PAL::getCNPostalAddressClassSingleton();
 }
 template<> Class getClass<PKContact>()
 {
-    return PAL::getPKContactClass();
+    return PAL::getPKContactClassSingleton();
 }
 template<> Class getClass<PKPaymentMerchantSession>()
 {
-    return PAL::getPKPaymentMerchantSessionClass();
+    return PAL::getPKPaymentMerchantSessionClassSingleton();
 }
 template<> Class getClass<PKPaymentSetupFeature>()
 {
-    return PAL::getPKPaymentSetupFeatureClass();
+    return PAL::getPKPaymentSetupFeatureClassSingleton();
 }
 template<> Class getClass<PKPayment>()
 {
-    return PAL::getPKPaymentClass();
+    return PAL::getPKPaymentClassSingleton();
 }
 template<> Class getClass<PKPaymentToken>()
 {
-    return PAL::getPKPaymentTokenClass();
+    return PAL::getPKPaymentTokenClassSingleton();
 }
 template<> Class getClass<PKShippingMethod>()
 {
-    return PAL::getPKShippingMethodClass();
+    return PAL::getPKShippingMethodClassSingleton();
 }
 template<> Class getClass<PKDateComponentsRange>()
 {
-    return PAL::getPKDateComponentsRangeClass();
+    return PAL::getPKDateComponentsRangeClassSingleton();
 }
 template<> Class getClass<PKPaymentMethod>()
 {
-    return PAL::getPKPaymentMethodClass();
+    return PAL::getPKPaymentMethodClassSingleton();
 }
 template<> Class getClass<PKSecureElementPass>()
 {
-    return PAL::getPKSecureElementPassClass();
+    return PAL::getPKSecureElementPassClassSingleton();
 }
 #endif
 
@@ -456,15 +456,15 @@ template<> void encodeObjectDirectly<NSObject<NSSecureCoding>>(Encoder& encoder,
     auto delegate = adoptNS([[WKSecureCodingArchivingDelegate alloc] init]);
 
 #if ENABLE(DATA_DETECTION)
-    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:PAL::getDDScannerResultClass()])
+    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:PAL::getDDScannerResultClassSingleton()])
         [delegate setRewriteMutableString:YES];
 #if PLATFORM(MAC)
-    if (PAL::isDataDetectorsFrameworkAvailable() && [object isKindOfClass:PAL::getWKDDActionContextClass()])
+    if (PAL::isDataDetectorsFrameworkAvailable() && [object isKindOfClass:PAL::getWKDDActionContextClassSingleton()])
         [delegate setRewriteMutableString:YES];
 #endif // PLATFORM(MAC)
 #endif // ENABLE(DATA_DETECTION)
 #if ENABLE(REVEAL)
-    if (PAL::isRevealCoreFrameworkAvailable() && [object isKindOfClass:PAL::getRVItemClass()])
+    if (PAL::isRevealCoreFrameworkAvailable() && [object isKindOfClass:PAL::getRVItemClassSingleton()])
         [delegate setRewriteMutableString:YES];
 #endif // ENABLE(REVEAL)
 
@@ -475,20 +475,20 @@ template<> void encodeObjectDirectly<NSObject<NSSecureCoding>>(Encoder& encoder,
 
 #if ENABLE(REVEAL)
     // FIXME: This can be removed for RVItem on operating systems that have rdar://109237983.
-    if (PAL::isRevealCoreFrameworkAvailable() && [object isKindOfClass:PAL::getRVItemClass()])
+    if (PAL::isRevealCoreFrameworkAvailable() && [object isKindOfClass:PAL::getRVItemClassSingleton()])
         [delegate setTransformURLs:NO];
 #endif
 #if ENABLE(DATA_DETECTION)
-    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:PAL::getDDScannerResultClass()])
+    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:PAL::getDDScannerResultClassSingleton()])
         [delegate setTransformURLs:NO];
 #if PLATFORM(MAC)
-    if (PAL::isDataDetectorsFrameworkAvailable() && [object isKindOfClass:PAL::getWKDDActionContextClass()])
+    if (PAL::isDataDetectorsFrameworkAvailable() && [object isKindOfClass:PAL::getWKDDActionContextClassSingleton()])
         [delegate setTransformURLs:NO];
 #endif
 #endif // ENABLE(DATA_DETECTION)
 
 #if USE(PASSKIT)
-    if (PAL::isPassKitCoreFrameworkAvailable() && [object isKindOfClass:PAL::getPKSecureElementPassClass()]) {
+    if (PAL::isPassKitCoreFrameworkAvailable() && [object isKindOfClass:PAL::getPKSecureElementPassClassSingleton()]) {
         [delegate setTransformURLs:NO];
         [delegate setRewriteMutableArray:YES];
     }
@@ -521,22 +521,22 @@ static constexpr bool haveSecureActionContext = false;
 #if ENABLE(DATA_DETECTION)
     // rdar://107553330 - don't re-introduce rdar://107676726
     if (PAL::isDataDetectorsCoreFrameworkAvailable()
-        && PAL::getDDScannerResultClass()
-        && allowedClasses.contains(PAL::getDDScannerResultClass()))
+        && PAL::getDDScannerResultClassSingleton()
+        && allowedClasses.contains(PAL::getDDScannerResultClassSingleton()))
         return haveSecureActionContext;
 #if PLATFORM(MAC)
     // rdar://107553348 - don't re-introduce rdar://107676726
     if (PAL::isDataDetectorsFrameworkAvailable()
-        && PAL::getWKDDActionContextClass()
-        && allowedClasses.contains(PAL::getWKDDActionContextClass()))
+        && PAL::getWKDDActionContextClassSingleton()
+        && allowedClasses.contains(PAL::getWKDDActionContextClassSingleton()))
         return haveSecureActionContext;
 #endif // PLATFORM(MAC)
 #endif // ENABLE(DATA_DETECTION)
 #if ENABLE(REVEAL)
     // rdar://107553310 - don't re-introduce rdar://107673064
     if (PAL::isRevealCoreFrameworkAvailable()
-        && PAL::getRVItemClass()
-        && allowedClasses.contains(PAL::getRVItemClass()))
+        && PAL::getRVItemClassSingleton()
+        && allowedClasses.contains(PAL::getRVItemClassSingleton()))
         return haveSecureActionContext;
 #endif // ENABLE(REVEAL)
 
@@ -560,11 +560,11 @@ static constexpr bool haveSecureActionContext = false;
     auto isDecodingPKPaymentRelatedType = [&] () {
         if (!PAL::isPassKitCoreFrameworkAvailable())
             return false;
-        if (PAL::getPKPaymentMethodClass() && allowedClasses.contains(PAL::getPKPaymentMethodClass()))
+        if (PAL::getPKPaymentMethodClassSingleton() && allowedClasses.contains(PAL::getPKPaymentMethodClassSingleton()))
             return true;
-        if (PAL::getPKSecureElementPassClass() && allowedClasses.contains(PAL::getPKSecureElementPassClass()))
+        if (PAL::getPKSecureElementPassClassSingleton() && allowedClasses.contains(PAL::getPKSecureElementPassClassSingleton()))
             return true;
-        if (PAL::isContactsFrameworkAvailable() && PAL::getCNContactClass() && allowedClasses.contains(PAL::getCNContactClass()))
+        if (PAL::isContactsFrameworkAvailable() && PAL::getCNContactClassSingleton() && allowedClasses.contains(PAL::getCNContactClassSingleton()))
             return true;
         return false;
     };
@@ -579,8 +579,8 @@ static constexpr bool haveSecureActionContext = false;
     static constexpr bool haveStrictDecodablePKContact = false;
 #endif
     if (PAL::isPassKitCoreFrameworkAvailable()
-        && PAL::getPKContactClass()
-        && allowedClasses.contains(PAL::getPKContactClass()))
+        && PAL::getPKContactClassSingleton()
+        && allowedClasses.contains(PAL::getPKContactClassSingleton()))
         return haveStrictDecodablePKContact;
 #endif // ENABLE(APPLE_PAY)
 
@@ -590,9 +590,9 @@ static constexpr bool haveSecureActionContext = false;
 
     if (allowedClasses.contains(NSTextAttachment.class) // rdar://107553273
 #if ENABLE(APPLE_PAY)
-        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentSetupFeatureClass() && allowedClasses.contains(PAL::getPKPaymentSetupFeatureClass())) // rdar://107553409
-        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentMerchantSessionClass() && allowedClasses.contains(PAL::getPKPaymentMerchantSessionClass())) // rdar://107553452
-        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentClass() && allowedClasses.contains(PAL::getPKPaymentClass()) && isInWebProcess())
+        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentSetupFeatureClassSingleton() && allowedClasses.contains(PAL::getPKPaymentSetupFeatureClassSingleton())) // rdar://107553409
+        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentMerchantSessionClassSingleton() && allowedClasses.contains(PAL::getPKPaymentMerchantSessionClassSingleton())) // rdar://107553452
+        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentClassSingleton() && allowedClasses.contains(PAL::getPKPaymentClassSingleton()) && isInWebProcess())
 #endif // ENABLE(APPLE_PAY)
         )
         return true;
@@ -638,14 +638,14 @@ template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClas
     // FIXME: Remove these exceptions for PKSecureElementPass
     // once we directly serialize them ourselves.
     if (PAL::isContactsFrameworkAvailable()) {
-        if (allowedClasses.contains(PAL::getPKPaymentClass()) || allowedClasses.contains(PAL::getPKPaymentMethodClass()) || allowedClasses.contains(PAL::getPKPaymentTokenClass())) {
-            allowedClasses.add(PAL::getPKSecureElementPassClass());
+        if (allowedClasses.contains(PAL::getPKPaymentClassSingleton()) || allowedClasses.contains(PAL::getPKPaymentMethodClassSingleton()) || allowedClasses.contains(PAL::getPKPaymentTokenClassSingleton())) {
+            allowedClasses.add(PAL::getPKSecureElementPassClassSingleton());
         }
     }
 
     if (PAL::isPassKitCoreFrameworkAvailable()) {
-        if (PAL::getPKSecureElementPassClass() && allowedClasses.contains(PAL::getPKSecureElementPassClass()))
-            allowedClasses.add(PAL::getPKPaymentPassClass());
+        if (PAL::getPKSecureElementPassClassSingleton() && allowedClasses.contains(PAL::getPKSecureElementPassClassSingleton()))
+            allowedClasses.add(PAL::getPKPaymentPassClassSingleton());
     }
 #endif
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm
@@ -57,7 +57,7 @@ RetainPtr<id> CoreIPCAVOutputContext::toID() const
     RetainPtr dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:2]);
     [dict setObject:m_data.contextID.createNSString().get() forKey:@"contextID"];
     [dict setObject:m_data.contextType.createNSString().get() forKey:@"contextType"];
-    return adoptNS([[PAL::getAVOutputContextClass() alloc] _initWithWebKitPropertyListData:dict.get()]);
+    return adoptNS([[PAL::getAVOutputContextClassSingleton() alloc] _initWithWebKitPropertyListData:dict.get()]);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
@@ -37,7 +37,7 @@ header: "CoreIPCAVOutputContext.h"
 
 #if USE(AVFOUNDATION) && !HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
 secure_coding_header: <pal/cocoa/AVFoundationSoftLink.h>
-[WebKitSecureCodingClass=PAL::getAVOutputContextClass(), SupportWKKeyedCoder] webkit_secure_coding AVOutputContext {
+[WebKitSecureCodingClass=PAL::getAVOutputContextClassSingleton(), SupportWKKeyedCoder] webkit_secure_coding AVOutputContext {
     AVOutputContextSerializationKeyContextID: String
     AVOutputContextSerializationKeyContextType: String
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm
@@ -44,7 +44,7 @@ CoreIPCCNPhoneNumber::CoreIPCCNPhoneNumber(CNPhoneNumber *cnPhoneNumber)
 
 RetainPtr<id> CoreIPCCNPhoneNumber::toID() const
 {
-    return [PAL::getCNPhoneNumberClass() phoneNumberWithDigits:m_digits.createNSString().get() countryCode:m_countryCode.createNSString().get()];
+    return [PAL::getCNPhoneNumberClassSingleton() phoneNumberWithDigits:m_digits.createNSString().get() countryCode:m_countryCode.createNSString().get()];
 }
 
 CoreIPCCNPostalAddress::CoreIPCCNPostalAddress(CNPostalAddress *cnPostalAddress)
@@ -62,7 +62,7 @@ CoreIPCCNPostalAddress::CoreIPCCNPostalAddress(CNPostalAddress *cnPostalAddress)
 
 RetainPtr<id> CoreIPCCNPostalAddress::toID() const
 {
-    RetainPtr<CNMutablePostalAddress> address = adoptNS([[PAL::getCNMutablePostalAddressClass() alloc] init]);
+    RetainPtr<CNMutablePostalAddress> address = adoptNS([[PAL::getCNMutablePostalAddressClassSingleton() alloc] init]);
 
     address.get().street = nsStringNilIfNull(m_street);
     address.get().subLocality = nsStringNilIfNull(m_subLocality);
@@ -151,13 +151,13 @@ static RetainPtr<NSArray> nsArrayFromVectorOfLabeledValues(const Vector<CoreIPCC
             return actualValue.toID();
         }, labeledValue.value);
 
-        return adoptNS([[PAL::getCNLabeledValueClass() alloc] initWithIdentifier:labeledValue.identifier.createNSString().get() label:labeledValue.label.createNSString().get() value:theValue.get()]);
+        return adoptNS([[PAL::getCNLabeledValueClassSingleton() alloc] initWithIdentifier:labeledValue.identifier.createNSString().get() label:labeledValue.label.createNSString().get() value:theValue.get()]);
     });
 }
 
 RetainPtr<id> CoreIPCCNContact::toID() const
 {
-    RetainPtr<CNMutableContact> result = adoptNS([[PAL::getCNMutableContactClass() alloc] initWithIdentifier:m_identifier.createNSString().get()]);
+    RetainPtr<CNMutableContact> result = adoptNS([[PAL::getCNMutableContactClassSingleton() alloc] initWithIdentifier:m_identifier.createNSString().get()]);
     result.get().contactType = m_personContactType ? CNContactTypePerson : CNContactTypeOrganization;
 
     if (!m_namePrefix.isNull())

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDActionContext.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDActionContext.serialization.in
@@ -23,7 +23,7 @@
 #if PLATFORM(MAC) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
 secure_coding_header: <pal/mac/DataDetectorsSoftLink.h>
 
-[WebKitSecureCodingClass=PAL::getWKDDActionContextClass()] webkit_secure_coding DDSecureActionContext {
+[WebKitSecureCodingClass=PAL::getWKDDActionContextClassSingleton()] webkit_secure_coding DDSecureActionContext {
     highlightFrame: NSValue
     aimFrame: NSValue
     eventTitle: String

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
 secure_coding_header: <pal/cocoa/DataDetectorsCoreSoftLink.h>
-[WebKitSecureCodingClass=PAL::getDDScannerResultClass()] webkit_secure_coding DDScannerResult {
+[WebKitSecureCodingClass=PAL::getDDScannerResultClassSingleton()] webkit_secure_coding DDScannerResult {
     AR: NSValue
     MS: String
     T: String

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm
@@ -42,7 +42,7 @@ RetainPtr<id> CoreIPCPKSecureElementPass::toID() const
 {
     RetainPtr data = toNSDataNoCopy(m_data.span(), FreeWhenDone::No);
     RELEASE_ASSERT(isInWebProcess());
-    return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getPKSecureElementPassClass() fromData:data.get() error:nil];
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getPKSecureElementPassClassSingleton() fromData:data.get() error:nil];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
@@ -48,7 +48,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 RetainPtr<id> CoreIPCPKContact::toID() const
 {
-    RetainPtr<PKContact> contact = adoptNS([[PAL::getPKContactClass() alloc] init]);
+    RetainPtr<PKContact> contact = adoptNS([[PAL::getPKContactClassSingleton() alloc] init]);
 
     if (m_name)
         contact.get().name = (NSPersonNameComponents *)m_name->toID();

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -38,7 +38,7 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     Vector<uint8_t> ipcData()
 }
 
-[WebKitSecureCodingClass=PAL::getPKPaymentMerchantSessionClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMerchantSession {
+[WebKitSecureCodingClass=PAL::getPKPaymentMerchantSessionClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMerchantSession {
     merchantIdentifier: String
     merchantSessionIdentifier: String
     nonce: String
@@ -55,7 +55,7 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     signedFields: Array<String>?
 }
 
-[WebKitSecureCodingClass=PAL::getPKPaymentClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPayment {
+[WebKitSecureCodingClass=PAL::getPKPaymentClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPayment {
     token: PKPaymentToken
     shippingContact: PKContact
     billingContact: PKContact
@@ -66,7 +66,7 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     installmentAuthorizationToken: String
 }
 
-[WebKitSecureCodingClass=PAL::getPKPaymentTokenClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentToken {
+[WebKitSecureCodingClass=PAL::getPKPaymentTokenClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentToken {
     paymentInstrumentName: String?
     paymentNetwork: String?
     transactionIdentifier: String
@@ -76,7 +76,7 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     retryNonce: String
 }
 
-[WebKitSecureCodingClass=PAL::getPKShippingMethodClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKShippingMethod {
+[WebKitSecureCodingClass=PAL::getPKShippingMethodClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKShippingMethod {
     label: String
     amount: Number
     type: Number
@@ -89,13 +89,13 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     dateComponentsRange: PKDateComponentsRange
 }
 
-[WebKitSecureCodingClass=PAL::getPKDateComponentsRangeClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKDateComponentsRange {
+[WebKitSecureCodingClass=PAL::getPKDateComponentsRangeClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKDateComponentsRange {
     startDateComponents: NSDateComponents
     endDateComponents: NSDateComponents
 }
 
 additional_forward_declaration: OBJC_CLASS PKSecureElementPass
-[WebKitSecureCodingClass=PAL::getPKPaymentMethodClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMethod {
+[WebKitSecureCodingClass=PAL::getPKPaymentMethodClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMethod {
     type: Number
     displayName: String
     network: String
@@ -107,7 +107,7 @@ additional_forward_declaration: OBJC_CLASS PKSecureElementPass
 }
 
 additional_forward_declaration: OBJC_CLASS NSSet
-[WebKitSecureCodingClass=PAL::getPKPaymentSetupFeatureClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentSetupFeature {
+[WebKitSecureCodingClass=PAL::getPKPaymentSetupFeatureClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentSetupFeature {
     identifiers: Set
     localizedDisplayName: String
     type: Number

--- a/Source/WebKit/Shared/Cocoa/DataDetectionResult.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/DataDetectionResult.serialization.in
@@ -25,7 +25,7 @@ headers: <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #if ENABLE(DATA_DETECTION)
 
 struct WebKit::DataDetectionResult {
-    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClass()]] RetainPtr<NSArray> results;
+    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClassSingleton()]] RetainPtr<NSArray> results;
 };
 
 #endif

--- a/Source/WebKit/Shared/Cocoa/PDFKitSoftLink.h
+++ b/Source/WebKit/Shared/Cocoa/PDFKitSoftLink.h
@@ -53,7 +53,7 @@ SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationWidgetSubtypeChoice, 
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationWidgetSubtypeSignature, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, PDFKit, PDFAnnotationWidgetSubtypeText, NSString *)
 
-SPECIALIZE_OBJC_TYPE_TRAITS(PDFActionResetForm, WebKit::getPDFActionResetFormClass())
-SPECIALIZE_OBJC_TYPE_TRAITS(PDFActionNamed, WebKit::getPDFActionNamedClass())
+SPECIALIZE_OBJC_TYPE_TRAITS(PDFActionResetForm, WebKit::getPDFActionResetFormClassSingleton())
+SPECIALIZE_OBJC_TYPE_TRAITS(PDFActionNamed, WebKit::getPDFActionNamedClassSingleton())
 
 #endif // HAVE(PDFKIT)

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -367,19 +367,19 @@ class WebCore::PaymentSessionError {
 
 headers: <pal/cocoa/PassKitSoftLink.h>
 class WebCore::PaymentMethod {
-    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClass()], Validator='m_pkPaymentMethod'] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClassSingleton()], Validator='m_pkPaymentMethod'] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
 };
 
 class WebCore::Payment {
-    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentClass()]] RetainPtr<PKPayment> pkPayment();
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentClassSingleton()]] RetainPtr<PKPayment> pkPayment();
 };
 
 class WebCore::PaymentContact {
-    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKContactClass()]] RetainPtr<PKContact> pkContact();
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKContactClassSingleton()]] RetainPtr<PKContact> pkContact();
 };
 
 class WebCore::PaymentMerchantSession {
-    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMerchantSessionClass()]] RetainPtr<PKPaymentMerchantSession> pkPaymentMerchantSession();
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMerchantSessionClassSingleton()]] RetainPtr<PKPaymentMerchantSession> pkPaymentMerchantSession();
 };
 #endif
 

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -84,7 +84,7 @@ struct WebKit::InteractionInformationAtPosition {
     RefPtr<WebCore::TextIndicator> textIndicator;
 #if ENABLE(DATA_DETECTION)
     String dataDetectorIdentifier;
-    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClass()]] RetainPtr<NSArray> dataDetectorResults;
+    [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClassSingleton()]] RetainPtr<NSArray> dataDetectorResults;
     WebCore::IntRect dataDetectorBounds;
 #endif
 

--- a/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
+++ b/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
@@ -25,7 +25,7 @@ headers: <WebCore/TextIndicator.h>
 #if PLATFORM(MAC)
 header: "WebHitTestResultData.h" <pal/mac/DataDetectorsSoftLink.h>
 [Nested] struct WebKit::WebHitTestResultPlatformData::DetectedDataActionContext {
-    [SecureCodingAllowed=[PAL::getWKDDActionContextClass()]] RetainPtr<WKDDActionContext> context;
+    [SecureCodingAllowed=[PAL::getWKDDActionContextClassSingleton()]] RetainPtr<WKDDActionContext> context;
 };
 [CustomHeader] struct WebKit::WebHitTestResultPlatformData {
     Markable<WebKit::WebHitTestResultPlatformData::DetectedDataActionContext> detectedDataActionContext;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -248,7 +248,7 @@ public:
     void setOverrideContentSecurityPolicy(const WTF::String& overrideContentSecurityPolicy) { m_data.overrideContentSecurityPolicy = overrideContentSecurityPolicy; }
 
 #if PLATFORM(COCOA)
-    ClassStructPtr attachmentFileWrapperClass() const { return m_data.attachmentFileWrapperClass.get(); }
+    ClassStructPtr attachmentFileWrapperClassSingleton() const { return m_data.attachmentFileWrapperClass.get(); }
     void setAttachmentFileWrapperClass(ClassStructPtr c) { m_data.attachmentFileWrapperClass = c; }
 
     const std::optional<Vector<WTF::String>>& additionalSupportedImageTypes() const { return m_data.additionalSupportedImageTypes; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2503,7 +2503,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
         [_writingToolsTextSuggestions setObject:suggestion forKey:suggestion.uuid];
     }
 
-    NSInteger delta = [WebKit::getWKIntelligenceReplacementTextEffectCoordinatorClass() characterDeltaForReceivedSuggestions:suggestions];
+    NSInteger delta = [WebKit::getWKIntelligenceReplacementTextEffectCoordinatorClassSingleton() characterDeltaForReceivedSuggestions:suggestions];
 
     auto operation = makeBlockPtr([webSession, replacementData, range, webContext, finished, weakSelf = WeakObjCPtr<WKWebView>(self)](void (^completion)(void)) {
         auto strongSelf = weakSelf.get();
@@ -2995,7 +2995,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
         return;
 
     if (allowGamepadsInput) {
-        _gamepadsRecentlyAccessedState = adoptNS([[WebCore::getGCEventInteractionClass() alloc] init]);
+        _gamepadsRecentlyAccessedState = adoptNS([[WebCore::getGCEventInteractionClassSingleton() alloc] init]);
         ((GCEventInteraction *)_gamepadsRecentlyAccessedState.get()).handledEventTypes = GCUIEventTypeGamepad;
         [self addInteraction:(id<UIInteraction>)_gamepadsRecentlyAccessedState.get()];
     } else {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -1036,7 +1036,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (Class)_attachmentFileWrapperClass
 {
-    return _pageConfiguration->attachmentFileWrapperClass();
+    return _pageConfiguration->attachmentFileWrapperClassSingleton();
 }
 
 - (void)_setAttachmentFileWrapperClass:(Class)attachmentFileWrapperClass

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
@@ -120,7 +120,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
     if (!title || [title length] == 0)
         title = [targetURL absoluteString];
 
-    [[getSSReadingListClass() defaultReadingList] addReadingListItemWithURL:targetURL title:title previewText:nil error:nil];
+    [[getSSReadingListClassSingleton() defaultReadingList] addReadingListItemWithURL:targetURL title:title previewText:nil error:nil];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4032,7 +4032,7 @@ static bool isLockdownModeWarningNeeded()
 #if PLATFORM(MACCATALYST)
         return NO;
 #else
-        return [(MCProfileConnection *)[PAL::getMCProfileConnectionClass() sharedConnection] isURLManaged:self.URL];
+        return [(MCProfileConnection *)[PAL::getMCProfileConnectionClassSingleton() sharedConnection] isURLManaged:self.URL];
 #endif
     };
 

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -260,7 +260,7 @@ void requestAVCaptureAccessForType(MediaPermissionType type, CompletionHandler<v
             completionHandler(authorized);
         });
     });
-    [PAL::getAVCaptureDeviceClass() requestAccessForMediaType:mediaType.get() completionHandler:decisionHandler.get()];
+    [PAL::getAVCaptureDeviceClassSingleton() requestAccessForMediaType:mediaType.get() completionHandler:decisionHandler.get()];
 #else
     UNUSED_PARAM(type);
     completionHandler(false);
@@ -271,7 +271,7 @@ MediaPermissionResult checkAVCaptureAccessForType(MediaPermissionType type)
 {
 #if HAVE(AVCAPTUREDEVICE)
     RetainPtr mediaType = type == MediaPermissionType::Audio ? AVMediaTypeAudio : AVMediaTypeVideo;
-    auto authorizationStatus = [PAL::getAVCaptureDeviceClass() authorizationStatusForMediaType:mediaType.get()];
+    auto authorizationStatus = [PAL::getAVCaptureDeviceClassSingleton() authorizationStatusForMediaType:mediaType.get()];
     if (authorizationStatus == AVAuthorizationStatusDenied || authorizationStatus == AVAuthorizationStatusRestricted)
         return MediaPermissionResult::Denied;
     if (authorizationStatus == AVAuthorizationStatusNotDetermined)
@@ -295,12 +295,12 @@ void requestSpeechRecognitionAccess(CompletionHandler<void(bool authorized)>&& c
             completionHandler(authorized);
         });
     });
-    [PAL::getSFSpeechRecognizerClass() requestAuthorization:decisionHandler.get()];
+    [PAL::getSFSpeechRecognizerClassSingleton() requestAuthorization:decisionHandler.get()];
 }
 
 MediaPermissionResult checkSpeechRecognitionServiceAccess()
 {
-    auto authorizationStatus = [PAL::getSFSpeechRecognizerClass() authorizationStatus];
+    auto authorizationStatus = [PAL::getSFSpeechRecognizerClassSingleton() authorizationStatus];
 IGNORE_WARNINGS_BEGIN("deprecated-enum-compare")
     if (authorizationStatus == SFSpeechRecognizerAuthorizationStatusDenied || authorizationStatus == SFSpeechRecognizerAuthorizationStatusRestricted)
         return MediaPermissionResult::Denied;

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -482,7 +482,7 @@ static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& actio
         return;
     }
 
-    [getWKMarketplaceKitClass() requestAppInstallationWithTopOrigin:requesterTopOriginURL.get() url:url.get() completionHandler:makeBlockPtr([addConsoleError = WTFMove(addConsoleError)](NSError *error) mutable {
+    [getWKMarketplaceKitClassSingleton() requestAppInstallationWithTopOrigin:requesterTopOriginURL.get() url:url.get() completionHandler:makeBlockPtr([addConsoleError = WTFMove(addConsoleError)](NSError *error) mutable {
         if (error)
             addConsoleError(error.description);
     }).get()];

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -58,7 +58,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SOAuthorizationCoordinator);
 
 SOAuthorizationCoordinator::SOAuthorizationCoordinator()
 {
-    m_hasAppSSO = !!PAL::getSOAuthorizationClass();
+    m_hasAppSSO = !!PAL::getSOAuthorizationClassSingleton();
 #if PLATFORM(MAC)
     // In the case of base system, which doesn't have AppSSO.framework.
     if (!m_hasAppSSO)
@@ -74,15 +74,15 @@ void SOAuthorizationCoordinator::canAuthorize(const URL& url, CompletionHandler<
         completionHandler(false);
         return;
     }
-    if ([PAL::getSOAuthorizationClass() respondsToSelector:@selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:)]) {
-        [PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url.createNSURL().get() responseCode:0 callerBundleIdentifier:nil useInternalExtensions:YES completion:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (BOOL result) mutable {
+    if ([PAL::getSOAuthorizationClassSingleton() respondsToSelector:@selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:)]) {
+        [PAL::getSOAuthorizationClassSingleton() canPerformAuthorizationWithURL:url.createNSURL().get() responseCode:0 callerBundleIdentifier:nil useInternalExtensions:YES completion:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (BOOL result) mutable {
             ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), result] () mutable {
                 completionHandler(result);
             });
         }).get()];
         return;
     }
-    completionHandler([PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url.createNSURL().get() responseCode:0]);
+    completionHandler([PAL::getSOAuthorizationClassSingleton() canPerformAuthorizationWithURL:url.createNSURL().get() responseCode:0]);
 }
 
 void SOAuthorizationCoordinator::tryAuthorize(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Function<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationNSURLExtras.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationNSURLExtras.mm
@@ -33,7 +33,7 @@
 + (BOOL)_web_canPerformAuthorizationWithURL:(NSURL *)url
 {
 #if HAVE(APP_SSO)
-    return [PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url responseCode:0];
+    return [PAL::getSOAuthorizationClassSingleton() canPerformAuthorizationWithURL:url responseCode:0];
 #else
     return false;
 #endif
@@ -42,7 +42,7 @@
 + (BOOL)_web_willPerformSOKerberosAuthorizationWithURL:(NSURL *)url
 {
 #if HAVE(APP_SSO)
-    return [PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url responseCode:401];
+    return [PAL::getSOAuthorizationClassSingleton() canPerformAuthorizationWithURL:url responseCode:401];
 #else
     return false;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -512,8 +512,8 @@ void SystemPreviewController::loadStarted(const URL& localFileURL)
         m_localFileURL.setFragmentIdentifier(m_fragmentIdentifier);
 
 #if PLATFORM(VISION)
-    if ([getASVLaunchPreviewClass() respondsToSelector:@selector(beginPreviewApplicationWithURLs:is3DContent:websiteURL:completion:)])
-        [getASVLaunchPreviewClass() beginPreviewApplicationWithURLs:localFileURLs() is3DContent:YES websiteURL:m_downloadURL.createNSURL().get() completion:^(NSError *error) { }];
+    if ([getASVLaunchPreviewClassSingleton() respondsToSelector:@selector(beginPreviewApplicationWithURLs:is3DContent:websiteURL:completion:)])
+        [getASVLaunchPreviewClassSingleton() beginPreviewApplicationWithURLs:localFileURLs() is3DContent:YES websiteURL:m_downloadURL.createNSURL().get() completion:^(NSError *error) { }];
 #endif
 
     m_state = State::Loading;
@@ -526,8 +526,8 @@ void SystemPreviewController::loadCompleted(const URL& localFileURL)
     ASSERT(equalIgnoringFragmentIdentifier(m_localFileURL, localFileURL));
 
 #if PLATFORM(VISION)
-    if ([getASVLaunchPreviewClass() respondsToSelector:@selector(launchPreviewApplicationWithURLs:completion:)])
-        [getASVLaunchPreviewClass() launchPreviewApplicationWithURLs:localFileURLs() completion:^(NSError *error) { }];
+    if ([getASVLaunchPreviewClassSingleton() respondsToSelector:@selector(launchPreviewApplicationWithURLs:completion:)])
+        [getASVLaunchPreviewClassSingleton() launchPreviewApplicationWithURLs:localFileURLs() completion:^(NSError *error) { }];
     m_state = State::Initial;
 #else
     if (m_qlPreviewControllerDataSource)
@@ -545,8 +545,8 @@ void SystemPreviewController::loadFailed()
     RELEASE_LOG(SystemPreview, "SystemPreview load has failed on %lld", m_systemPreviewInfo.element.nodeIdentifier ? m_systemPreviewInfo.element.nodeIdentifier->toUInt64() : 0);
 
 #if PLATFORM(VISION)
-    if (m_state == State::Loading && [getASVLaunchPreviewClass() respondsToSelector:@selector(cancelPreviewApplicationWithURLs:error:completion:)])
-        [getASVLaunchPreviewClass() cancelPreviewApplicationWithURLs:localFileURLs() error:nil completion:^(NSError *error) { }];
+    if (m_state == State::Loading && [getASVLaunchPreviewClassSingleton() respondsToSelector:@selector(cancelPreviewApplicationWithURLs:error:completion:)])
+        [getASVLaunchPreviewClassSingleton() cancelPreviewApplicationWithURLs:localFileURLs() error:nil completion:^(NSError *error) { }];
 #else
     if (m_qlPreviewControllerDataSource)
         [m_qlPreviewControllerDataSource.get() failWithError:nil];

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
@@ -109,10 +109,10 @@ static WebCore::VideoFrameRotation computeVideoFrameRotation(int rotation)
 -(std::optional<WebCore::VideoFrameRotation>)start:(const String&)persistentId layer:(CALayer*)layer {
     auto iterator = m_coordinators.add(persistentId, RetainPtr<AVCaptureDeviceRotationCoordinator> { }).iterator;
     if (!iterator->value) {
-        if (!PAL::getAVCaptureDeviceRotationCoordinatorClass())
+        if (!PAL::getAVCaptureDeviceRotationCoordinatorClassSingleton())
             return { };
 
-        RetainPtr avDevice = [PAL::getAVCaptureDeviceClass() deviceWithUniqueID:persistentId.createNSString().get()];
+        RetainPtr avDevice = [PAL::getAVCaptureDeviceClassSingleton() deviceWithUniqueID:persistentId.createNSString().get()];
         if (!avDevice)
             return { };
 

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -240,7 +240,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
     WebCore::ContactInfo contactInfo;
 
     if (_properties.contains(WebCore::ContactProperty::Name)) {
-        RetainPtr contactName = [getCNContactFormatterClass() stringFromContact:contact style:CNContactFormatterStyleFullName];
+        RetainPtr contactName = [getCNContactFormatterClassSingleton() stringFromContact:contact style:CNContactFormatterStyleFullName];
         contactInfo.name = { contactName.get() };
     }
 
@@ -299,7 +299,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
         if ([emails isKindOfClass:[NSArray class]]) {
             RetainPtr<NSMutableArray<CNLabeledValue<NSString*>*>> emailAddresses = adoptNS([[NSMutableArray alloc] init]);
             for (NSString *email in [emails filteredArrayUsingPredicate:stringValuePredicate.get()]) {
-                RetainPtr<CNLabeledValue<NSString*>> labeledValue = [getCNLabeledValueClass() labeledValueWithLabel:nil value:email];
+                RetainPtr<CNLabeledValue<NSString*>> labeledValue = [getCNLabeledValueClassSingleton() labeledValueWithLabel:nil value:email];
                 [emailAddresses addObject:labeledValue.get()];
             }
             [contact setEmailAddresses:emailAddresses.get()];
@@ -309,8 +309,8 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
         if ([phoneNumbers isKindOfClass:[NSArray class]]) {
             RetainPtr<NSMutableArray<CNLabeledValue<CNPhoneNumber*>*>> numbers = adoptNS([[NSMutableArray alloc] init]);
             for (NSString *phoneNumber in [phoneNumbers filteredArrayUsingPredicate:stringValuePredicate.get()]) {
-                RetainPtr<CNPhoneNumber> cnPhoneNumber = [getCNPhoneNumberClass() phoneNumberWithStringValue:phoneNumber];
-                RetainPtr<CNLabeledValue<CNPhoneNumber*>> labeledValue = [getCNLabeledValueClass() labeledValueWithLabel:nil value:cnPhoneNumber.get()];
+                RetainPtr<CNPhoneNumber> cnPhoneNumber = [getCNPhoneNumberClassSingleton() phoneNumberWithStringValue:phoneNumber];
+                RetainPtr<CNLabeledValue<CNPhoneNumber*>> labeledValue = [getCNLabeledValueClassSingleton() labeledValueWithLabel:nil value:cnPhoneNumber.get()];
                 [numbers addObject:labeledValue.get()];
             }
             [contact setPhoneNumbers:numbers.get()];

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -931,7 +931,7 @@ void WebPageProxy::startApplePayAMSUISession(URL&& originatingURL, ApplePayAMSUI
     RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstance() initWithRequestDictionary:dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[request.engagementRequest.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil])]);
     [amsRequest setOriginatingURL:originatingURL.createNSURL().get()];
 
-    auto amsBag = retainPtr([getAMSUIEngagementTaskClass() createBagForSubProfile]);
+    auto amsBag = retainPtr([getAMSUIEngagementTaskClassSingleton() createBagForSubProfile]);
 
     m_applePayAMSUISession = adoptNS([allocAMSUIEngagementTaskInstance() initWithRequest:amsRequest.get() bag:amsBag.get() presentingViewController:presentingViewController.get()]);
     [m_applePayAMSUISession setRemotePresentation:YES];

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -52,7 +52,7 @@ static bool usageTrackingAvailable()
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] () {
         available = PAL::isUsageTrackingFrameworkAvailable()
-            && PAL::getUSVideoUsageClass()
+            && PAL::getUSVideoUsageClassSingleton()
             && PAL::canLoad_UsageTracking_USVideoMetadataKeyCanShowControlsManager()
             && PAL::canLoad_UsageTracking_USVideoMetadataKeyCanShowNowPlayingControls()
             && PAL::canLoad_UsageTracking_USVideoMetadataKeyIsSuspended()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -47,10 +47,10 @@ NSString *interactionRegionElementIdentifierKey = @"WKInteractionRegionElementId
 
 RCPRemoteEffectInputTypes interactionRegionInputTypes = RCPRemoteEffectInputTypesAll ^ RCPRemoteEffectInputTypePointer;
 
-static Class interactionRegionLayerClass()
+static Class interactionRegionLayerClassSingleton()
 {
-    if (getRCPGlowEffectLayerClass())
-        return getRCPGlowEffectLayerClass();
+    if (getRCPGlowEffectLayerClassSingleton())
+        return getRCPGlowEffectLayerClassSingleton();
     return [CALayer class];
 }
 
@@ -92,7 +92,7 @@ static bool applyBackgroundColorForDebugging()
 
 static void configureLayerForInteractionRegion(CALayer *layer, NSString *groupName)
 {
-    if (![layer isKindOfClass:getRCPGlowEffectLayerClass()])
+    if (![layer isKindOfClass:getRCPGlowEffectLayerClassSingleton()])
         return;
 
     [(RCPGlowEffectLayer *)layer setBrightnessMultiplier:brightnessMultiplier() forInputTypes:interactionRegionInputTypes];
@@ -106,7 +106,7 @@ static void configureLayerForInteractionRegion(CALayer *layer, NSString *groupNa
 
 static void reconfigureLayerContentHint(CALayer *layer, WebCore::InteractionRegion::ContentHint contentHint)
 {
-    if (![layer isKindOfClass:getRCPGlowEffectLayerClass()])
+    if (![layer isKindOfClass:getRCPGlowEffectLayerClassSingleton()])
         return;
 
     if (contentHint == WebCore::InteractionRegion::ContentHint::Photo)
@@ -169,7 +169,7 @@ static void applyBackgroundColorForDebuggingToLayer(CALayer *layer, const WebCor
 static CALayer *createInteractionRegionLayer(WebCore::InteractionRegion::Type type, WebCore::NodeIdentifier identifier, NSString *groupName)
 {
     CALayer *layer = type == InteractionRegion::Type::Interaction
-        ? [[interactionRegionLayerClass() alloc] init]
+        ? [[interactionRegionLayerClassSingleton() alloc] init]
         : [[CALayer alloc] init];
 
     [layer setHitTestsAsOpaque:YES];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -278,7 +278,7 @@ UIScrollView *findActingScrollParent(UIScrollView *scrollView, const RemoteLayer
     return nil;
 }
 
-static Class scrollViewScrollIndicatorClass()
+static Class scrollViewScrollIndicatorClassSingleton()
 {
     static dispatch_once_t onceToken;
     static Class scrollIndicatorClass;
@@ -317,7 +317,7 @@ static Class scrollViewScrollIndicatorClass()
             }
         }
 
-        if ([view isKindOfClass:WebKit::scrollViewScrollIndicatorClass()] && [[view superview] isKindOfClass:WKChildScrollView.class]) {
+        if ([view isKindOfClass:WebKit::scrollViewScrollIndicatorClassSingleton()] && [[view superview] isKindOfClass:WKChildScrollView.class]) {
             if (WebKit::isScrolledBy((WKChildScrollView *)[view superview], viewsAtPoint.last().get())) {
                 LOG_WITH_STREAM(UIHitTesting, stream << " " << (void*)view.get() << " is the scroll indicator of child scroll view, which is scrolled by " << (void*)viewsAtPoint.last().get());
                 return view.get();
@@ -385,7 +385,7 @@ static Class scrollViewScrollIndicatorClass()
 
 + (Class)layerClass
 {
-    return PAL::getMTMaterialLayerClass();
+    return PAL::getMTMaterialLayerClassSingleton();
 }
 
 @end

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -51,7 +51,7 @@ AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator(const Authe
 {
 #if HAVE(ASC_AUTH_UI)
     m_context = adoptNS([allocASCAuthorizationPresentationContextInstance() initWithRequestContext:nullptr appIdentifier:nullptr]);
-    if ([getASCAuthorizationPresentationContextClass() instancesRespondToSelector:@selector(setServiceName:)])
+    if ([getASCAuthorizationPresentationContextClassSingleton() instancesRespondToSelector:@selector(setServiceName:)])
         [m_context setServiceName:rpId.createNSString().get()];
 
     switch (type) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -89,10 +89,10 @@ using CBOR = cbor::CBORValue;
 BOOL shouldUseAlternateKeychainAttribute()
 {
 #if HAVE(UNIFIED_ASC_AUTH_UI)
-    if (![WebKit::getASCWebKitSPISupportClass() respondsToSelector:@selector(shouldUseAlternateKeychainAttribute)])
+    if (![WebKit::getASCWebKitSPISupportClassSingleton() respondsToSelector:@selector(shouldUseAlternateKeychainAttribute)])
         return NO;
 
-    return [WebKit::getASCWebKitSPISupportClass() shouldUseAlternateKeychainAttribute];
+    return [WebKit::getASCWebKitSPISupportClassSingleton() shouldUseAlternateKeychainAttribute];
 #else
     return NO;
 #endif

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
@@ -55,7 +55,7 @@ NfcService::~NfcService() = default;
 bool NfcService::isAvailable()
 {
 #if HAVE(NEAR_FIELD)
-    return [[getNFHardwareManagerClass() sharedHardwareManager] areFeaturesSupported:NFFeatureReaderMode outError:nil];
+    return [[getNFHardwareManagerClassSingleton() sharedHardwareManager] areFeaturesSupported:NFFeatureReaderMode outError:nil];
 #else
     return false;
 #endif
@@ -122,7 +122,7 @@ void NfcService::platformStartDiscovery()
             protectedThis->m_connection = NfcConnection::create(WTFMove(session), *protectedThis);
         });
     });
-    [[getNFHardwareManagerClass() sharedHardwareManager] startReaderSession:callback.get()];
+    [[getNFHardwareManagerClassSingleton() sharedHardwareManager] startReaderSession:callback.get()];
 #endif // HAVE(NEAR_FIELD)
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WKASCAuthorizationPresenterDelegate.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WKASCAuthorizationPresenterDelegate.mm
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
         coordinator.setCredentialRequestHandler(WTFMove(requestHandler));
     }];
 
-    if ([loginChoice isKindOfClass:WebKit::getASCPlatformPublicKeyCredentialLoginChoiceClass()]) {
+    if ([loginChoice isKindOfClass:WebKit::getASCPlatformPublicKeyCredentialLoginChoiceClassSingleton()]) {
         auto *platformLoginChoice = (ASCPlatformPublicKeyCredentialLoginChoice *)loginChoice;
 
         if ([platformLoginChoice isRegistrationRequest]) {
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    if ([loginChoice isKindOfClass:WebKit::getASCSecurityKeyPublicKeyCredentialLoginChoiceClass()]) {
+    if ([loginChoice isKindOfClass:WebKit::getASCSecurityKeyPublicKeyCredentialLoginChoiceClassSingleton()]) {
         auto *securityKeyLoginChoice = (ASCSecurityKeyPublicKeyCredentialLoginChoice *)loginChoice;
 
         if ([securityKeyLoginChoice credentialKind] == ASCSecurityKeyPublicKeyCredentialKindAssertion) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -329,7 +329,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForRegistration(con
             if (prf->eval)
                 request.get().prf = adoptNS([allocASAuthorizationPublicKeyCredentialPRFRegistrationInputInstance() initWithInputValues:toASAssertionPRFInputValue(prf->eval).get()]).get();
             else
-                request.get().prf = [getASAuthorizationPublicKeyCredentialPRFRegistrationInputClass() checkForSupport];
+                request.get().prf = [getASAuthorizationPublicKeyCredentialPRFRegistrationInputClassSingleton() checkForSupport];
         }
 #endif
 
@@ -599,7 +599,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     ASSERT_NOT_REACHED();
                     break;
                 }
-            } else if ([auth.get().credential isKindOfClass:getASAuthorizationPlatformPublicKeyCredentialRegistrationClass()]) {
+            } else if ([auth.get().credential isKindOfClass:getASAuthorizationPlatformPublicKeyCredentialRegistrationClassSingleton()]) {
                 response.isAuthenticatorAttestationResponse = true;
                 auto credential = retainPtr((ASAuthorizationPlatformPublicKeyCredentialRegistration *)auth.get().credential);
                 response.rawId = toArrayBuffer(credential.get().credentialID);
@@ -632,7 +632,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
 
                 if (hasExtensionOutput)
                     response.extensionOutputs = extensionOutputs;
-            } else if ([auth.get().credential isKindOfClass:getASAuthorizationPlatformPublicKeyCredentialAssertionClass()]) {
+            } else if ([auth.get().credential isKindOfClass:getASAuthorizationPlatformPublicKeyCredentialAssertionClassSingleton()]) {
                 auto credential = retainPtr((ASAuthorizationPlatformPublicKeyCredentialAssertion *)auth.get().credential);
                 response.rawId = toArrayBuffer(credential.get().credentialID);
                 response.authenticatorData = toArrayBuffer(credential.get().rawAuthenticatorData);
@@ -663,7 +663,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
 
                 if (hasExtensionOutput)
                     response.extensionOutputs = extensionOutputs;
-            } else if ([auth.get().credential isKindOfClass:getASAuthorizationSecurityKeyPublicKeyCredentialRegistrationClass()]) {
+            } else if ([auth.get().credential isKindOfClass:getASAuthorizationSecurityKeyPublicKeyCredentialRegistrationClassSingleton()]) {
                 auto credential = retainPtr((ASAuthorizationSecurityKeyPublicKeyCredentialRegistration *)auth.get().credential);
                 response.isAuthenticatorAttestationResponse = true;
                 response.rawId = toArrayBuffer(credential.get().credentialID);
@@ -673,7 +673,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                 else
                     response.transports = { };
                 response.clientDataJSON = toArrayBuffer(credential.get().rawClientDataJSON);
-            } else if ([auth.get().credential isKindOfClass:getASAuthorizationSecurityKeyPublicKeyCredentialAssertionClass()]) {
+            } else if ([auth.get().credential isKindOfClass:getASAuthorizationSecurityKeyPublicKeyCredentialAssertionClassSingleton()]) {
                 auto credential = retainPtr((ASAuthorizationSecurityKeyPublicKeyCredentialAssertion *)auth.get().credential);
                 response.rawId = toArrayBuffer(credential.get().credentialID);
                 response.authenticatorData = toArrayBuffer(credential.get().rawAuthenticatorData);
@@ -785,7 +785,7 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
 
 static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensions(const AuthenticationExtensionsClientInputs& extensions)
 {
-    if ([getASCWebAuthenticationExtensionsClientInputsClass() instancesRespondToSelector:@selector(initWithAppID:)])
+    if ([getASCWebAuthenticationExtensionsClientInputsClassSingleton() instancesRespondToSelector:@selector(initWithAppID:)])
         return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid.createNSString().get()]);
 
     return nil;
@@ -906,7 +906,7 @@ static inline RetainPtr<ASCPublicKeyCredentialAssertionOptions> configureAsserti
     auto clientDataJson = WebCore::buildClientDataJson(ClientDataType::Get, options.challenge, callerOrigin.securityOrigin(), scope, topOrigin);
     RetainPtr nsClientDataJSON = toNSData(clientDataJson->span());
     RetainPtr<ASCPublicKeyCredentialAssertionOptions> assertionOptions;
-    if ([getASCPublicKeyCredentialAssertionOptionsClass() instancesRespondToSelector:@selector(initWithKind:relyingPartyIdentifier:clientDataJSON:userVerificationPreference:allowedCredentials:origin:)])
+    if ([getASCPublicKeyCredentialAssertionOptionsClassSingleton() instancesRespondToSelector:@selector(initWithKind:relyingPartyIdentifier:clientDataJSON:userVerificationPreference:allowedCredentials:origin:)])
         assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get() origin:callerOrigin.toString().createNSString().get()]);
     else
         assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId.createNSString().get() clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get()]);
@@ -1028,7 +1028,7 @@ static inline void continueAfterRequest(RetainPtr<id <ASCCredentialProtocol>> cr
     ExceptionData exceptionData = { };
     RetainPtr<NSString> rawAttachment;
 
-    if ([credential isKindOfClass:getASCPlatformPublicKeyCredentialRegistrationClass()]) {
+    if ([credential isKindOfClass:getASCPlatformPublicKeyCredentialRegistrationClassSingleton()]) {
         response.isAuthenticatorAttestationResponse = true;
 
         ASCPlatformPublicKeyCredentialRegistration *registrationCredential = credential.get();
@@ -1040,7 +1040,7 @@ static inline void continueAfterRequest(RetainPtr<id <ASCCredentialProtocol>> cr
             response.transports = toAuthenticatorTransports(registrationCredential.transports);
         if ([registrationCredential respondsToSelector:@selector(extensionOutputsCBOR)])
             response.extensionOutputs = toExtensionOutputs(registrationCredential.extensionOutputsCBOR);
-    } else if ([credential isKindOfClass:getASCSecurityKeyPublicKeyCredentialRegistrationClass()]) {
+    } else if ([credential isKindOfClass:getASCSecurityKeyPublicKeyCredentialRegistrationClassSingleton()]) {
         response.isAuthenticatorAttestationResponse = true;
 
         ASCSecurityKeyPublicKeyCredentialRegistration *registrationCredential = credential.get();
@@ -1052,7 +1052,7 @@ static inline void continueAfterRequest(RetainPtr<id <ASCCredentialProtocol>> cr
             response.transports = toAuthenticatorTransports(registrationCredential.transports);
         if ([registrationCredential respondsToSelector:@selector(extensionOutputsCBOR)])
             response.extensionOutputs = toExtensionOutputs(registrationCredential.extensionOutputsCBOR);
-    } else if ([credential isKindOfClass:getASCPlatformPublicKeyCredentialAssertionClass()]) {
+    } else if ([credential isKindOfClass:getASCPlatformPublicKeyCredentialAssertionClassSingleton()]) {
         response.isAuthenticatorAttestationResponse = false;
 
         ASCPlatformPublicKeyCredentialAssertion *assertionCredential = credential.get();
@@ -1064,7 +1064,7 @@ static inline void continueAfterRequest(RetainPtr<id <ASCCredentialProtocol>> cr
         rawAttachment = assertionCredential.attachment;
         if ([assertionCredential respondsToSelector:@selector(extensionOutputsCBOR)])
             response.extensionOutputs = toExtensionOutputs(assertionCredential.extensionOutputsCBOR);
-    } else if ([credential isKindOfClass:getASCSecurityKeyPublicKeyCredentialAssertionClass()]) {
+    } else if ([credential isKindOfClass:getASCSecurityKeyPublicKeyCredentialAssertionClassSingleton()]) {
         response.isAuthenticatorAttestationResponse = false;
 
         ASCSecurityKeyPublicKeyCredentialAssertion *assertionCredential = credential.get();
@@ -1191,8 +1191,8 @@ void WebAuthenticatorCoordinatorProxy::performRequestLegacy(RetainPtr<ASCCredent
 
 static inline void getCanCurrentProcessAccessPasskeyForRelyingParty(const WebCore::SecurityOriginData& data, CompletionHandler<void(bool)>&& handler)
 {
-    if ([getASCWebKitSPISupportClass() respondsToSelector:@selector(getCanCurrentProcessAccessPasskeysForRelyingParty:withCompletionHandler:)]) {
-        [getASCWebKitSPISupportClass() getCanCurrentProcessAccessPasskeysForRelyingParty:data.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
+    if ([getASCWebKitSPISupportClassSingleton() respondsToSelector:@selector(getCanCurrentProcessAccessPasskeysForRelyingParty:withCompletionHandler:)]) {
+        [getASCWebKitSPISupportClassSingleton() getCanCurrentProcessAccessPasskeysForRelyingParty:data.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
             ensureOnMainRunLoop([handler = WTFMove(handler), result]() mutable {
                 handler(result);
             });
@@ -1204,8 +1204,8 @@ static inline void getCanCurrentProcessAccessPasskeyForRelyingParty(const WebCor
 
 static inline void getArePasskeysDisallowedForRelyingParty(const WebCore::SecurityOriginData& data, CompletionHandler<void(bool)>&& handler)
 {
-    if ([getASCWebKitSPISupportClass() respondsToSelector:@selector(getArePasskeysDisallowedForRelyingParty:withCompletionHandler:)]) {
-        [getASCWebKitSPISupportClass() getArePasskeysDisallowedForRelyingParty:data.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
+    if ([getASCWebKitSPISupportClassSingleton() respondsToSelector:@selector(getArePasskeysDisallowedForRelyingParty:withCompletionHandler:)]) {
+        [getASCWebKitSPISupportClassSingleton() getArePasskeysDisallowedForRelyingParty:data.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](BOOL result) mutable {
             ensureOnMainRunLoop([handler = WTFMove(handler), result]() mutable {
                 handler(result);
             });
@@ -1218,19 +1218,19 @@ static inline void getArePasskeysDisallowedForRelyingParty(const WebCore::Securi
 void WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(const WebCore::SecurityOriginData& data, QueryCompletionHandler&& handler)
 {
     getCanCurrentProcessAccessPasskeyForRelyingParty(data, [handler = WTFMove(handler)](bool canAccessPasskeyData) mutable {
-        handler(canAccessPasskeyData && [getASCWebKitSPISupportClass() shouldUseAlternateCredentialStore]);
+        handler(canAccessPasskeyData && [getASCWebKitSPISupportClassSingleton() shouldUseAlternateCredentialStore]);
     });
 }
 
 void WebAuthenticatorCoordinatorProxy::getClientCapabilities(const WebCore::SecurityOriginData& originData, CapabilitiesCompletionHandler&& handler)
 {
-    if (![getASCWebKitSPISupportClass() respondsToSelector:@selector(getClientCapabilitiesForRelyingParty:withCompletionHandler:)]) {
+    if (![getASCWebKitSPISupportClassSingleton() respondsToSelector:@selector(getClientCapabilitiesForRelyingParty:withCompletionHandler:)]) {
         Vector<KeyValuePair<String, bool>> capabilities;
         handler(WTFMove(capabilities));
         return;
     }
 
-    [getASCWebKitSPISupportClass() getClientCapabilitiesForRelyingParty:originData.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](NSDictionary<NSString *, NSNumber *> *result) mutable {
+    [getASCWebKitSPISupportClassSingleton() getClientCapabilitiesForRelyingParty:originData.securityOrigin()->domain().createNSString().get() withCompletionHandler:makeBlockPtr([handler = WTFMove(handler)](NSDictionary<NSString *, NSNumber *> *result) mutable {
         Vector<KeyValuePair<String, bool>> capabilities;
         for (NSString *key in result)
             capabilities.append({ key, result[key].boolValue });
@@ -1249,7 +1249,7 @@ void WebAuthenticatorCoordinatorProxy::isUserVerifyingPlatformAuthenticatorAvail
             handler(false);
             return;
         }
-        if ([getASCWebKitSPISupportClass() shouldUseAlternateCredentialStore]) {
+        if ([getASCWebKitSPISupportClassSingleton() shouldUseAlternateCredentialStore]) {
             getArePasskeysDisallowedForRelyingParty(data, [handler = WTFMove(handler)](bool passkeysDisallowed) mutable {
                 handler(!passkeysDisallowed);
             });
@@ -1302,7 +1302,7 @@ void WebAuthenticatorCoordinatorProxy::signalUnknownCredential(const WebCore::Se
     }
 
 #if USE(APPLE_INTERNAL_SDK)
-    [getCredentialUpdaterShimClass() signalUnknownCredentialWithRelyingPartyIdentifier:options.rpId.createNSString().get() credentialID:WTF::toNSData(*decodedCredentialId).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    [getCredentialUpdaterShimClassSingleton() signalUnknownCredentialWithRelyingPartyIdentifier:options.rpId.createNSString().get() credentialID:WTF::toNSData(*decodedCredentialId).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(WebAuthn, "Error signaling unknown credential: %@.", error.localizedDescription);
             completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling unknown credential."_s });
@@ -1333,7 +1333,7 @@ void WebAuthenticatorCoordinatorProxy::signalAllAcceptedCredentials(const WebCor
     }
 
 #if USE(APPLE_INTERNAL_SDK)
-    [getCredentialUpdaterShimClass() signalAllAcceptedCredentialsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() acceptedCredentialIDs:credentialIds.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    [getCredentialUpdaterShimClassSingleton() signalAllAcceptedCredentialsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() acceptedCredentialIDs:credentialIds.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(WebAuthn, "Error signaling all accepted credentials: %@.", error.localizedDescription);
             completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling all accepted credentials"_s });
@@ -1354,7 +1354,7 @@ void WebAuthenticatorCoordinatorProxy::signalCurrentUserDetails(const WebCore::S
     }
 
 #if USE(APPLE_INTERNAL_SDK)
-    [getCredentialUpdaterShimClass() signalCurrentUserDetailsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() newName:options.name.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+    [getCredentialUpdaterShimClassSingleton() signalCurrentUserDetailsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() newName:options.name.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(WebAuthn, "Error signaling current user details: %@.", error.localizedDescription);
             completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling current user details."_s });

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -227,22 +227,22 @@ void MockNfcService::platformStartDiscovery()
     if (!!m_configuration.nfc) {
         weakGlobalNfcService() = *this;
 
-        Method methodToSwizzle1 = class_getInstanceMethod(getNFReaderSessionClass(), @selector(setDelegate:));
+        Method methodToSwizzle1 = class_getInstanceMethod(getNFReaderSessionClassSingleton(), @selector(setDelegate:));
         method_setImplementation(methodToSwizzle1, (IMP)NFReaderSessionSetDelegate);
 
-        Method methodToSwizzle2 = class_getInstanceMethod(getNFReaderSessionClass(), @selector(connectTag:));
+        Method methodToSwizzle2 = class_getInstanceMethod(getNFReaderSessionClassSingleton(), @selector(connectTag:));
         if (m_configuration.nfc->error == Mock::NfcError::NoConnections)
             method_setImplementation(methodToSwizzle2, (IMP)NFReaderSessionConnectTagFail);
         else
             method_setImplementation(methodToSwizzle2, (IMP)NFReaderSessionConnectTag);
 
-        Method methodToSwizzle3 = class_getInstanceMethod(getNFReaderSessionClass(), @selector(transceive:));
+        Method methodToSwizzle3 = class_getInstanceMethod(getNFReaderSessionClassSingleton(), @selector(transceive:));
         method_setImplementation(methodToSwizzle3, (IMP)NFReaderSessionTransceive);
 
-        Method methodToSwizzle4 = class_getInstanceMethod(getNFReaderSessionClass(), @selector(stopPolling));
+        Method methodToSwizzle4 = class_getInstanceMethod(getNFReaderSessionClassSingleton(), @selector(stopPolling));
         method_setImplementation(methodToSwizzle4, (IMP)NFReaderSessionStopPolling);
 
-        Method methodToSwizzle5 = class_getInstanceMethod(getNFReaderSessionClass(), @selector(startPollingWithError:));
+        Method methodToSwizzle5 = class_getInstanceMethod(getNFReaderSessionClassSingleton(), @selector(startPollingWithError:));
         method_setImplementation(methodToSwizzle5, (IMP)NFReaderSessionStartPollingWithError);
 
         auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -828,14 +828,14 @@ void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReini
         crossSiteTrackingPreventionRelaxedApps = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionRelaxedAppsKey];
 #elif !PLATFORM(MACCATALYST)
         isSafari = WTF::IOSApplication::isMobileSafari();
-        if ([PAL::getMCProfileConnectionClass() instancesRespondToSelector:@selector(crossSiteTrackingPreventionRelaxedDomains)])
-            crossSiteTrackingPreventionRelaxedDomains = [(MCProfileConnection *)[PAL::getMCProfileConnectionClass() sharedConnection] crossSiteTrackingPreventionRelaxedDomains];
+        if ([PAL::getMCProfileConnectionClassSingleton() instancesRespondToSelector:@selector(crossSiteTrackingPreventionRelaxedDomains)])
+            crossSiteTrackingPreventionRelaxedDomains = [(MCProfileConnection *)[PAL::getMCProfileConnectionClassSingleton() sharedConnection] crossSiteTrackingPreventionRelaxedDomains];
         else
             crossSiteTrackingPreventionRelaxedDomains = @[];
 
         auto relaxedAppsSelector = NSSelectorFromString(@"crossSiteTrackingPreventionRelaxedApps");
-        if ([PAL::getMCProfileConnectionClass() instancesRespondToSelector:relaxedAppsSelector])
-            crossSiteTrackingPreventionRelaxedApps = [[PAL::getMCProfileConnectionClass() sharedConnection] performSelector:relaxedAppsSelector];
+        if ([PAL::getMCProfileConnectionClassSingleton() instancesRespondToSelector:relaxedAppsSelector])
+            crossSiteTrackingPreventionRelaxedApps = [[PAL::getMCProfileConnectionClassSingleton() sharedConnection] performSelector:relaxedAppsSelector];
         else
             crossSiteTrackingPreventionRelaxedApps = @[];
 #endif

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -71,12 +71,12 @@ void ARKitCoordinator::getPrimaryDeviceInfo(WebPageProxy&, DeviceInfoCallback&& 
     RELEASE_LOG(XR, "ARKitCoordinator::getPrimaryDeviceInfo");
     ASSERT(RunLoop::isMain());
 
-    if (![getARWorldTrackingConfigurationClass() isSupported]) {
+    if (![getARWorldTrackingConfigurationClassSingleton() isSupported]) {
         RELEASE_LOG_ERROR(XR, "ARKitCoordinator: WorldTrackingConfiguration is not supported");
         return callback(std::nullopt);
     }
 
-    NSArray<ARVideoFormat *> *supportedVideoFormats = [getARWorldTrackingConfigurationClass() supportedVideoFormats];
+    NSArray<ARVideoFormat *> *supportedVideoFormats = [getARWorldTrackingConfigurationClassSingleton() supportedVideoFormats];
     if (![supportedVideoFormats count])
         return callback(std::nullopt);
 

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -126,7 +126,7 @@ static const float swipeSnapshotRemovalRenderTreeSizeTargetFraction = 0.5;
     return YES;
 }
 
-static Class interactiveTransitionGestureRecognizerClass()
+static Class interactiveTransitionGestureRecognizerClassSingleton()
 {
 #if HAVE(UI_PARALLAX_TRANSITION_GESTURE_RECOGNIZER)
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
@@ -139,7 +139,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (UIPanGestureRecognizer *)gestureRecognizerForInteractiveTransition:(_UINavigationInteractiveTransitionBase *)transition WithTarget:(id)target action:(SEL)action
 {
-    RetainPtr recognizer = adoptNS([[interactiveTransitionGestureRecognizerClass() alloc] initWithTarget:target action:action]);
+    RetainPtr recognizer = adoptNS([[interactiveTransitionGestureRecognizerClassSingleton() alloc] initWithTarget:target action:action]);
 
     bool isLTR = [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:[_gestureRecognizerView.get() semanticContentAttribute]] == UIUserInterfaceLayoutDirectionLeftToRight;
 
@@ -159,7 +159,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (recognizer == [_backTransitionController gestureRecognizer] || recognizer == [_forwardTransitionController gestureRecognizer])
         return YES;
 
-    if ([recognizer isKindOfClass:interactiveTransitionGestureRecognizerClass()])
+    if ([recognizer isKindOfClass:interactiveTransitionGestureRecognizerClassSingleton()])
         return recognizer.delegate == _backTransitionController || recognizer.delegate == _forwardTransitionController;
 
     return NO;

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -309,7 +309,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!targetURL)
         return;
 
-    auto *controller = [PAL::getDDDetectionControllerClass() sharedController];
+    auto *controller = [PAL::getDDDetectionControllerClassSingleton() sharedController];
     if ([controller respondsToSelector:@selector(interactionDidStartForURL:)])
         [controller interactionDidStartForURL:targetURL.get()];
 #endif
@@ -560,7 +560,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _appendOpenActionsForURL:targetURL actions:defaultActions.get() elementInfo:elementInfo];
 
 #if HAVE(SAFARI_SERVICES_FRAMEWORK)
-    if ([getSSReadingListClass() supportsURL:targetURL])
+    if ([getSSReadingListClassSingleton() supportsURL:targetURL])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeAddToReadingList info:elementInfo assistant:self]];
 #endif
 
@@ -603,7 +603,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeShare info:elementInfo assistant:self]];
 
 #if HAVE(SAFARI_SERVICES_FRAMEWORK)
-    if ([getSSReadingListClass() supportsURL:targetURL])
+    if ([getSSReadingListClassSingleton() supportsURL:targetURL])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeAddToReadingList info:elementInfo assistant:self]];
 #endif
     if (TCCAccessPreflight(WebKit::get_TCC_kTCCServicePhotos(), NULL) != kTCCAccessPreflightDenied)
@@ -755,7 +755,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto retainedSelf = retainPtr(self);
     _WKElementAction *elementAction = [_WKElementAction elementActionWithTitle:action.localizedName actionHandler:^(_WKActivatedElementInfo *actionInfo) {
         retainedSelf->_isPresentingDDUserInterface = action.hasUserInterface;
-        [[PAL::getDDDetectionControllerClass() sharedController] performAction:action fromAlertController:retainedSelf->_interactionSheet.get() interactionDelegate:retainedSelf.get()];
+        [[PAL::getDDDetectionControllerClassSingleton() sharedController] performAction:action fromAlertController:retainedSelf->_interactionSheet.get() interactionDelegate:retainedSelf.get()];
     }];
     elementAction.dismissalHandler = ^BOOL {
         return !action.hasUserInterface;
@@ -780,7 +780,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!targetURL)
         return;
 
-    DDDetectionController *controller = [PAL::getDDDetectionControllerClass() sharedController];
+    DDDetectionController *controller = [PAL::getDDDetectionControllerClassSingleton() sharedController];
     NSDictionary *context = nil;
     NSString *textAtSelection = nil;
 
@@ -913,7 +913,7 @@ static NSMutableArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr
 {
 #if ENABLE(DATA_DETECTION)
     if (_dataDetectorContextMenuPresenter && interaction == _dataDetectorContextMenuPresenter->interaction()) {
-        DDDetectionController *controller = [PAL::getDDDetectionControllerClass() sharedController];
+        DDDetectionController *controller = [PAL::getDDDetectionControllerClassSingleton() sharedController];
         NSDictionary *context = nil;
         NSString *textAtSelection = nil;
 
@@ -931,7 +931,7 @@ static NSMutableArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr
         else
             sourceRect = _positionInformation->bounds;
 
-        auto ddContextMenuActionClass = PAL::getDDContextMenuActionClass();
+        auto ddContextMenuActionClass = PAL::getDDContextMenuActionClassSingleton();
         auto finalContext = [ddContextMenuActionClass updateContext:newContext withSourceRect:sourceRect];
 
         if (ddResult)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -854,9 +854,9 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
         return;
 
     if (registerProcess)
-        [WebKit::getNSAccessibilityRemoteUIElementClass() registerRemoteUIProcessIdentifier:pid];
+        [WebKit::getNSAccessibilityRemoteUIElementClassSingleton() registerRemoteUIProcessIdentifier:pid];
     else
-        [WebKit::getNSAccessibilityRemoteUIElementClass() unregisterRemoteUIProcessIdentifier:pid];
+        [WebKit::getNSAccessibilityRemoteUIElementClassSingleton() unregisterRemoteUIProcessIdentifier:pid];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4806,7 +4806,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return NO;
 
 #if !PLATFORM(MACCATALYST)
-        if ([(MCProfileConnection *)[PAL::getMCProfileConnectionClass() sharedConnection] effectiveBoolValueForSetting:PAL::get_ManagedConfiguration_MCFeatureDefinitionLookupAllowed()] == MCRestrictedBoolExplicitNo)
+        if ([(MCProfileConnection *)[PAL::getMCProfileConnectionClassSingleton() sharedConnection] effectiveBoolValueForSetting:PAL::get_ManagedConfiguration_MCFeatureDefinitionLookupAllowed()] == MCRestrictedBoolExplicitNo)
             return NO;
 #endif
             
@@ -4818,7 +4818,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return NO;
 
 #if !PLATFORM(MACCATALYST)
-        if ([(MCProfileConnection *)[PAL::getMCProfileConnectionClass() sharedConnection] effectiveBoolValueForSetting:PAL::get_ManagedConfiguration_MCFeatureDefinitionLookupAllowed()] == MCRestrictedBoolExplicitNo)
+        if ([(MCProfileConnection *)[PAL::getMCProfileConnectionClassSingleton() sharedConnection] effectiveBoolValueForSetting:PAL::get_ManagedConfiguration_MCFeatureDefinitionLookupAllowed()] == MCRestrictedBoolExplicitNo)
             return NO;
 #endif
 
@@ -4863,7 +4863,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if HAVE(TRANSLATION_UI_SERVICES)
     if (action == @selector(_translate:) || action == @selector(translate:)) {
-        if (!PAL::isTranslationUIServicesFrameworkAvailable() || ![PAL::getLTUITranslationViewControllerClass() isAvailable])
+        if (!PAL::isTranslationUIServicesFrameworkAvailable() || ![PAL::getLTUITranslationViewControllerClassSingleton() isAvailable])
             return NO;
         return !editorState.isInPasswordField && editorState.selectionIsRange;
     }
@@ -10124,7 +10124,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         sourceRect = positionInformation.bounds;
 
     CGRect frameInContainerViewCoordinates = [self convertRect:sourceRect toView:self.containerForContextMenuHintPreviews];
-    return [PAL::getDDContextMenuActionClass() updateContext:context.get() withSourceRect:frameInContainerViewCoordinates];
+    return [PAL::getDDContextMenuActionClassSingleton() updateContext:context.get() withSourceRect:frameInContainerViewCoordinates];
 #else
     return context.autorelease();
 #endif
@@ -14899,7 +14899,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // Previously, UIPreviewItemController would detect the case where there was no previewViewController
         // and create one. We need to replicate this code for the new API.
         if (!previewViewController || [url.createNSURL() iTunesStoreURL]) {
-            auto ddContextMenuActionClass = PAL::getDDContextMenuActionClass();
+            auto ddContextMenuActionClass = PAL::getDDContextMenuActionClassSingleton();
             BEGIN_BLOCK_OBJC_EXCEPTIONS
             NSDictionary *context = [self dataDetectionContextForPositionInformation:_positionInformation];
             RetainPtr<UIContextMenuConfiguration> dataDetectorsResult = [ddContextMenuActionClass contextMenuConfigurationForURL:url.createNSURL().get() identifier:_positionInformation.dataDetectorIdentifier.createNSString().get() selectedText:self.selectedText results:_positionInformation.dataDetectorResults.get() inView:self context:context menuIdentifier:nil];
@@ -15227,7 +15227,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)continueContextMenuInteractionWithDataDetectors:(void(^)(UIContextMenuConfiguration *))continueWithContextMenuConfiguration
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    auto ddContextMenuActionClass = PAL::getDDContextMenuActionClass();
+    auto ddContextMenuActionClass = PAL::getDDContextMenuActionClassSingleton();
     auto context = retainPtr([self dataDetectionContextForPositionInformation:_positionInformation]);
     RetainPtr<UIContextMenuConfiguration> configurationFromDataDetectors;
 
@@ -15366,7 +15366,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
 #if defined(DD_CONTEXT_MENU_SPI_VERSION) && DD_CONTEXT_MENU_SPI_VERSION >= 2
-    if ([configuration isKindOfClass:PAL::getDDContextMenuConfigurationClass()]) {
+    if ([configuration isKindOfClass:PAL::getDDContextMenuConfigurationClassSingleton()]) {
         DDContextMenuConfiguration *ddConfiguration = static_cast<DDContextMenuConfiguration *>(configuration);
 
         BOOL shouldExpandPreview = NO;
@@ -15537,7 +15537,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             if ([uiDelegate respondsToSelector:@selector(_dataDetectionContextForWebView:)])
                 context = [uiDelegate _dataDetectionContextForWebView:self.webView];
 
-            DDDetectionController *controller = [PAL::getDDDetectionControllerClass() sharedController];
+            DDDetectionController *controller = [PAL::getDDDetectionControllerClassSingleton() sharedController];
             NSDictionary *newContext = nil;
             RetainPtr<NSMutableDictionary> extendedContext;
             DDResultRef ddResult = [controller resultForURL:dataForPreview.get()[UIPreviewDataLink] identifier:_positionInformation.dataDetectorIdentifier.createNSString().get() selectedText:[self selectedText] results:_positionInformation.dataDetectorResults.get() context:context extendedContext:&newContext];

--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -451,7 +451,7 @@ inline static String pointerType(UITouchType type)
         return;
 #endif
 
-    _pointerLockState.currentMouse = dynamic_objc_cast<GCMouse>([WebCore::getGCMouseClass() current]);
+    _pointerLockState.currentMouse = dynamic_objc_cast<GCMouse>([WebCore::getGCMouseClassSingleton() current]);
     if (!_pointerLockState.currentMouse)
         return;
 

--- a/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
@@ -82,7 +82,7 @@ typedef NSInteger WKAirPlayRoutePickerRouteSharingPolicy;
     [routingController setDiscoveryMode:MPRouteDiscoveryModeDetailed];
 
     RetainPtr<MPMediaControlsConfiguration> configuration;
-    if ([getMPMediaControlsConfigurationClass() instancesRespondToSelector:@selector(setSortByIsVideoRoute:)]) {
+    if ([getMPMediaControlsConfigurationClassSingleton() instancesRespondToSelector:@selector(setSortByIsVideoRoute:)]) {
         configuration = adoptNS([allocMPMediaControlsConfigurationInstance() init]);
         configuration.get().sortByIsVideoRoute = hasVideo;
     }

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -923,9 +923,9 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
 
     if (auto allowedImagePickerType = _allowedImagePickerTypes.toSingleValue()) {
         if (*allowedImagePickerType == WKFileUploadPanelImagePickerType::Image)
-            [configuration setFilter:[getPHPickerFilterClass() imagesFilter]];
+            [configuration setFilter:[getPHPickerFilterClassSingleton() imagesFilter]];
         else
-            [configuration setFilter:[getPHPickerFilterClass() videosFilter]];
+            [configuration setFilter:[getPHPickerFilterClassSingleton() videosFilter]];
     }
 
     _uploadFileManager = adoptNS([[NSFileManager alloc] init]);

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1137,7 +1137,7 @@ void PageClientImpl::handleContextMenuWritingTools(WebCore::WritingTools::Reques
 {
     RetainPtr webView = this->webView();
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[PAL::getWTWritingToolsClass() sharedInstance] showTool:WebKit::convertToPlatformRequestedTool(tool) forSelectionRect:selectionRect ofView:m_view.get().get() forDelegate:webView.get()];
+    [[PAL::getWTWritingToolsClassSingleton() sharedInstance] showTool:WebKit::convertToPlatformRequestedTool(tool) forSelectionRect:selectionRect ofView:m_view.get().get() forDelegate:webView.get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -85,7 +85,7 @@
     _contentPreventsDefault = NO;
     
     RetainPtr<id> animationController = [_immediateActionRecognizer animationController];
-    if (PAL::isQuickLookUIFrameworkAvailable() && [animationController isKindOfClass:PAL::getQLPreviewMenuItemClass()]) {
+    if (PAL::isQuickLookUIFrameworkAvailable() && [animationController isKindOfClass:PAL::getQLPreviewMenuItemClassSingleton()]) {
         RetainPtr menuItem = (QLPreviewMenuItem *)animationController.get();
         menuItem.get().delegate = nil;
     }
@@ -118,7 +118,7 @@
     if (_currentActionContext && _hasActivatedActionContext) {
         _hasActivatedActionContext = NO;
         if (PAL::isDataDetectorsFrameworkAvailable())
-            [PAL::getDDActionsManagerClass() didUseActions];
+            [PAL::getDDActionsManagerClassSingleton() didUseActions];
     }
 
     _state = WebKit::ImmediateActionState::None;
@@ -211,7 +211,7 @@
     if (_currentActionContext) {
         _hasActivatedActionContext = YES;
         if (PAL::isDataDetectorsFrameworkAvailable()) {
-            if (![PAL::getDDActionsManagerClass() shouldUseActionsWithContext:_currentActionContext.get()])
+            if (![PAL::getDDActionsManagerClassSingleton() shouldUseActionsWithContext:_currentActionContext.get()])
                 [self _cancelImmediateAction];
         }
     }
@@ -423,7 +423,7 @@
 
     actionContext.get().altMode = YES;
     actionContext.get().immediate = YES;
-    if (![[PAL::getDDActionsManagerClass() sharedManager] hasActionsForResult:actionContext.get().mainResult actionContext:actionContext.get()])
+    if (![[PAL::getDDActionsManagerClassSingleton() sharedManager] hasActionsForResult:actionContext.get().mainResult actionContext:actionContext.get()])
         return nil;
 
     RefPtr<WebKit::WebPageProxy> page = _page.get();
@@ -441,7 +441,7 @@
 
     [_currentActionContext setHighlightFrame:[_view.window convertRectToScreen:[_view convertRect:_hitTestResultData.platformData.detectedDataBoundingBox toView:nil]]];
 
-    RetainPtr menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForResult:[_currentActionContext mainResult] actionContext:_currentActionContext.get()];
+    RetainPtr menuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForResult:[_currentActionContext mainResult] actionContext:_currentActionContext.get()];
 
     if (menuItems.get().count != 1)
         return nil;
@@ -476,7 +476,7 @@
     if (!hitTestResult)
         return nil;
 
-    RetainPtr menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForTargetURL:hitTestResult->absoluteLinkURL().createNSString().get() actionContext:_currentActionContext.get()];
+    RetainPtr menuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForTargetURL:hitTestResult->absoluteLinkURL().createNSString().get() actionContext:_currentActionContext.get()];
 
     if (menuItems.get().count != 1)
         return nil;

--- a/Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm
+++ b/Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm
@@ -79,10 +79,10 @@
 
 - (void)closePanelIfNecessary
 {
-    if (!PAL::isQuickLookUIFrameworkAvailable() || ![PAL::getQLPreviewPanelClass() sharedPreviewPanelExists])
+    if (!PAL::isQuickLookUIFrameworkAvailable() || ![PAL::getQLPreviewPanelClassSingleton() sharedPreviewPanelExists])
         return;
 
-    if (RetainPtr panel = [PAL::getQLPreviewPanelClass() sharedPreviewPanel]; [self isControlling:panel.get()])
+    if (RetainPtr panel = [PAL::getQLPreviewPanelClassSingleton() sharedPreviewPanel]; [self isControlling:panel.get()])
         [panel close];
 }
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -916,7 +916,7 @@ void WebPageProxy::handleContextMenuLookUpImage()
 
 void WebPageProxy::showImageInQuickLookPreviewPanel(ShareableBitmap& imageBitmap, const String& tooltip, const URL& imageURL, QuickLookPreviewActivity activity)
 {
-    if (!PAL::isQuickLookUIFrameworkAvailable() || !PAL::getQLPreviewPanelClass() || ![PAL::getQLItemClass() instancesRespondToSelector:@selector(initWithDataProvider:contentType:previewTitle:)])
+    if (!PAL::isQuickLookUIFrameworkAvailable() || !PAL::getQLPreviewPanelClassSingleton() || ![PAL::getQLItemClassSingleton() instancesRespondToSelector:@selector(initWithDataProvider:contentType:previewTitle:)])
         return;
 
     RetainPtr image = imageBitmap.createPlatformImage(DontCopyBackingStore);
@@ -940,7 +940,7 @@ void WebPageProxy::showImageInQuickLookPreviewPanel(ShareableBitmap& imageBitmap
     if (RefPtr pageClient = this->pageClient())
         pageClient->makeFirstResponder();
 
-    RetainPtr previewPanel = [PAL::getQLPreviewPanelClass() sharedPreviewPanel];
+    RetainPtr previewPanel = [PAL::getQLPreviewPanelClassSingleton() sharedPreviewPanel];
     [previewPanel makeKeyAndOrderFront:nil];
 
     if (![m_quickLookPreviewController isControlling:previewPanel.get()]) {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2883,7 +2883,7 @@ void WebViewImpl::selectionDidChange()
         auto selectionRect = isRange ? m_page->editorState().postLayoutData->selectionBoundingRect : IntRect { };
 
         // The affordance will only show up if the selected range consists of >= 50 characters.
-        [[PAL::getWTWritingToolsClass() sharedInstance] scheduleShowAffordanceForSelectionRect:selectionRect ofView:m_view.getAutoreleased() forDelegate:(NSObject<WTWritingToolsDelegate> *)m_view.getAutoreleased()];
+        [[PAL::getWTWritingToolsClassSingleton() sharedInstance] scheduleShowAffordanceForSelectionRect:selectionRect ofView:m_view.getAutoreleased() forDelegate:(NSObject<WTWritingToolsDelegate> *)m_view.getAutoreleased()];
     }
 #endif
 
@@ -3529,7 +3529,7 @@ void WebViewImpl::dismissContentRelativeChildWindowsFromViewOnly()
         WebCore::DictionaryLookup::hidePopup();
 
         if (PAL::isDataDetectorsFrameworkAvailable())
-            [[PAL::getDDActionsManagerClass() sharedManager] requestBubbleClosureUnanchorOnFailure:YES];
+            [[PAL::getDDActionsManagerClassSingleton() sharedManager] requestBubbleClosureUnanchorOnFailure:YES];
     }
 
     m_page->clearTextIndicatorWithAnimation(WebCore::TextIndicatorDismissalAnimation::FadeOut);
@@ -4840,7 +4840,7 @@ void WebViewImpl::showWritingTools(WTRequestedTool tool)
         selectionRect = page().selectionBoundingRectInRootViewCoordinates();
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[PAL::getWTWritingToolsClass() sharedInstance] showTool:tool forSelectionRect:selectionRect ofView:m_view.getAutoreleased() forDelegate:(NSObject<WTWritingToolsDelegate> *)m_view.getAutoreleased()];
+    [[PAL::getWTWritingToolsClassSingleton() sharedInstance] showTool:tool forSelectionRect:selectionRect ofView:m_view.getAutoreleased() forDelegate:(NSObject<WTWritingToolsDelegate> *)m_view.getAutoreleased()];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
@@ -6770,7 +6770,7 @@ void WebViewImpl::setMediaSessionCoordinatorForTesting(MediaSessionCoordinatorPr
 
 bool WebViewImpl::canHandleContextMenuTranslation() const
 {
-    return PAL::isTranslationUIServicesFrameworkAvailable() && [PAL::getLTUITranslationViewControllerClass() isAvailable];
+    return PAL::isTranslationUIServicesFrameworkAvailable() && [PAL::getLTUITranslationViewControllerClassSingleton() isAvailable];
 }
 
 void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo& info)
@@ -6823,7 +6823,7 @@ void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContext
 
 bool WebViewImpl::canHandleContextMenuWritingTools() const
 {
-    return PAL::isWritingToolsUIFrameworkAvailable() && [PAL::getWTWritingToolsViewControllerClass() isAvailable] && m_page->writingToolsBehavior() != WebCore::WritingTools::Behavior::None;
+    return PAL::isWritingToolsUIFrameworkAvailable() && [PAL::getWTWritingToolsViewControllerClassSingleton() isAvailable] && m_page->writingToolsBehavior() != WebCore::WritingTools::Behavior::None;
 }
 
 #endif

--- a/Source/WebKit/WebProcess/ApplePay/cocoa/WebPaymentCoordinatorCocoa.mm
+++ b/Source/WebKit/WebProcess/ApplePay/cocoa/WebPaymentCoordinatorCocoa.mm
@@ -40,7 +40,7 @@ WebPaymentCoordinator::AvailablePaymentNetworksSet WebPaymentCoordinator::platfo
 #endif
 
     WebPaymentCoordinator::AvailablePaymentNetworksSet availableNetworks;
-    for (PKPaymentNetwork network in [PAL::getPKPaymentRequestClass() availableNetworks])
+    for (PKPaymentNetwork network in [PAL::getPKPaymentRequestClassSingleton() availableNetworks])
         availableNetworks.add(network);
     return availableNetworks;
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -511,7 +511,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFPlugin);
 
 bool PDFPlugin::pdfKitLayerControllerIsAvailable()
 {
-    return getPDFLayerControllerClass();
+    return getPDFLayerControllerClassSingleton();
 }
 
 Ref<PDFPlugin> PDFPlugin::create(HTMLPlugInElement& pluginElement)
@@ -558,8 +558,8 @@ PDFPlugin::PDFPlugin(HTMLPlugInElement& element)
     if ([m_pdfLayerController respondsToSelector:@selector(setDeviceColorSpace:)])
         [m_pdfLayerController setDeviceColorSpace:screenColorSpace(frame->protectedCoreLocalFrame()->view()).platformColorSpace()];
     
-    if ([getPDFLayerControllerClass() respondsToSelector:@selector(setUseIOSurfaceForTiles:)])
-        [getPDFLayerControllerClass() setUseIOSurfaceForTiles:false];
+    if ([getPDFLayerControllerClassSingleton() respondsToSelector:@selector(setUseIOSurfaceForTiles:)])
+        [getPDFLayerControllerClassSingleton() setUseIOSurfaceForTiles:false];
 }
 
 PDFPlugin::~PDFPlugin() = default;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm
@@ -42,7 +42,7 @@ namespace WebKit {
 
 static bool hasActionsForResult(DDScannerResult *dataDetectorResult)
 {
-    RetainPtr ddActionsManagerClass = PAL::getDDActionsManagerClass();
+    RetainPtr ddActionsManagerClass = PAL::getDDActionsManagerClassSingleton();
     return [[ddActionsManagerClass.get() sharedManager] hasActionsForResult:RetainPtr { [dataDetectorResult coreResult] }.get() actionContext:nil];
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -154,7 +154,7 @@ Ref<WebCore::PlatformCALayer> PlatformCALayerRemoteCustom::clone(PlatformCALayer
 
     if (layerType() == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
         
-        if (PAL::isAVFoundationFrameworkAvailable() && [platformLayer() isKindOfClass:PAL::getAVPlayerLayerClass()]) {
+        if (PAL::isAVFoundationFrameworkAvailable() && [platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()]) {
             clonedLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);
 
             RetainPtr destinationPlayerLayer = static_cast<AVPlayerLayer *>(clonedLayer.get());

--- a/Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm
@@ -66,7 +66,7 @@ using namespace WebCore;
     ASSERT(!_locationManager);
 
     _locationManager = adoptNS([allocCLLocationManagerInstance() init]);
-    _lastAuthorizationStatus = [getCLLocationManagerClass() authorizationStatus];
+    _lastAuthorizationStatus = [getCLLocationManagerClassSingleton() authorizationStatus];
 
     [ _locationManager setDelegate:self];
 }
@@ -89,12 +89,12 @@ using namespace WebCore;
 
 - (void)requestGeolocationAuthorization
 {
-    if (![getCLLocationManagerClass() locationServicesEnabled]) {
+    if (![getCLLocationManagerClassSingleton() locationServicesEnabled]) {
         [_positionListener geolocationAuthorizationDenied];
         return;
     }
 
-    switch ([getCLLocationManagerClass() authorizationStatus]) {
+    switch ([getCLLocationManagerClassSingleton() authorizationStatus]) {
     case kCLAuthorizationStatusNotDetermined: {
         if (!_isWaitingForAuthorization) {
             _isWaitingForAuthorization = YES;
@@ -121,8 +121,8 @@ static bool isAuthorizationGranted(CLAuthorizationStatus authorizationStatus)
 
 - (void)start
 {
-    if (![getCLLocationManagerClass() locationServicesEnabled]
-        || !isAuthorizationGranted([getCLLocationManagerClass() authorizationStatus])) {
+    if (![getCLLocationManagerClassSingleton() locationServicesEnabled]
+        || !isAuthorizationGranted([getCLLocationManagerClassSingleton() authorizationStatus])) {
         [_locationManager stopUpdatingLocation];
         [_positionListener resetGeolocation];
         return;

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -91,7 +91,7 @@
     _webView = nil;
 
     id animationController = [_immediateActionRecognizer animationController];
-    if (PAL::isQuickLookUIFrameworkAvailable() && [animationController isKindOfClass:PAL::getQLPreviewMenuItemClass()]) {
+    if (PAL::isQuickLookUIFrameworkAvailable() && [animationController isKindOfClass:PAL::getQLPreviewMenuItemClassSingleton()]) {
         QLPreviewMenuItem *menuItem = (QLPreviewMenuItem *)animationController;
         menuItem.delegate = nil;
     }
@@ -145,12 +145,12 @@
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return;
 
-    DDActionsManager *actionsManager = [PAL::getDDActionsManagerClass() sharedManager];
+    DDActionsManager *actionsManager = [PAL::getDDActionsManagerClassSingleton() sharedManager];
     [actionsManager requestBubbleClosureUnanchorOnFailure:YES];
 
     if (_currentActionContext && _hasActivatedActionContext) {
         _hasActivatedActionContext = NO;
-        [PAL::getDDActionsManagerClass() didUseActions];
+        [PAL::getDDActionsManagerClassSingleton() didUseActions];
     }
 
     _type = WebImmediateActionNone;
@@ -219,7 +219,7 @@
 
     if (_currentActionContext) {
         _hasActivatedActionContext = YES;
-        if (![PAL::getDDActionsManagerClass() shouldUseActionsWithContext:_currentActionContext.get()])
+        if (![PAL::getDDActionsManagerClassSingleton() shouldUseActionsWithContext:_currentActionContext.get()])
             [self _cancelImmediateAction];
     }
 }
@@ -450,7 +450,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
 
     [detectedItem->actionContext setAltMode:YES];
     [detectedItem->actionContext setImmediate:YES];
-    if (![[PAL::getDDActionsManagerClass() sharedManager] hasActionsForResult:[detectedItem->actionContext mainResult] actionContext:detectedItem->actionContext.get()])
+    if (![[PAL::getDDActionsManagerClassSingleton() sharedManager] hasActionsForResult:[detectedItem->actionContext mainResult] actionContext:detectedItem->actionContext.get()])
         return nil;
 
     auto indicator = WebCore::TextIndicator::createWithRange(detectedItem->range, { }, WebCore::TextIndicatorPresentationTransition::FadeIn);
@@ -465,7 +465,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
 
     [_currentActionContext setHighlightFrame:[_webView.window convertRectToScreen:detectedItem->boundingBox]];
 
-    NSArray *menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForResult:[_currentActionContext mainResult] actionContext:_currentActionContext.get()];
+    NSArray *menuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForResult:[_currentActionContext mainResult] actionContext:_currentActionContext.get()];
     if (menuItems.count != 1)
         return nil;
 
@@ -498,7 +498,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
 
     [_currentActionContext setHighlightFrame:[_webView.window convertRectToScreen:elementBoundingBoxInWindowCoordinatesFromNode(_hitTestResult.URLElement())]];
 
-    NSArray *menuItems = [[PAL::getDDActionsManagerClass() sharedManager] menuItemsForTargetURL:_hitTestResult.absoluteLinkURL().string().createNSString().get() actionContext:_currentActionContext.get()];
+    NSArray *menuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForTargetURL:_hitTestResult.absoluteLinkURL().string().createNSString().get() actionContext:_currentActionContext.get()];
     if (menuItems.count != 1)
         return nil;
     
@@ -562,7 +562,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
 
 - (id<NSImmediateActionAnimationController>)_animationControllerForText
 {
-    if (!PAL::getLULookupDefinitionModuleClass())
+    if (!PAL::getLULookupDefinitionModuleClassSingleton())
         return nil;
 
     auto node = _hitTestResult.innerNode();

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -109,8 +109,8 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     static Class theClass = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        ASSERT(getAVPlayerViewClass());
-        Class aClass = objc_allocateClassPair(getAVPlayerViewClass(), "WebAVPlayerView", 0);
+        ASSERT(getAVPlayerViewClassSingleton());
+        Class aClass = objc_allocateClassPair(getAVPlayerViewClassSingleton(), "WebAVPlayerView", 0);
         theClass = aClass;
         class_addMethod(theClass, @selector(setWebDelegate:), (IMP)WebAVPlayerView_setWebDelegate, "v@:@");
         class_addMethod(theClass, @selector(webDelegate), (IMP)WebAVPlayerView_webDelegate, "@@:");

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9557,7 +9557,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 
 + (BOOL)_canHandleContextMenuTranslation
 {
-    return PAL::isTranslationUIServicesFrameworkAvailable() && [PAL::getLTUITranslationViewControllerClass() isAvailable];
+    return PAL::isTranslationUIServicesFrameworkAvailable() && [PAL::getLTUITranslationViewControllerClassSingleton() isAvailable];
 }
 
 - (void)_handleContextMenuTranslation:(const WebCore::TranslationContextMenuInfo&)info

--- a/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
@@ -81,7 +81,7 @@
     JSValueProtect([mainFrame globalContext], m_notificationFunctionCallback);
 }
 
-static Class webAccessibilityObjectWrapperClass()
+static Class webAccessibilityObjectWrapperClassSingleton()
 {
     static Class cls = objc_getClass("WebAccessibilityObjectWrapper");
     ASSERT(cls);
@@ -93,7 +93,7 @@ static Class webAccessibilityObjectWrapperClass()
     // Once we start requesting notifications, it's on for the duration of the program.
     // This is to avoid any race conditions between tests turning this flag on and off. Instead
     // AccessibilityNotificationHandler can ignore events it doesn't care about.
-    [webAccessibilityObjectWrapperClass() accessibilitySetShouldRepostNotifications:YES];
+    [webAccessibilityObjectWrapperClassSingleton() accessibilitySetShouldRepostNotifications:YES];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_notificationReceived:) name:@"AXDRTNotification" object:nil];
 }
 
@@ -111,7 +111,7 @@ static JSValueRef makeValueRefForValue(JSContextRef context, id value)
             return JSValueMakeBoolean(context, [value boolValue]);
         return JSValueMakeNumber(context, [value doubleValue]);
     }
-    if ([value isKindOfClass:webAccessibilityObjectWrapperClass()])
+    if ([value isKindOfClass:webAccessibilityObjectWrapperClassSingleton()])
         return AccessibilityUIElement::makeJSAccessibilityUIElement(context, value);
     if ([value isKindOfClass:[NSDictionary class]])
         return makeObjectRefForDictionary(context, value);

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -649,14 +649,14 @@ inline bool operator==(const ObjCHolderForTesting& a, const ObjCHolderForTesting
         class_addMethod([NSURLProtectionSpace class], @selector(oldIsEqual:), oldIsEqual2, "v@:@");
 
 #if USE(PASSKIT)
-        class_addMethod(PAL::getPKPaymentMethodClass(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
-        class_addMethod(PAL::getPKPaymentTokenClass(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
-        class_addMethod(PAL::getPKDateComponentsRangeClass(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
-        class_addMethod(PAL::getPKShippingMethodClass(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
-        class_addMethod(PAL::getPKPaymentClass(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
+        class_addMethod(PAL::getPKPaymentMethodClassSingleton(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
+        class_addMethod(PAL::getPKPaymentTokenClassSingleton(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
+        class_addMethod(PAL::getPKDateComponentsRangeClassSingleton(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
+        class_addMethod(PAL::getPKShippingMethodClassSingleton(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
+        class_addMethod(PAL::getPKPaymentClassSingleton(), @selector(isEqual:), (IMP)wkSecureCoding_isEqual, "v@:@");
 #endif
 #if ENABLE(DATA_DETECTION) && PLATFORM(MAC)
-        class_addMethod(PAL::getWKDDActionContextClass(), @selector(isEqual:), (IMP)wkDDActionContext_isEqual, "v@:@");
+        class_addMethod(PAL::getWKDDActionContextClassSingleton(), @selector(isEqual:), (IMP)wkDDActionContext_isEqual, "v@:@");
 #endif
     });
 
@@ -670,7 +670,7 @@ inline bool operator==(const ObjCHolderForTesting& a, const ObjCHolderForTesting
     EXPECT_TRUE(bObject != nil);
 
 #if USE(PASSKIT)
-    if ([aObject isKindOfClass:PAL::getCNPostalAddressClass()])
+    if ([aObject isKindOfClass:PAL::getCNPostalAddressClassSingleton()])
         return CNPostalAddressTesting_isEqual(aObject, bObject);
 #endif
 
@@ -893,7 +893,7 @@ static void destroyTempKeychain(SecKeychainRef keychainRef)
 #if USE(PASSKIT)
 static RetainPtr<CNMutablePostalAddress> postalAddressForTesting()
 {
-    RetainPtr<CNMutablePostalAddress> address = adoptNS([PAL::getCNMutablePostalAddressClass() new]);
+    RetainPtr<CNMutablePostalAddress> address = adoptNS([PAL::getCNMutablePostalAddressClassSingleton() new]);
     address.get().street = @"1 Apple Park Way";
     address.get().subLocality = @"Birdland";
     address.get().city = @"Cupertino";
@@ -908,10 +908,10 @@ static RetainPtr<CNMutablePostalAddress> postalAddressForTesting()
 
 static RetainPtr<PKContact> pkContactForTesting()
 {
-    RetainPtr<PKContact> contact = adoptNS([PAL::getPKContactClass() new]);
+    RetainPtr<PKContact> contact = adoptNS([PAL::getPKContactClassSingleton() new]);
     contact.get().name = personNameComponentsForTesting().get();
     contact.get().emailAddress = @"admin@webkit.org";
-    contact.get().phoneNumber = [PAL::getCNPhoneNumberClass() phoneNumberWithDigits:@"4085551234" countryCode:@"us"];
+    contact.get().phoneNumber = [PAL::getCNPhoneNumberClassSingleton() phoneNumberWithDigits:@"4085551234" countryCode:@"us"];
     contact.get().postalAddress = postalAddressForTesting().get();
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     contact.get().supplementarySubLocality = @"City 17";
@@ -1158,7 +1158,7 @@ TEST(IPCSerialization, Basic)
     // Digits must be non-null at init-time, but countryCode can be null.
     // However, Contacts will calculate a default country code if you pass in a null one,
     // so testing encode/decode of such an instance is pointless.
-    RetainPtr<CNPhoneNumber> phoneNumber = [PAL::getCNPhoneNumberClass() phoneNumberWithDigits:@"4085551234" countryCode:@"us"];
+    RetainPtr<CNPhoneNumber> phoneNumber = [PAL::getCNPhoneNumberClassSingleton() phoneNumberWithDigits:@"4085551234" countryCode:@"us"];
     runTestNS({ phoneNumber.get() });
 
     // CNPostalAddress
@@ -1706,7 +1706,7 @@ TEST(IPCSerialization, NSURLRequest)
 #if USE(AVFOUNDATION) && PLATFORM(MAC)
 TEST(IPCSerialization, AVOutputContext)
 {
-    RetainPtr<AVOutputContext> outputContext = adoptNS([[PAL::getAVOutputContextClass() alloc] init]);
+    RetainPtr<AVOutputContext> outputContext = adoptNS([[PAL::getAVOutputContextClassSingleton() alloc] init]);
     runTestNS({ outputContext.get() });
 }
 #endif // USE(AVFOUNDATION) && PLATFORM(MAC)
@@ -1725,7 +1725,7 @@ static RetainPtr<DDScannerResult> fakeDataDetectorResultForTesting()
     if (!CFArrayGetCount(results.get()))
         return nil;
 
-    return [[PAL::getDDScannerResultClass() resultsFromCoreResults:results.get()] firstObject];
+    return [[PAL::getDDScannerResultClassSingleton() resultsFromCoreResults:results.get()] firstObject];
 }
 
 @interface PKPaymentMerchantSession ()
@@ -1772,7 +1772,7 @@ TEST(IPCSerialization, SecureCoding)
 
     // PKPaymentMerchantSession
     // This initializer doesn't exercise retryNonce or domain
-    RetainPtr<PKPaymentMerchantSession> session = adoptNS([[PAL::getPKPaymentMerchantSessionClass() alloc]
+    RetainPtr<PKPaymentMerchantSession> session = adoptNS([[PAL::getPKPaymentMerchantSessionClassSingleton() alloc]
         initWithMerchantIdentifier:@"WebKit Open Source Project"
         merchantSessionIdentifier:@"WebKitMerchantSession"
         nonce:@"WebKitNonce"
@@ -1788,7 +1788,7 @@ TEST(IPCSerialization, SecureCoding)
     runTestNS({ session.get() });
 
     // This initializer adds in domain, but retryNonce is still unexercised
-    session = adoptNS([[PAL::getPKPaymentMerchantSessionClass() alloc]
+    session = adoptNS([[PAL::getPKPaymentMerchantSessionClassSingleton() alloc]
         initWithMerchantIdentifier:@"WebKit Open Source Project"
         merchantSessionIdentifier:@"WebKitMerchantSession"
         nonce:@"WebKitNonce"
@@ -1801,11 +1801,11 @@ TEST(IPCSerialization, SecureCoding)
     runTestNS({ session.get() });
 
     RetainPtr<CNPostalAddress> address = postalAddressForTesting();
-    RetainPtr<CNLabeledValue> labeledPostalAddress = adoptNS([[PAL::getCNLabeledValueClass() alloc] initWithLabel:@"Work" value:address.get()]);
+    RetainPtr<CNLabeledValue> labeledPostalAddress = adoptNS([[PAL::getCNLabeledValueClassSingleton() alloc] initWithLabel:@"Work" value:address.get()]);
 
-    RetainPtr<CNLabeledValue> labeledEmailAddress = adoptNS([[PAL::getCNLabeledValueClass() alloc] initWithLabel:@"WorkSPAM" value:@"spam@webkit.org"]);
+    RetainPtr<CNLabeledValue> labeledEmailAddress = adoptNS([[PAL::getCNLabeledValueClassSingleton() alloc] initWithLabel:@"WorkSPAM" value:@"spam@webkit.org"]);
 
-    RetainPtr<CNMutableContact> billingContact = adoptNS([PAL::getCNMutableContactClass() new]);
+    RetainPtr<CNMutableContact> billingContact = adoptNS([PAL::getCNMutableContactClassSingleton() new]);
     billingContact.get().contactType = CNContactTypePerson;
     billingContact.get().namePrefix = @"Mrs";
     billingContact.get().givenName = @"WebKit";
@@ -1819,7 +1819,7 @@ TEST(IPCSerialization, SecureCoding)
     billingContact.get().emailAddresses = @[ labeledEmailAddress.get() ];
     runTestNS({ billingContact.get() });
 
-    RetainPtr<PKPaymentMethod> paymentMethod = adoptNS([PAL::getPKPaymentMethodClass() new]);
+    RetainPtr<PKPaymentMethod> paymentMethod = adoptNS([PAL::getPKPaymentMethodClassSingleton() new]);
     paymentMethod.get().displayName = @"WebKitPay";
     paymentMethod.get().network = @"WebKitCard";
     paymentMethod.get().type = PKPaymentMethodTypeCredit;
@@ -1827,7 +1827,7 @@ TEST(IPCSerialization, SecureCoding)
 
     runTestNS({ paymentMethod.get() });
 
-    RetainPtr<PKPaymentToken> paymentToken = adoptNS([PAL::getPKPaymentTokenClass() new]);
+    RetainPtr<PKPaymentToken> paymentToken = adoptNS([PAL::getPKPaymentTokenClassSingleton() new]);
     paymentToken.get().paymentMethod = paymentMethod.get();
     paymentToken.get().transactionIdentifier = @"WebKitTXIdentifier";
     paymentToken.get().paymentData = [NSData new];
@@ -1871,18 +1871,18 @@ TEST(IPCSerialization, SecureCoding)
 
     runTestNS({ endComponents.get() });
 
-    RetainPtr<PKDateComponentsRange> dateRange = adoptNS([[PAL::getPKDateComponentsRangeClass() alloc] initWithStartDateComponents:startComponents.get() endDateComponents:endComponents.get()]);
+    RetainPtr<PKDateComponentsRange> dateRange = adoptNS([[PAL::getPKDateComponentsRangeClassSingleton() alloc] initWithStartDateComponents:startComponents.get() endDateComponents:endComponents.get()]);
 
     runTestNS({ dateRange.get() });
 
-    RetainPtr<PKShippingMethod> shippingMethod = adoptNS([PAL::getPKShippingMethodClass() new]);
+    RetainPtr<PKShippingMethod> shippingMethod = adoptNS([PAL::getPKShippingMethodClassSingleton() new]);
     shippingMethod.get().identifier = @"WebKitPostalService";
     shippingMethod.get().detail = @"Ships in 1 to 2 bugzillas";
     shippingMethod.get().dateComponentsRange = dateRange.get();
 
     runTestNS({ shippingMethod.get() });
 
-    RetainPtr<PKPayment> payment = adoptNS([PAL::getPKPaymentClass() new]);
+    RetainPtr<PKPayment> payment = adoptNS([PAL::getPKPaymentClassSingleton() new]);
     payment.get().token = paymentToken.get();
     payment.get().billingContact = pkContactForTesting().get();
     payment.get().shippingContact = pkContactForTesting().get();

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm
@@ -33,61 +33,61 @@ namespace TestWebKitAPI {
 
 TEST(AVFoundationSoftLink, Classes)
 {
-    EXPECT_NE(PAL::getAVPlayerClass(), nullptr);
-    EXPECT_NE(PAL::getAVPlayerItemClass(), nullptr);
-    EXPECT_NE(PAL::getAVPlayerItemVideoOutputClass(), nullptr);
-    EXPECT_NE(PAL::getAVPlayerLayerClass(), nullptr);
-    EXPECT_NE(PAL::getAVURLAssetClass(), nullptr);
-    EXPECT_NE(PAL::getAVAssetImageGeneratorClass(), nullptr);
-    EXPECT_NE(PAL::getAVMetadataItemClass(), nullptr);
-    EXPECT_NE(PAL::getAVAssetCacheClass(), nullptr);
-    EXPECT_NE(PAL::getAVPlayerItemLegibleOutputClass(), nullptr);
-    EXPECT_NE(PAL::getAVMediaSelectionGroupClass(), nullptr);
-    EXPECT_NE(PAL::getAVMediaSelectionOptionClass(), nullptr);
-    EXPECT_NE(PAL::getAVOutputContextClass(), nullptr);
-    EXPECT_NE(PAL::getAVAssetReaderClass(), nullptr);
-    EXPECT_NE(PAL::getAVAssetWriterClass(), nullptr);
-    EXPECT_NE(PAL::getAVAssetWriterInputClass(), nullptr);
-    EXPECT_NE(PAL::getAVMutableAudioMixClass(), nullptr);
-    EXPECT_NE(PAL::getAVMutableAudioMixInputParametersClass(), nullptr);
+    EXPECT_NE(PAL::getAVPlayerClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVPlayerItemClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVPlayerItemVideoOutputClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVPlayerLayerClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVURLAssetClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAssetImageGeneratorClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVMetadataItemClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAssetCacheClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVPlayerItemLegibleOutputClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVMediaSelectionGroupClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVMediaSelectionOptionClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVOutputContextClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAssetReaderClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAssetWriterClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAssetWriterInputClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVMutableAudioMixClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVMutableAudioMixInputParametersClassSingleton(), nullptr);
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-    EXPECT_NE(PAL::getAVCaptureConnectionClass(), nullptr);
-    EXPECT_NE(PAL::getAVCaptureDeviceClass(), nullptr);
-    EXPECT_NE(PAL::getAVCaptureDeviceFormatClass(), nullptr);
-    EXPECT_NE(PAL::getAVCaptureDeviceInputClass(), nullptr);
-    EXPECT_NE(PAL::getAVCaptureOutputClass(), nullptr);
-    EXPECT_NE(PAL::getAVCaptureSessionClass(), nullptr);
-    EXPECT_NE(PAL::getAVCaptureVideoDataOutputClass(), nullptr);
-    EXPECT_NE(PAL::getAVFrameRateRangeClass(), nullptr);
+    EXPECT_NE(PAL::getAVCaptureConnectionClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVCaptureDeviceClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVCaptureDeviceFormatClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVCaptureDeviceInputClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVCaptureOutputClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVCaptureSessionClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVCaptureVideoDataOutputClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVFrameRateRangeClassSingleton(), nullptr);
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    EXPECT_NE(PAL::getAVPersistableContentKeyRequestClass(), nullptr);
-    EXPECT_NE(PAL::getAVAudioSessionClass(), nullptr);
-    EXPECT_NE(PAL::getAVSpeechSynthesizerClass(), nullptr);
-    EXPECT_NE(PAL::getAVSpeechUtteranceClass(), nullptr);
-    EXPECT_NE(PAL::getAVSpeechSynthesisVoiceClass(), nullptr);
+    EXPECT_NE(PAL::getAVPersistableContentKeyRequestClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAudioSessionClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVSpeechSynthesizerClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVSpeechUtteranceClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVSpeechSynthesisVoiceClassSingleton(), nullptr);
 #endif
 
 #if HAVE(AVAUDIO_ROUTING_ARBITER)
-    EXPECT_NE(PAL::getAVAudioRoutingArbiterClass(), nullptr);
+    EXPECT_NE(PAL::getAVAudioRoutingArbiterClassSingleton(), nullptr);
 #endif
 
 #if !PLATFORM(WATCHOS)
-    EXPECT_NE(PAL::getAVRouteDetectorClass(), nullptr);
+    EXPECT_NE(PAL::getAVRouteDetectorClassSingleton(), nullptr);
 #endif
 
-    EXPECT_NE(PAL::getAVContentKeyResponseClass(), nullptr);
-    EXPECT_NE(PAL::getAVContentKeySessionClass(), nullptr);
-    EXPECT_NE(PAL::getAVAssetResourceLoadingRequestClass(), nullptr);
-    EXPECT_NE(PAL::getAVAssetReaderSampleReferenceOutputClass(), nullptr);
+    EXPECT_NE(PAL::getAVContentKeyResponseClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVContentKeySessionClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAssetResourceLoadingRequestClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVAssetReaderSampleReferenceOutputClassSingleton(), nullptr);
 #if !PLATFORM(WATCHOS)
-    EXPECT_NE(PAL::getAVVideoPerformanceMetricsClass(), nullptr);
+    EXPECT_NE(PAL::getAVVideoPerformanceMetricsClassSingleton(), nullptr);
 #endif
-    EXPECT_NE(PAL::getAVSampleBufferAudioRendererClass(), nullptr);
-    EXPECT_NE(PAL::getAVSampleBufferDisplayLayerClass(), nullptr);
-    EXPECT_NE(PAL::getAVSampleBufferRenderSynchronizerClass(), nullptr);
+    EXPECT_NE(PAL::getAVSampleBufferAudioRendererClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVSampleBufferDisplayLayerClassSingleton(), nullptr);
+    EXPECT_NE(PAL::getAVSampleBufferRenderSynchronizerClassSingleton(), nullptr);
 }
 
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -137,7 +137,7 @@ public:
     AllowedLinkFilteringDataRequestSwizzler(NSArray<NSString *> *parameters)
     {
         m_swizzler = makeUnique<InstanceMethodSwizzler>(
-            PAL::getWPResourcesClass(),
+            PAL::getWPResourcesClassSingleton(),
             @selector(requestAllowedLinkFilteringData:completionHandler:),
             makeAllowedLinkFilteringDataRequestHandler(parameters)
         );
@@ -161,7 +161,7 @@ public:
         m_didHandleRequest = false;
         // Ensure that the previous swizzler is destroyed before creating the new one.
         m_swizzler = nullptr;
-        m_swizzler = makeUnique<InstanceMethodSwizzler>(PAL::getWPResourcesClass(), @selector(requestLinkFilteringData:completionHandler:), makeQueryParameterRequestHandler(parameters, domains, paths, m_didHandleRequest));
+        m_swizzler = makeUnique<InstanceMethodSwizzler>(PAL::getWPResourcesClassSingleton(), @selector(requestLinkFilteringData:completionHandler:), makeQueryParameterRequestHandler(parameters, domains, paths, m_didHandleRequest));
         [[NSNotificationCenter defaultCenter] postNotificationName:PAL::get_WebPrivacy_WPResourceDataChangedNotificationName() object:nil userInfo:@{ PAL::get_WebPrivacy_WPNotificationUserInfoResourceTypeKey() : @(WPResourceTypeLinkFilteringData) }];
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebFilter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebFilter.mm
@@ -47,7 +47,7 @@ static BOOL isManagedSessionMethodOverride(id self, SEL selector)
 
 TEST(WebKit, WebFilterFeatureHasFrontboardServiceAccess)
 {
-    Method isManagedSessionMethod = class_getClassMethod(getWebFilterEvaluatorClass(), @selector(isManagedSession));
+    Method isManagedSessionMethod = class_getClassMethod(getWebFilterEvaluatorClassSingleton(), @selector(isManagedSession));
     ASSERT(isManagedSessionMethod);
     isManagedSessionMethodOriginal = method_setImplementation(isManagedSessionMethod, (IMP)isManagedSessionMethodOverride);
     ASSERT(isManagedSessionMethodOriginal);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
@@ -414,11 +414,11 @@ static BOOL isManagedSession(id self, SEL _cmd)
 TEST(ContentFiltering, LazilyLoadPlatformFrameworks)
 {
     // Swizzle [NEFilterSource filterRequired] to return YES in the UI process since NetworkExtension will not be loaded otherwise.
-    Method method = class_getClassMethod(getNEFilterSourceClass(), @selector(filterRequired));
+    Method method = class_getClassMethod(getNEFilterSourceClassSingleton(), @selector(filterRequired));
     method_setImplementation(method, reinterpret_cast<IMP>(filterRequired));
 
     // Swizzle [WebFilterEvaluator isManagedSession] to return YES in the UI process since WebContentAnalysis will not be loaded otherwise.
-    method = class_getClassMethod(getWebFilterEvaluatorClass(), @selector(isManagedSession));
+    method = class_getClassMethod(getWebFilterEvaluatorClassSingleton(), @selector(isManagedSession));
     method_setImplementation(method, reinterpret_cast<IMP>(isManagedSession));
 
     @autoreleasepool {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
@@ -298,8 +298,8 @@ template <typename FunctionType>
 std::pair<std::unique_ptr<InstanceMethodSwizzler>, std::unique_ptr<InstanceMethodSwizzler>> makeImageAnalysisRequestSwizzler(FunctionType function)
 {
     return std::pair {
-        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerClass(), @selector(processRequest:progressHandler:completionHandler:), reinterpret_cast<IMP>(function)),
-        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerRequestClass(), @selector(initWithCGImage:orientation:requestType:), reinterpret_cast<IMP>(makeFakeRequest))
+        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerClassSingleton(), @selector(processRequest:progressHandler:completionHandler:), reinterpret_cast<IMP>(function)),
+        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerRequestClassSingleton(), @selector(initWithCGImage:orientation:requestType:), reinterpret_cast<IMP>(makeFakeRequest))
     };
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -95,14 +95,14 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
         return nil;
 
     _imageAnalysisRequestSwizzler = WTF::makeUnique<InstanceMethodSwizzler>(
-        PAL::getVKImageAnalyzerClass(),
+        PAL::getVKImageAnalyzerClassSingleton(),
         @selector(processRequest:progressHandler:completionHandler:),
         reinterpret_cast<IMP>(swizzledProcessRequest)
     );
 
 #if PLATFORM(IOS_FAMILY)
     _imageAnalysisInteractionSwizzler = WTF::makeUnique<InstanceMethodSwizzler>(
-        PAL::getVKCImageAnalysisInteractionClass(),
+        PAL::getVKCImageAnalysisInteractionClassSingleton(),
         @selector(setAnalysis:),
         reinterpret_cast<IMP>(swizzledSetAnalysis)
     );
@@ -116,7 +116,7 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
     );
 #else
     _imageAnalysisOverlaySwizzler = WTF::makeUnique<InstanceMethodSwizzler>(
-        PAL::getVKCImageAnalysisOverlayViewClass(),
+        PAL::getVKCImageAnalysisOverlayViewClassSingleton(),
         @selector(setAnalysis:),
         reinterpret_cast<IMP>(swizzledSetAnalysis)
     );
@@ -206,12 +206,12 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 {
 #if PLATFORM(IOS_FAMILY)
     for (id<UIInteraction> interaction in self.textInputContentView.interactions) {
-        if ([interaction isKindOfClass:PAL::getVKCImageAnalysisInteractionClass()])
+        if ([interaction isKindOfClass:PAL::getVKCImageAnalysisInteractionClassSingleton()])
             return YES;
     }
 #else
     for (NSView *subview in self.subviews) {
-        if ([subview isKindOfClass:PAL::getVKCImageAnalysisOverlayViewClass()])
+        if ([subview isKindOfClass:PAL::getVKCImageAnalysisOverlayViewClassSingleton()])
             return YES;
     }
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -149,8 +149,8 @@ template <typename FunctionType>
 std::pair<std::unique_ptr<InstanceMethodSwizzler>, std::unique_ptr<InstanceMethodSwizzler>> makeImageAnalysisRequestSwizzler(FunctionType function)
 {
     return std::pair {
-        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerClass(), @selector(processRequest:progressHandler:completionHandler:), reinterpret_cast<IMP>(function)),
-        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerRequestClass(), @selector(initWithCGImage:orientation:requestType:), reinterpret_cast<IMP>(makeFakeRequest))
+        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerClassSingleton(), @selector(processRequest:progressHandler:completionHandler:), reinterpret_cast<IMP>(function)),
+        makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerRequestClassSingleton(), @selector(initWithCGImage:orientation:requestType:), reinterpret_cast<IMP>(makeFakeRequest))
     };
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -506,7 +506,7 @@ TEST(SOAuthorizationRedirect, NoInterceptions)
 TEST(SOAuthorizationRedirect, DisableSSO)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -531,9 +531,9 @@ TEST(SOAuthorizationRedirect, InterceptionError)
 {
     resetState();
     // This test relies on us not swizzling most of the SOAuthorizationClass methods.
-    ClassMethodSwizzler swizzler0(PAL::getSOAuthorizationClass(), @selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURLCompletion));
-    ClassMethodSwizzler swizzler1(PAL::getSOAuthorizationClass(), @selector(canPerformAuthorizationWithURL:responseCode:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURL));
-    InstanceMethodSwizzler swizzler2(PAL::getSOAuthorizationClass(), @selector(getAuthorizationHintsWithURL:responseCode:completion:), reinterpret_cast<IMP>(overrideGetAuthorizationHintsWithURL));
+    ClassMethodSwizzler swizzler0(PAL::getSOAuthorizationClassSingleton(), @selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURLCompletion));
+    ClassMethodSwizzler swizzler1(PAL::getSOAuthorizationClassSingleton(), @selector(canPerformAuthorizationWithURL:responseCode:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURL));
+    InstanceMethodSwizzler swizzler2(PAL::getSOAuthorizationClassSingleton(), @selector(getAuthorizationHintsWithURL:responseCode:completion:), reinterpret_cast<IMP>(overrideGetAuthorizationHintsWithURL));
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -551,7 +551,7 @@ TEST(SOAuthorizationRedirect, InterceptionError)
 TEST(SOAuthorizationRedirect, InterceptionDoNotHandle)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -573,7 +573,7 @@ TEST(SOAuthorizationRedirect, InterceptionDoNotHandle)
 TEST(SOAuthorizationRedirect, InterceptionCancel)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -596,7 +596,7 @@ TEST(SOAuthorizationRedirect, InterceptionCancel)
 TEST(SOAuthorizationRedirect, InterceptionCompleteWithoutData)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -618,7 +618,7 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteWithoutData)
 TEST(SOAuthorizationRedirect, InterceptionUnexpectedCompletion)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -641,7 +641,7 @@ TEST(SOAuthorizationRedirect, InterceptionUnexpectedCompletion)
 TEST(SOAuthorizationRedirect, InterceptionSucceed1)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -688,7 +688,7 @@ static constexpr auto SimpleHtml =
 TEST(SOAuthorizationRedirect, InterceptionSucceed2)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationBasicDelegate alloc] init]);
@@ -721,7 +721,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
 TEST(SOAuthorizationRedirect, InterceptionSucceed3)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -755,7 +755,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
 TEST(SOAuthorizationRedirect, InterceptionSucceed4)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -784,7 +784,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed4)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -807,7 +807,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWith302POST)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -849,7 +849,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith302POST)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWith302AfterRedirection)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { SimpleHtml } },
@@ -894,7 +894,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith302AfterRedirection)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -946,7 +946,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1004,7 +1004,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)
 TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1058,7 +1058,7 @@ TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1092,7 +1092,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1127,7 +1127,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1165,7 +1165,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1188,7 +1188,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1223,7 +1223,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
 TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     RetainPtr<NSURL> testURL2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -1252,7 +1252,7 @@ TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1282,7 +1282,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
 TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1314,7 +1314,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
 TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1350,7 +1350,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
 TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1392,7 +1392,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
 TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1423,7 +1423,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
 TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -1457,7 +1457,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)
 TEST(SOAuthorizationRedirect, AuthorizationOptions)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
@@ -1476,7 +1476,7 @@ TEST(SOAuthorizationRedirect, AuthorizationOptions)
 TEST(SOAuthorizationRedirect, InterceptionDidNotHandleTwice)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1496,7 +1496,7 @@ TEST(SOAuthorizationRedirect, InterceptionDidNotHandleTwice)
 TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1518,7 +1518,7 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)
 TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnore)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1537,7 +1537,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnore)
 TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1564,7 +1564,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
 TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnoreAsync)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1587,7 +1587,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnoreAsync)
 TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1619,7 +1619,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)
 TEST(SOAuthorizationRedirect, InterceptionCancelWithUI)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1650,7 +1650,7 @@ TEST(SOAuthorizationRedirect, InterceptionCancelWithUI)
 TEST(SOAuthorizationRedirect, InterceptionErrorWithUI)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1680,7 +1680,7 @@ TEST(SOAuthorizationRedirect, InterceptionErrorWithUI)
 TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1719,7 +1719,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)
 TEST(SOAuthorizationRedirect, ShowUITwice)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1755,7 +1755,7 @@ TEST(SOAuthorizationRedirect, ShowUITwice)
 TEST(SOAuthorizationRedirect, NSNotificationCenter)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1785,7 +1785,7 @@ TEST(SOAuthorizationRedirect, NSNotificationCenter)
 TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturization)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1829,7 +1829,7 @@ TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturization)
 TEST(SOAuthorizationRedirect, DismissUIDuringHiding)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1876,7 +1876,7 @@ TEST(SOAuthorizationRedirect, DismissUIDuringHiding)
 TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturizationThenAnother)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -1930,7 +1930,7 @@ TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturizationThenAnother)
 TEST(SOAuthorizationRedirect, DismissUIDuringHidingThenAnother)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -2010,7 +2010,7 @@ TEST(SOAuthorizationPopUp, NoInterceptions)
 TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -2035,7 +2035,7 @@ TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)
 TEST(SOAuthorizationPopUp, NoInterceptionsWithoutUserGesture)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     // The default value of javaScriptCanOpenWindowsAutomatically is NO on iOS, and YES on macOS.
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -2054,7 +2054,7 @@ TEST(SOAuthorizationPopUp, NoInterceptionsWithoutUserGesture)
 TEST(SOAuthorizationPopUp, InterceptionError)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -2091,7 +2091,7 @@ TEST(SOAuthorizationPopUp, InterceptionError)
 TEST(SOAuthorizationPopUp, InterceptionCancel)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -2127,7 +2127,7 @@ TEST(SOAuthorizationPopUp, InterceptionCancel)
 TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2165,7 +2165,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
 TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2203,7 +2203,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
 TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2241,7 +2241,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
 TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -2282,7 +2282,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
 TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2320,7 +2320,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
 TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2364,7 +2364,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
 TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2430,7 +2430,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
 TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2468,7 +2468,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
 TEST(SOAuthorizationPopUp, AuthorizationOptions)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
@@ -2493,7 +2493,7 @@ TEST(SOAuthorizationPopUp, AuthorizationOptions)
 TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
@@ -2519,7 +2519,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)
 TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
@@ -2559,7 +2559,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
 TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
@@ -2606,7 +2606,7 @@ TEST(SOAuthorizationSubFrame, NoInterceptions)
 TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     auto testHtml = generateHTML(parentTemplate, URL { "http://www.example.com"_str }.string());
 
@@ -2625,7 +2625,7 @@ TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)
 TEST(SOAuthorizationSubFrame, InterceptionError)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -2657,7 +2657,7 @@ TEST(SOAuthorizationSubFrame, InterceptionError)
 TEST(SOAuthorizationSubFrame, InterceptionCancel)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -2689,7 +2689,7 @@ TEST(SOAuthorizationSubFrame, InterceptionCancel)
 TEST(SOAuthorizationSubFrame, InterceptionSuccess)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };
@@ -2720,7 +2720,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccess)
 TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -2756,7 +2756,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)
 TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };
@@ -2786,7 +2786,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)
 TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };
@@ -2817,7 +2817,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)
 TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };
@@ -2848,7 +2848,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)
 TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };
@@ -2887,7 +2887,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)
 TEST(SOAuthorizationSubFrame, AuthorizationOptions)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };
@@ -2910,7 +2910,7 @@ TEST(SOAuthorizationSubFrame, AuthorizationOptions)
 TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
@@ -2935,7 +2935,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)
 #endif
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };
@@ -2967,7 +2967,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)
 TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
@@ -2989,7 +2989,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)
 TEST(SOAuthorizationSubFrame, InterceptionErrorWithReferrer)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     HTTPServer server([parentHtml = generateHTML(parentTemplate, "simple.html"_s), frameHtml = generateHTML(iframeTemplate, "parent.postMessage('Referrer: ' + document.referrer, '*');"_s)] (const Connection& connection) {
@@ -3038,7 +3038,7 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorWithReferrer)
 TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -3063,7 +3063,7 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)
 TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)
 {
     resetState();
-    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
     SWIZZLE_AKAUTH();
 
     URL testURL { "http://www.example.com"_str };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
@@ -72,7 +72,7 @@ static void testSuppressUsageRecordingWithDataStore(RetainPtr<WKWebsiteDataStore
     __block bool suppressUsageRecording = false;
 
     InstanceMethodSwizzler swizzler {
-        PAL::getSTWebpageControllerClass(),
+        PAL::getSTWebpageControllerClassSingleton(),
         @selector(setSuppressUsageRecording:),
         imp_implementationWithBlock(^(id object, bool value) {
             suppressUsageRecording = value;
@@ -327,7 +327,7 @@ TEST(ScreenTime, IdentifierNil)
     __block NSString *identifier = @"testing123";
 
     InstanceMethodSwizzler swizzler {
-        PAL::getSTWebpageControllerClass(),
+        PAL::getSTWebpageControllerClassSingleton(),
         @selector(setProfileIdentifier:),
         imp_implementationWithBlock(^(id object, NSString *profileIdentifier) {
             identifier = profileIdentifier;
@@ -350,7 +350,7 @@ TEST(ScreenTime, IdentifierString)
     __block RetainPtr identifier = @"";
 
     InstanceMethodSwizzler swizzler {
-        PAL::getSTWebpageControllerClass(),
+        PAL::getSTWebpageControllerClassSingleton(),
         @selector(setProfileIdentifier:),
         imp_implementationWithBlock(^(id object, NSString *profileIdentifier) {
             identifier = profileIdentifier;
@@ -381,7 +381,7 @@ TEST(ScreenTime, IdentifierStringWithRemoveData)
     RetainPtr dataTypeScreenTime = adoptNS([[NSSet alloc] initWithArray:@[ WKWebsiteDataTypeScreenTime ]]);
 
     InstanceMethodSwizzler swizzler {
-        PAL::getSTWebHistoryClass(),
+        PAL::getSTWebHistoryClassSingleton(),
         @selector(deleteHistoryDuringInterval:),
         imp_implementationWithBlock(^(STWebHistory *object, NSDateInterval *) {
             identifier = object.profileIdentifier;
@@ -604,7 +604,7 @@ TEST(ScreenTime, FetchData)
 {
     __block RetainPtr<NSSet<NSURL *>> urls;
     InstanceMethodSwizzler swizzler {
-        PAL::getSTWebHistoryClass(),
+        PAL::getSTWebHistoryClassSingleton(),
         @selector(fetchAllHistoryWithCompletionHandler:),
         imp_implementationWithBlock(^(id object, void (^completionHandler)(NSSet<NSURL *> *urls, NSError *error)) {
             urls = [NSSet setWithArray:@[ adoptNS([[NSURL alloc] initWithString:@"https://www.webkit.org/"]).get() ]];
@@ -636,7 +636,7 @@ TEST(ScreenTime, RemoveDataWithTimeInterval)
 {
     __block bool removedHistory = false;
     InstanceMethodSwizzler swizzler {
-        PAL::getSTWebHistoryClass(),
+        PAL::getSTWebHistoryClassSingleton(),
         @selector(deleteHistoryDuringInterval:),
         imp_implementationWithBlock(^(id object, NSDateInterval *interval) {
             removedHistory = true;
@@ -675,7 +675,7 @@ TEST(ScreenTime, RemoveData)
     ]]);
 
     InstanceMethodSwizzler fetchHistorySwizzler {
-        PAL::getSTWebHistoryClass(),
+        PAL::getSTWebHistoryClassSingleton(),
         @selector(fetchAllHistoryWithCompletionHandler:),
         imp_implementationWithBlock(^(id object, void (^completionHandler)(NSSet<NSURL *> *urls, NSError *error)) {
             completionHandler(fetchedURLs.get(), nil);
@@ -684,7 +684,7 @@ TEST(ScreenTime, RemoveData)
 
     __block RetainPtr<NSMutableSet<NSURL *>> deletedURLs = adoptNS([[NSMutableSet alloc] init]);
     InstanceMethodSwizzler deleteHistorySwizzler {
-        PAL::getSTWebHistoryClass(),
+        PAL::getSTWebHistoryClassSingleton(),
         @selector(deleteHistoryForURL:),
         imp_implementationWithBlock(^(id object, NSURL *url) {
             [deletedURLs addObject:url];
@@ -778,7 +778,7 @@ TEST(ScreenTime, DoNotDonateURLsInOccludedWebView)
     __block bool done = false;
 
     InstanceMethodSwizzler swizzler {
-        PAL::getSTWebpageControllerClass(),
+        PAL::getSTWebpageControllerClassSingleton(),
         @selector(setSuppressUsageRecording:),
         imp_implementationWithBlock(^(id object, bool value) {
             suppressUsageRecording = value;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
@@ -136,7 +136,7 @@ public:
     FingerprintingScriptsRequestSwizzler(NSArray<NSString *> *hosts, Vector<WPScriptAccessCategories>&& allowedCategories = { })
     {
         m_swizzler = makeUnique<InstanceMethodSwizzler>(
-            PAL::getWPResourcesClass(),
+            PAL::getWPResourcesClassSingleton(),
             @selector(requestFingerprintingScripts:completionHandler:),
             makeFingerprintingScriptsRequestHandler(hosts, WTFMove(allowedCategories))
         );
@@ -149,7 +149,7 @@ private:
 static bool supportsFingerprintingScriptRequests()
 {
     return PAL::isWebPrivacyFrameworkAvailable()
-        && [PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestFingerprintingScripts:completionHandler:)];
+        && [PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestFingerprintingScripts:completionHandler:)];
 }
 
 static RetainPtr<TestWKWebView> setUpWebViewForFingerprintingTests(NSString *pageURLString, id<WKUIDelegate> uiDelegate, NSDictionary<NSString *, NSString *> *responseData,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEditActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEditActions.mm
@@ -370,7 +370,7 @@ TEST(WebKit, CanInvokeTranslateWithTextSelection)
 
     auto makeTranslationAvailabilityScope = [](BOOL available) -> ClassMethodSwizzler {
         return {
-            PAL::getLTUITranslationViewControllerClass(),
+            PAL::getLTUITranslationViewControllerClassSingleton(),
             @selector(isAvailable),
             imp_implementationWithBlock(^BOOL {
                 return available;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -158,7 +158,7 @@ using PlatformTextPlaceholder = NSTextPlaceholder;
 
 #if PLATFORM(MAC)
 #define FORCE_WRITING_TOOLS_AVAILABLE() \
-ClassMethodSwizzler availabilitySwizzler(PAL::getWTWritingToolsViewControllerClass(), @selector(isAvailable), imp_implementationWithBlock(^{ \
+ClassMethodSwizzler availabilitySwizzler(PAL::getWTWritingToolsViewControllerClassSingleton(), @selector(isAvailable), imp_implementationWithBlock(^{ \
     return YES; \
 }));
 #else
@@ -2648,7 +2648,7 @@ TEST(WritingTools, APIWithBehaviorNone)
     // If `CocoaWritingToolsBehaviorNone`, there should be no affordance, no context menu item, and no inline editing support.
 
 #if PLATFORM(MAC)
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
         didCallScheduleShowAffordanceForSelectionRect = true;
     }));
 #endif
@@ -2698,7 +2698,7 @@ TEST(WritingTools, APIWithBehaviorDefault)
     FORCE_WRITING_TOOLS_AVAILABLE()
 
 #if PLATFORM(MAC)
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
         didCallScheduleShowAffordanceForSelectionRect = true;
     }));
 #endif
@@ -2748,7 +2748,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
     FORCE_WRITING_TOOLS_AVAILABLE()
 
 #if PLATFORM(MAC)
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
         didCallScheduleShowAffordanceForSelectionRect = true;
     }));
 #endif
@@ -2927,7 +2927,7 @@ TEST(WritingTools, ShowAffordance)
 {
     FORCE_WRITING_TOOLS_AVAILABLE()
 
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
         didCallScheduleShowAffordanceForSelectionRect = true;
     }));
 
@@ -2967,7 +2967,7 @@ TEST(WritingTools, DISABLED_ShowAffordanceForMultipleLines)
 
     __block int count = 0;
 
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(scheduleShowAffordanceForSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, NSRect rect, NSView *view, id delegate) {
 
         auto actualRect = WebCore::IntRect { rect };
         auto expectedRect = expectedRects[count];
@@ -2992,7 +2992,7 @@ TEST(WritingTools, ShowPanelWithNoSelection)
     __block WTRequestedTool requestedTool = WTRequestedToolIndex;
     __block NSRect selectionRect = NSZeroRect;
 
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
         requestedTool = tool;
         selectionRect = rect;
         done = true;
@@ -3017,7 +3017,7 @@ TEST(WritingTools, ShowPanelWithCaretSelection)
     __block WTRequestedTool requestedTool = WTRequestedToolIndex;
     __block NSRect selectionRect = NSZeroRect;
 
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
         requestedTool = tool;
         selectionRect = rect;
         done = true;
@@ -3058,7 +3058,7 @@ TEST(WritingTools, ShowPanelWithRangedSelection)
     __block WTRequestedTool requestedTool = WTRequestedToolIndex;
     __block NSRect selectionRect = NSZeroRect;
 
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
         requestedTool = tool;
         selectionRect = rect;
         done = true;
@@ -3085,7 +3085,7 @@ TEST(WritingTools, ShowToolWithRangedSelection)
     __block WTRequestedTool requestedTool = WTRequestedToolIndex;
     __block NSRect selectionRect = NSZeroRect;
 
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
         requestedTool = tool;
         selectionRect = rect;
         done = true;
@@ -3114,7 +3114,7 @@ TEST(WritingTools, ShowInvalidToolWithRangedSelection)
     __block WTRequestedTool requestedTool = WTRequestedToolIndex;
     __block NSRect selectionRect = NSZeroRect;
 
-    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClass(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
+    InstanceMethodSwizzler swizzler(PAL::getWTWritingToolsClassSingleton(), @selector(showTool:forSelectionRect:ofView:forDelegate:), imp_implementationWithBlock(^(id object, WTRequestedTool tool, NSRect rect, NSView *view, id delegate) {
         requestedTool = tool;
         selectionRect = rect;
         done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm
@@ -65,7 +65,7 @@ static void waitUntilAudioSessionCategoryIsEqualTo(NSString *expectedValue)
 {
     int tries = 0;
     do {
-        if ([[[getAVAudioSessionClass() sharedInstance] category] isEqualToString:expectedValue])
+        if ([[[getAVAudioSessionClassSingleton() sharedInstance] category] isEqualToString:expectedValue])
             return;
         Util::runFor(0.1_s);
     } while (++tries <= 100);
@@ -98,17 +98,17 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
     RetainPtr<AudioSessionCategoryUIWebViewDelegate> uiDelegate = adoptNS([[AudioSessionCategoryUIWebViewDelegate alloc] init]);
     uiWebView.get().delegate = uiDelegate.get();
 
-    EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
+    EXPECT_EQ([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
 
     [uiWebView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"html"]]];
 
     Util::run(&didBeginPlaying);
 
     waitUntilAudioSessionCategoryIsEqualTo(getAVAudioSessionCategoryPlayback());
-    EXPECT_WK_STREQ(getAVAudioSessionCategoryPlayback(), [[getAVAudioSessionClass() sharedInstance] category]);
-    EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], routeSharingPolicyLongFormAudio());
+    EXPECT_WK_STREQ(getAVAudioSessionCategoryPlayback(), [[getAVAudioSessionClassSingleton() sharedInstance] category]);
+    EXPECT_EQ([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], routeSharingPolicyLongFormAudio());
 #if HAVE(ROUTE_SHARING_POLICY_LONG_FORM_VIDEO)
-    EXPECT_NE([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyLongFormVideo);
+    EXPECT_NE([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyLongFormVideo);
 #endif
 
     didBeginPlaying = false;
@@ -118,8 +118,8 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
     Util::run(&didBeginPlaying);
 
     waitUntilAudioSessionCategoryIsEqualTo(getAVAudioSessionCategoryAmbient());
-    EXPECT_WK_STREQ(getAVAudioSessionCategoryAmbient(), [[getAVAudioSessionClass() sharedInstance] category]);
-    EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
+    EXPECT_WK_STREQ(getAVAudioSessionCategoryAmbient(), [[getAVAudioSessionClassSingleton() sharedInstance] category]);
+    EXPECT_EQ([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
 
     didBeginPlaying = false;
 
@@ -128,8 +128,8 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
     Util::run(&didBeginPlaying);
 
     waitUntilAudioSessionCategoryIsEqualTo(getAVAudioSessionCategoryAmbient());
-    EXPECT_WK_STREQ(getAVAudioSessionCategoryAmbient(), [[getAVAudioSessionClass() sharedInstance] category]);
-    EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
+    EXPECT_WK_STREQ(getAVAudioSessionCategoryAmbient(), [[getAVAudioSessionClassSingleton() sharedInstance] category]);
+    EXPECT_EQ([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
 
     didBeginPlaying = false;
 
@@ -138,8 +138,8 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
     Util::run(&didBeginPlaying);
 
     waitUntilAudioSessionCategoryIsEqualTo(getAVAudioSessionCategoryAmbient());
-    EXPECT_WK_STREQ(getAVAudioSessionCategoryAmbient(), [[getAVAudioSessionClass() sharedInstance] category]);
-    EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
+    EXPECT_WK_STREQ(getAVAudioSessionCategoryAmbient(), [[getAVAudioSessionClassSingleton() sharedInstance] category]);
+    EXPECT_EQ([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyDefault);
 
     didBeginPlaying = false;
 
@@ -148,10 +148,10 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
     Util::run(&didBeginPlaying);
 
     waitUntilAudioSessionCategoryIsEqualTo(getAVAudioSessionCategoryPlayback());
-    EXPECT_WK_STREQ(getAVAudioSessionCategoryPlayback(), [[getAVAudioSessionClass() sharedInstance] category]);
-    EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], routeSharingPolicyLongFormAudio());
+    EXPECT_WK_STREQ(getAVAudioSessionCategoryPlayback(), [[getAVAudioSessionClassSingleton() sharedInstance] category]);
+    EXPECT_EQ([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], routeSharingPolicyLongFormAudio());
 #if HAVE(ROUTE_SHARING_POLICY_LONG_FORM_VIDEO)
-    EXPECT_NE([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyLongFormVideo);
+    EXPECT_NE([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], AVAudioSessionRouteSharingPolicyLongFormVideo);
 #endif
 
     didBeginPlaying = false;
@@ -161,8 +161,8 @@ TEST(WebKitLegacy, AudioSessionCategoryIOS)
     Util::run(&didBeginPlaying);
 
     waitUntilAudioSessionCategoryIsEqualTo(getAVAudioSessionCategoryPlayback());
-    EXPECT_WK_STREQ(getAVAudioSessionCategoryPlayback(), [[getAVAudioSessionClass() sharedInstance] category]);
-    EXPECT_EQ([[getAVAudioSessionClass() sharedInstance] routeSharingPolicy], routeSharingPolicyLongFormAudio());
+    EXPECT_WK_STREQ(getAVAudioSessionCategoryPlayback(), [[getAVAudioSessionClassSingleton() sharedInstance] category]);
+    EXPECT_EQ([[getAVAudioSessionClassSingleton() sharedInstance] routeSharingPolicy], routeSharingPolicyLongFormAudio());
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1438,7 +1438,7 @@ TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)
 #if HAVE(DELAY_INIT_LINKING)
         CoreTelephonyClient.class,
 #else
-        PAL::getCoreTelephonyClientClass(),
+        PAL::getCoreTelephonyClientClassSingleton(),
 #endif
         @selector(isAutofilleSIMIdAllowedForDomain:error:),
         reinterpret_cast<IMP>(allowESIMAutoFillForWebKit)

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -60,7 +60,7 @@ static WKWebView *globalWebView = nil;
 
 @end
 
-static Class touchEventsGestureRecognizerClass()
+static Class touchEventsGestureRecognizerClassSingleton()
 {
     static Class result = nil;
     static dispatch_once_t onceToken;
@@ -103,7 +103,7 @@ static const WebKit::WKTouchEvent* simulatedTouchEvent(id, SEL)
 
 TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)
 {
-    InstanceMethodSwizzler lastTouchEventSwizzler { touchEventsGestureRecognizerClass(), @selector(lastTouchEvent), reinterpret_cast<IMP>(simulatedTouchEvent) };
+    InstanceMethodSwizzler lastTouchEventSwizzler { touchEventsGestureRecognizerClassSingleton(), @selector(lastTouchEvent), reinterpret_cast<IMP>(simulatedTouchEvent) };
     @autoreleasepool {
         RetainPtr messageHandler = adoptNS([TouchEventScriptMessageHandler new]);
         RetainPtr controller = adoptNS([[WKUserContentController alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
@@ -467,7 +467,7 @@ TEST(UIPasteboardTests, PerformAsDataOwnerWithManagedURL)
     };
 
     auto managedConfigurationSwizzler = InstanceMethodSwizzler {
-        PAL::getMCProfileConnectionClass(),
+        PAL::getMCProfileConnectionClassSingleton(),
         @selector(isURLManaged:),
         [TestMCProfileConnection instanceMethodForSelector:@selector(isURLManaged:)]
     };

--- a/Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm
@@ -99,7 +99,7 @@ static NSWindow *getKeyWindowForTesting()
 
 TEST(Gamepad, Basic)
 {
-    [WebCore::getGCControllerClass() setShouldMonitorBackgroundEvents:YES];
+    [WebCore::getGCControllerClassSingleton() setShouldMonitorBackgroundEvents:YES];
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
@@ -279,7 +279,7 @@ TEST(Gamepad, GamepadState)
     Vector<double> expectedButtons2 = { 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0 };
 #endif
 
-    [WebCore::getGCControllerClass() setShouldMonitorBackgroundEvents:YES];
+    [WebCore::getGCControllerClassSingleton() setShouldMonitorBackgroundEvents:YES];
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
@@ -409,7 +409,7 @@ TEST(Gamepad, Dualshock3Basic)
     NSString *expectedName = @"\"54c-268-Virtual Dualshock3\"";
 #endif
 
-    [WebCore::getGCControllerClass() setShouldMonitorBackgroundEvents:YES];
+    [WebCore::getGCControllerClassSingleton() setShouldMonitorBackgroundEvents:YES];
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
@@ -476,7 +476,7 @@ TEST(Gamepad, Dualshock3Basic)
 #if !HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 TEST(Gamepad, Stadia)
 {
-    [WebCore::getGCControllerClass() setShouldMonitorBackgroundEvents:YES];
+    [WebCore::getGCControllerClassSingleton() setShouldMonitorBackgroundEvents:YES];
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
@@ -562,7 +562,7 @@ TEST(Gamepad, LogitechBasic)
         @"\"46d-c216-Virtual Logitech F310\"",
         @"\"46d-c219-Virtual Logitech F710\""]];
 #endif
-    [WebCore::getGCControllerClass() setShouldMonitorBackgroundEvents:YES];
+    [WebCore::getGCControllerClassSingleton() setShouldMonitorBackgroundEvents:YES];
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
@@ -637,7 +637,7 @@ TEST(Gamepad, LogitechBasic)
 
 TEST(Gamepad, FullInfoAfterConnection)
 {
-    [WebCore::getGCControllerClass() setShouldMonitorBackgroundEvents:YES];
+    [WebCore::getGCControllerClassSingleton() setShouldMonitorBackgroundEvents:YES];
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 

--- a/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
@@ -283,7 +283,7 @@ IMP makeRequestHandler(CGImageRef image, CGRect cropRect)
 }
 
 RemoveBackgroundSwizzler::RemoveBackgroundSwizzler(CGImageRef image, CGRect cropRect)
-    : m_removeBackgroundRequestSwizzler { PAL::getVKCRemoveBackgroundRequestHandlerClass(), @selector(performRequest:completion:), makeRequestHandler(image, cropRect) }
+    : m_removeBackgroundRequestSwizzler { PAL::getVKCRemoveBackgroundRequestHandlerClassSingleton(), @selector(performRequest:completion:), makeRequestHandler(image, cropRect) }
 {
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h
@@ -49,7 +49,7 @@
 
 namespace WTR {
 
-Class webAccessibilityObjectWrapperClass();
+Class webAccessibilityObjectWrapperClassSingleton();
 JSValueRef makeValueRefForValue(JSContextRef, id value);
 extern NSDictionary *searchPredicateForSearchCriteria(JSContextRef, AccessibilityUIElement* startElement, AccessibilityTextMarkerRange* startRange, bool forward, unsigned resultsLimit, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -58,7 +58,7 @@
 
 namespace WTR {
 
-Class webAccessibilityObjectWrapperClass()
+Class webAccessibilityObjectWrapperClassSingleton()
 {
     static Class cls = objc_getClass("WebAccessibilityObjectWrapper");
     ASSERT(cls);
@@ -95,7 +95,7 @@ JSValueRef makeValueRefForValue(JSContextRef context, id value)
             return JSValueMakeBoolean(context, [value boolValue]);
         return JSValueMakeNumber(context, [value doubleValue]);
     }
-    if ([value isKindOfClass:webAccessibilityObjectWrapperClass()])
+    if ([value isKindOfClass:webAccessibilityObjectWrapperClassSingleton()])
         return toJS(context, WTR::AccessibilityUIElement::create(static_cast<PlatformUIElement>(value)).ptr());
     if ([value isKindOfClass:[NSDictionary class]])
         return makeJSObject(context, value);

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.mm
@@ -93,7 +93,7 @@
     // Once we start requesting notifications, it's on for the duration of the program.
     // This is to avoid any race conditions between tests turning this flag on and off. Instead
     // AccessibilityNotificationHandler can ignore events it doesn't care about.
-    [WTR::webAccessibilityObjectWrapperClass() accessibilitySetShouldRepostNotifications:YES];
+    [WTR::webAccessibilityObjectWrapperClassSingleton() accessibilitySetShouldRepostNotifications:YES];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_notificationReceived:) name:@"AXDRTNotification" object:nil];
 }
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -182,7 +182,7 @@ void TestController::cocoaPlatformInitialize(const Options& options)
 
 #if ENABLE(IMAGE_ANALYSIS)
     m_imageAnalysisRequestSwizzler = makeUnique<InstanceMethodSwizzler>(
-        PAL::getVKCImageAnalyzerClass(),
+        PAL::getVKCImageAnalyzerClassSingleton(),
         @selector(processRequest:progressHandler:completionHandler:),
         reinterpret_cast<IMP>(swizzledProcessImageAnalysisRequest)
     );

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -658,7 +658,7 @@ static bool isQuickboardViewController(UIViewController *viewController)
 
     [UIView performWithoutAnimation:^{
         for (id<UIInteraction> interaction in self.contentView.interactions) {
-            if ([interaction isKindOfClass:getUIEditMenuInteractionClass()])
+            if ([interaction isKindOfClass:getUIEditMenuInteractionClassSingleton()])
                 [(UIEditMenuInteraction *)interaction dismissMenu];
         }
     }];

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -526,7 +526,7 @@ static InterpolationType interpolationFromString(NSString *string)
         BKSHIDEventSetDigitizerInfo(strongEvent.get(), contextID, false, false, NULL, 0, 0);
 
         static auto canSetActiveModifiers = [&] {
-            return [getBKSHIDEventDigitizerAttributesClass() instancesRespondToSelector:@selector(setActiveModifiers:)];
+            return [getBKSHIDEventDigitizerAttributesClassSingleton() instancesRespondToSelector:@selector(setActiveModifiers:)];
         }();
 
         if (canSetActiveModifiers && IOHIDEventGetType(strongEvent.get()) == kIOHIDEventTypeDigitizer) {

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -322,7 +322,7 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
     restorePortraitOrientationIfNeeded();
 
     // Ensures that only the UCB is on-screen when showing the keyboard, if the hardware keyboard is attached.
-    TIPreferencesController *textInputPreferences = [getTIPreferencesControllerClass() sharedPreferencesController];
+    TIPreferencesController *textInputPreferences = [getTIPreferencesControllerClassSingleton() sharedPreferencesController];
     if (!textInputPreferences.automaticMinimizationEnabled)
         textInputPreferences.automaticMinimizationEnabled = YES;
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -648,7 +648,7 @@ enum class IsKeyDown : bool { No, Yes };
 
 static UIPhysicalKeyboardEvent *createUIPhysicalKeyboardEvent(NSString *hidInputString, NSString *uiEventInputString, UIKeyModifierFlags modifierFlags, UIKeyboardInputFlags inputFlags, IsKeyDown isKeyDown)
 {
-    auto* keyboardEvent = [getUIPhysicalKeyboardEventClass() _eventWithInput:uiEventInputString inputFlags:inputFlags];
+    auto* keyboardEvent = [getUIPhysicalKeyboardEventClassSingleton() _eventWithInput:uiEventInputString inputFlags:inputFlags];
     [keyboardEvent _setModifierFlags:modifierFlags];
     auto hidEvent = createHIDKeyEvent(hidInputString, keyboardEvent.timestamp, isKeyDown == IsKeyDown::Yes);
     [keyboardEvent _setHIDEvent:hidEvent.get() keyboard:nullptr];

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -75,7 +75,7 @@ static PlatformWindow wtr_NSApplication_keyWindow(id self, SEL _cmd)
     return WTR::PlatformWebView::keyWindow();
 }
 
-static Class menuImplClass()
+static Class menuImplClassSingleton()
 {
     static dispatch_once_t onceToken;
     static Class menuImplClass;
@@ -153,7 +153,7 @@ void TestController::platformInitialize(const Options& options)
     static InstanceMethodSwizzler cancelTrackingSwizzler { NSMenu.class, @selector(cancelTracking), reinterpret_cast<IMP>(swizzledCancelTracking) };
     static ClassMethodSwizzler menuPopUpSwizzler { NSMenu.class, @selector(popUpContextMenu:withEvent:forView:), reinterpret_cast<IMP>(swizzledPopUpContextMenu) };
     static InstanceMethodSwizzler menuImplPopUpSwizzler {
-        menuImplClass(),
+        menuImplClassSingleton(),
         NSSelectorFromString(@"popUpMenu:atLocation:width:forView:withSelectedItem:withFont:withFlags:withOptions:"),
         reinterpret_cast<IMP>(swizzledPopUpMenu)
     };


### PR DESCRIPTION
#### 0db627188af75ff5e30da6171eea106620460baf
<pre>
Rename `*Class()` soft-linking functions to `*ClassSingleton()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298586">https://bugs.webkit.org/show_bug.cgi?id=298586</a>

Reviewed by Geoffrey Garen.

Rename `*Class()` soft-linking functions to `*ClassSingleton()` to silence
Safer CPP static analysis false positives.

* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm:
(WebCore::ShapeDetection::configureRequestToUseCPUOrGPU):
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::makeNSArrayElement):
(WebCore::makeVectorElement):
(WebCore::createPlatformConfiguration):
(WebCore::PaymentInstallmentConfiguration::applePayInstallmentConfiguration):
* Source/WebCore/Modules/applepay/cocoa/PaymentAPIVersionCocoa.mm:
(WebCore::PaymentAPIVersion::current):
* Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm:
(WebCore::platformRecurringSummaryItem):
(WebCore::platformDeferredSummaryItem):
(WebCore::platformAutomaticReloadSummaryItem):
(WebCore::platformDisbursementSummaryItem):
(WebCore::platformInstantFundsOutFeeSummaryItem):
(WebCore::platformSummaryItem):
* Source/WebCore/PAL/pal/avfoundation/OutputContext.mm:
(PAL::OutputContext::sharedAudioPresentationOutputContext):
* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/LockdownModeCocoa.mm:
(PAL::isLockdownModeEnabled):
* Source/WebCore/PAL/pal/cocoa/RevealSoftLink.mm:
* Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.h:
(PAL::getWKDDActionContextClassSingleton):
(PAL::getWKDDActionContextClass): Deleted.
* Source/WebCore/PAL/pal/mac/DataDetectorsSoftLink.mm:
* Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm:
(PAL::ScreenSleepDisabler::updateState):
* Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm:
(PAL::updateCurrentUserInterfaceIdiom):
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase accessibilityCustomContent]):
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::processDataDetectorScannerResults):
* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
(-[WebRevealHighlight drawHighlightContentForItem:context:]):
(WebCore::canCreateRevealItems):
(WebCore::DictionaryLookup::rangeAtHitTestResult):
(WebCore::showPopupOrCreateAnimationController):
* Source/WebCore/editing/cocoa/FontAttributesCocoa.mm:
(WebCore::TextList::createTextList const):
(WebCore::FontAttributes::createDictionary const):
* Source/WebCore/editing/cocoa/FontShadowCocoa.mm:
(WebCore::FontShadow::createShadow const):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(_WebMessageDocumentClassSingleton):
(HTMLConverter::_addAttachmentForElement):
(_WebMessageDocumentClass): Deleted.
* Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm:
(WebCore::webCoreTextAttachmentMissingPlatformImage):
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::setEligibleForSmartRoutingInternal):
(WebCore::AudioSessionCocoa::tryToSetActiveInternal):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::nowPlayingActivityController):
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(-[WebInterruptionObserverHelper initWithCallback:]):
(WebCore::AudioSessionIOS::setHostProcessAttribution):
(WebCore::AudioSessionIOS::setPresentingProcesses):
(WebCore::AudioSessionIOS::setCategory):
(WebCore::AudioSessionIOS::category const):
(WebCore::AudioSessionIOS::mode const):
(WebCore::AudioSessionIOS::routeSharingPolicy const):
(WebCore::AudioSessionIOS::routingContextUID const):
(WebCore::AudioSessionIOS::sampleRate const):
(WebCore::AudioSessionIOS::bufferSize const):
(WebCore::AudioSessionIOS::numberOfOutputChannels const):
(WebCore::AudioSessionIOS::maximumNumberOfOutputChannels const):
(WebCore::AudioSessionIOS::preferredBufferSize const):
(WebCore::AudioSessionIOS::setPreferredBufferSize):
(WebCore::AudioSessionIOS::outputLatency const):
(WebCore::AudioSessionIOS::updateSpatialExperience):
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::updateActiveAudioRouteSupportsSpatialPlayback):
(MediaSessionHelperIOS::providePresentingApplicationPID):
(MediaSessionHelperIOS::updateCarPlayIsConnected):
(-[WebMediaSessionHelper initWithCallback:]):
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm:
(WebCore::SharedRoutingArbitrator::beginRoutingArbitrationForToken):
(WebCore::SharedRoutingArbitrator::endRoutingArbitrationForToken):
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::unpackWebFilterEvaluatorData):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::enabled const):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::wcrBrowserEngineClientEnabled):
* Source/WebCore/platform/cocoa/PlatformNSAdaptiveImageGlyph.h:
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper speakUtterance:]):
(WebCore::PlatformSpeechSynthesizer::initializeVoiceList):
* Source/WebCore/platform/cocoa/TextRecognitionResultCocoa.mm:
(WebCore::TextRecognitionResult::decodeVKCImageAnalysis):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setPlayerController:]):
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_playerLayer):
(WebCore::WebAVPlayerLayerView_videoView):
(WebCore::WebAVPlayerLayerView_dealloc):
(WebCore::allocWebAVPlayerLayerViewInstance):
(WebCore::allocWebAVPictureInPicturePlayerLayerViewInstance):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::prewarmGameControllerDevicesIfNecessary):
(WebCore::GameControllerGamepadProvider::startMonitoringGamepads):
* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm:
(WebCore::gameControllerFrameworkWillHandleHIDDevice):
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::label const):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm:
(WebCore::MediaPlaybackTargetCocoa::create):
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm:
(WebCore::MediaSelectionGroupAVFObjC::updateOptions):
* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm:
(-[WebAVSampleBufferListenerPrivate observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm:
(WebCore::AVAssetMIMETypeCache::canDecodeExtendedType):
(WebCore::AVAssetMIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm:
(WebCore::AVOutputDeviceMenuControllerTargetPicker::devicePicker):
* Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm:
(WebCore::AVRoutePickerViewTargetPicker::isAvailable):
(WebCore::AVRoutePickerViewTargetPicker::outputContextInternal):
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm:
(WebCore::AVStreamDataParserMIMETypeCache::isAvailable const):
(WebCore::AVStreamDataParserMIMETypeCache::canDecodeExtendedType):
(WebCore::AVStreamDataParserMIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::contentKeySession):
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::supportsPersistableState):
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::supportsPersistentKeys):
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::ensureSessionOrGroup):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::isAvailable):
(WebCore::CDMSessionAVContentKeySession::releaseKeys):
(WebCore::CDMSessionAVContentKeySession::update):
(WebCore::CDMSessionAVContentKeySession::generateKeyReleaseMessage):
(WebCore::CDMSessionAVContentKeySession::createContentKeySession):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm:
(WebCore::InbandTextTrackPrivateAVFObjC::label const):
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(-[WebAVSampleBufferStatusChangeListener observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::assetCacheForPath):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createImageGenerator):
(WebCore::MediaPlayerPrivateAVFoundationObjC::tracksChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isAvailable):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::isAvailable):
* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::isContentTypeSupported):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::setVideoLayer):
* Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm:
(-[WebAVContentKeyGroup expire]):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::layerTypeForPlatformLayer):
(WebCore::PlatformCALayerCocoa::PlatformCALayerCocoa):
(WebCore::PlatformCALayerCocoa::clone const):
(WebCore::PlatformCALayerCocoa::avPlayerLayer const):
* Source/WebCore/platform/graphics/cocoa/ColorCocoa.mm:
(WebCore::cocoaColor):
* Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm:
(WebCore::contentSizeCategory):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::GraphicsContextCG::drawFocusRing):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::isAvailable):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCocoa.mm:
(WebCore::cocoaFontClassSingleton):
(WebCore::SystemFontDatabaseCoreText::smallCaptionFontDescriptor):
(WebCore::SystemFontDatabaseCoreText::menuFontDescriptor):
(WebCore::SystemFontDatabaseCoreText::statusBarFontDescriptor):
(WebCore::SystemFontDatabaseCoreText::miniControlFontDescriptor):
(WebCore::SystemFontDatabaseCoreText::smallControlFontDescriptor):
(WebCore::SystemFontDatabaseCoreText::controlFontDescriptor):
(WebCore::cocoaFontClass): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime):
* Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm:
(WebCore::LocalCurrentTraitCollection::LocalCurrentTraitCollection):
(WebCore::LocalCurrentTraitCollection::~LocalCurrentTraitCollection):
* Source/WebCore/platform/ios/LocalizedDeviceModel.mm:
(WebCore::localizedDeviceModel):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::generalUIPasteboard):
(WebCore::PlatformPasteboard::performAsDataOwner):
(WebCore::PlatformPasteboard::color):
(WebCore::registerItemsToPasteboard):
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::currentEDRHeadroomForDisplay):
(WebCore::maxEDRHeadroomForDisplay):
(WebCore::screenSize):
(WebCore::availableScreenSize):
(WebCore::screenScaleFactor):
(WebCore::collectScreenProperties):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm:
(WebCore::PlaybackSessionInterfaceAVKitLegacy::currentTimeChanged):
* Source/WebCore/platform/ios/UIViewControllerUtilities.mm:
(WebCore::viewController):
* Source/WebCore/platform/ios/UserAgentIOS.mm:
(WebCore::isClassic):
(WebCore::isClassicPad):
(WebCore::isClassicPhone):
* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(callSuper):
(WebValidationBubbleViewController_viewDidLoad):
(allocWebValidationBubbleViewControllerInstance):
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(WebAVPictureInPictureContentViewController_initWithController):
(WebAVPictureInPictureContentViewController_viewWillLayoutSubviews):
(WebAVPictureInPictureContentViewController_dealloc):
(allocWebAVPictureInPictureContentViewControllerInstance):
(WebCore::supportsPictureInPicture):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::clearUIColor):
(WebCore::blackUIColor):
(WebCore::greyUIColor):
(WebCore::VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing):
(WebCore::VideoPresentationInterfaceIOS::doSetup):
* Source/WebCore/platform/ios/WebAVPlayerController.h:
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(createWebAVPlayerControllerForwarderClassSingleton):
(createWebAVPlayerController):
(webAVPlayerControllerClassSingleton):
(-[WebAVPlayerController init]):
(-[WebAVPlayerController updateMinMaxTiming]):
(-[WebAVPlayerController hasSeekableLiveStreamingContent]):
(createWebAVPlayerControllerForwarderClass): Deleted.
(webAVPlayerControllerClass): Deleted.
* Source/WebCore/platform/ios/WebCoreMotionManager.mm:
(-[WebCoreMotionManager initializeOnMainThread]):
* Source/WebCore/platform/ios/WebEvent.mm:
(+[WebEvent modifierFlags]):
* Source/WebCore/platform/ios/WebItemProviderPasteboard.mm:
(allLoadableClasses):
* Source/WebCore/platform/mac/CursorMac.mm:
(WebCore::createCoreCursorClassSingleton):
(WebCore::coreCursorClassSingleton):
(WebCore::cursor):
(WebCore::createCoreCursorClass): Deleted.
(WebCore::coreCursorClass): Deleted.
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):
(WebCore::preferredDynamicRangeMode):
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::setPlayBackControlsManager):
(WebCore::PlaybackSessionInterfaceMac::updatePlaybackControlsManagerTiming):
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::jsValueWithValueInContext):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC updatePrerollAttributes]):
(WebCore::supportsPictureInPicture):
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.mm:
(WebCore::AVAudioSessionCaptureDeviceManager::createAudioSession):
(WebCore::AVAudioSessionCaptureDeviceManager::setPreferredAudioSessionDeviceIDs):
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm:
(-[WebCoreAudioCaptureSourceIOSListener initWithCallback:]):
* Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm:
(-[WebCoreMediaCaptureStatusBarHandler start]):
* Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.mm:
(-[WebCoreReplayKitScreenRecorderHelper initWithCallback:]):
(-[WebCoreReplayKitScreenRecorderHelper disconnect]):
(WebCore::ReplayKitCaptureSource::isAvailable):
(WebCore::ReplayKitCaptureSource::start):
(WebCore::ReplayKitCaptureSource::captureStateDidChange):
(WebCore::ReplayKitCaptureSource::stop):
* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm:
(WebCore::AVCaptureDeviceManager::currentCameras):
(WebCore::toCaptureDevice):
(WebCore::AVCaptureDeviceManager::retrieveCaptureDevices):
(WebCore::AVCaptureDeviceManager::~AVCaptureDeviceManager):
(WebCore::AVCaptureDeviceManager::setUserPreferredCamera):
(WebCore::AVCaptureDeviceManager::registerForDeviceNotifications):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::create):
(WebCore::AVVideoCaptureSource::photoConfiguration):
(WebCore::AVVideoCaptureSource::setupSession):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm:
(WebCore::getSharedAVAudioApplication):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::isAvailable):
(WebCore::ScreenCaptureKitSharingSessionManager::cancelPicking):
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::systemFocusRingColor):
(WebCore::systemColorFromCSSValueSystemColorInformation):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::fakeDataDetectorResultForTesting):
* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::setCaptureAttributionString):
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::ensureAVCaptureServerConnection):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::RKModelLoaderUSD::load):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::load):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::removeNetworkWebsiteData):
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::makeTextRecognitionResult):
(WebKit::languageIdentifierSupportsLiveText):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::platformContext const):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
(WebKit::toNSError):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm:
(-[WKPaymentAuthorizationViewControllerDelegate _getPaymentServicesMerchantURL:]):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::LinkDecorationFilteringController::updateList):
(WebKit::requestLinkDecorationFilteringData):
(WebKit::StorageAccessPromptQuirkController::updateList):
(WebKit::StorageAccessUserAgentStringQuirkController::updateList):
(WebKit::RestrictedOpenerDomainsController::update):
(WebKit::ResourceMonitorURLsController::prepare):
(WebKit::ResourceMonitorURLsController::getSource):
(WebKit::TrackerAddressLookupInfo::populateIfNeeded):
(WebKit::TrackerDomainLookupInfo::populateIfNeeded):
(WebKit::ScriptTrackingPrivacyController::updateList):
* Source/WebKit/Platform/ios/PaymentAuthorizationController.mm:
(-[WKPaymentAuthorizationControllerDelegate _getPaymentServicesMerchantURL:]):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::menuItemTitleForTelephoneNumberGroup):
(WebKit::actionForMenuItem):
(WebKit::menuItemForTelephoneNumber):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/API/c/cf/WKStringCF.mm:
(wkNSStringClassSingleton):
(WKStringCreateWithCFString):
(wkNSStringClass): Deleted.
* Source/WebKit/Shared/API/c/cf/WKURLCF.mm:
(wkNSURLClassSingleton):
(WKURLCreateWithCFURL):
(wkNSURLClass): Deleted.
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in:
* Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm:
(WebKit::toPlatformConfiguration):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKShippingMethod):
(WebKit::WebPaymentCoordinatorProxy::getSetupFeatures):
(WebKit::WebPaymentCoordinatorProxy::platformBeginApplePaySetup):
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCanMakePayments):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCanMakePayments):
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;DDScannerResult&gt;):
(IPC::getClass&lt;WKDDActionContext&gt;):
(IPC::getClass&lt;AVOutputContext&gt;):
(IPC::getClass&lt;CNContact&gt;):
(IPC::getClass&lt;CNPhoneNumber&gt;):
(IPC::getClass&lt;CNPostalAddress&gt;):
(IPC::getClass&lt;PKContact&gt;):
(IPC::getClass&lt;PKPaymentMerchantSession&gt;):
(IPC::getClass&lt;PKPaymentSetupFeature&gt;):
(IPC::getClass&lt;PKPayment&gt;):
(IPC::getClass&lt;PKPaymentToken&gt;):
(IPC::getClass&lt;PKShippingMethod&gt;):
(IPC::getClass&lt;PKDateComponentsRange&gt;):
(IPC::getClass&lt;PKPaymentMethod&gt;):
(IPC::getClass&lt;PKSecureElementPass&gt;):
(IPC::encodeObjectDirectly&lt;NSObject&lt;NSSecureCoding&gt;&gt;):
(IPC::shouldEnableStrictMode):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSObject&lt;NSSecureCoding&gt;&gt;):
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm:
(WebKit::CoreIPCAVOutputContext::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCContacts.mm:
(WebKit::CoreIPCCNPhoneNumber::toID const):
(WebKit::CoreIPCCNPostalAddress::toID const):
(WebKit::nsArrayFromVectorOfLabeledValues):
(WebKit::CoreIPCCNContact::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDDActionContext.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm:
(WebKit::CoreIPCPKSecureElementPass::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm:
(WebKit::CoreIPCPKContact::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Source/WebKit/Shared/Cocoa/DataDetectionResult.serialization.in:
* Source/WebKit/Shared/Cocoa/PDFKitSoftLink.h:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::attachmentFileWrapperClassSingleton const):
(API::PageConfiguration::attachmentFileWrapperClass const): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView _setAllowGamepadsInput:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _attachmentFileWrapperClass]):
* Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm:
(addToReadingList):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _effectiveDataOwner:]):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::requestAVCaptureAccessForType):
(WebKit::checkAVCaptureAccessForType):
(WebKit::requestSpeechRecognitionAccess):
(WebKit::checkSpeechRecognitionServiceAccess):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::interceptMarketplaceKitNavigation):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
(WebKit::SOAuthorizationCoordinator::SOAuthorizationCoordinator):
(WebKit::SOAuthorizationCoordinator::canAuthorize):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationNSURLExtras.mm:
(+[NSURL _web_canPerformAuthorizationWithURL:]):
(+[NSURL _web_willPerformSOKerberosAuthorizationWithURL:]):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm:
(-[WKRotationCoordinatorObserver start:layer:]):
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker _contactInfoFromCNContact:]):
(-[WKContactPicker _contactsFromJSContacts:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::startApplePayAMSUISession):
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
(WebKit::usageTrackingAvailable):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::interactionRegionLayerClassSingleton):
(WebKit::configureLayerForInteractionRegion):
(WebKit::reconfigureLayerContentHint):
(WebKit::createInteractionRegionLayer):
(WebKit::interactionRegionLayerClass): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::scrollViewScrollIndicatorClassSingleton):
(-[UIView _web_findDescendantViewAtPoint:withEvent:]):
(WebKit::scrollViewScrollIndicatorClass): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::shouldUseAlternateKeychainAttribute):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm:
(WebKit::NfcService::isAvailable):
(WebKit::NfcService::platformStartDiscovery):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WKASCAuthorizationPresenterDelegate.mm:
(-[WKASCAuthorizationPresenterDelegate authorizationPresenter:credentialRequestedForLoginChoice:authenticatedContext:completionHandler:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForRegistration):
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
(WebKit::toASCExtensions):
(WebKit::configureAssertionOptions):
(WebKit::continueAfterRequest):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(WebKit::MockNfcService::platformStartDiscovery):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::initializeManagedDomains):
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::getPrimaryDeviceInfo):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(interactiveTransitionGestureRecognizerClassSingleton):
(-[WKSwipeTransitionController gestureRecognizerForInteractiveTransition:WithTarget:action:]):
(-[WKSwipeTransitionController isNavigationSwipeGestureRecognizer:]):
(interactiveTransitionGestureRecognizerClass): Deleted.
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant interactionDidStartWithPositionInformation:]):
(-[WKActionSheetAssistant defaultActionsForLinkSheet:]):
(-[WKActionSheetAssistant defaultActionsForImageSheet:]):
(-[WKActionSheetAssistant _elementActionForDDAction:]):
(-[WKActionSheetAssistant showDataDetectorsUIForPositionInformation:]):
(-[WKActionSheetAssistant contextMenuInteraction:configurationForMenuAtLocation:]):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _updateRemoteAccessibilityRegistration:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView dataDetectionContextForPositionInformation:]):
(-[WKContentView assignLegacyDataForContextMenuInteraction]):
(-[WKContentView continueContextMenuInteractionWithDataDetectors:]):
(-[WKContentView contextMenuInteraction:willPerformPreviewActionForMenuWithConfiguration:animator:]):
(-[WKContentView _dataForPreviewItemController:atPosition:type:]):
* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseInteraction beginPointerLockMouseTracking]):
* Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm:
(-[WKAirPlayRoutePicker showFromView:routeSharingPolicy:routingContextUID:hasVideo:]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::handleContextMenuWritingTools):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController willDestroyView:]):
(-[WKImmediateActionController _clearImmediateActionState]):
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
(-[WKImmediateActionController _animationControllerForDataDetectedLink]):
* Source/WebKit/UIProcess/mac/WKQuickLookPreviewController.mm:
(-[WKQuickLookPreviewController closePanelIfNecessary]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::showImageInQuickLookPreviewPanel):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::dismissContentRelativeChildWindowsFromViewOnly):
(WebKit::WebViewImpl::showWritingTools):
(WebKit::WebViewImpl::canHandleContextMenuTranslation const):
(WebKit::WebViewImpl::canHandleContextMenuWritingTools const):
* Source/WebKit/WebProcess/ApplePay/cocoa/WebPaymentCoordinatorCocoa.mm:
(WebKit::WebPaymentCoordinator::platformAvailablePaymentNetworks):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::pdfKitLayerControllerIsAvailable):
(WebKit::PDFPlugin::PDFPlugin):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm:
(WebKit::hasActionsForResult):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::clone const):
* Source/WebKitLegacy/ios/Misc/WebGeolocationCoreLocationProvider.mm:
(-[WebGeolocationCoreLocationProvider createLocationManager]):
(-[WebGeolocationCoreLocationProvider requestGeolocationAuthorization]):
(-[WebGeolocationCoreLocationProvider start]):
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
(-[WebImmediateActionController webViewClosed]):
(-[WebImmediateActionController _clearImmediateActionState]):
(-[WebImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
(-[WebImmediateActionController _animationControllerForDataDetectedText]):
(-[WebImmediateActionController _animationControllerForDataDetectedLink]):
(-[WebImmediateActionController _animationControllerForText]):
* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm:
(allocWebAVPlayerViewInstance):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView _canHandleContextMenuTranslation]):
* Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm:
(webAccessibilityObjectWrapperClassSingleton):
(-[AccessibilityNotificationHandler startObserving]):
(makeValueRefForValue):
(webAccessibilityObjectWrapperClass): Deleted.
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(operator==):
(postalAddressForTesting):
(pkContactForTesting):
(TEST(IPCSerialization, Basic)):
(TEST(IPCSerialization, AVOutputContext)):
(fakeDataDetectorResultForTesting):
(TEST(IPCSerialization, SecureCoding)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm:
(TestWebKitAPI::TEST(AVFoundationSoftLink, Classes)):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::AllowedLinkFilteringDataRequestSwizzler::AllowedLinkFilteringDataRequestSwizzler):
(TestWebKitAPI::QueryParameterRequestSwizzler::update):
* Tools/TestWebKitAPI/Tests/WebKit/WebFilter.mm:
(TEST(WebKit, WebFilterFeatureHasFrontboardServiceAccess)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm:
(TEST(ContentFiltering, LazilyLoadPlatformFrameworks)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm:
(makeImageAnalysisRequestSwizzler):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
(-[FullscreenVideoTextRecognitionWebView initWithFrame:configuration:]):
(-[FullscreenVideoTextRecognitionWebView hasActiveImageAnalysis]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm:
(TestWebKitAPI::makeImageAnalysisRequestSwizzler):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DisableSSO)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionDoNotHandle)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCompleteWithoutData)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionUnexpectedCompletion)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed1)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed2)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed3)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceed4)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith302POST)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith302AfterRedirection)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionDidNotHandleTwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnoreAsync)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionCancelWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionErrorWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, ShowUITwice)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, NSNotificationCenter)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturization)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringHiding)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturizationThenAnother)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DismissUIDuringHidingThenAnother)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, NoInterceptionsWithoutUserGesture)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionError)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionCancel)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccess)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, AuthorizationOptions)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionErrorWithReferrer)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(testSuppressUsageRecordingWithDataStore):
(TEST(ScreenTime, IdentifierNil)):
(TEST(ScreenTime, IdentifierString)):
(TEST(ScreenTime, IdentifierStringWithRemoveData)):
(TEST(ScreenTime, FetchData)):
(TEST(ScreenTime, RemoveDataWithTimeInterval)):
(TEST(ScreenTime, RemoveData)):
(TEST(ScreenTime, DoNotDonateURLsInOccludedWebView)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::supportsFingerprintingScriptRequests):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEditActions.mm:
(TestWebKitAPI::TEST(WebKit, CanInvokeTranslateWithTextSelection)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, APIWithBehaviorNone)):
(TEST(WritingTools, APIWithBehaviorDefault)):
(TEST(WritingTools, APIWithBehaviorComplete)):
(TEST(WritingTools, ShowAffordance)):
(TEST(WritingTools, DISABLED_ShowAffordanceForMultipleLines)):
(TEST(WritingTools, ShowPanelWithNoSelection)):
(TEST(WritingTools, ShowPanelWithCaretSelection)):
(TEST(WritingTools, ShowPanelWithRangedSelection)):
(TEST(WritingTools, ShowToolWithRangedSelection)):
(TEST(WritingTools, ShowInvalidToolWithRangedSelection)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm:
(TestWebKitAPI::waitUntilAudioSessionCategoryIsEqualTo):
(TestWebKitAPI::TEST(WebKitLegacy, AudioSessionCategoryIOS)):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)):
* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:
(touchEventsGestureRecognizerClassSingleton):
(TestWebKitAPI::TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)):
(touchEventsGestureRecognizerClass): Deleted.
* Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm:
(TestWebKitAPI::TEST(UIPasteboardTests, PerformAsDataOwnerWithManagedURL)):
* Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm:
(TestWebKitAPI::Basic)):
(TestWebKitAPI::(Gamepad, GamepadState)):
(TestWebKitAPI::(Gamepad, Dualshock3Basic)):
(TestWebKitAPI::(Gamepad, Stadia)):
(TestWebKitAPI::(Gamepad, LogitechBasic)):
(TestWebKitAPI::(Gamepad, FullInfoAfterConnection)):
* Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm:
(TestWebKitAPI::RemoveBackgroundSwizzler::RemoveBackgroundSwizzler):
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h:
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::webAccessibilityObjectWrapperClassSingleton):
(WTR::makeValueRefForValue):
(WTR::webAccessibilityObjectWrapperClass): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.mm:
(-[AccessibilityNotificationHandler startObserving]):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaPlatformInitialize):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView immediatelyDismissEditMenuInteractionIfNeeded]):
* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(-[HIDEventGenerator _sendHIDEvent:]):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::createUIPhysicalKeyboardEvent):
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::menuImplClassSingleton):
(WTR::TestController::platformInitialize):
(WTR::menuImplClass): Deleted.

Canonical link: <a href="https://commits.webkit.org/299825@main">https://commits.webkit.org/299825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3485fb439347de50611827b7a6386aa71af5463b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120247 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72320 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91321 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60616 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71873 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/119604 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25913 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70231 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112373 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129501 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118763 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99938 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99780 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43800 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52735 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147462 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46498 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37884 "Found 1 new JSC binary failure: testapi, Found 18651 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->