### PR TITLE
Fix bad interaction of anchor positioning and overscroll

### DIFF
--- a/LayoutTests/fast/scrolling/anchor-overscroll-fixed-expected.html
+++ b/LayoutTests/fast/scrolling/anchor-overscroll-fixed-expected.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Test anchor positioning vs overscroll</title>
+
+<style>
+* { box-sizing: border-box; }
+html {
+  border: solid black;
+  width: 200vw;
+  height: 200vh;
+  scrollbar-width: none;
+  position: relative;
+}
+body {
+  margin: 0;
+}
+
+#anchor {
+  width: 40vw;
+  height: 40vh;
+  margin-inline-start: 80vw;
+  margin-block-start: 80vh;
+  background: orange;
+}
+
+.anchored {
+  position: absolute;
+  top: 120vh;
+  left: 40vw;
+  width: 40vw;
+  height: 40vh;
+  border: solid aqua 4px;
+  background: teal;
+}
+</style>
+
+<div id="anchor"></div>
+<div class="anchored"></div>
+
+<script src="../../resources/ui-helper.js"></script>
+<script>
+async function run()
+{
+  // Scroll to end.
+  var scrollHeight = document.documentElement.offsetHeight / 2;
+  document.documentElement.scrollTop = scrollHeight - 10;
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  // Scroll down into overscroll area.
+  await UIHelper.startMonitoringWheelEvents();
+  eventSender.mouseMoveTo(10, 10);
+  eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -53, "began", "none");
+  eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -53, "changed", "none");
+  await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  document.documentElement.classList.remove('reftest-wait');
+}
+
+run();
+</script>

--- a/LayoutTests/fast/scrolling/anchor-overscroll-fixed.html
+++ b/LayoutTests/fast/scrolling/anchor-overscroll-fixed.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Test anchor positioning vs overscroll</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#scroll">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#fallback-apply">
+<script src="resources/overscroll-behavior-support.js"></script>
+
+<style>
+* { box-sizing: border-box; }
+html {
+  border: solid black;
+  width: 200vw;
+  height: 200vh;
+  scrollbar-width: none;
+}
+body {
+  margin: 0;
+}
+
+#anchor {
+  anchor-name: --a;
+  width: 40vw;
+  height: 40vh;
+  margin-inline-start: 80vw;
+  margin-block-start: 80vh;
+  background: orange;
+}
+
+.anchored {
+  position: fixed;
+  width: 40vw;
+  height: 40vh;
+  position-anchor: --a;
+}
+.anchored.area {
+  position-area: start;
+  position-try: end start, start end, end end;
+  background: teal;
+}
+.anchored.inset {
+  position-try: --ia1, --ia2, --ia3;
+  inset-block-end: anchor(outside);
+  inset-inline-end: anchor(outside);
+  border: solid aqua 4px;
+}
+
+@position-try --ia1 {
+  inset: auto;
+  inset-block-start: anchor(outside);
+  inset-inline-end: anchor(outside);
+}
+@position-try --ia2 {
+  inset: auto;
+  inset-block-end: anchor(outside);
+  inset-inline-start: anchor(outside);
+}
+@position-try --ia3 {
+  inset: auto;
+  inset-block-start: anchor(outside);
+  inset-inline-start: anchor(outside);
+}
+</style>
+
+<div id="anchor"></div>
+<div class="anchored area" id=position-area></div>
+<div class="anchored inset" id=anchor-func></div>
+
+<script src="../../resources/ui-helper.js"></script>
+<script>
+async function run()
+{
+  // Scroll to end.
+  var scrollHeight = document.documentElement.offsetHeight / 2;
+  document.documentElement.scrollTop = scrollHeight - 10;
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  // Scroll down into overscroll area.
+  await UIHelper.startMonitoringWheelEvents();
+  eventSender.mouseMoveTo(10, 10);
+  eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -53, "began", "none");
+  eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -53, "changed", "none");
+  await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  document.documentElement.classList.remove('reftest-wait');
+}
+
+run();
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Should use the last (fourth) position option initially
-FAIL Should still use the last position option as long as it fits. assert_equals: Anchored element should be at the left of anchor expected 650 but got 800
+PASS Should still use the last position option as long as it fits.
 PASS Should use the third position option with enough space below, and not enough above
-FAIL Should use the second position option with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 550
-FAIL Should still use the second position option as long as it fits assert_equals: Anchored element should be at the top of anchor expected 350 but got 450
-FAIL Should use the first position option with enough space below and right assert_equals: Anchored element should be at the bottom of anchor expected 199 but got 350
+FAIL Should use the second position option with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+FAIL Should still use the second position option as long as it fits assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+PASS Should use the first position option with enough space below and right
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Should use the last position option initially
-FAIL Should stay at initial position, since it still fits assert_equals: Anchored element should be at the top of anchor expected 450 but got 600
+PASS Should stay at initial position, since it still fits
 PASS Should use the third position option with enough space left
 PASS Should use the first position option with enough space left and below
-FAIL Should use the second position option with enough space below (and not enough above) assert_equals: Anchored element should be at the right of anchor expected 135 but got 35
+PASS Should use the second position option with enough space below (and not enough above)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
 FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got 335
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 235
+FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
 PASS Should use the first fallback position with enough space left and above
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
 FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
-FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 350
+FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 250
 PASS Should use the first fallback position with enough space right and below
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
 FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 235
+FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
 PASS Should use the first fallback position with enough space right and above
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Should use the first fallback position at the initial scroll offset
-FAIL Should use the second fallback position after scrolling left assert_equals: Anchored element should be at the left of anchor expected 601 but got 700
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004-expected.txt
@@ -1,5 +1,0 @@
-
-PASS Should use the first fallback position at the initial scroll offsets
-FAIL Should use the second fallback position after scrolling viewport down assert_equals: Anchored element should be at the bottom of anchor expected 199 but got 100
-PASS Should use the third fallback position after scrolling the vrl scroller left
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-005-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-005-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Should use the first fallback position at the initial scroll offset
-FAIL Should use the second fallback position after scrolling left assert_equals: Anchored element should be at the left of anchor expected 601 but got 700
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
@@ -1,8 +1,0 @@
-
-PASS Should use the last (fourth) position option initially
-FAIL Should still use the last position option as long as it fits. assert_equals: Anchored element should be at the top of anchor expected 350 but got 600
-FAIL Should use the third position option with enough space below, and not enough above assert_equals: Anchored element should be at the bottom of anchor expected 199 but got 500
-FAIL Should use the second position option with enough space right assert_equals: Anchored element should be at the top of anchor expected 450 but got 600
-FAIL Should still use the second position option as long as it fits assert_equals: Anchored element should be at the top of anchor expected 350 but got 600
-FAIL Should use the first position option with enough space below and right assert_equals: Anchored element should be at the bottom of anchor expected 199 but got 500
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt
@@ -1,7 +1,0 @@
-
-PASS Should use the last position option initially
-FAIL Should stay at initial position, since it still fits assert_equals: Anchored element should be at the top of anchor expected 450 but got 600
-FAIL Should use the third position option with enough space left assert_equals: Anchored element should be at the left of anchor expected 586 but got 85
-FAIL Should use the first position option with enough space left and below assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
-FAIL Should use the second position option with enough space below (and not enough above) assert_equals: Anchored element should be at the right of anchor expected 135 but got -15
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
@@ -1,6 +1,0 @@
-
-PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space left assert_equals: Anchored element should be at the left of anchor expected 135 but got 85
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the right of anchor expected 135 but got -15
-FAIL Should use the first fallback position with enough space left and above assert_equals: Anchored element should be at the left of anchor expected 586 but got 85
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
@@ -1,6 +1,0 @@
-
-PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
-FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the left of anchor expected 650 but got 800
-FAIL Should use the first fallback position with enough space right and below assert_equals: Anchored element should be at the right of anchor expected 199 but got 700
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
@@ -1,6 +1,0 @@
-
-PASS Should use the last fallback position initially
-FAIL Should use the third fallback position with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 700
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the left of anchor expected 650 but got 800
-FAIL Should use the first fallback position with enough space right and above assert_equals: Anchored element should be at the right of anchor expected 199 but got 700
-

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -167,7 +167,7 @@ public:
 
     Vector<AnchorScrollAdjuster>& anchorScrollAdjusters() { return m_anchorScrollAdjusters; }
     const AnchorScrollAdjuster* anchorScrollAdjusterFor(const RenderBox& anchored) const;
-    void registerAnchorScrollAdjuster(AnchorScrollAdjuster&&);
+    AnchorScrollAdjuster::Diff registerAnchorScrollAdjuster(AnchorScrollAdjuster&&);
     void unregisterAnchorScrollAdjusterFor(const RenderBox& anchored);
     void invalidateAnchorDependenciesForScroller(const RenderBox& scroller);
     void removeScrollerFromAnchorScrollAdjusters(const RenderBox& scroller);

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -773,9 +773,6 @@ bool RenderBlock::simplifiedLayout()
 
     updateScrollInfoAfterLayout();
 
-    if (Style::AnchorPositionEvaluator::isAnchorPositioned(style()))
-        Style::AnchorPositionEvaluator::captureScrollSnapshots(*this);
-
     clearNeedsLayout();
     return true;
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1255,6 +1255,19 @@ ScrollPosition RenderBox::scrollPosition() const
     return scrollableArea->scrollPosition();
 }
 
+ScrollPosition RenderBox::constrainedScrollPosition() const
+{
+    if (!hasPotentiallyScrollableOverflow())
+        return { 0, 0 };
+
+    ASSERT(hasLayer());
+    auto* scrollableArea = layer()->scrollableArea();
+    if (!scrollableArea)
+        return { 0, 0 };
+
+    return scrollableArea->constrainedScrollPosition(scrollableArea->scrollPosition());
+}
+
 LayoutSize RenderBox::cachedSizeForOverflowClip() const
 {
     ASSERT(hasNonVisibleOverflow());

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -558,6 +558,7 @@ public:
     virtual bool shouldInvalidatePreferredWidths() const;
 
     ScrollPosition scrollPosition() const;
+    ScrollPosition constrainedScrollPosition() const;
     LayoutSize cachedSizeForOverflowClip() const;
 
     // Returns false if the rect has no intersection with the applied clip rect. When the context specifies edge-inclusive

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -129,15 +129,24 @@ RenderBox* AnchorScrollAdjuster::anchored() const
     return m_anchored.ptr();
 }
 
+bool AnchorScrollAdjuster::recaptureDiffers(const AnchorScrollAdjuster& other) const
+{
+    bool same = m_anchored.ptr() == other.m_anchored.ptr()
+        && m_scrollSnapshots == other.m_scrollSnapshots
+        && m_stickySnapshot == other.m_stickySnapshot;
+    return !same;
+}
+
 void AnchorScrollAdjuster::addSnapshot(const RenderBox& scroller)
 {
     ASSERT(scroller.hasPotentiallyScrollableOverflow() && !is<RenderView>(scroller));
-    m_scrollSnapshots.constructAndAppend(scroller, scroller.scrollPosition());
+    m_scrollSnapshots.constructAndAppend(scroller, scroller.constrainedScrollPosition());
 }
 
 void AnchorScrollAdjuster::addViewportSnapshot(const RenderView& renderView)
 {
-    auto position = renderView.frameView().scrollPositionRespectingCustomFixedPosition();
+    auto& view = renderView.frameView();
+    auto position = view.constrainedScrollPosition(ScrollPosition(view.scrollPositionRespectingCustomFixedPosition()));
     m_scrollSnapshots.insert(0, AnchorScrollSnapshot { position });
     m_adjustForViewport = true;
 }
@@ -147,8 +156,9 @@ LayoutSize AnchorScrollAdjuster::adjustmentForViewport(const RenderView& renderV
     if (m_adjustForViewport) {
         // Viewport snapshot is stored in the first slot.
         ASSERT(m_scrollSnapshots.size() && !m_scrollSnapshots.first().m_scroller);
+        auto& view = renderView.frameView();
         return m_scrollSnapshots.first().m_scrollSnapshot
-            - renderView.frameView().scrollPositionRespectingCustomFixedPosition();
+            - view.constrainedScrollPosition(IntPoint(view.scrollPositionRespectingCustomFixedPosition()));
     }
     return { };
 }
@@ -230,21 +240,17 @@ static inline void clearAnchorScrollSnapshots(RenderBox& anchored)
     anchored.layoutContext().unregisterAnchorScrollAdjusterFor(anchored);
 }
 
-void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored)
+void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored, bool invalidateStyleForScrollPositionChanges)
 {
-    ASSERT(Style::AnchorPositionEvaluator::isAnchorPositioned(anchored.style()));
-
-    if (!anchored.layer()) {
-        ASSERT_NOT_REACHED();
+    if (!anchored.layer())
         return;
-    }
 
     CheckedPtr defaultAnchor = AnchorPositionEvaluator::defaultAnchorForBox(anchored);
     if (!defaultAnchor)
         return clearAnchorScrollSnapshots(anchored);
 
     AnchorScrollAdjuster adjuster(anchored, *defaultAnchor);
-    if (!adjuster.mayNeedAdjustment())
+    if (!adjuster.mayNeedAdjustment()) // Note: We sometimes hit this path during interleaved layout because style bits aren't set yet.
         return clearAnchorScrollSnapshots(anchored);
 
     CheckedPtr containingBlock = anchored.containingBlock();
@@ -269,7 +275,12 @@ void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored)
     if (!anchored.style().positionTryFallbacks().isEmpty())
         adjuster.setFallbackLimits(anchored);
 
-    anchored.layoutContext().registerAnchorScrollAdjuster(WTFMove(adjuster));
+    auto captureDiff = anchored.layoutContext().registerAnchorScrollAdjuster(WTFMove(adjuster));
+    if (invalidateStyleForScrollPositionChanges && AnchorScrollAdjuster::SnapshotsDiffer == captureDiff && anchored.style().usesAnchorFunctions()) {
+        // Scroll positions changed since the last capture, which means anchor() resolution needs updating.
+        if (CheckedPtr element = anchored.element())
+            element->invalidateForAnchorRectChange();
+    }
     anchored.layer()->setAnchorScrollAdjustment({ });
 }
 
@@ -406,6 +417,12 @@ static LayoutSize offsetFromAncestorContainer(const RenderElement& descendantCon
             break;
         LayoutSize currentOffset = currentContainer->offsetFromContainer(*nextContainer, referencePoint);
 
+        if (CheckedPtr boxContainer = dynamicDowncast<RenderBox>(*nextContainer)) {
+            // Clamp overscroll so we don't layout into it.
+            if (boxContainer->hasPotentiallyScrollableOverflow())
+                currentOffset += boxContainer->scrollPosition() - boxContainer->constrainedScrollPosition();
+        }
+
         offset += currentOffset;
         referencePoint.move(currentOffset);
         currentContainer = WTFMove(nextContainer);
@@ -423,7 +440,7 @@ static LayoutSize offsetFromAncestorContainer(const RenderElement& descendantCon
     }
 
     if (auto ancestorBox = dynamicDowncast<RenderBox>(ancestorContainer)) // Zero out containing block scroll position.
-        offset += toLayoutSize(ancestorBox->scrollPosition());
+        offset += toLayoutSize(ancestorBox->constrainedScrollPosition());
 
     return offset;
 }
@@ -494,8 +511,10 @@ LayoutRect AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(C
                 break;
             }
         }
-        if (!isFixedAnchor)
-            anchorLocation.moveBy(-anchorBox->view().frameView().scrollPositionRespectingCustomFixedPosition());
+        if (!isFixedAnchor) {
+            auto& view = anchorBox->view().frameView();
+            anchorLocation.moveBy(-view.constrainedScrollPosition(ScrollPosition(view.scrollPositionRespectingCustomFixedPosition())));
+        }
     }
 
     if (CheckedPtr containingBox = dynamicDowncast<RenderBox>(containingBlock)) {
@@ -1239,8 +1258,13 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
             state.stage = renderer && renderer->style().usesAnchorFunctions() ? AnchorPositionResolutionStage::ResolveAnchorFunctions : AnchorPositionResolutionStage::Resolved;
             continue;
         }
-        if (state.stage == AnchorPositionResolutionStage::Resolved)
+        if (state.stage == AnchorPositionResolutionStage::Resolved) {
+            if (CheckedPtr anchored = elementAndState.key.first->renderer()) {
+                if (auto anchoredBox = dynamicDowncast<RenderBox>(anchored.get()))
+                    AnchorPositionEvaluator::captureScrollSnapshots(*anchoredBox, false);
+            }
             state.stage = AnchorPositionResolutionStage::Positioned;
+        }
     }
 }
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -63,6 +63,7 @@ struct AnchorScrollSnapshot {
     inline LayoutSize adjustmentForCurrentScrollPosition() const;
     AnchorScrollSnapshot(const RenderBox& scroller, LayoutPoint snapshot);
     AnchorScrollSnapshot(LayoutPoint snapshot);
+    bool operator==(const AnchorScrollSnapshot&) const = default;
 };
 
 class AnchorScrollAdjuster {
@@ -77,6 +78,9 @@ public:
 
     inline void addSnapshot(const RenderBox& scroller);
     inline void addViewportSnapshot(const RenderView&);
+
+    enum Diff : uint8_t { New, SnapshotsDiffer, SnapshotsMatch };
+    bool recaptureDiffers(const AnchorScrollAdjuster&) const; // Snapshot differences can require invalidation.
 
     void setFallbackLimits(const RenderBox& anchored);
     bool hasFallbackLimits() const { return m_hasFallback; }
@@ -170,7 +174,7 @@ public:
     static void updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(Element&, const RenderStyle&, AnchorPositionedStates&);
 
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderElement& containingBlock, const RenderBox& anchoredBox);
-    static void captureScrollSnapshots(RenderBox& anchored);
+    static void captureScrollSnapshots(RenderBox& anchored, bool invalidateStyleForScrollPositionChanges = true);
 
     static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap&);
 


### PR DESCRIPTION
#### 43c5d324c08a2c8f6c5ba88a499435f50975b73e
<pre>
Fix bad interaction of anchor positioning and overscroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=298031">https://bugs.webkit.org/show_bug.cgi?id=298031</a>
<a href="https://rdar.apple.com/159356009">rdar://159356009</a>

Reviewed by Antti Koivisto.

This patch fixes several problems that are triggered during overscroll:
1. We need to clamp the scroll position to avoid laying out into the
   overscroll area.
2. We need to not recapture scroll positions when we are running layout
   only on the children (and therefore not recalculating the rect itself).
3. We need to ensure that a scroll-dependent anchor() gets recalculated
   whenever layout triggers a recapture of the scroll positions, so that
   the capture and the anchor() resolution don&apos;t get out of sync.

* LayoutTests/fast/scrolling/anchor-overscroll-fixed-expected.html: Added.
* LayoutTests/fast/scrolling/anchor-overscroll-fixed.html: Added.

Add test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-005-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt: Removed.

Pass more tests.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::registerAnchorScrollAdjuster):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:

Return whether or not the recapture differs.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::simplifiedLayout):

Don&apos;t capture during layout that skips rect calculation, so that the
rect and the capture stay in sync.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::constrainedScrollPosition const):

Add helper method to get the constrained scroll position.

* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::AnchorScrollAdjuster::recaptureDiffers const):

Add helper method to identify differing captures.

(WebCore::AnchorScrollAdjuster::addSnapshot):
(WebCore::AnchorScrollAdjuster::addViewportSnapshot):
(WebCore::AnchorScrollAdjuster::adjustmentForViewport const):

Constrain the scroll position.

(WebCore::Style::AnchorPositionEvaluator::captureScrollSnapshots):

Allow calling captureScrollSnapshots() from style resolution.
Trigger style invalidation when the capture differs.

(WebCore::Style::offsetFromAncestorContainer):
(WebCore::Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock):

Constrain the scroll position.

(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):

Capture scroll positions when resolving anchor() functions so they can
be compared to the positions captured during layout.

* Source/WebCore/style/AnchorPositionEvaluator.h:

Update API for above changes.

Canonical link: <a href="https://commits.webkit.org/300061@main">https://commits.webkit.org/300061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/772a86a74f96d2e9a497083c5e872360a53e9ccd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73274 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/691bd9f2-8789-4a35-aab1-999956cfc9f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92063 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7137a53-6b01-43f3-9975-38a08a203708) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72741 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0db822f-e1ea-4ffe-9389-ff1a90170a92) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26734 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71206 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130465 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100666 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44814 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53691 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->