### PR TITLE
Support SVGAElement type attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1555,7 +1555,7 @@ FAIL SVGAElement interface: attribute ping assert_true: The prototype object mus
 PASS SVGAElement interface: attribute rel
 PASS SVGAElement interface: attribute relList
 PASS SVGAElement interface: attribute hreflang
-FAIL SVGAElement interface: attribute type assert_true: The prototype object must have a property "type" expected true got false
+PASS SVGAElement interface: attribute type
 FAIL SVGAElement interface: attribute text assert_true: The prototype object must have a property "text" expected true got false
 FAIL SVGAElement interface: attribute referrerPolicy assert_true: The prototype object must have a property "referrerPolicy" expected true got false
 FAIL SVGAElement interface: attribute origin assert_true: The prototype object must have a property "origin" expected true got false
@@ -1577,7 +1577,7 @@ FAIL SVGAElement interface: objects.a must inherit property "ping" with the prop
 PASS SVGAElement interface: objects.a must inherit property "rel" with the proper type
 PASS SVGAElement interface: objects.a must inherit property "relList" with the proper type
 PASS SVGAElement interface: objects.a must inherit property "hreflang" with the proper type
-FAIL SVGAElement interface: objects.a must inherit property "type" with the proper type assert_inherits: property "type" not found in prototype chain
+PASS SVGAElement interface: objects.a must inherit property "type" with the proper type
 FAIL SVGAElement interface: objects.a must inherit property "text" with the proper type assert_inherits: property "text" not found in prototype chain
 FAIL SVGAElement interface: objects.a must inherit property "referrerPolicy" with the proper type assert_inherits: property "referrerPolicy" not found in prototype chain
 FAIL SVGAElement interface: objects.a must inherit property "origin" with the proper type assert_inherits: property "origin" not found in prototype chain

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-01-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SVGAElement.type getter
+PASS Test anchor's type getter when type attribute missing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-01.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-01.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>SVGAElement.type getter</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+  </metadata>
+  <a id="test" href="a"></a>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      var a = document.getElementById("test");
+
+      test(function() {
+        assert_equals(a.type, "");
+       }, "Test anchor's type getter when type attribute missing");
+    });
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-02-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-02-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SVGAElement.type getter
+PASS Test anchor's type getter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-02.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-getter-02.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>SVGAElement.type getter</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+  </metadata>
+  <a id="test" href="a" type="text/plain"></a>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      var a = document.getElementById("test");
+
+      test(function() {
+        assert_equals(a.type, "text/plain");
+       }, "Test anchor's type getter");
+    });
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-setter-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-setter-01-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SVGAElement.type setter
+PASS Test anchor's type setter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-setter-01.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.type-setter-01.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>SVGAElement.type setter</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement"/>
+  </metadata>
+  <a id="test" href="a"></a>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+        var a = document.getElementById("test");
+
+        test(function() {
+            a.type = "plain/text"
+            assert_equals(a.type, "plain/text");
+        }, "Test anchor's type setter");
+    });
+  ]]></script>
+</svg>

--- a/Source/WebCore/svg/SVGAElement.idl
+++ b/Source/WebCore/svg/SVGAElement.idl
@@ -31,6 +31,7 @@
     [Reflect] attribute DOMString hreflang;
     [Reflect] attribute DOMString rel;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    [Reflect] attribute DOMString type;
 };
 
 SVGAElement includes SVGURIReference;


### PR DESCRIPTION
#### cce70bac4210b0c88e84132ec46c830309ed6f5e
<pre>
Support SVGAElement type attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=298605">https://bugs.webkit.org/show_bug.cgi?id=298605</a>

Reviewed by Darin Adler.

This adds the type IDL attribute to the SVGAElement.

Canonical link: <a href="https://commits.webkit.org/299770@main">https://commits.webkit.org/299770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30d80a1d8feefe883b17709caf398adea2e50fe2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91218 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60524 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25800 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70081 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129362 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99677 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25311 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43660 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52597 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->