### PR TITLE
HBO Max videos are labeled as ads in PiP

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -107,7 +107,7 @@ public:
     void willBeginPlayback();
     void willPausePlayback();
 
-    Document* document() const;
+    WEBCORE_EXPORT Document* document() const;
     RefPtr<Document> protectedDocument() const;
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1297,6 +1297,14 @@ bool Quirks::shouldEnableFontLoadingAPIQuirk() const
     return m_quirksData.shouldEnableFontLoadingAPIQuirk;
 }
 
+#if HAVE(PIP_SKIP_PREROLL)
+// play.hbomax.com rdar://158430821
+bool Quirks::shouldDisableAdSkippingInPip() const
+{
+    return needsQuirks() && m_quirksData.shouldDisableAdSkippingInPip;
+}
+#endif
+
 // hulu.com rdar://100199996
 bool Quirks::needsVideoShouldMaintainAspectRatioQuirk() const
 {
@@ -2597,6 +2605,11 @@ static void handleHBOMaxQuirks(QuirksData& quirksData, const URL& quirksURL, con
 
     // play.hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
     quirksData.shouldEnableFontLoadingAPIQuirk = true;
+
+#if HAVE(PIP_SKIP_PREROLL)
+    // play.hbomax.com rdar://158430821
+    quirksData.shouldDisableAdSkippingInPip = true;
+#endif
 }
 
 static void handleHotelsQuirks(QuirksData& quirksData, const URL&, const String& quirksDomainString, const URL&)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -209,6 +209,9 @@ public:
     WEBCORE_EXPORT bool shouldDisableFullscreenVideoAspectRatioAdaptiveSizing() const;
 #endif
 
+#if HAVE(PIP_SKIP_PREROLL)
+    WEBCORE_EXPORT bool shouldDisableAdSkippingInPip() const;
+#endif
     bool shouldDisableLazyIframeLoadingQuirk() const;
 
     bool shouldBlockFetchWithNewlineAndLessThan() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -199,6 +199,10 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldEnterNativeFullscreenWhenCallingElementRequestFullscreen : 1 { false };
     bool shouldDelayReloadWhenRegisteringServiceWorker : 1 { false };
     bool shouldDisableDOMAudioSession : 1 { false };
+
+#if HAVE(PIP_SKIP_PREROLL)
+    bool shouldDisableAdSkippingInPip : 1 { false };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -614,9 +614,14 @@ void PlaybackSessionManager::actionHandlersChanged()
     if (!m_controlsManagerContextId)
         return;
 
-    bool canSkipAd = m_mediaSession->hasActionHandler(MediaSessionAction::Skipad);
-    if (RefPtr page = m_page.get())
-        page->send(Messages::PlaybackSessionManagerProxy::CanSkipAdChanged(processQualify(*m_controlsManagerContextId), canSkipAd));
+    bool skipAdHasHandler = m_mediaSession->hasActionHandler(MediaSessionAction::Skipad);
+
+    bool skipAdIsDisabledQuirk = false;
+    if (RefPtr document = m_mediaSession->document(); document && document->quirks().shouldDisableAdSkippingInPip())
+        skipAdIsDisabledQuirk = true;
+
+    if (RefPtr page = m_page.get() && !skipAdIsDisabledQuirk)
+        page->send(Messages::PlaybackSessionManagerProxy::CanSkipAdChanged(processQualify(*m_controlsManagerContextId), skipAdHasHandler));
 }
 
 void PlaybackSessionManager::skipAd(WebCore::HTMLMediaElementIdentifier contextId)


### PR DESCRIPTION
#### 902a75fcfd40e6cb45b5e90639ff68779d50dd92
<pre>
HBO Max videos are labeled as ads in PiP
<a href="https://bugs.webkit.org/show_bug.cgi?id=298611">https://bugs.webkit.org/show_bug.cgi?id=298611</a>
<a href="https://rdar.apple.com/158430821">rdar://158430821</a>

Reviewed by Ryan Reno.

HBO sets the skipAd action handler to an empty function, presumably
to attempt to say that the user cannot skip ads in pip. Until they
remove this, we should quirk HBO to not allow ad skipping on the site.

* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableAdSkippingInPip const):
(WebCore::handleHBOMaxQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::actionHandlersChanged):

Canonical link: <a href="https://commits.webkit.org/299784@main">https://commits.webkit.org/299784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/728f6d53a1c51d95cbbd9102661f89e47a3f7d16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72216 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0746b9f6-0769-43d2-a222-5ffd24577605) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60549 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/85b635de-6cd3-49f8-a007-277c5395fe12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71792 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6d70c5c-6bd7-4f85-9d9c-4c7419d00770) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70118 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129396 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99859 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99702 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43694 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19096 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52631 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->