### PR TITLE
Array allocation sinking should split allocations into two, an Array allocation and a Butterfly allocation

### DIFF
--- a/JSTests/stress/array-allocation-elimination-closure-capture.js
+++ b/JSTests/stress/array-allocation-elimination-closure-capture.js
@@ -1,0 +1,207 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Test array allocation with closure capture scenarios
+
+// Function that creates a closure value
+function createClosureValue(multiplier) {
+    return function(x) {
+        return x * multiplier;
+    };
+}
+
+// Function that allocates an array with fixed size
+function allocateArrayForClosure(baseValue) {
+    const arr = new Array(5);
+    for (let i = 0; i < 5; i++) {
+        arr[i] = baseValue + i;
+    }
+    return arr;
+}
+
+// Function that uses array and captures closure
+function processWithClosure(closureFn, arr) {
+    let result = 0;
+    for (let i = 0; i < arr.length; i++) {
+        result += closureFn(arr[i]);
+    }
+    return result;
+}
+
+// Complex scenario: array allocation, closure capture, and usage all in different functions
+function complexClosureTest(multiplier, baseValue) {
+    const closureFn = createClosureValue(multiplier);
+    const arr = allocateArrayForClosure(baseValue);
+    return processWithClosure(closureFn, arr);
+}
+
+// Scenario where closure modifies array behavior
+function closureModifiesArray(capturedValue) {
+    return function(baseValue) {
+        const arr = new Array(4);
+        for (let i = 0; i < 4; i++) {
+            arr[i] = (baseValue + i) + capturedValue;
+        }
+
+        // Array usage within the closure
+        let sum = 0;
+        for (let i = 0; i < arr.length; i++) {
+            sum += arr[i] * 2;
+        }
+        return sum;
+    };
+}
+
+// Nested closure with array
+function nestedClosureWithArray(outerValue) {
+    return function(middleValue) {
+        return function(baseValue) {
+            const arr = new Array(3);
+            for (let i = 0; i < 3; i++) {
+                arr[i] = baseValue + i + outerValue + middleValue;
+            }
+
+            // Process array using captured values
+            let product = 1;
+            for (let i = 0; i < arr.length; i++) {
+                product *= (arr[i] % 10) || 1; // avoid zero
+            }
+            return product;
+        };
+    };
+}
+
+let escapedArray = null;
+// Array that sometimes escapes through closure
+function conditionalEscapeViaClosure(shouldEscape) {
+
+    return function(baseValue) {
+        const arr = new Array(4);
+        for (let i = 0; i < 4; i++) {
+            arr[i] = baseValue + i * 2;
+        }
+
+        if (shouldEscape) {
+            escapedArray = arr;
+            return arr.length;
+        } else {
+            // Use array locally
+            let sum = 0;
+            for (let i = 0; i < arr.length; i++) {
+                sum += arr[i];
+            }
+            return sum;
+        }
+    };
+}
+
+// Closure that captures array from outer scope
+function captureArrayInClosure(baseValue) {
+    const arr = new Array(6);
+    for (let i = 0; i < 6; i++) {
+        arr[i] = baseValue + i;
+    }
+
+    // Return closure that uses the captured array
+    return function(multiplier) {
+        let result = 0;
+        for (let i = 0; i < arr.length; i++) {
+            result += arr[i] * multiplier;
+        }
+        return result;
+    };
+}
+
+// Multiple arrays with closure interactions
+function multiArrayClosure(factor1, factor2) {
+    return function(baseValue) {
+        const arr1 = new Array(3);
+        const arr2 = new Array(3);
+
+        for (let i = 0; i < 3; i++) {
+            arr1[i] = (baseValue + i) * factor1;
+            arr2[i] = (baseValue + i) * factor2;
+        }
+
+        // Combine arrays using closure variables
+        let combined = 0;
+        for (let i = 0; i < 3; i++) {
+            combined += arr1[i] + arr2[i];
+        }
+        return combined;
+    };
+}
+
+noInline(complexClosureTest);
+noInline(closureModifiesArray);
+noInline(nestedClosureWithArray);
+noInline(conditionalEscapeViaClosure);
+noInline(captureArrayInClosure);
+noInline(multiArrayClosure);
+
+// Run tests
+for (let i = 0; i < testLoopCount; i++) {
+    const baseValue = i % 8;
+    const multiplier = 1 + (i % 3); // multipliers 1-3
+
+    // Test complex closure scenario (array size 5)
+    let result1 = complexClosureTest(multiplier, baseValue);
+    let expected1 = 0;
+    for (let j = 0; j < 5; j++) {
+        expected1 += (baseValue + j) * multiplier;
+    }
+    assert(result1 === expected1, `complexClosureTest(${multiplier}, ${baseValue}) failed: got ${result1}, expected ${expected1}`);
+
+    // Test closure that modifies array behavior (array size 4)
+    const closureFn = closureModifiesArray(i % 5);
+    let result2 = closureFn(baseValue);
+    let expected2 = 0;
+    for (let j = 0; j < 4; j++) {
+        expected2 += (baseValue + j + (i % 5)) * 2;
+    }
+    assert(result2 === expected2, `closureModifiesArray test failed: got ${result2}, expected ${expected2}`);
+
+    // Test nested closure (array size 3)
+    const nestedFn = nestedClosureWithArray(i % 3)(i % 4);
+    let result3 = nestedFn(baseValue);
+    let expected3 = 1;
+    for (let j = 0; j < 3; j++) {
+        let val = (baseValue + j + (i % 3) + (i % 4)) % 10;
+        if (val !== 0) expected3 *= val;
+    }
+    assert(result3 === expected3, `nestedClosureWithArray test failed: got ${result3}, expected ${expected3}`);
+
+    // Test conditional escape via closure - non-escaping case (array size 4)
+    const condEscapeFn = conditionalEscapeViaClosure(false);
+    let result4 = condEscapeFn(baseValue);
+    let expected4 = 0;
+    for (let j = 0; j < 4; j++) {
+        expected4 += baseValue + j * 2;
+    }
+    assert(result4 === expected4, `conditionalEscapeViaClosure(false) test failed: got ${result4}, expected ${expected4}`);
+
+    // Test conditional escape via closure - escaping case (array size 4)
+    const condEscapeFn2 = conditionalEscapeViaClosure(true);
+    let result5 = condEscapeFn2(baseValue);
+    assert(result5 === 4, `conditionalEscapeViaClosure(true) test failed: got ${result5}, expected 4`);
+
+    // Test capture array in closure (array size 6)
+    const capturedFn = captureArrayInClosure(baseValue);
+    let result6 = capturedFn(multiplier);
+    let expected6 = 0;
+    for (let j = 0; j < 6; j++) {
+        expected6 += (baseValue + j) * multiplier;
+    }
+    assert(result6 === expected6, `captureArrayInClosure test failed: got ${result6}, expected ${expected6}`);
+
+    // Test multiple arrays with closure (arrays size 3 each)
+    const multiArrayFn = multiArrayClosure(2, 3);
+    let result7 = multiArrayFn(baseValue);
+    let expected7 = 0;
+    for (let j = 0; j < 3; j++) {
+        expected7 += (baseValue + j) * 2 + (baseValue + j) * 3; // factor1 + factor2
+    }
+    assert(result7 === expected7, `multiArrayClosure test failed: got ${result7}, expected ${expected7}`);
+}

--- a/JSTests/stress/array-allocation-elimination-conditional-usage.js
+++ b/JSTests/stress/array-allocation-elimination-conditional-usage.js
@@ -1,0 +1,108 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Test conditional array usage - some branches use array, others don't
+function testConditionalArrayUsage(useArray, writeValue) {
+    const arr = new Array(5);
+
+    if (useArray) {
+        // Branch that uses the array
+        arr[0] = writeValue;
+        arr[2] = writeValue + 10;
+        arr[4] = writeValue + 20;
+
+        let sum = 0;
+        for (let i = 0; i < 5; i++) {
+            if (arr[i] !== undefined) {
+                sum += arr[i];
+            }
+        }
+        return sum;
+    } else {
+        // Branch that doesn't use the array at all
+        return writeValue * 3 + 30; // Same result as the sum above when writeValue = 0
+    }
+}
+
+// Test with nested conditionals
+function testNestedConditionalArray(outer, inner, value) {
+    const arr = new Array(3);
+
+    if (outer) {
+        arr[0] = value;
+
+        if (inner) {
+            arr[1] = value * 2;
+            arr[2] = value * 3;
+            return arr[0] + arr[1] + arr[2]; // value * 6
+        } else {
+            // Only use first element
+            return arr[0]; // value
+        }
+    } else {
+        // Don't use array at all
+        return inner ? value * 6 : value;
+    }
+}
+
+// Test with early return that skips array usage
+function testEarlyReturnArray(shouldReturn, value) {
+    const arr = new Array(4);
+
+    if (shouldReturn) {
+        return value * 42;
+    }
+
+    // This array usage should be eliminated when shouldReturn is true
+    arr[0] = value;
+    arr[1] = value + 1;
+    arr[3] = value + 3;
+
+    return arr[0] + arr[1] + arr[3]; // value * 3 + 4
+}
+
+noInline(testConditionalArrayUsage);
+noInline(testNestedConditionalArray);
+noInline(testEarlyReturnArray);
+
+// Run tests to trigger optimization
+for (let i = 0; i < testLoopCount; i++) {
+    // Test the branch that uses the array
+    let result1 = testConditionalArrayUsage(true, i % 100);
+    let expected1 = (i % 100) + (i % 100 + 10) + (i % 100 + 20);
+    assert(result1 === expected1, `testConditionalArrayUsage(true, ${i % 100}) failed: got ${result1}, expected ${expected1}`);
+
+    // Test the branch that doesn't use the array
+    let result2 = testConditionalArrayUsage(false, i % 100);
+    let expected2 = (i % 100) * 3 + 30;
+    assert(result2 === expected2, `testConditionalArrayUsage(false, ${i % 100}) failed: got ${result2}, expected ${expected2}`);
+
+    // Test nested conditionals
+    let val = i % 10;
+
+    // outer=true, inner=true
+    let result3 = testNestedConditionalArray(true, true, val);
+    assert(result3 === val * 6, `testNestedConditionalArray(true, true, ${val}) failed: got ${result3}, expected ${val * 6}`);
+
+    // outer=true, inner=false
+    let result4 = testNestedConditionalArray(true, false, val);
+    assert(result4 === val, `testNestedConditionalArray(true, false, ${val}) failed: got ${result4}, expected ${val}`);
+
+    // outer=false, inner=true
+    let result5 = testNestedConditionalArray(false, true, val);
+    assert(result5 === val * 6, `testNestedConditionalArray(false, true, ${val}) failed: got ${result5}, expected ${val * 6}`);
+
+    // outer=false, inner=false
+    let result6 = testNestedConditionalArray(false, false, val);
+    assert(result6 === val, `testNestedConditionalArray(false, false, ${val}) failed: got ${result6}, expected ${val}`);
+
+    // Test early return
+    let result7 = testEarlyReturnArray(true, val);
+    assert(result7 === val * 42, `testEarlyReturnArray(true, ${val}) failed: got ${result7}, expected ${val * 42}`);
+
+    let result8 = testEarlyReturnArray(false, val);
+    let expected8 = val * 3 + 4;
+    assert(result8 === expected8, `testEarlyReturnArray(false, ${val}) failed: got ${result8}, expected ${expected8}`);
+}

--- a/JSTests/stress/array-allocation-elimination-cross-function.js
+++ b/JSTests/stress/array-allocation-elimination-cross-function.js
@@ -1,0 +1,165 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Function that allocates and returns an array
+function allocateArray(size, fillValue) {
+    const arr = new Array(size);
+    for (let i = 0; i < size; i++) {
+        arr[i] = fillValue + i;
+    }
+    return arr;
+}
+
+// Function that processes an array but doesn't escape it
+function processArray(arr) {
+    let sum = 0;
+    for (let i = 0; i < arr.length; i++) {
+        sum += arr[i] * 2;
+    }
+    return sum;
+}
+
+// Function that modifies an array in place
+function modifyArray(arr, multiplier) {
+    for (let i = 0; i < arr.length; i++) {
+        arr[i] *= multiplier;
+    }
+}
+
+// Function that escapes the array by storing it globally
+let globalArray = null;
+function escapeArray(arr) {
+    globalArray = arr;
+    return arr.length;
+}
+noInline(escapeArray);
+
+// Simple allocation + usage pattern
+function allocateAndUse(size, value) {
+    const arr = allocateArray(size, value);
+    return processArray(arr);
+}
+
+// Allocation + modification + usage pattern
+function allocateModifyAndUse(size, value) {
+    const arr = allocateArray(size, value);
+    modifyArray(arr, 3);
+    return processArray(arr);
+}
+
+// Pattern where array sometimes escapes
+function conditionalEscape(shouldEscape, size, value) {
+    const arr = allocateArray(size, value);
+
+    if (shouldEscape) {
+        return escapeArray(arr);
+    } else {
+        return processArray(arr);
+    }
+}
+
+// Chain of functions passing array
+function chainedProcessing(size, value) {
+    function step1(arr) {
+        // Double all values
+        for (let i = 0; i < arr.length; i++) {
+            arr[i] *= 2;
+        }
+        return arr;
+    }
+
+    function step2(arr) {
+        // Add index to each value
+        for (let i = 0; i < arr.length; i++) {
+            arr[i] += i;
+        }
+        return arr;
+    }
+
+    function step3(arr) {
+        // Sum all values
+        let sum = 0;
+        for (let i = 0; i < arr.length; i++) {
+            sum += arr[i];
+        }
+        return sum;
+    }
+
+    const initial = allocateArray(size, value);
+    const after1 = step1(initial);
+    const after2 = step2(after1);
+    return step3(after2);
+}
+
+// Array allocated in inner function, used in outer
+function nestedAllocation(size, value) {
+    function innerAllocate() {
+        return new Array(size).fill(value);
+    }
+
+    const arr = innerAllocate();
+    let product = 1;
+    for (let i = 0; i < arr.length; i++) {
+        product *= arr[i];
+    }
+    return product;
+}
+
+noInline(allocateAndUse);
+noInline(allocateModifyAndUse);
+noInline(conditionalEscape);
+noInline(chainedProcessing);
+noInline(nestedAllocation);
+
+// Test the cross-function scenarios
+for (let i = 0; i < testLoopCount; i++) {
+    const size = 3 + (i % 5); // sizes 3-7
+    const value = i % 10;
+
+    // Test simple allocation and usage
+    let result1 = allocateAndUse(size, value);
+    let expected1 = 0;
+    for (let j = 0; j < size; j++) {
+        expected1 += (value + j) * 2;
+    }
+    assert(result1 === expected1, `allocateAndUse(${size}, ${value}) failed: got ${result1}, expected ${expected1}`);
+
+    // Test allocation, modification, and usage
+    let result2 = allocateModifyAndUse(size, value);
+    let expected2 = 0;
+    for (let j = 0; j < size; j++) {
+        expected2 += (value + j) * 3 * 2; // modified by 3, then doubled in processArray
+    }
+    assert(result2 === expected2, `allocateModifyAndUse(${size}, ${value}) failed: got ${result2}, expected ${expected2}`);
+
+    // Test conditional escape - non-escaping case
+    let result3 = conditionalEscape(false, size, value);
+    let expected3 = expected1; // same as allocateAndUse
+    assert(result3 === expected3, `conditionalEscape(false, ${size}, ${value}) failed: got ${result3}, expected ${expected3}`);
+
+    // Test conditional escape - escaping case
+    globalArray = null;
+    let result4 = conditionalEscape(true, size, value);
+    assert(result4 === size, `conditionalEscape(true, ${size}, ${value}) failed: got ${result4}, expected ${size}`);
+    assert(globalArray !== null && globalArray.length === size, "Array was not properly escaped");
+
+    // Test chained processing
+    let result5 = chainedProcessing(size, value);
+    let expected5 = 0;
+    for (let j = 0; j < size; j++) {
+        // step1: (value + j) * 2
+        // step2: (value + j) * 2 + j
+        // step3: sum all
+        expected5 += (value + j) * 2 + j;
+    }
+    assert(result5 === expected5, `chainedProcessing(${size}, ${value}) failed: got ${result5}, expected ${expected5}`);
+
+    // Test nested allocation (only when value > 0 to avoid zero product)
+    if (value > 0) {
+        let result6 = nestedAllocation(size, value);
+        let expected6 = Math.pow(value, size);
+        assert(result6 === expected6, `nestedAllocation(${size}, ${value}) failed: got ${result6}, expected ${expected6}`);
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3725,10 +3725,30 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
-    case NewArrayWithConstantSize:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewButterflyWithSize: {
+        SpeculatedType validTypes = [&]() {
+            switch (node->indexingType()) {
+            case ALL_INT32_INDEXING_TYPES: return SpecInt32Only;
+            case ALL_DOUBLE_INDEXING_TYPES: return SpecBytecodeNumber;
+            case ALL_CONTIGUOUS_INDEXING_TYPES: return SpecBytecodeTop;
+            default: break;
+            }
+            RELEASE_ASSERT_NOT_REACHED();
+        }();
+        for (unsigned i = 1; i < node->numChildren(); ++i)
+            RELEASE_ASSERT(isSubtypeSpeculation(forNode(m_graph.varArgChild(node, i)).m_type, validTypes));
+
+        [[fallthrough]];
+    }
+    case NewButterflyWithSize:
+        // We don't represent storage/butterflies in AI.
+        clearForNode(node);
+        break;
+
+    case NewArrayWithButterfly: {
         setForNode(node, m_graph.globalObjectFor(node->origin.semantic)->arrayStructureForIndexingTypeDuringAllocation(node->indexingMode()));
         break;
+    }
 
     case NewTypedArray: {
         switch (node->child1().useKind()) {
@@ -3990,7 +4010,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewButterflyWithSize:
+    case PhantomNewArrayWithButterfly:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -525,7 +525,6 @@ private:
         case NewTypedArray:
         case NewTypedArrayBuffer:
         case NewArrayWithSize:
-        case NewArrayWithConstantSize:
         case NewArrayWithSpecies:
         case NewArrayWithSizeAndStructure: {
             // Negative zero is not observable. NaN versus undefined are only observable

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1924,12 +1924,20 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         write(HeapObjectCount);
         return;
 
-    case NewArrayWithConstantSize:
-    case PhantomNewArrayWithConstantSize:
-    case MaterializeNewArrayWithConstantSize:
+    case NewButterflyWithSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
+    case MaterializeNewButterflyWithSize: {
         read(HeapObjectCount);
         write(HeapObjectCount);
-        def(HeapLocation(ArrayLengthLoc, Butterfly_publicLength, node), LazyNode(graph.freeze(jsNumber(node->newArraySize()))));
+        // FIXME: In this phase we say the Array is where the length of the array is def'd but this differs from ObjectAllocationSinking.
+        return;
+    }
+
+    case NewArrayWithButterfly:
+        read(HeapObjectCount);
+        write(HeapObjectCount);
+        def(HeapLocation(ArrayLengthLoc, Butterfly_publicLength, node), LazyNode(node->child1().node()));
         return;
 
     case NewTypedArray:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -288,7 +288,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(MultiPutByOffset, Common) \
     CLONE_STATUS(NewArray, Common) \
     CLONE_STATUS(NewArrayBuffer, Common) \
-    CLONE_STATUS(NewArrayWithConstantSize, Common) \
+    CLONE_STATUS(NewArrayWithButterfly, Common) \
     CLONE_STATUS(NewArrayWithSize, Common) \
     CLONE_STATUS(NewArrayWithSpread, Common) \
     CLONE_STATUS(NewFunction, Common) \

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1106,10 +1106,14 @@ private:
                 if (m_graph.isWatchingHavingABadTimeWatchpoint(node)) {
                     if (node->child1().useKind() == Int32Use && node->child1()->isInt32Constant()) {
                         int32_t length = node->child1()->asInt32();
-                        if (length >= 0
+                        if (0 <= length
                             && length < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH
-                            && isNewArrayWithConstantSizeIndexingType(node->indexingType())) {
-                                node->convertToNewArrayWithConstantSize(m_graph, length);
+                            && !hasAnyArrayStorage(node->indexingType())) {
+                                m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
+                                alreadyHandled = true; // Don't allow the default constant folder to do things to this.
+
+                                Node* butterfly = m_insertionSet.insertNode(indexInBlock, SpecNone, NewButterflyWithSize, node->origin, OpInfo(node->indexingType()), node->child1());
+                                node->convertToNewArrayWithButterfly(m_graph, butterfly);
                                 changed = true;
                         }
                     }
@@ -1676,7 +1680,8 @@ private:
             }
 
             case PhantomNewObject:
-            case PhantomNewArrayWithConstantSize:
+            case PhantomNewArrayWithButterfly:
+            case PhantomNewButterflyWithSize:
             case PhantomNewFunction:
             case PhantomNewGeneratorFunction:
             case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -225,7 +225,8 @@ bool doesGC(Graph& graph, Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -413,8 +414,9 @@ bool doesGC(Graph& graph, Node* node)
     case NewArrayWithSpread:
     case NewInternalFieldObject:
     case Spread:
+    case NewButterflyWithSize:
     case NewArrayWithSize:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case NewArrayBuffer:
@@ -440,7 +442,7 @@ bool doesGC(Graph& graph, Node* node)
     case EnumeratorNextUpdatePropertyName:
     case EnumeratorNextUpdateIndexAndMode:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewButterflyWithSize:
     case MaterializeNewInternalFieldObject:
     case MaterializeCreateActivation:
     case SetFunctionName:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2064,11 +2064,6 @@ private:
             break;
         }
 
-        case NewArrayWithConstantSize: {
-            watchHavingABadTime(node);
-            break;
-        }
-
         case NewArrayWithSpecies: {
             ArrayMode arrayMode = node->arrayMode().refine(m_graph, node, node->child2()->prediction(), ArrayMode::unusedIndexSpeculatedType);
             node->setArrayMode(arrayMode);
@@ -2664,8 +2659,11 @@ private:
         case Int52Constant:
         case Identity: // This should have been cleaned up.
         case BooleanToNumber:
+        case NewArrayWithButterfly:
+        case NewButterflyWithSize:
         case PhantomNewObject:
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewButterflyWithSize:
+        case PhantomNewArrayWithButterfly:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -2687,7 +2685,7 @@ private:
         case CheckStructureOrEmpty:
         case CheckArrayOrEmpty:
         case MaterializeNewObject:
-        case MaterializeNewArrayWithConstantSize:
+        case MaterializeNewButterflyWithSize:
         case MaterializeCreateActivation:
         case MaterializeNewInternalFieldObject:
         case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -863,7 +863,8 @@ bool LoopUnrollingPhase::LoopData::isMaterialNode(Graph& graph, Node* node)
     case ZombieHint:
     case ExitOK:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -71,8 +71,9 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case BottomValue:
     case PutHint:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
     case PhantomNewInternalFieldObject:
+    case PhantomNewButterflyWithSize:
     case PutStack:
     case KillStack:
     case GetStack:
@@ -172,7 +173,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case CreateActivation:
     case MaterializeCreateActivation:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewButterflyWithSize:
     case MaterializeNewInternalFieldObject:
     case NewFunction:
     case NewGeneratorFunction:
@@ -184,7 +185,8 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case NewRegExp:
     case NewMap:
     case NewSet:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
+    case NewButterflyWithSize:
     case ToNumber:
     case ToNumeric:
     case ToObject:

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -268,12 +268,14 @@ void Node::convertToNewArrayWithSize()
     m_opInfo = indexingType;
 }
 
-void Node::convertToNewArrayWithConstantSize(Graph&, uint32_t size)
+void Node::convertToNewArrayWithButterfly(Graph&, Node* butterfly)
 {
     ASSERT(op() == NewArrayWithSize);
-    ASSERT(size < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
-    setOpAndDefaultFlags(NewArrayWithConstantSize);
-    m_opInfo2 = size;
+    IndexingType indexingType = this->indexingType();
+    setOpAndDefaultFlags(NewArrayWithButterfly);
+    ASSERT(child1()->asInt32() < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+    children.child2() = Edge(butterfly);
+    ASSERT_UNUSED(indexingType, indexingType == this->indexingType());
 }
 
 void Node::convertToNewArrayWithSizeAndStructure(Graph& graph, RegisteredStructure structure)

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -727,17 +727,22 @@ public:
         children.setChild1(index);
     }
 
-    void convertToPhantomNewArrayWithConstantSize()
+    void convertToPhantomNewArrayWithButterfly()
     {
-        ASSERT(m_op == NewArrayWithConstantSize);
-        m_op = PhantomNewArrayWithConstantSize;
-        m_flags &= ~NodeHasVarArgs;
-        m_flags |= NodeMustGenerate;
-        // No need to clear the infos, as the indexing type and array
-        // size are still required for materialization when an OSR exit occurs.
-        children = AdjacencyList();
+        ASSERT(m_op == NewArrayWithButterfly);
+        setOpAndDefaultFlags(PhantomNewArrayWithButterfly);
+        // OpInfo/children shouldn't change and are needed for OSR exit.
+        ASSERT(child1().useKind() == Int32Use);
     }
     
+    void convertToPhantomNewButterflyWithSize()
+    {
+        ASSERT(m_op == NewButterflyWithSize);
+        setOpAndDefaultFlags(PhantomNewButterflyWithSize);
+        // OpInfo/children shouldn't change and are needed for OSR exit.
+        ASSERT(child1().useKind() == Int32Use);
+    }
+
     void convertToPhantomNewObject()
     {
         ASSERT(m_op == NewObject);
@@ -916,7 +921,7 @@ public:
 
     void convertToNewArrayBuffer(FrozenValue* immutableButterfly);
     void convertToNewArrayWithSize();
-    void convertToNewArrayWithConstantSize(Graph&, uint32_t);
+    void convertToNewArrayWithButterfly(Graph&, Node* butterfly);
     void convertToNewArrayWithSizeAndStructure(Graph&, RegisteredStructure);
 
     void convertToNewBoundFunction(FrozenValue*);
@@ -1454,32 +1459,16 @@ public:
         return newArrayBufferData().vectorLengthHint;
     }
 
-    unsigned hasNewArraySize()
-    {
-        switch (op()) {
-        case NewArrayWithConstantSize:
-        case PhantomNewArrayWithConstantSize:
-        case MaterializeNewArrayWithConstantSize:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    unsigned newArraySize()
-    {
-        ASSERT(hasNewArraySize());
-        return op() == MaterializeNewArrayWithConstantSize ? objectMaterializationData().m_newArraySize : m_opInfo2.as<unsigned>();
-    }
-
     bool hasIndexingType()
     {
         switch (op()) {
         case NewArray:
         case NewArrayWithSize:
-        case NewArrayWithConstantSize:
-        case PhantomNewArrayWithConstantSize:
-        case MaterializeNewArrayWithConstantSize:
+        case NewArrayWithButterfly:
+        case NewButterflyWithSize:
+        case PhantomNewArrayWithButterfly:
+        case PhantomNewButterflyWithSize:
+        case MaterializeNewButterflyWithSize:
         case NewArrayBuffer:
         case PhantomNewArrayBuffer:
         case NewArrayWithSpecies:
@@ -2514,7 +2503,7 @@ public:
     {
         switch (op()) {
         case MaterializeNewObject:
-        case MaterializeNewArrayWithConstantSize:
+        case MaterializeNewButterflyWithSize:
         case MaterializeNewInternalFieldObject:
         case MaterializeCreateActivation:
             return true;
@@ -2602,7 +2591,8 @@ public:
     bool isPhantomAllocation()
     {
         switch (op()) {
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewArrayWithButterfly:
+        case PhantomNewButterflyWithSize:
         case PhantomNewObject:
         case PhantomDirectArguments:
         case PhantomCreateRest:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -403,13 +403,15 @@ namespace JSC { namespace DFG {
     macro(NewObject, NodeResultJS) \
     macro(NewGenerator, NodeResultJS) \
     macro(NewAsyncGenerator, NodeResultJS) \
+    /* FIXME: A lot of these could likely be consolidated but there's some subtle differences between them, particularly when having a bad time. */ \
     macro(NewArray, NodeResultJS | NodeHasVarArgs) \
     macro(NewArrayWithSpread, NodeResultJS | NodeHasVarArgs) \
     macro(NewArrayWithSpecies, NodeResultJS | NodeMustGenerate) \
     macro(NewArrayWithSize, NodeResultJS | NodeMustGenerate) \
-    macro(NewArrayWithConstantSize, NodeResultJS | NodeMustGenerate) \
     macro(NewArrayWithSizeAndStructure, NodeResultJS | NodeMustGenerate) \
     macro(NewArrayBuffer, NodeResultJS) \
+    macro(NewArrayWithButterfly, NodeResultJS) \
+    macro(NewButterflyWithSize, NodeResultStorage) \
     macro(NewInternalFieldObject, NodeResultJS) \
     macro(NewTypedArray, NodeResultJS | NodeMustGenerate) \
     macro(NewTypedArrayBuffer, NodeResultJS | NodeMustGenerate) \
@@ -425,8 +427,9 @@ namespace JSC { namespace DFG {
     \
     macro(Spread, NodeResultJS | NodeMustGenerate) \
     /* Support for allocation sinking. */\
-    macro(PhantomNewArrayWithConstantSize, NodeResultJS | NodeMustGenerate) \
-    macro(MaterializeNewArrayWithConstantSize, NodeResultJS | NodeHasVarArgs) \
+    macro(PhantomNewButterflyWithSize, NodeResultStorage | NodeMustGenerate) \
+    macro(MaterializeNewButterflyWithSize, NodeResultStorage | NodeHasVarArgs) \
+    macro(PhantomNewArrayWithButterfly, NodeResultJS | NodeMustGenerate) \
     macro(PhantomNewObject, NodeResultJS | NodeMustGenerate) \
     macro(PutHint, NodeMustGenerate) \
     macro(CheckStructureImmediate, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGObjectMaterializationData.h
+++ b/Source/JavaScriptCore/dfg/DFGObjectMaterializationData.h
@@ -38,7 +38,6 @@ namespace JSC { namespace DFG {
 struct ObjectMaterializationData {
     // Determines the meaning of the passed nodes.
     Vector<PromotedLocationDescriptor> m_properties;
-    unsigned m_newArraySize { 0 };
     void dump(PrintStream&) const;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2198,9 +2198,10 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSize, char*, (JSGlobalObject* glob
     }
 
     JSArray* result;
-    if (butterfly)
+    if (butterfly) {
+        ASSERT(butterfly->publicLength() <= butterfly->vectorLength());
         result = JSArray::createWithButterfly(vm, nullptr, arrayStructure, butterfly);
-    else {
+    } else {
         result = JSArray::tryCreate(vm, arrayStructure, size);
         if (!result) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
@@ -2586,6 +2587,27 @@ JSC_DEFINE_JIT_OPERATION(operationAllocateComplexPropertyStorage, Butterfly*, (V
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     OPERATION_RETURN(scope, object->allocateMoreOutOfLineStorage(vm, object->structure()->outOfLineCapacity(), newSize));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationAllocateUnitializedAuxiliaryBase, void*, (VM* vmPointer, size_t allocationSize))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // allocationSize accounts for IndexingHeader already.
+    unsigned indexingPayloadInBytes = allocationSize - sizeof(IndexingHeader);
+    // If we wanted to lift this restriction we'd need to teach DFG's NewArrayWithButterfly and the Phantom/Materialize friends
+    // about converting the new Array's IndexingType / Structure.
+    ASSERT(indexingPayloadInBytes / sizeof(JSValue) < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+    constexpr bool hasIndexingHeader = true;
+    unsigned preCapacity = 0;
+    unsigned propertyCapacity = 0;
+    Butterfly* result = Butterfly::createUninitialized(vm, nullptr, preCapacity, propertyCapacity, hasIndexingHeader, indexingPayloadInBytes);
+
+
+    OPERATION_RETURN(scope, result->base(preCapacity, propertyCapacity));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationEnsureInt32, Butterfly*, (VM* vmPointer, JSCell* cell))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -264,6 +264,8 @@ JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorageWithInitialCapac
 JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorage, Butterfly*, (VM*, size_t newSize));
 JSC_DECLARE_JIT_OPERATION(operationAllocateComplexPropertyStorageWithInitialCapacity, Butterfly*, (VM*, JSObject*));
 JSC_DECLARE_JIT_OPERATION(operationAllocateComplexPropertyStorage, Butterfly*, (VM*, JSObject*, size_t newSize));
+// Note: This doesn't return a `Butterfly*` because it's not shifted properly so you'll have to do `Butterfly::fromBase` yourself. Hence the `Base` suffix.
+JSC_DECLARE_JIT_OPERATION(operationAllocateUnitializedAuxiliaryBase, void*, (VM*, size_t allocationSizeInBytes));
 JSC_DECLARE_JIT_OPERATION(operationEnsureInt32, Butterfly*, (VM*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationEnsureDouble, Butterfly*, (VM*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationEnsureContiguous, Butterfly*, (VM*, JSCell*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1331,7 +1331,6 @@ private:
         case NewArrayWithSpread:
         case NewArray:
         case NewArrayWithSize:
-        case NewArrayWithConstantSize:
         case NewArrayWithSizeAndStructure:
         case CreateRest:
         case NewArrayBuffer:
@@ -1573,6 +1572,8 @@ private:
             break;
         }
 
+        case NewArrayWithButterfly:
+        case NewButterflyWithSize:
         case PutByValAlias:
         case DoubleAsInt32:
         case CheckTypeInfoFlags:
@@ -1593,7 +1594,8 @@ private:
         case Identity:
         case BooleanToNumber:
         case PhantomNewObject:
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewArrayWithButterfly:
+        case PhantomNewButterflyWithSize:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -1614,7 +1616,7 @@ private:
         case CheckStructureOrEmpty:
         case CheckArrayOrEmpty:
         case MaterializeNewObject:
-        case MaterializeNewArrayWithConstantSize:
+        case MaterializeNewButterflyWithSize:
         case MaterializeCreateActivation:
         case MaterializeNewInternalFieldObject:
         case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
@@ -53,10 +53,13 @@ enum PromotedLocationKind {
     ArgumentCountPLoc,
     ArgumentPLoc,
     ArgumentsCalleePLoc,
+    // FIXME: All these Array/ArrayButterfly properties don't need to be exclusive to Arrays and could work just as well on objects.
     ArrayPLoc,
-    ArrayLengthPropertyPLoc,
-    ArrayButterflyPropertyPLoc,
-    ArrayIndexedPropertyPLoc,
+    // The butterfly slot in the array.
+    ArrayButterflyPLoc,
+    // These are slots in the butterfly.
+    ArrayButterflyPublicLengthPLoc,
+    ArrayButterflyIndexedPropertyPLoc,
     ClosureVarPLoc,
     InternalFieldObjectPLoc,
     FunctionActivationPLoc,
@@ -114,6 +117,7 @@ public:
     {
         switch (kind()) {
         case NamedPropertyPLoc:
+        case ArrayButterflyIndexedPropertyPLoc:
         case ClosureVarPLoc:
         case RegExpObjectLastIndexPLoc:
         case InternalFieldObjectPLoc:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -652,7 +652,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NewAsyncGenerator:
     case NewArray:
     case NewArrayWithSize:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
+    case NewButterflyWithSize:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case NewArrayBuffer:
@@ -733,7 +734,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case MultiDeleteByOffset:
     case GetPropertyEnumerator:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:
@@ -743,7 +745,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case PhantomNewRegExp:
     case PutHint:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewButterflyWithSize:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PhantomDirectArguments:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13699,52 +13699,6 @@ void SpeculativeJIT::compileLazyJSConstant(Node* node)
     jsValueResult(resultRegs, node);
 }
 
-void SpeculativeJIT::compileMaterializeNewArrayWithConstantSize(Node* node)
-{
-    ObjectMaterializationData& data = node->objectMaterializationData();
-
-    GPRTemporary size(this);
-    GPRTemporary result(this);
-
-    GPRReg sizeGPR = size.gpr();
-    GPRReg storageGPR = result.gpr();
-    GPRReg resultGPR = result.gpr();
-
-    // Step 1: Speculate appropriately on all of the children.
-    for (unsigned i = 0; i < node->numChildren(); ++i)
-        speculate(node, m_graph.varArgChild(node, i));
-
-    // Step 1: Create a new array with constant size.
-    compileNewArrayWithConstantSizeImpl(node, sizeGPR, resultGPR);
-
-    // Step 2: Get the butterfly storage and fill the slots.
-    loadPtr(Address(resultGPR, JSObject::butterflyOffset()), storageGPR);
-    ASSERT(node->numChildren() == data.m_properties.size());
-    for (unsigned i = 0; i < node->numChildren(); ++i) {
-        Edge edge = m_graph.varArgChild(node, i);
-        unsigned index = data.m_properties[i].info();
-        switch (node->indexingType()) {
-        case ALL_DOUBLE_INDEXING_TYPES: {
-            SpeculateDoubleOperand value(this, edge);
-            storeDouble(value.fpr(), Address(storageGPR, sizeof(double) * index));
-            break;
-        }
-        case ALL_INT32_INDEXING_TYPES:
-        case ALL_CONTIGUOUS_INDEXING_TYPES: {
-            JSValueOperand value(this, edge, ManualOperandSpeculation); // We already speculated. So this does not require speculation.
-            JSValueRegs valueRegs = value.jsValueRegs();
-            storeValue(valueRegs, Address(storageGPR, sizeof(EncodedJSValue) * index));
-            break;
-        }
-        default:
-            DFG_CRASH(m_graph, node, "Bad indexing type");
-            break;
-        }
-    }
-
-    cellResult(resultGPR, node);
-}
-
 void SpeculativeJIT::compileMaterializeNewObject(Node* node)
 {
     RegisteredStructure structure = node->structureSet().at(0);
@@ -14887,27 +14841,78 @@ void SpeculativeJIT::compileNewArrayWithSize(Node* node)
     cellResult(resultGPR, node);
 }
 
-void SpeculativeJIT::compileNewArrayWithConstantSizeImpl(Node* node, GPRReg sizeGPR, GPRReg resultGPR)
+void SpeculativeJIT::compileNewButterflyWithSize(Node* node)
 {
-    ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(node));
-    ASSERT(!hasAnyArrayStorage(node->indexingType()));
+    GPRTemporary storage(this);
+    JSValueRegsTemporary scratch(this);
+    GPRTemporary scratch2(this);
 
-    move(TrustedImm32(node->newArraySize()), sizeGPR);
+    GPRReg storageGPR = storage.gpr();
+    JSValueRegs scratchRegs = scratch.regs();
+    GPRReg scratchGPR = scratchRegs.payloadGPR();
+    GPRReg scratch2GPR = scratch2.gpr();
 
-    constexpr bool shouldConvertLargeSizeToArrayStorage = false;
-    compileAllocateNewArrayWithSize(node, resultGPR, sizeGPR, node->indexingType(), shouldConvertLargeSizeToArrayStorage);
+    IndexingType indexingMode = node->indexingMode();
+    ASSERT(!hasAnyArrayStorage(indexingMode));
+    ASSERT(!isCopyOnWrite(indexingMode));
+    unsigned butterflyLength = node->child1()->asInt32();
+    ASSERT(butterflyLength < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+
+    constexpr bool hasIndexingHeader = true;
+    size_t allocationSize = Butterfly::totalSize(0, 0, hasIndexingHeader, butterflyLength * sizeof(JSValue));
+
+    JumpList slowCases;
+    emitAllocate(storageGPR, JITAllocator::constant(vm().auxiliarySpace().allocatorForNonInline(allocationSize, AllocatorForMode::EnsureAllocator)), scratchGPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationAllocateUnitializedAuxiliaryBase, storageGPR, TrustedImmPtr(&vm()), TrustedImmPtr(allocationSize)));
+
+    GPRReg sizeGPR = scratch2GPR;
+
+    move(Imm32(butterflyLength), sizeGPR);
+
+    // FIXME: do post increment store pair.
+    addPtr(TrustedImm32(sizeof(IndexingHeader)), storageGPR);
+    static_assert(Butterfly::offsetOfPublicLength() + static_cast<ptrdiff_t>(sizeof(uint32_t)) == Butterfly::offsetOfVectorLength());
+    storePair32(sizeGPR, sizeGPR, storageGPR, TrustedImm32(Butterfly::offsetOfPublicLength()));
+
+    if (hasDouble(indexingMode))
+        moveTrustedValue(jsNaN(), scratchRegs);
+    else
+        moveTrustedValue(JSValue(), scratchRegs);
+
+    emitInitializeButterfly(storageGPR, sizeGPR, scratchRegs, sizeGPR);
+    storageResult(storageGPR, node);
 }
 
-void SpeculativeJIT::compileNewArrayWithConstantSize(Node* node)
+void SpeculativeJIT::compileNewArrayWithButterfly(Node* node)
 {
-    GPRTemporary size(this);
+    ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(node));
+
+    IndexingType indexingMode = node->indexingMode();
+    ASSERT(!hasAnyArrayStorage(node->indexingMode()));
+    ASSERT(!isCopyOnWrite(indexingMode));
+    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+    RegisteredStructure structure = m_graph.registerStructure(globalObject->arrayStructureForIndexingTypeDuringAllocation(node->indexingMode()));
+
+    ASSERT(node->child1()->isInt32Constant());
+    StorageOperand storage(this, node->child2());
     GPRTemporary result(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
 
-    GPRReg sizeGPR = size.gpr();
+    GPRReg storageGPR = storage.gpr();
     GPRReg resultGPR = result.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
 
-    compileNewArrayWithConstantSizeImpl(node, sizeGPR, resultGPR);
-    cellResult(result.gpr(), node);
+    JumpList slowCases;
+
+    emitAllocateJSObject<JSArray>(resultGPR, TrustedImmPtr(structure), storageGPR, scratch1GPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationNewArrayWithSize, result.gpr(), LinkableConstant::globalObject(*this, node), structure, TrustedImm32(node->child1()->asInt32()), storageGPR));
+
+    DFG_ASSERT(m_graph, node, indexingMode & IsArray, indexingMode);
+    cellResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileNewArrayWithSpecies(Node* node)
@@ -16211,17 +16216,13 @@ void SpeculativeJIT::compileAllocateNewArrayWithSize(Node* node, GPRReg resultGP
 
 #if USE(JSVALUE64)
     JSValueRegs emptyValueRegs(scratchGPR);
-    if (hasDouble(structure->indexingType()))
-        move(TrustedImm64(std::bit_cast<int64_t>(PNaN)), emptyValueRegs.gpr());
-    else
-        move(TrustedImm64(JSValue::encode(JSValue())), emptyValueRegs.gpr());
 #else
     JSValueRegs emptyValueRegs(scratchGPR, scratch2GPR);
-    if (hasDouble(structure->indexingType()))
-        moveValue(JSValue(JSValue::EncodeAsDouble, PNaN), emptyValueRegs);
-    else
-        moveValue(JSValue(), emptyValueRegs);
 #endif
+    if (hasDouble(structure->indexingType()))
+        moveTrustedValue(jsNaN(), emptyValueRegs);
+    else
+        moveTrustedValue(JSValue(), emptyValueRegs);
     emitInitializeButterfly(storageGPR, sizeGPR, emptyValueRegs, resultGPR);
 
     emitAllocateJSObject<JSArray>(resultGPR, TrustedImmPtr(structure), storageGPR, scratchGPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1712,7 +1712,6 @@ public:
     void compileSetRegExpObjectLastIndex(Node*);
     void compileLazyJSConstant(Node*);
     void compileMaterializeNewObject(Node*);
-    void compileMaterializeNewArrayWithConstantSize(Node*);
     void compileRecordRegExpCachedResult(Node*);
     void compileToObjectOrCallObjectConstructor(Node*);
     void compileResolveScope(Node*);
@@ -1758,9 +1757,9 @@ public:
     void compileSetArgumentCountIncludingThis(Node*);
     void compileStrCat(Node*);
     void compileNewArrayBuffer(Node*);
+    void compileNewButterflyWithSize(Node*);
     void compileNewArrayWithSize(Node*);
-    void compileNewArrayWithConstantSizeImpl(Node*, GPRReg, GPRReg);
-    void compileNewArrayWithConstantSize(Node*);
+    void compileNewArrayWithButterfly(Node*);
     void compileNewArrayWithSpecies(Node*);
     void compileNewArrayWithSizeAndStructure(Node*);
     void compileNewTypedArray(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3191,8 +3191,13 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case NewArrayWithConstantSize: {
-        compileNewArrayWithConstantSize(node);
+    case NewButterflyWithSize: {
+        compileNewButterflyWithSize(node);
+        break;
+    }
+
+    case NewArrayWithButterfly: {
+        compileNewArrayWithButterfly(node);
         break;
     }
 
@@ -4306,10 +4311,6 @@ void SpeculativeJIT::compile(Node* node)
         compileMaterializeNewObject(node);
         break;
 
-    case MaterializeNewArrayWithConstantSize:
-        compileMaterializeNewArrayWithConstantSize(node);
-        break;
-
     case PutDynamicVar: {
         compilePutDynamicVar(node);
         break;
@@ -4399,7 +4400,8 @@ void SpeculativeJIT::compile(Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -4411,6 +4413,7 @@ void SpeculativeJIT::compile(Node* node)
     case CheckStructureImmediate:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
+    case MaterializeNewButterflyWithSize:
     case PutStack:
     case KillStack:
     case GetStack:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4553,8 +4553,13 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case NewArrayWithConstantSize: {
-        compileNewArrayWithConstantSize(node);
+    case NewButterflyWithSize: {
+        compileNewButterflyWithSize(node);
+        break;
+    }
+
+    case NewArrayWithButterfly: {
+        compileNewArrayWithButterfly(node);
         break;
     }
 
@@ -6004,10 +6009,6 @@ void SpeculativeJIT::compile(Node* node)
         compileMaterializeNewObject(node);
         break;
 
-    case MaterializeNewArrayWithConstantSize:
-        compileMaterializeNewArrayWithConstantSize(node);
-        break;
-
     case CallDOM:
         compileCallDOM(node);
         break;
@@ -6577,7 +6578,8 @@ void SpeculativeJIT::compile(Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -6590,6 +6592,7 @@ void SpeculativeJIT::compile(Node* node)
     case GetVectorLength:
     case PutHint:
     case CheckStructureImmediate:
+    case MaterializeNewButterflyWithSize:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -381,7 +381,8 @@ private:
             case NewAsyncGenerator:
             case NewArray:
             case NewArrayWithSize:
-            case NewArrayWithConstantSize:
+            case NewArrayWithButterfly:
+            case NewButterflyWithSize:
             case NewArrayWithSizeAndStructure:
             case NewArrayBuffer:
             case NewInternalFieldObject:
@@ -394,7 +395,7 @@ private:
             case NewSet:
             case NewSymbol:
             case MaterializeNewObject:
-            case MaterializeNewArrayWithConstantSize:
+            case MaterializeNewButterflyWithSize:
             case MaterializeCreateActivation:
             case MakeRope:
             case MakeAtomString:

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGNodeFlags.h"
-#include "SpeculatedType.h"
+#include "IndexingType.h"
 #include <wtf/PrintStream.h>
 
 namespace JSC { namespace DFG {

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -363,9 +363,17 @@ public:
                         VALIDATE((node), !hasAnyArrayStorage(structure->indexingType()));
                     }
                     break;
-                case MaterializeNewArrayWithConstantSize:
-                    VALIDATE((node), isNewArrayWithConstantSizeIndexingType(node->indexingType()));
+                case NewArrayWithButterfly:
+                case NewButterflyWithSize:
+                case MaterializeNewButterflyWithSize: {
+                    // These only support constant size butterflies right now.
+                    Edge sizeChild = node->op() == MaterializeNewButterflyWithSize ? m_graph.varArgChild(node, 0) : node->child1();
+                    VALIDATE((node), sizeChild->isInt32Constant());
+                    VALIDATE((node), !hasAnyArrayStorage(node->indexingType()));
+                    if (node->op() == MaterializeNewButterflyWithSize)
+                        VALIDATE((node), !hasUndecided(node->indexingType()));
                     break;
+                }
                 case DoubleConstant:
                 case Int52Constant:
                     VALIDATE((node), node->isNumberConstant());
@@ -677,7 +685,8 @@ private:
                 case CheckInBounds:
                 case CheckInBoundsInt52:
                 case PhantomNewObject:
-                case PhantomNewArrayWithConstantSize:
+                case PhantomNewArrayWithButterfly:
+                case PhantomNewButterflyWithSize:
                 case PhantomNewFunction:
                 case PhantomNewGeneratorFunction:
                 case PhantomNewAsyncFunction:
@@ -898,7 +907,7 @@ private:
                     continue;
                 switch (node->op()) {
                 case PhantomNewObject:
-                case PhantomNewArrayWithConstantSize:
+                case PhantomNewButterflyWithSize:
                 case PhantomNewFunction:
                 case PhantomNewGeneratorFunction:
                 case PhantomNewAsyncFunction:
@@ -918,6 +927,29 @@ private:
                 case GetMyArgumentByVal:
                 case GetMyArgumentByValOutOfBounds:
                     break;
+
+                case PhantomNewArrayWithButterfly:
+                    // Conceptually it would be valid to sink/eliminate the Array wrapper around a butterfly.
+                    // The problem is that our GC doesn't scan auxilary buffers it sees on the stack since
+                    // they don't have an indexing header. This means any new objects that are stored into
+                    // the butterfly wouldn't be marked. e.g. something like:
+                    //
+                    // 1: NewButterflyWithSize
+                    // 2: PhantomNewArrayWithButterfly
+                    // 3: NewObject
+                    // -: PutByVal(@2, 1, @3, @1)
+                    // ... GC
+                    // 4: GetByVal(@2, 1, @1)
+                    // -: Use(@4) <-- UAF
+                    //
+                    // It's possible we work around this by one of:
+                    // 1) Allocating a JSCellButterfly but that only saves a few bytes so it probably
+                    //    wouldn't be profitable.
+                    // 2) Conservatively scanning any auxilary found on the stack but not visited by an
+                    //    object.
+                    VALIDATE((node), node->child2()->op() == PhantomNewButterflyWithSize);
+                    break;
+
 
                 case Check:
                 case CheckVarargs:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -251,7 +251,8 @@ inline CapabilityLevel canCompile(Node* node)
     case MakeRope:
     case MakeAtomString:
     case NewArrayWithSize:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
+    case NewButterflyWithSize:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case TryGetById:
@@ -344,7 +345,8 @@ inline CapabilityLevel canCompile(Node* node)
     case EnumeratorPutByVal:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:
@@ -355,7 +357,7 @@ inline CapabilityLevel canCompile(Node* node)
     case PutHint:
     case CheckStructureImmediate:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewButterflyWithSize:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PhantomDirectArguments:

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,10 +36,20 @@ using namespace JSC::DFG;
 
 ExitTimeObjectMaterialization::ExitTimeObjectMaterialization(Node* node, CodeOrigin codeOrigin)
     : m_type(node->op())
-    , m_indexingType(node->op() == DFG::PhantomNewArrayWithConstantSize ? node->indexingType() : NoIndexingShape)
-    , m_size(node->op() == DFG::PhantomNewArrayWithConstantSize ? node->newArraySize() : 0)
+    , m_indexingType(node->hasIndexingType() ? node->indexingType() : NoIndexingShape)
+    , m_size(0)
     , m_origin(codeOrigin)
 {
+    switch (node->op()) {
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize: {
+        // These assume constant size right now.
+        m_size = node->child1()->asInt32();
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 ExitTimeObjectMaterialization::~ExitTimeObjectMaterialization() = default;
@@ -47,6 +57,7 @@ ExitTimeObjectMaterialization::~ExitTimeObjectMaterialization() = default;
 void ExitTimeObjectMaterialization::add(
     PromotedLocationDescriptor location, const ExitValue& value)
 {
+    // FIXME: We should probably do some validation here that any values stored a Butterfly are correct for the indexing type.
     m_properties.append(ExitPropertyValue(location, value));
 }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1260,8 +1260,11 @@ private:
         case NewArrayWithSize:
             compileNewArrayWithSize();
             break;
-        case NewArrayWithConstantSize:
-            compileNewArrayWithConstantSize();
+        case NewArrayWithButterfly:
+            compileNewArrayWithButterfly();
+            break;
+        case NewButterflyWithSize:
+            compileNewButterflyWithSize();
             break;
         case NewArrayWithSpecies:
             compileNewArrayWithSpecies();
@@ -1746,8 +1749,8 @@ private:
         case MaterializeNewObject:
             compileMaterializeNewObject();
             break;
-        case MaterializeNewArrayWithConstantSize:
-            compileMaterializeNewArrayWithConstantSize();
+        case MaterializeNewButterflyWithSize:
+            compileMaterializeNewButterflyWithSize();
             break;
         case MaterializeCreateActivation:
             compileMaterializeCreateActivation();
@@ -1891,12 +1894,17 @@ private:
             break;
         }
 
+        case PhantomNewArrayWithButterfly: {
+            // It would be very bad to get here in this state and could lead to horrible GC bugs. See ObjectAllocationSinking::handleNode for details.
+            RELEASE_ASSERT(m_node->child2()->op() == PhantomNewButterflyWithSize);
+            [[fallthrough]];
+        }
         case PhantomLocal:
         case MovHint:
         case ZombieHint:
         case ExitOK:
         case PhantomNewObject:
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewButterflyWithSize:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -10211,23 +10219,29 @@ IGNORE_CLANG_WARNINGS_END
         setJSValue(vmCall(Int64, operationNewArrayWithSize, weakPointer(globalObject), structureValue, publicLength, m_out.intPtrZero));
     }
 
-    LValue compileNewArrayWithConstantSizeImpl()
+    void compileNewButterflyWithSize()
     {
-        LValue publicLength = m_out.constInt32(m_node->newArraySize());
-
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-
         ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(m_node));
-        ASSERT(!hasAnyArrayStorage(m_node->indexingType()));
-        IndexingType indexingType = m_node->indexingType();
-        LValue result = allocateJSArray(
-            publicLength, publicLength, weakPointer(globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType)), m_out.constInt32(indexingType)).array;
-        return result;
+        ASSERT(!isCopyOnWrite(m_node->indexingMode()));
+
+        LValue publicLength = lowInt32(m_node->child1());
+        LValue indexingType = m_out.constInt32(m_node->indexingType());
+
+        LValue butterfly = allocateButterfly(indexingType, m_out.int32Zero, publicLength, publicLength);
+
+        setStorage(butterfly);
+        // No mutator fence is needed. Butterflies are only scanned when the GC discovers them in an object not on the stack.
     }
 
-    void compileNewArrayWithConstantSize()
+    void compileNewArrayWithButterfly()
     {
-        setJSValue(compileNewArrayWithConstantSizeImpl());
+        ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(m_node));
+        ASSERT(!hasAnyArrayStorage(m_node->indexingType()));
+
+        LValue publicLength = lowInt32(m_node->child1());
+        LValue butterfly = lowStorage(m_node->child2());
+        LValue array = allocateJSArray(m_node->indexingType(), publicLength, butterfly);
+        setJSValue(array);
         mutatorFence();
     }
 
@@ -17249,21 +17263,21 @@ IGNORE_CLANG_WARNINGS_END
             });
     }
 
-    void compileMaterializeNewArrayWithConstantSize()
+    void compileMaterializeNewButterflyWithSize()
     {
-        // Step 1: Speculate appropriately on all of the children.
         for (unsigned i = 0; i < m_node->numChildren(); ++i)
-            speculate(m_graph.varArgChild(m_node, i));
+            RELEASE_ASSERT(!m_interpreter.needsTypeCheck(m_graph.varArgChild(m_node, i)));
 
-        // Step 2: Create a new array with constant size.
-        LValue result = compileNewArrayWithConstantSizeImpl();
-
-        // Step 3: Get the buttferfly storage and fill the slots.
-        LValue butterfly = m_out.loadPtr(result, m_heaps.JSObject_butterfly);
         IndexingType indexingType = m_node->indexingType();
+        LValue publicLength = lowInt32(m_graph.varArgChild(m_node, 0));
+        // FIXME: we should sort the properties by index then we can shouldInitializeElements = false here but when we do the properties below.
+        LValue butterfly = allocateButterfly(m_out.constInt32(indexingType), m_out.int32Zero, publicLength, publicLength);
+
         ObjectMaterializationData& data = m_node->objectMaterializationData();
+
         for (unsigned i = 0; i < data.m_properties.size(); ++i) {
-            Edge edge = m_graph.varArgChild(m_node, i);
+            // Add one to account for `length`
+            Edge edge = m_graph.varArgChild(m_node, i + 1);
             unsigned index = data.m_properties[i].info();
             switch (m_node->indexingType()) {
             case ALL_DOUBLE_INDEXING_TYPES:
@@ -17281,8 +17295,8 @@ IGNORE_CLANG_WARNINGS_END
             }
         }
 
-        setJSValue(result);
-        mutatorFence();
+        setStorage(butterfly);
+        // No mutator fence because the object we insert this into is expected to do that.
     }
 
     void compileMaterializeNewObject()
@@ -20698,6 +20712,106 @@ IGNORE_CLANG_WARNINGS_END
         LValue butterfly;
     };
 
+    // FIXME: Reduced version of the JSArray allocation below. We should consolidate them.
+    LValue allocateButterfly(LValue indexingType, LValue preCapacity, LValue publicLength, LValue vectorLength, bool shouldInitializeElements = true)
+    {
+        LBasicBlock slowBlock = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        if (preCapacity->hasInt32() && vectorLength->hasInt32()) {
+            unsigned vectorLengthConst = static_cast<unsigned>(vectorLength->asInt32());
+            if (vectorLengthConst <= MAX_STORAGE_VECTOR_LENGTH) {
+                vectorLengthConst = Butterfly::optimalContiguousVectorLength(
+                    preCapacity->asInt32(), vectorLengthConst);
+                vectorLength = m_out.constInt32(vectorLengthConst);
+            }
+        } else {
+            // We don't compute the optimal vector length for new Array(blah) where blah is not
+            // statically known, since the compute effort of doing it here is probably not worth it.
+        }
+
+        static_assert(MarkedSpace::largeCutoff < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH * sizeof(JSValue), "This assumes any butterfly allocation that would be force to change indexing type would hit the slow path anyway.");
+        static_assert(1 << 3 == sizeof(JSValue));
+
+        LValue payloadSizeInBytes =
+            m_out.shl(
+                m_out.zeroExt(
+                    m_out.add(vectorLength, preCapacity),
+                    pointerType()),
+                m_out.constIntPtr(3));
+
+        LValue butterflySize = m_out.add(
+            payloadSizeInBytes, m_out.constIntPtr(sizeof(IndexingHeader)));
+
+        LValue allocator = allocatorForSize(vm().auxiliarySpace(), butterflySize, slowBlock);
+        LValue base = allocateHeapCell(allocator, slowBlock);
+        ValueFromBlock fastBase = m_out.anchor(base);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowBlock);
+        VM& vm = this->vm();
+        LValue slowButterflyBase = lazySlowPath(
+            [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
+                return createLazyCallGenerator(vm,
+                    operationAllocateUnitializedAuxiliaryBase, locations[0].directGPR(), CCallHelpers::TrustedImmPtr(&vm),
+                    locations[1].directGPR());
+            },
+            payloadSizeInBytes);
+        ValueFromBlock slowBase = m_out.anchor(slowButterflyBase);
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation);
+        LValue butterflyBase = m_out.phi(pointerType(), fastBase, slowBase);
+        LValue butterfly = m_out.add(
+            butterflyBase,
+            m_out.add(
+                m_out.shl(m_out.zeroExt(preCapacity, pointerType()), m_out.constIntPtr(3)),
+                m_out.constIntPtr(sizeof(IndexingHeader))));
+
+
+        m_out.store32(publicLength, butterfly, m_heaps.Butterfly_publicLength);
+        m_out.store32(vectorLength, butterfly, m_heaps.Butterfly_vectorLength);
+
+        initializeArrayElements(
+            indexingType,
+            shouldInitializeElements ? m_out.int32Zero : publicLength, vectorLength,
+            butterfly);
+
+        return butterfly;
+    }
+
+    LValue allocateJSArray(IndexingType indexingType, LValue publicLength, LValue butterfly)
+    {
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        VM& vm = this->vm();
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        RegisteredStructure structure = m_graph.registerStructure(globalObject->arrayStructureForIndexingTypeDuringAllocation(
+            indexingType));
+
+        LValue structureValue = weakStructure(structure);
+        LValue array = allocateObject<JSArray>(structureValue, butterfly, slowCase);
+        ValueFromBlock fastArray = m_out.anchor(array);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowCase);
+        LValue slowResult = lazySlowPath(
+            [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
+                return createLazyCallGenerator(vm,
+                    operationNewArrayWithSize, locations[0].directGPR(), CCallHelpers::TrustedImmPtr(globalObject),
+                    locations[1].directGPR(), locations[2].directGPR(), locations[3].directGPR());
+            },
+            structureValue, publicLength, butterfly);
+        ValueFromBlock slowArray = m_out.anchor(slowResult);
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation);
+        return m_out.phi(pointerType(), fastArray, slowArray);
+    }
+
+    // FIXME: We don't need to handle large array sizes because anything that big has to be precise allocated anyway.
+    // FIXME: We should try replacing this with the two methods above.
     ArrayValues allocateJSArray(LValue publicLength, LValue vectorLength, LValue structure, LValue indexingType, bool shouldInitializeElements = true, bool shouldLargeArraySizeCreateArrayStorage = true)
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -73,7 +73,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
     DeferGCForAWhile deferGC(vm);
 
     switch (materialization->type()) {
-    case PhantomNewArrayWithConstantSize: {
+    case PhantomNewArrayWithButterfly: {
         JSArray* array = jsCast<JSArray*>(JSValue::decode(*encodedValue));
         for (unsigned i = materialization->properties().size(); i--;) {
             const ExitPropertyValue& property = materialization->properties()[i];
@@ -233,7 +233,13 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
     DeferGCForAWhile deferGC(vm);
 
     switch (materialization->type()) {
-    case PhantomNewArrayWithConstantSize: {
+    case PhantomNewButterflyWithSize: {
+
+        UNREACHABLE_FOR_PLATFORM();
+        return nullptr;
+    }
+
+    case PhantomNewArrayWithButterfly: {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         size_t size = materialization->size();

--- a/Source/JavaScriptCore/runtime/IndexingType.cpp
+++ b/Source/JavaScriptCore/runtime/IndexingType.cpp
@@ -49,13 +49,13 @@ IndexingType leastUpperBoundOfIndexingTypeAndType(IndexingType indexingType, Spe
     case ALL_INT32_INDEXING_TYPES:
         if (isInt32Speculation(type))
             return (indexingType & ~IndexingShapeMask) | Int32Shape;
-        // FIXME: Should this really say that it wants a double for NaNs.
-        if (isFullNumberSpeculation(type))
+        // Double storage uses PNaN as its "hole" value so we'd want to use a Contiguous storage if we saw one.
+        if (isBytecodeRealNumberSpeculation(type))
             return (indexingType & ~IndexingShapeMask) | DoubleShape;
         return (indexingType & ~IndexingShapeMask) | ContiguousShape;
     case ALL_DOUBLE_INDEXING_TYPES:
-        // FIXME: Should this really say that it wants a double for NaNs.
-        if (isFullNumberSpeculation(type))
+        // Double storage uses PNaN as its "hole" value so we'd want to use a Contiguous storage if we saw one.
+        if (isBytecodeRealNumberSpeculation(type))
             return indexingType;
         return (indexingType & ~IndexingShapeMask) | ContiguousShape;
     case ALL_CONTIGUOUS_INDEXING_TYPES:

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -210,19 +210,6 @@ inline unsigned arrayIndexFromIndexingType(IndexingType indexingType)
     return (indexingType & IndexingShapeMask) >> IndexingShapeShift;
 }
 
-inline bool isNewArrayWithConstantSizeIndexingType(IndexingType indexingType)
-{
-    switch (indexingType) {
-    case ALL_DOUBLE_INDEXING_TYPES:
-    case ALL_INT32_INDEXING_TYPES:
-    case ALL_CONTIGUOUS_INDEXING_TYPES: {
-        return true;
-    }
-    default:
-        return false;
-    }
-}
-
 inline IndexingType indexingTypeForValue(JSValue value)
 {
     if (value.isInt32())


### PR DESCRIPTION
#### f014a32890763b138b22bbcf4c6bf413ce343a44
<pre>
Array allocation sinking should split allocations into two, an Array allocation and a Butterfly allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=298606">https://bugs.webkit.org/show_bug.cgi?id=298606</a>
<a href="https://rdar.apple.com/159207754">rdar://159207754</a>

Reviewed by Yusuke Suzuki.

This patch minorly rearchitects how we do Array allocation sinking in DFG. Previously we tried to model Arrays
in ObjectAllocationSinking as two allocations one where the actual Array was allocated and a &quot;Butterfly&quot;
at each `GetButterfly`. This meant that there was now a reverse data dependency between the GetButterfly and
the Array allocation Nodes. This was a little unintuitive but also meant that any control flow that would
merge two `GetButterfly`s would escape the Array.

This PR simplifies things by more directly representing the heap in ObjectAllocationSinking. There are now
two nodes that get sunk when sinking an Array: NewButterflyWithSize and NewArrayWithButterfly. All the
indexed properties and the length are stored on the LocalHeap of NewButterflyWithSize and NewArrayWithButterfly&apos;s
LocalHeap only contains the butterfly. Right now we only handle in-bounds loads/stores to the butterfly
but this model makes it substantially easier to model growing the Array&apos;s Butterfly in the future.

One other interesting change in this PR is that we could handle sizes greater than MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH
in the slow path. MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH is always bigger than a MarkBlock&apos;s max allocation size
(by a lot) so any allocation that big will always take the slow path. This patch fixes that issue for the new nodes
but we should consider addressing that for other Array allocation Nodes in a follow up.

Lastly, this patch &quot;corrects&quot; leastUpperBoundOfIndexingTypeAndType so it no longer recommends Double storage
when the value is a NaN. Preivously this would just be a perf issue but with this patch it&apos;s needed for
correctness.

Overall, this change is perf neutral or maybe a slight progression on JetStream 3.

Canonical link: <a href="https://commits.webkit.org/299806@main">https://commits.webkit.org/299806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8edc8f20ea1a095d7bdae72df6f434009a8134fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120150 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72223 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/344d5067-3312-4b1f-b736-441dce9fd1dd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48421 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91247 "Found 1 new test failure: imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60554 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c4032e0-7f55-4d4b-bc70-1ffaa5b6a7b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0015942-5775-4d7a-92a3-5863d59fc22f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25833 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70125 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112275 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129403 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118666 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99867 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25334 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43701 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52638 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147365 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46400 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37864 "Found 1 new JSC binary failure: testapi, Found 18665 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49747 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48084 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->