### PR TITLE
REGRESSION(299181@main): [ macOS wk2 ] 2x http/wpt/service-workers/ (layout-tests) tests are constant failures

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2398,10 +2398,6 @@ webkit.org/b/297860 http/tests/site-isolation/edge-sampling-viewport-constrained
 
 webkit.org/b/297006 [ Debug ] http/tests/media/media-element-frame-destroyed-crash.html [ Skip ]
 
-# webkit.org/b/297974 [ macOS wk2 ] 2x http/wpt/service-workers/ (layout-tests) tests are constant failures 
-[ Release ] http/wpt/service-workers/service-worker-spinning-install.https.html [ Failure ]
-http/wpt/service-workers/service-worker-spinning-activate.https.html [ Failure ]
-
 webkit.org/b/267778 [ Release ] fast/forms/listbox-padding-clip-selected.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/298256 [ Debug ] fast/dom/document-all.html [ Pass Timeout ]

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -713,11 +713,19 @@ void ScriptExecutionContext::registerServiceWorker(ServiceWorker& serviceWorker)
 {
     auto addResult = m_serviceWorkers.add(serviceWorker.identifier(), &serviceWorker);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
+
+    ensureOnMainThread([identifier = serviceWorker.identifier()] {
+        ServiceWorkerProvider::singleton().protectedServiceWorkerConnection()->registerServiceWorkerInServer(identifier);
+    });
 }
 
 void ScriptExecutionContext::unregisterServiceWorker(ServiceWorker& serviceWorker)
 {
     m_serviceWorkers.remove(serviceWorker.identifier());
+
+    ensureOnMainThread([identifier = serviceWorker.identifier()] {
+        ServiceWorkerProvider::singleton().protectedServiceWorkerConnection()->unregisterServiceWorkerInServer(identifier);
+    });
 }
 
 ServiceWorkerContainer* ScriptExecutionContext::serviceWorkerContainer()

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -90,6 +90,9 @@ public:
     virtual void removeServiceWorkerRegistrationInServer(ServiceWorkerRegistrationIdentifier) = 0;
     virtual void scheduleUnregisterJobInServer(ServiceWorkerRegistrationIdentifier, ServiceWorkerOrClientIdentifier, CompletionHandler<void(ExceptionOr<bool>&&)>&&) = 0;
 
+    virtual void registerServiceWorkerInServer(ServiceWorkerIdentifier) = 0;
+    virtual void unregisterServiceWorkerInServer(ServiceWorkerIdentifier) = 0;
+
     WEBCORE_EXPORT virtual void scheduleJob(ServiceWorkerOrClientIdentifier, const ServiceWorkerJobData&);
 
     virtual void didResolveRegistrationPromise(const ServiceWorkerRegistrationKey&) = 0;

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -77,6 +77,9 @@ ServiceWorker::ServiceWorker(ScriptExecutionContext& context, ServiceWorkerData&
 
 ServiceWorker::~ServiceWorker()
 {
+    if (m_isStopped)
+        return;
+
     if (RefPtr context = scriptExecutionContext())
         context->unregisterServiceWorker(*this);
 }

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
@@ -190,6 +190,16 @@ void WorkerSWClientConnection::removeServiceWorkerRegistrationInServer(ServiceWo
     });
 }
 
+void WorkerSWClientConnection::registerServiceWorkerInServer(ServiceWorkerIdentifier)
+{
+    ASSERT_NOT_REACHED();
+}
+
+void WorkerSWClientConnection::unregisterServiceWorkerInServer(ServiceWorkerIdentifier)
+{
+    ASSERT_NOT_REACHED();
+}
+
 void WorkerSWClientConnection::didResolveRegistrationPromise(const ServiceWorkerRegistrationKey& key)
 {
     callOnMainThread([key = crossThreadCopy(key)]() mutable {

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.h
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.h
@@ -52,6 +52,8 @@ private:
     void whenRegistrationReady(const SecurityOriginData& topOrigin, const URL& clientURL, WhenRegistrationReadyCallback&&) final;
     void addServiceWorkerRegistrationInServer(ServiceWorkerRegistrationIdentifier) final;
     void removeServiceWorkerRegistrationInServer(ServiceWorkerRegistrationIdentifier) final;
+    void registerServiceWorkerInServer(ServiceWorkerIdentifier) final;
+    void unregisterServiceWorkerInServer(ServiceWorkerIdentifier) final;
     void didResolveRegistrationPromise(const ServiceWorkerRegistrationKey&) final;
     void postMessageToServiceWorker(ServiceWorkerIdentifier destination, MessageWithMessagePorts&&, const ServiceWorkerOrClientIdentifier& source) final;
     SWServerConnectionIdentifier serverConnectionIdentifier() const final;

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -417,6 +417,18 @@ void SWServer::Connection::removeServiceWorkerRegistrationInServer(ServiceWorker
         server->removeClientServiceWorkerRegistration(*this, identifier);
 }
 
+void SWServer::Connection::registerServiceWorkerInServer(ServiceWorkerIdentifier identifier)
+{
+    if (RefPtr server = m_server.get())
+        server->registerServiceWorkerConnection(*this, identifier);
+}
+
+void SWServer::Connection::unregisterServiceWorkerInServer(ServiceWorkerIdentifier identifier)
+{
+    if (RefPtr server = m_server.get())
+        server->unregisterServiceWorkerConnection(*this, identifier);
+}
+
 SWServer::SWServer(SWServerDelegate& delegate, UniqueRef<SWOriginStore>&& originStore, bool processTerminationDelayEnabled, String&& registrationDatabaseDirectory, PAL::SessionID sessionID, bool shouldRunServiceWorkersOnMainThreadForTesting, bool hasServiceWorkerEntitlement, std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue, ServiceWorkerIsInspectable inspectable)
     : m_delegate(delegate)
     , m_originStore(WTFMove(originStore))
@@ -848,6 +860,18 @@ void SWServer::removeClientServiceWorkerRegistration(Connection& connection, Ser
 {
     if (RefPtr registration = m_registrations.get(identifier))
         registration->removeClientServiceWorkerRegistration(connection.identifier());
+}
+
+void SWServer::registerServiceWorkerConnection(Connection& connection, ServiceWorkerIdentifier identifier)
+{
+    if (RefPtr worker = m_runningOrTerminatingWorkers.get(identifier))
+        worker->registerServiceWorkerConnection(connection.identifier());
+}
+
+void SWServer::unregisterServiceWorkerConnection(Connection& connection, ServiceWorkerIdentifier identifier)
+{
+    if (RefPtr worker = m_runningOrTerminatingWorkers.get(identifier))
+        worker->unregisterServiceWorkerConnection(connection.identifier());
 }
 
 void SWServer::updateWorker(const ServiceWorkerJobDataIdentifier& jobDataIdentifier, const std::optional<ProcessIdentifier>& requestingProcessIdentifier, SWServerRegistration& registration, const URL& url, const ScriptBuffer& script, const CertificateInfo& certificateInfo, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy, const CrossOriginEmbedderPolicy& coep, const String& referrerPolicy, WorkerType type, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&& scriptResourceMap, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier)

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -140,6 +140,8 @@ public:
         WEBCORE_EXPORT void finishFetchingScriptInServer(const ServiceWorkerJobDataIdentifier&, const ServiceWorkerRegistrationKey&, WorkerFetchResult&&);
         WEBCORE_EXPORT void addServiceWorkerRegistrationInServer(ServiceWorkerRegistrationIdentifier);
         WEBCORE_EXPORT void removeServiceWorkerRegistrationInServer(ServiceWorkerRegistrationIdentifier);
+        WEBCORE_EXPORT void registerServiceWorkerInServer(ServiceWorkerIdentifier);
+        WEBCORE_EXPORT void unregisterServiceWorkerInServer(ServiceWorkerIdentifier);
         WEBCORE_EXPORT void whenRegistrationReady(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&&);
 
         WEBCORE_EXPORT void storeRegistrationsOnDisk(CompletionHandler<void()>&&);
@@ -328,6 +330,8 @@ private:
 
     void addClientServiceWorkerRegistration(Connection&, ServiceWorkerRegistrationIdentifier);
     void removeClientServiceWorkerRegistration(Connection&, ServiceWorkerRegistrationIdentifier);
+    void registerServiceWorkerConnection(Connection&, ServiceWorkerIdentifier);
+    void unregisterServiceWorkerConnection(Connection&, ServiceWorkerIdentifier);
 
     void terminatePreinstallationWorker(SWServerWorker&);
 

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -41,6 +41,7 @@
 #include <WebCore/Timer.h>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/HashCountedSet.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/URLHash.h>
@@ -157,6 +158,9 @@ public:
     void needsRunning() { m_lastNeedRunningTime = ApproximateTime::now(); }
     bool isIdle(Seconds) const;
 
+    void registerServiceWorkerConnection(SWServerConnectionIdentifier);
+    void unregisterServiceWorkerConnection(SWServerConnectionIdentifier);
+
     std::optional<ExceptionData> addRoutes(Vector<ServiceWorkerRoute>&&);
 
 private:
@@ -177,6 +181,7 @@ private:
     WeakPtr<SWServer> m_server;
     ServiceWorkerRegistrationKey m_registrationKey;
     WeakPtr<SWServerRegistration> m_registration;
+    HashCountedSet<SWServerConnectionIdentifier> m_connectionsWithServiceWorker;
     ServiceWorkerData m_data;
     ScriptBuffer m_script;
     CertificateInfo m_certificateInfo;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -34,6 +34,9 @@ messages -> WebSWServerConnection {
     [EnabledBy=ServiceWorkersEnabled] AddServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier identifier)
     [EnabledBy=ServiceWorkersEnabled] RemoveServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier identifier)
 
+    [EnabledBy=ServiceWorkersEnabled] RegisterServiceWorkerInServer(WebCore::ServiceWorkerIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] UnregisterServiceWorkerInServer(WebCore::ServiceWorkerIdentifier identifier)
+
     [EnabledBy=ServiceWorkersEnabled] PostMessageToServiceWorker(WebCore::ServiceWorkerIdentifier destination, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerOrClientIdentifier source)
 
     [EnabledBy=ServiceWorkersEnabled] DidResolveRegistrationPromise(WebCore::ServiceWorkerRegistrationKey key)

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -114,6 +114,21 @@ void WebSWClientConnection::removeServiceWorkerRegistrationInServer(ServiceWorke
     }
 }
 
+void WebSWClientConnection::registerServiceWorkerInServer(ServiceWorkerIdentifier identifier)
+{
+    if (WebProcess::singleton().registerServiceWorker(identifier))
+        send(Messages::WebSWServerConnection::RegisterServiceWorkerInServer { identifier });
+}
+
+void WebSWClientConnection::unregisterServiceWorkerInServer(ServiceWorkerIdentifier identifier)
+{
+    if (WebProcess::singleton().unregisterServiceWorker(identifier)) {
+        RunLoop::mainSingleton().dispatch([identifier, connection = Ref { *this }]() {
+            connection->send(Messages::WebSWServerConnection::UnregisterServiceWorkerInServer { identifier });
+        });
+    }
+}
+
 void WebSWClientConnection::scheduleUnregisterJobInServer(ServiceWorkerRegistrationIdentifier registrationIdentifier, WebCore::ServiceWorkerOrClientIdentifier documentIdentifier, CompletionHandler<void(ExceptionOr<bool>&&)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::WebSWServerConnection::ScheduleUnregisterJobInServer { ServiceWorkerJobIdentifier::generate(), registrationIdentifier, documentIdentifier }, [completionHandler = WTFMove(completionHandler)](auto&& result) mutable {

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
@@ -63,6 +63,9 @@ public:
     void addServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier) final;
     void removeServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier) final;
 
+    void registerServiceWorkerInServer(WebCore::ServiceWorkerIdentifier) final;
+    void unregisterServiceWorkerInServer(WebCore::ServiceWorkerIdentifier) final;
+
     void disconnectedFromWebProcess();
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2212,6 +2212,17 @@ bool WebProcess::removeServiceWorkerRegistration(WebCore::ServiceWorkerRegistrat
     return m_swRegistrationCounts.remove(identifier);
 }
 
+bool WebProcess::registerServiceWorker(WebCore::ServiceWorkerIdentifier identifier)
+{
+    return m_swServiceWorkerCounts.add(identifier).isNewEntry;
+}
+
+bool WebProcess::unregisterServiceWorker(WebCore::ServiceWorkerIdentifier identifier)
+{
+    ASSERT(m_swServiceWorkerCounts.contains(identifier));
+    return m_swServiceWorkerCounts.remove(identifier);
+}
+
 #if ENABLE(MEDIA_STREAM)
 void WebProcess::addMockMediaDevice(const WebCore::MockMediaDevice& device)
 {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -439,6 +439,9 @@ public:
     void addServiceWorkerRegistration(WebCore::ServiceWorkerRegistrationIdentifier);
     bool removeServiceWorkerRegistration(WebCore::ServiceWorkerRegistrationIdentifier);
 
+    bool registerServiceWorker(WebCore::ServiceWorkerIdentifier);
+    bool unregisterServiceWorker(WebCore::ServiceWorkerIdentifier);
+
     void grantAccessToAssetServices(Vector<WebKit::SandboxExtensionHandle>&& assetServicesHandles);
     void revokeAccessToAssetServices();
     void switchFromStaticFontRegistryToUserFontRegistry(Vector<SandboxExtension::Handle>&& fontMachExtensionHandles);
@@ -886,6 +889,7 @@ private:
 #endif
 
     HashCountedSet<WebCore::ServiceWorkerRegistrationIdentifier> m_swRegistrationCounts;
+    HashCountedSet<WebCore::ServiceWorkerIdentifier> m_swServiceWorkerCounts;
 
     HashMap<StorageAreaMapIdentifier, WeakPtr<StorageAreaMap>> m_storageAreaMaps;
 


### PR DESCRIPTION
#### b4ee52d5126b7b02101c8c03963124d016ce063b
<pre>
REGRESSION(299181@main): [ macOS wk2 ] 2x http/wpt/service-workers/ (layout-tests) tests are constant failures
<a href="https://rdar.apple.com/159292159">rdar://159292159</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297974">https://bugs.webkit.org/show_bug.cgi?id=297974</a>

Reviewed by Brady Eidson.

We were using registrations as a way to send worker state update from network process to web processes.
But, it is possible for a web process to have a worker but no registration.
This happens in the failing tests as registrations get GCed.

To fix the issue, instead of relying on registrations, we now register web process connections to SWServerWorker.
When a SWServerWorker state is updated, it will have the full list of web processes to send updates to.

This list of web processes is either web processes that have a ServiceWorkerRegistration of the given service worker, or web processes that have a ServiceWorker of the given service worker.
The former is needed as a registration may get updated to have a new service worker, which may be updated before the web process has time to create the ServiceWorker object.
The latter is needed if the ServiceWorkerRegistration of a ServiceWorker gets collected or if the ServiceWorker is created without any ServiceWorkerRegistration (for instance as part of MessageEventSource).

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::applyToSWClientConnection):
(WebCore::ScriptExecutionContext::registerServiceWorker):
(WebCore::ScriptExecutionContext::unregisterServiceWorker):
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/WorkerSWClientConnection.cpp:
(WebCore::WorkerSWClientConnection::registerServiceWorkerInServer):
(WebCore::WorkerSWClientConnection::unregisterServiceWorkerInServer):
* Source/WebCore/workers/service/WorkerSWClientConnection.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::Connection::registerServiceWorkerInServer):
(WebCore::SWServer::Connection::unregisterServiceWorkerInServer):
(WebCore::SWServer::registerServiceWorkerConnection):
(WebCore::SWServer::unregisterServiceWorkerConnection):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::setState):
(WebCore::SWServerWorker::registerServiceWorkerConnection):
(WebCore::SWServerWorker::unregisterServiceWorkerConnection):
* Source/WebCore/workers/service/server/SWServerWorker.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::registerServiceWorkerInServer):
(WebKit::WebSWClientConnection::unregisterServiceWorkerInServer):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::registerServiceWorker):
(WebKit::WebProcess::runegisterServiceWorker):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/299839@main">https://commits.webkit.org/299839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d14b49347ee4f8ff8d8d2e7f3b79723597d55f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72471 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdb29bb1-1f74-4a65-832f-1cb00e858845) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48667 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd942c3a-e657-4a9c-836c-21036fa02538) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32575 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/107928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71989 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1d04819-a376-472a-bf6a-28d24b2d2127) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31610 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70383 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129652 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35908 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25350 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23376 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52884 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->