### PR TITLE
Use `ReflectSetter` for `async` in `HTMLScriptElement`

### DIFF
--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -181,12 +181,6 @@ ExceptionOr<void> HTMLScriptElement::setInnerText(Variant<RefPtr<TrustedScript>,
     setTrustedScriptText(newValue);
     setInnerText(WTFMove(newValue));
     return { };
-}
-
-void HTMLScriptElement::setAsync(bool async)
-{
-    setBooleanAttribute(asyncAttr, async);
-    handleAsyncAttribute();
 }
 
 bool HTMLScriptElement::async() const

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2017 Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Nikolas Zimmermann <zimmermann@kde.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -53,7 +53,6 @@ public:
     String src() const;
     ExceptionOr<void> setSrc(Variant<RefPtr<TrustedScriptURL>, String>&&);
 
-    WEBCORE_EXPORT void setAsync(bool);
     WEBCORE_EXPORT bool async() const;
 
     WEBCORE_EXPORT String crossOrigin() const;

--- a/Source/WebCore/html/HTMLScriptElement.idl
+++ b/Source/WebCore/html/HTMLScriptElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -17,6 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement
+
 [
     Exposed=Window
 ] interface HTMLScriptElement : HTMLElement {
@@ -27,7 +29,7 @@
     [CEReactions=NotNeeded, Reflect="for"] attribute DOMString htmlFor;
     [CEReactions=NotNeeded, Reflect] attribute DOMString event;
     [CEReactions=NotNeeded, Reflect] attribute DOMString charset;
-    [CEReactions=NotNeeded] attribute boolean async;
+    [CEReactions=NotNeeded, ReflectSetter] attribute boolean async;
     [CEReactions=NotNeeded, Reflect] attribute boolean defer;
     [CEReactions=NotNeeded] attribute (TrustedScriptURL or USVString) src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,12 +92,6 @@
 {
     WebCore::JSMainThreadNullState state;
     return IMPL->async();
-}
-
-- (void)setAsync:(BOOL)newAsync
-{
-    WebCore::JSMainThreadNullState state;
-    IMPL->setAsync(newAsync);
 }
 
 - (BOOL)defer


### PR DESCRIPTION
#### 85d7d48a35e86d274d0c3c2accbd2d6c017de84d
<pre>
Use `ReflectSetter` for `async` in `HTMLScriptElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298601">https://bugs.webkit.org/show_bug.cgi?id=298601</a>
<a href="https://rdar.apple.com/problem/160200604">rdar://problem/160200604</a>

Reviewed by NOBODY (OOPS!).

This patch just leverages `ReflectSetter` for `async` in HTMLScriptElement
post suggestion from Anne since similar was done for SVGScriptElement.

* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::setAsync): Deleted.
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLScriptElement.idl:
* Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm:
(-[DOMHTMLScriptElement setAsync:]): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85d7d48a35e86d274d0c3c2accbd2d6c017de84d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72164 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0353d00-393a-4bfb-afe0-72caa87938ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48362 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91201 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60510 "Found 4 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/451e282e-8465-4625-9e29-3236ee9495e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123043 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32333 "Found 4 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47a663f4-018f-4b20-94c7-599b13021b31) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31368 "Found 7 new test failures: imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/in-order.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25782 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70063 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101812 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25969 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129344 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47011 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35658 "Found 12 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99817 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/execorder.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99661 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45115 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23139 "Found 11 new test failures: fast/dom/Document/document-current-script.html fast/dom/HTMLScriptElement/script-async-attr.html http/tests/misc/async-script-removed.html http/tests/misc/script-async-load-execute-in-order.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_007.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/async_010.htm imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/091.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/105.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/123.html imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/126.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43642 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46873 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52579 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46340 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48025 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->