### PR TITLE
[JSC] Support `Promise.all` in async stack trace

### DIFF
--- a/JSTests/stress/async-stack-trace-promise-all-basic.js
+++ b/JSTests/stress/async-stack-trace-promise-all-basic.js
@@ -1,0 +1,156 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-promise-all-basic.js";
+
+function nop() {}
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+{
+  async function fine() { }
+  async function thrower() { await fine(); throw new Error('error'); }
+  async function run() { await Promise.all([fine(), thrower()]); }
+
+  for (let i = 0; i < testLoopCount; i++) {
+       shouldThrowAsync(
+           async function test() {
+               await run();
+           }, Error, "error",
+           [
+               ["thrower", "65:59"],
+               ["async run", "66:43"],
+               ["async test", "71:25"],
+               ["drainMicrotasks", "[native code]"],
+               ["shouldThrowAsync", "19:20"],
+               ["global code", "69:24"]
+           ],
+       );
+       drainMicrotasks();
+   }
+}
+
+{
+  async function task1() { await nop(); }
+  async function task2() {
+    await nop();
+
+
+
+    throw new Error('task2 error');
+  }
+  async function task3() { await nop(); }
+  async function runner() { await Promise.all([task1(), task2(), task3()]); }
+
+  for (let i = 0; i < testLoopCount; i++) {
+       shouldThrowAsync(
+           async function test() {
+               await runner();
+           }, Error, "task2 error",
+           [
+               ["task2", "93:20"],
+               ["async runner", "96:46"],
+               ["async test", "101:28"],
+               ["drainMicrotasks", "[native code]"],
+               ["shouldThrowAsync", "19:20"],
+               ["global code", "99:24"]
+           ],
+       );
+       drainMicrotasks();
+   }
+}
+
+{
+  async function task1() {}
+
+  async function task2() {
+    await foo();
+  }
+  async function foo() {
+    await bar();
+  }
+  async function bar() {
+    await 1;
+    await Promise.all([task1(), baz()]);
+  }
+  async function baz() {
+    await 2;
+    throw new Error('task2 error');
+  }
+
+  async function task3() {}
+  async function runner() { await Promise.all([task1(), task2(), task3()]); }
+
+  for (let i = 0; i < testLoopCount; i++) {
+       shouldThrowAsync(
+           async function test() {
+               await runner();
+           }, Error, "task2 error",
+           [
+               ["baz", "131:20"],
+               ["async bar", "127:22"],
+               ["async foo", "123:14"],
+               ["async task2", "120:14"],
+               ["async runner", "135:46"],
+               ["async test", "140:28"],
+               ["drainMicrotasks", "[native code]"],
+               ["shouldThrowAsync", "19:20"],
+               ["global code", "138:24"]
+           ],
+       );
+       drainMicrotasks();
+   }
+}

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1723,6 +1723,8 @@
 		A7F9935F0FD7325100A0B2D0 /* JSONObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A7F9935D0FD7325100A0B2D0 /* JSONObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A7FB61001040C38B0017A286 /* PropertyDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FB604B103F5EAB0017A286 /* PropertyDescriptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A7FCC26D17A0B6AA00786D1A /* FTLSwitchCase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FCC26C17A0B6AA00786D1A /* FTLSwitchCase.h */; };
+		AA785BEB2E77BECA0097F688 /* JSPromiseAllContext.h in Headers */ = {isa = PBXBuildFile; fileRef = AA785BEA2E77BECA0097F688 /* JSPromiseAllContext.h */; };
+		AA785BEE2E77BED70097F688 /* JSPromiseAllContextInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = AA785BED2E77BED70097F688 /* JSPromiseAllContextInlines.h */; };
 		AD00659E1ECAC812000CA926 /* WasmLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = AD00659D1ECAC7FE000CA926 /* WasmLimits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD2FCBE31DB58DAD00B3E736 /* JSWebAssemblyCompileError.h in Headers */ = {isa = PBXBuildFile; fileRef = AD2FCBA71DB58DA400B3E736 /* JSWebAssemblyCompileError.h */; };
 		AD2FCBE51DB58DAD00B3E736 /* JSWebAssemblyInstance.h in Headers */ = {isa = PBXBuildFile; fileRef = AD2FCBA91DB58DA400B3E736 /* JSWebAssemblyInstance.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5380,6 +5382,9 @@
 		A7FF647A18C52E8500B55307 /* SpillRegistersMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpillRegistersMode.h; sourceTree = "<group>"; };
 		A8E894310CD0602400367179 /* JSCallbackObjectFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCallbackObjectFunctions.h; sourceTree = "<group>"; };
 		A8E894330CD0603F00367179 /* JSGlobalObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGlobalObject.h; sourceTree = "<group>"; };
+		AA785BEA2E77BECA0097F688 /* JSPromiseAllContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPromiseAllContext.h; sourceTree = "<group>"; };
+		AA785BEC2E77BECF0097F688 /* JSPromiseAllContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSPromiseAllContext.cpp; sourceTree = "<group>"; };
+		AA785BED2E77BED70097F688 /* JSPromiseAllContextInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPromiseAllContextInlines.h; sourceTree = "<group>"; };
 		AAE814122E667AED00DF3D3A /* CachedCall.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CachedCall.cpp; sourceTree = "<group>"; };
 		AD00659D1ECAC7FE000CA926 /* WasmLimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmLimits.h; sourceTree = "<group>"; };
 		AD1CF06816DCAB2D00B97123 /* PropertyTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PropertyTable.cpp; sourceTree = "<group>"; };
@@ -8686,6 +8691,9 @@
 				276B38782A71D11700252F4E /* JSONObjectInlines.h */,
 				7C184E1817BEDBD3007CB63A /* JSPromise.cpp */,
 				7C184E1917BEDBD3007CB63A /* JSPromise.h */,
+				AA785BEC2E77BECF0097F688 /* JSPromiseAllContext.cpp */,
+				AA785BEA2E77BECA0097F688 /* JSPromiseAllContext.h */,
+				AA785BED2E77BED70097F688 /* JSPromiseAllContextInlines.h */,
 				7C184E2017BEE240007CB63A /* JSPromiseConstructor.cpp */,
 				7C184E2117BEE240007CB63A /* JSPromiseConstructor.h */,
 				7C184E1C17BEE22E007CB63A /* JSPromisePrototype.cpp */,
@@ -11557,6 +11565,8 @@
 				A7F9935F0FD7325100A0B2D0 /* JSONObject.h in Headers */,
 				276B387B2A71D11800252F4E /* JSONObjectInlines.h in Headers */,
 				7C184E1B17BEDBD3007CB63A /* JSPromise.h in Headers */,
+				AA785BEB2E77BECA0097F688 /* JSPromiseAllContext.h in Headers */,
+				AA785BEE2E77BED70097F688 /* JSPromiseAllContextInlines.h in Headers */,
 				7C184E2317BEE240007CB63A /* JSPromiseConstructor.h in Headers */,
 				7C184E1F17BEE22E007CB63A /* JSPromisePrototype.h in Headers */,
 				2A05ABD61961DF2400341750 /* JSPropertyNameEnumerator.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -937,6 +937,7 @@ runtime/JSNativeStdFunction.cpp
 runtime/JSONObject.cpp
 runtime/JSObject.cpp
 runtime/JSPromise.cpp
+runtime/JSPromiseAllContext.cpp
 runtime/JSPromiseConstructor.cpp
 runtime/JSPromisePrototype.cpp
 runtime/JSPropertyNameEnumerator.cpp

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -215,6 +215,7 @@ namespace JSC {
     macro(pop) \
     macro(wrapForValidIteratorCreate) \
     macro(asyncFromSyncIteratorCreate) \
+    macro(promiseAllContextCreate) \
     macro(regExpStringIteratorCreate) \
     macro(iteratorHelperCreate) \
     macro(syncIterator) \

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -80,7 +80,9 @@ function promiseOnRejectedWithContext(argument, context)
 {
     "use strict";
 
-    return @rejectPromiseWithFirstResolvingFunctionCallCheck(context.globalContext.promise, argument);
+    @assert(@isPromiseAllContext(context));
+
+    return @rejectPromiseWithFirstResolvingFunctionCallCheck(@getPromiseAllContextInternalField(context, @promiseAllContextFieldPromise), argument);
 }
 
 @linkTimeConstant
@@ -88,13 +90,17 @@ function promiseAllOnFulfilled(argument, context)
 {
     "use strict";
 
-    var globalContext = context.globalContext;
-    var values = globalContext.values;
+    @assert(@isPromiseAllContext(context));
 
-    @putByValDirect(values, context.index, argument);
+    var promise = @getPromiseAllContextInternalField(context, @promiseAllContextFieldPromise);
+    var values = @getPromiseAllContextInternalField(context, @promiseAllContextFieldValues);
+    var remainingElementsCountObj = @getPromiseAllContextInternalField(context, @promiseAllContextFieldRemainingElementsCount);
+    var index = @getPromiseAllContextInternalField(context, @promiseAllContextFieldIndex);
 
-    if (!--globalContext.remainingElementsCount)
-        return @resolvePromiseWithFirstResolvingFunctionCallCheck(globalContext.promise, values);
+    @putByValDirect(values, index, argument);
+
+    if (!--remainingElementsCountObj.value)
+        return @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, values);
 }
 
 @linkTimeConstant
@@ -108,9 +114,11 @@ function promiseNewOnRejected(promise)
 }
 
 @linkTimeConstant
-function promiseAllNewResolveElement(globalContext, index)
+function promiseAllNewResolveElement(context, index)
 {
     "use strict";
+
+    @assert(@isPromiseAllContext(context));
 
     var alreadyCalled = false;
     return (argument) => {
@@ -118,11 +126,14 @@ function promiseAllNewResolveElement(globalContext, index)
             return @undefined;
         alreadyCalled = true;
 
-        var values = globalContext.values;
+        var values = @getPromiseAllContextInternalField(context, @promiseAllContextFieldValues);
         @putByValDirect(values, index, argument);
 
-        if (!--globalContext.remainingElementsCount)
-            return @resolvePromiseWithFirstResolvingFunctionCallCheck(globalContext.promise, values);
+        var remainingElementsCount = @getPromiseAllContextInternalField(context, @promiseAllContextFieldRemainingElementsCount);
+        if (!--remainingElementsCount.value) {
+            var promise = @getPromiseAllContextInternalField(context, @promiseAllContextFieldPromise);
+            return @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, values);
+        }
     };
 }
 
@@ -135,11 +146,7 @@ function all(iterable)
 
     var promise = @newPromise();
     var values = [];
-    var globalContext = {
-        promise,
-        values,
-        remainingElementsCount: 1,
-    };
+    var remainingElementsCountObj = { value: 1 };
     var index = 0;
     var onRejected;
 
@@ -151,23 +158,24 @@ function all(iterable)
         for (var value of iterable) {
             @putByValDirect(values, index, @undefined);
             var nextPromise = promiseResolve.@call(this, value);
-            ++globalContext.remainingElementsCount;
+            ++remainingElementsCountObj.value;
             var then = nextPromise.then;
+            var context = @promiseAllContextCreate(promise, values, remainingElementsCountObj, index);
             if (@isPromise(nextPromise) && then === @defaultPromiseThen) {
                 var constructor = @speciesConstructor(nextPromise, @Promise);
                 var promiseOrCapability;
                 if (constructor !== @Promise)
                     promiseOrCapability = @newPromiseCapabilitySlow(constructor);
-                @performPromiseThen(nextPromise, @promiseAllOnFulfilled, @promiseOnRejectedWithContext, promiseOrCapability, { globalContext, index });
+                @performPromiseThen(nextPromise, @promiseAllOnFulfilled, @promiseOnRejectedWithContext, promiseOrCapability, context);
             } else {
                 if (!onRejected)
                     onRejected = @promiseNewOnRejected(promise);
-                then.@call(nextPromise, @promiseAllNewResolveElement(globalContext, index), onRejected);
+                then.@call(nextPromise, @promiseAllNewResolveElement(context, index), onRejected);
             }
             ++index;
         }
 
-        if (!--globalContext.remainingElementsCount)
+        if (!--remainingElementsCountObj.value)
             @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, values);
     } catch (error) {
         @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, error);

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -62,6 +62,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getRegExpStringIteratorInternalField) \
     macro(getProxyInternalField) \
     macro(getWrapForValidIteratorInternalField) \
+    macro(getPromiseAllContextInternalField) \
     macro(getDisposableStackInternalField) \
     macro(idWithProfile) \
     macro(isAsyncDisposableStack) \
@@ -76,6 +77,7 @@ enum class LinkTimeConstant : int32_t;
     macro(isIteratorHelper) \
     macro(isAsyncGenerator) \
     macro(isPromise) \
+    macro(isPromiseAllContext) \
     macro(isRegExpObject) \
     macro(isMap) \
     macro(isSet) \
@@ -108,6 +110,7 @@ enum class LinkTimeConstant : int32_t;
     macro(putMapIteratorInternalField) \
     macro(putSetIteratorInternalField) \
     macro(putRegExpStringIteratorInternalField) \
+    macro(putPromiseAllContextInternalField) \
     macro(putDisposableStackInternalField) \
     macro(superSamplerBegin) \
     macro(superSamplerEnd) \
@@ -199,6 +202,10 @@ enum class LinkTimeConstant : int32_t;
     macro(abstractModuleRecordFieldState) \
     macro(wrapForValidIteratorFieldIteratedIterator) \
     macro(wrapForValidIteratorFieldIteratedNextMethod) \
+    macro(promiseAllContextFieldPromise) \
+    macro(promiseAllContextFieldValues) \
+    macro(promiseAllContextFieldRemainingElementsCount) \
+    macro(promiseAllContextFieldIndex) \
     macro(regExpStringIteratorFieldRegExp) \
     macro(regExpStringIteratorFieldString) \
     macro(regExpStringIteratorFieldGlobal) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -147,6 +147,7 @@ class JSGlobalObject;
     v(BigUint64Array, nullptr) \
     v(wrapForValidIteratorCreate, nullptr) \
     v(asyncFromSyncIteratorCreate, nullptr) \
+    v(promiseAllContextCreate, nullptr) \
     v(regExpStringIteratorCreate, nullptr) \
     v(iteratorHelperCreate, nullptr) \
     v(ReferenceError, nullptr) \

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -927,6 +927,7 @@ namespace JSC {
         RegisterID* emitIsAsyncGenerator(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSAsyncGeneratorType); }
         RegisterID* emitIsJSArray(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, ArrayType); }
         RegisterID* emitIsPromise(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSPromiseType); }
+        RegisterID* emitIsPromiseAllContext(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSPromiseAllContextType); }
         RegisterID* emitIsProxyObject(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, ProxyObjectType); }
         RegisterID* emitIsRegExpObject(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, RegExpObjectType); }
         RegisterID* emitIsMap(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSMapType); }

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -45,6 +45,7 @@
 #include "JSInternalPromise.h"
 #include "JSIteratorHelper.h"
 #include "JSMapIterator.h"
+#include "JSPromiseAllContext.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
 #include "JSWrapForValidIterator.h"
@@ -1113,6 +1114,9 @@ private:
                 break;
             case JSAsyncFromSyncIteratorType:
                 target = handleInternalFieldClass<JSAsyncFromSyncIterator>(node, writes);
+                break;
+            case JSPromiseAllContextType:
+                target = handleInternalFieldClass<JSPromiseAllContext>(node, writes);
                 break;
             case JSRegExpStringIteratorType:
                 target = handleInternalFieldClass<JSRegExpStringIterator>(node, writes);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -66,6 +66,7 @@
 #include "JSLexicalEnvironment.h"
 #include "JSMap.h"
 #include "JSMapIterator.h"
+#include "JSPromiseAllContext.h"
 #include "JSPromiseConstructor.h"
 #include "JSPropertyNameEnumerator.h"
 #include "JSRegExpStringIterator.h"
@@ -2359,6 +2360,16 @@ JSC_DEFINE_JIT_OPERATION(operationNewAsyncFromSyncIterator, JSCell*, (VM* vmPoin
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     OPERATION_RETURN(scope, JSAsyncFromSyncIterator::createWithInitialValues(vm, structure));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationNewPromiseAllContext, JSCell*, (VM* vmPointer, Structure* structure))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, JSPromiseAllContext::createWithInitialValues(vm, structure));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewRegExpStringIterator, JSCell*, (VM* vmPointer, Structure* structure))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -176,6 +176,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewSetIterator, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewIteratorHelper, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewWrapForValidIterator, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncFromSyncIterator, JSCell*, (VM*, Structure*));
+JSC_DECLARE_JIT_OPERATION(operationNewPromiseAllContext, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewRegExpStringIterator, JSCell*, (VM*, Structure*));
 
 JSC_DECLARE_JIT_OPERATION(operationPutByValCellStringStrict, void, (JSGlobalObject*, JSCell*, JSCell* string, EncodedJSValue encodedValue));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -66,6 +66,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSIteratorHelper.h"
 #include "JSLexicalEnvironment.h"
 #include "JSMapIterator.h"
+#include "JSPromiseAllContext.h"
 #include "JSPropertyNameEnumerator.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
@@ -15555,6 +15556,9 @@ void SpeculativeJIT::compileNewInternalFieldObject(Node* node)
         break;
     case JSAsyncFromSyncIteratorType:
         compileNewInternalFieldObjectImpl<JSAsyncFromSyncIterator>(node, operationNewAsyncFromSyncIterator);
+        break;
+    case JSPromiseAllContextType:
+        compileNewInternalFieldObjectImpl<JSPromiseAllContext>(node, operationNewPromiseAllContext);
         break;
     case JSRegExpStringIteratorType:
         compileNewInternalFieldObjectImpl<JSRegExpStringIterator>(node, operationNewRegExpStringIterator);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -91,6 +91,7 @@
 #include "JSIteratorHelper.h"
 #include "JSLexicalEnvironment.h"
 #include "JSMapIterator.h"
+#include "JSPromiseAllContext.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
 #include "JSWebAssemblyInstance.h"
@@ -9404,6 +9405,9 @@ IGNORE_CLANG_WARNINGS_END
             break;
         case JSAsyncFromSyncIteratorType:
             compileNewInternalFieldObjectImpl<JSAsyncFromSyncIterator>(operationNewAsyncFromSyncIterator);
+            break;
+        case JSPromiseAllContextType:
+            compileNewInternalFieldObjectImpl<JSPromiseAllContext>(operationNewPromiseAllContext);
             break;
         case JSRegExpStringIteratorType:
             compileNewInternalFieldObjectImpl<JSRegExpStringIterator>(operationNewRegExpStringIterator);

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -52,6 +52,7 @@
 #include "JITWorklistInlines.h"
 #include "JSFinalizationRegistry.h"
 #include "JSIterator.h"
+#include "JSPromiseAllContext.h"
 #include "JSRawJSONObject.h"
 #include "JSRemoteFunction.h"
 #include "JSVirtualMachineInternal.h"

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -297,6 +297,7 @@ class Heap;
     v(weakSetSpace, weakSetHeapCellType, JSWeakSet) \
     v(withScopeSpace, cellHeapCellType, JSWithScope) \
     v(wrapForValidIteratorSpace, cellHeapCellType, JSWrapForValidIterator) \
+    v(promiseAllContextSpace, cellHeapCellType, JSPromiseAllContext) \
     v(asyncFromSyncIteratorSpace, cellHeapCellType, JSAsyncFromSyncIterator) \
     v(regExpStringIteratorSpace, cellHeapCellType, JSRegExpStringIterator) \
     v(disposableStackSpace, cellHeapCellType, JSDisposableStack) \

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -59,6 +59,7 @@
 #include "JSModuleRecord.h"
 #include "JSObject.h"
 #include "JSPromise.h"
+#include "JSPromiseAllContext.h"
 #include "JSRemoteFunction.h"
 #include "JSString.h"
 #include "JSWebAssemblyException.h"
@@ -461,20 +462,36 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
 
     VM& vm = this->vm();
 
-    auto getParentGenerator = [&](JSGenerator* gen) -> JSGenerator* {
-        JSValue contextValue = gen->internalField(static_cast<unsigned>(JSGenerator::Field::Context)).get();
-        JSPromise* awaitedPromise = jsDynamicCast<JSPromise*>(contextValue);
-        if (awaitedPromise && awaitedPromise->status(vm) == JSPromise::Status::Pending) {
-            JSValue reactionsValue = awaitedPromise->internalField(JSPromise::Field::ReactionsOrResult).get();
+    auto getContextValueFromPromise = [&](JSPromise* promise) -> JSValue {
+        if (promise && promise->status(vm) == JSPromise::Status::Pending) {
+            JSValue reactionsValue = promise->internalField(JSPromise::Field::ReactionsOrResult).get();
             if (JSObject* reactions = jsDynamicCast<JSObject*>(reactionsValue)) {
-                Structure* structure = reactions->structure();
-                unsigned attributes;
-                PropertyOffset offset = structure->getConcurrently(vm.propertyNames->builtinNames().contextPrivateName().impl(), attributes);
-                if (offset != invalidOffset && !(attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
-                    JSValue contextFieldValue = reactions->getDirect(offset);
-                    if (auto* resultGenerator = jsDynamicCast<JSGenerator*>(contextFieldValue))
-                        return resultGenerator;
-                }
+                Structure* reactionsStructure = reactions->structure();
+                unsigned contextFieldAttributes;
+                PropertyOffset contextOffset = reactionsStructure->getConcurrently(vm.propertyNames->builtinNames().contextPrivateName().impl(), contextFieldAttributes);
+                if (contextOffset != invalidOffset && !(contextFieldAttributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue)))
+                    return reactions->getDirect(contextOffset);
+            }
+        }
+        return JSValue();
+    };
+
+    auto getParentGenerator = [&](JSGenerator* gen) -> JSGenerator* {
+        JSValue generatorContext = gen->internalField(static_cast<unsigned>(JSGenerator::Field::Context)).get();
+        JSPromise* awaitedPromise = jsDynamicCast<JSPromise*>(generatorContext);
+        JSValue promiseContext = getContextValueFromPromise(awaitedPromise);
+
+        // handle simple `await`
+        if (auto* generator = jsDynamicCast<JSGenerator*>(promiseContext))
+            return generator;
+
+        // handle `Promise.all`
+        if (auto* promiseAllContext = jsDynamicCast<JSPromiseAllContext*>(promiseContext)) {
+            JSValue promiseValue = promiseAllContext->promise();
+            if (auto* promise = jsDynamicCast<JSPromise*>(promiseValue)) {
+                JSValue promiseContext = getContextValueFromPromise(promise);
+                if (auto* generator = jsDynamicCast<JSGenerator*>(promiseContext))
+                    return generator;
             }
         }
         return nullptr;

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -330,6 +330,7 @@
     macro(disposeAsync) \
     macro(keys) \
     macro(flat) \
+    macro(promise) \
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -198,6 +198,7 @@ namespace JSC {
     macro(IteratorHelperCreateIntrinsic) \
     macro(WrapForValidIteratorCreateIntrinsic) \
     macro(AsyncFromSyncIteratorCreateIntrinsic) \
+    macro(PromiseAllContextCreateIntrinsic) \
     macro(RegExpStringIteratorCreateIntrinsic) \
     \
     /* Getter intrinsics. */ \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -201,6 +201,7 @@
 #include "JSWebAssemblyTag.h"
 #include "JSWithScope.h"
 #include "JSWrapForValidIteratorInlines.h"
+#include "JSPromiseAllContextInlines.h"
 #include "LazyClassStructureInlines.h"
 #include "LazyPropertyInlines.h"
 #include "LinkTimeConstant.h"
@@ -1199,6 +1200,8 @@ void JSGlobalObject::init(VM& vm)
     auto* wrapForValidIteratorPrototype = WrapForValidIteratorPrototype::create(vm, this, WrapForValidIteratorPrototype::createStructure(vm, this, m_iteratorPrototype.get()));
     m_wrapForValidIteratorStructure.set(vm, this, JSWrapForValidIterator::createStructure(vm, this, wrapForValidIteratorPrototype));
 
+    m_promiseAllContextStructure.set(vm, this, JSPromiseAllContext::createStructure(vm, this, jsNull()));
+
     auto* asyncFromSyncIteratorPrototype = AsyncFromSyncIteratorPrototype::create(vm, this, AsyncFromSyncIteratorPrototype::createStructure(vm, this, m_iteratorPrototype.get()));
     m_asyncFromSyncIteratorStructure.set(vm, this, JSAsyncFromSyncIterator::createStructure(vm, this, asyncFromSyncIteratorPrototype));
 
@@ -1599,6 +1602,11 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     // AsyncFromSyncIterator Helpers
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncFromSyncIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
         init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "asyncFromSyncIteratorCreate"_s, asyncFromSyncIteratorPrivateFuncCreate, ImplementationVisibility::Private, AsyncFromSyncIteratorCreateIntrinsic));
+    });
+
+    // PromiseAllContext Helpers
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseAllContextCreate)].initLater([](const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "promiseAllContextCreate"_s, promiseAllContextPrivateFuncCreate, ImplementationVisibility::Private, PromiseAllContextCreateIntrinsic));
     });
 
     // RegExpStringIteratorHelpers
@@ -2715,6 +2723,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_mapIteratorStructure);
     visitor.append(thisObject->m_setIteratorStructure);
     visitor.append(thisObject->m_wrapForValidIteratorStructure);
+    visitor.append(thisObject->m_promiseAllContextStructure);
     visitor.append(thisObject->m_asyncFromSyncIteratorStructure);
     visitor.append(thisObject->m_regExpStringIteratorStructure);
     thisObject->m_iteratorResultObjectStructure.visit(visitor);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -382,6 +382,7 @@ public:
     WriteBarrierStructureID m_mapIteratorStructure;
     WriteBarrierStructureID m_setIteratorStructure;
     WriteBarrierStructureID m_wrapForValidIteratorStructure;
+    WriteBarrierStructureID m_promiseAllContextStructure;
     WriteBarrierStructureID m_regExpMatchesArrayStructure;
     WriteBarrierStructureID m_regExpMatchesArrayWithIndicesStructure;
     WriteBarrierStructureID m_regExpMatchesIndicesArrayStructure;
@@ -907,6 +908,7 @@ public:
     Structure* mapIteratorStructure() const { return m_mapIteratorStructure.get(); }
     Structure* setIteratorStructure() const { return m_setIteratorStructure.get(); }
     Structure* wrapForValidIteratorStructure() const { return m_wrapForValidIteratorStructure.get(); }
+    Structure* promiseAllContextStructure() const { return m_promiseAllContextStructure.get(); }
     Structure* stringObjectStructure() const { return m_stringObjectStructure.get(); }
     Structure* symbolObjectStructure() const { return m_symbolObjectStructure.get(); }
     Structure* iteratorResultObjectStructure() const { return m_iteratorResultObjectStructure.get(this); }

--- a/Source/JavaScriptCore/runtime/JSPromiseAllContext.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseAllContext.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Codeblog CORP.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSPromiseAllContext.h"
+
+#include "JSCInlines.h"
+#include "JSInternalFieldObjectImplInlines.h"
+
+namespace JSC {
+
+const ClassInfo JSPromiseAllContext::s_info = { "PromiseAllContext"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSPromiseAllContext) };
+
+JSPromiseAllContext* JSPromiseAllContext::createWithInitialValues(VM& vm, Structure* structure)
+{
+    auto values = initialValues();
+    JSPromiseAllContext* context = new (NotNull, allocateCell<JSPromiseAllContext>(vm)) JSPromiseAllContext(vm, structure);
+    context->finishCreation(vm, values[0], values[1], values[2], values[3]);
+    return context;
+}
+
+JSPromiseAllContext* JSPromiseAllContext::create(VM& vm, Structure* structure, JSValue promise, JSValue values, JSValue remainingElementsCount, JSValue index)
+{
+    JSPromiseAllContext* result = new (NotNull, allocateCell<JSPromiseAllContext>(vm)) JSPromiseAllContext(vm, structure);
+    result->finishCreation(vm, promise, values, remainingElementsCount, index);
+    return result;
+}
+
+void JSPromiseAllContext::finishCreation(VM& vm, JSValue promise, JSValue values, JSValue remainingElementsCount, JSValue index)
+{
+    Base::finishCreation(vm);
+    this->setPromise(vm, promise);
+    this->setValues(vm, values);
+    this->setRemainingElementsCount(vm, remainingElementsCount);
+    this->setIndex(vm, index);
+}
+
+template<typename Visitor>
+void JSPromiseAllContext::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSPromiseAllContext*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSPromiseAllContext);
+
+JSC_DEFINE_HOST_FUNCTION(promiseAllContextPrivateFuncCreate, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    return JSValue::encode(JSPromiseAllContext::create(globalObject->vm(), globalObject->promiseAllContextStructure(), callFrame->uncheckedArgument(0), callFrame->uncheckedArgument(1), callFrame->uncheckedArgument(2), callFrame->uncheckedArgument(3)));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSPromiseAllContext.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseAllContext.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 Codeblog CORP.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSInternalFieldObjectImpl.h"
+
+namespace JSC {
+
+const static uint8_t JSPromiseAllContextNumberOfInternalFields = 4;
+
+class JSPromiseAllContext final : public JSInternalFieldObjectImpl<JSPromiseAllContextNumberOfInternalFields> {
+public:
+    using Base = JSInternalFieldObjectImpl<JSPromiseAllContextNumberOfInternalFields>;
+
+    DECLARE_EXPORT_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    enum class Field : uint8_t {
+        Promise = 0,
+        Values,
+        RemainingElementsCount,
+        Index,
+    };
+    static_assert(numberOfInternalFields == JSPromiseAllContextNumberOfInternalFields);
+
+    static std::array<JSValue, numberOfInternalFields> initialValues()
+    {
+        return { {
+            jsNull(),
+            jsNull(),
+            jsNull(),
+            jsNumber(0),
+        } };
+    }
+
+    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.promiseAllContextSpace<mode>();
+    }
+
+    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    static JSPromiseAllContext* createWithInitialValues(VM&, Structure*);
+    static JSPromiseAllContext* create(VM&, Structure*, JSValue promise, JSValue values, JSValue remainingElementsCount, JSValue index);
+
+    JSValue promise() const { return internalField(Field::Promise).get(); }
+    JSValue values() const { return internalField(Field::Values).get(); }
+    JSValue remainingElementsCount() const { return internalField(Field::RemainingElementsCount).get(); }
+    JSValue index() const { return internalField(Field::Index).get(); }
+
+    void setPromise(VM& vm, JSValue promise) { internalField(Field::Promise).set(vm, this, promise); }
+    void setValues(VM& vm, JSValue values) { internalField(Field::Values).set(vm, this, values); }
+    void setRemainingElementsCount(VM& vm, JSValue remainingElementsCount) { internalField(Field::RemainingElementsCount).set(vm, this, remainingElementsCount); }
+    void setIndex(VM& vm, JSValue index) { internalField(Field::Index).set(vm, this, index); }
+
+private:
+    JSPromiseAllContext(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(VM&, JSValue promise, JSValue values, JSValue remainingElementsCount, JSValue index);
+};
+
+STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSPromiseAllContext);
+
+JSC_DECLARE_HOST_FUNCTION(promiseAllContextPrivateFuncCreate);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSPromiseAllContextInlines.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseAllContextInlines.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Codeblog CORP.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSPromiseAllContext.h"
+#include "Structure.h"
+
+namespace JSC {
+
+inline Structure* JSPromiseAllContext::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(JSPromiseAllContextType, StructureFlags), info());
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSType.cpp
+++ b/Source/JavaScriptCore/runtime/JSType.cpp
@@ -127,6 +127,7 @@ void printInternal(PrintStream& out, JSC::JSType type)
     CASE(JSAsyncFromSyncIteratorType)
     CASE(DisposableStackType)
     CASE(AsyncDisposableStackType)
+    CASE(JSPromiseAllContextType)
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -131,6 +131,7 @@ namespace JSC {
     macro(JSRegExpStringIteratorType, SpecObjectOther) \
     macro(JSAsyncFromSyncIteratorType, SpecObjectOther) \
     macro(JSPromiseType, SpecPromiseObject) \
+    macro(JSPromiseAllContextType, SpecObjectOther) \
     macro(JSMapType, SpecMapObject) \
     macro(JSSetType, SpecSetObject) \
     macro(JSWeakMapType, SpecWeakMapObject) \


### PR DESCRIPTION
#### 99d0a3203c0295292034106966037bf3f1576c81
<pre>
[JSC] Support `Promise.all` in async stack trace
<a href="https://bugs.webkit.org/show_bug.cgi?id=298600">https://bugs.webkit.org/show_bug.cgi?id=298600</a>

Reviewed by Yusuke Suzuki.

This patch changes async stack trace to support `Promise.all`.

Test: JSTests/stress/async-stack-trace-promise-all-basic.js

Test: JSTests/stress/async-stack-trace-promise-all-basic.js
* JSTests/stress/async-stack-trace-promise-all-basic.js: Added.
(nop):
(shouldThrowAsync):
(throw.new.Error.async fine):
(throw.new.Error.async thrower):
(throw.new.Error.async run):
(async task1):
(async task2):
(async task3):
(async runner):
(throw.new.Error.async drainMicrotasks):
(async foo):
(async bar):
(async baz):
(async drainMicrotasks):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(linkTimeConstant.promiseOnRejectedWithContext):
(linkTimeConstant.promiseAllOnFulfilled):
(linkTimeConstant.promiseAllNewResolveElement):
(all):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitIsPromiseAllContext):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::promiseAllContextInternalFieldIndex):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getPromiseAllContextInternalField):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putPromiseAllContextInternalField):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNewInternalFieldObject):
* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::promiseAllContextStructure const):
* Source/JavaScriptCore/runtime/JSPromiseAllContext.cpp: Added.
(JSC::JSPromiseAllContext::createWithInitialValues):
(JSC::JSPromiseAllContext::create):
(JSC::JSPromiseAllContext::finishCreation):
(JSC::JSPromiseAllContext::visitChildrenImpl):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSPromiseAllContext.h: Added.
* Source/JavaScriptCore/runtime/JSPromiseAllContextInlines.h: Added.
(JSC::JSPromiseAllContext::createStructure):
* Source/JavaScriptCore/runtime/JSType.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/JSType.h:

Canonical link: <a href="https://commits.webkit.org/300283@main">https://commits.webkit.org/300283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70e1565d5205938bdbf8ac2b68ad840bfea5e4fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74124 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92749 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61631 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73405 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27446 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72088 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114179 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131355 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120557 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101309 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101180 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25650 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46548 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45684 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54561 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150715 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48297 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38561 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->