### PR TITLE
[Build Speed] Remove RenderObjectInlines.h from all non-Inlines.h headers

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3064,8 +3064,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderMedia.h
     rendering/RenderModel.h
     rendering/RenderObject.h
+    rendering/RenderObjectDocument.h
     rendering/RenderObjectEnums.h
     rendering/RenderObjectInlines.h
+    rendering/RenderObjectNode.h
+    rendering/RenderObjectStyle.h
     rendering/RenderOverflow.h
     rendering/RenderPtr.h
     rendering/RenderReplaced.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -579,6 +579,7 @@ rendering/RenderMenuList.cpp
 rendering/RenderMultiColumnFlow.cpp
 rendering/RenderMultiColumnSet.cpp
 rendering/RenderObject.cpp
+rendering/RenderObjectNode.h
 rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
 rendering/RenderReplaced.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -828,6 +828,7 @@ rendering/RenderListMarker.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderMultiColumnSet.cpp
 rendering/RenderObject.cpp
+rendering/RenderObjectNode.h
 rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
 rendering/RenderReplaced.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -30,7 +30,8 @@
 #include "AXCoreObject.h"
 
 #include "LocalFrameView.h"
-#include "RenderObject.h"
+#include "RenderObjectStyle.h"
+#include "Settings.h"
 #include "TextDecorationPainter.h"
 #include <wtf/Deque.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -28,6 +28,7 @@
 
 #include "AXObjectCache.h"
 #include "ContainerNodeInlines.h"
+#include "DocumentInlines.h"
 #include "RenderElement.h"
 
 namespace WebCore {

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -47,6 +47,7 @@
 #import "FrameInlines.h"
 #import "FrameSelection.h"
 #import "LayoutRect.h"
+#import "LocalFrameInlines.h"
 #import "LocalizedStrings.h"
 #import "Page.h"
 #import "RenderTextControl.h"

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityObject.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "DocumentInlines.h"
 #include "HTMLSelectElement.h"
 #include "LocalFrame.h"
 #include "Page.h"

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -32,7 +32,7 @@
 #include "AccessibilityObject.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "Page.h"
 #include "RenderObject.h"
 

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -31,6 +31,7 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "DocumentInlines.h"
+#include "FloatQuad.h"
 #include "FontCascade.h"
 #include "LocalFrame.h"
 #include "NodeTraversal.h"

--- a/Source/WebCore/dom/NodeRenderStyle.h
+++ b/Source/WebCore/dom/NodeRenderStyle.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <WebCore/Node.h>
-#include <WebCore/RenderObjectInlines.h>
+#include <WebCore/RenderObjectStyle.h>
 #include <WebCore/RenderStyle.h>
 
 namespace WebCore {

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -108,6 +108,7 @@
 #include "RenderImage.h"
 #include "RenderInline.h"
 #include "RenderLayer.h"
+#include "RenderObjectStyle.h"
 #include "RenderTextControl.h"
 #include "RenderedDocumentMarker.h"
 #include "RenderedPosition.h"

--- a/Source/WebCore/editing/InsertLineBreakCommand.cpp
+++ b/Source/WebCore/editing/InsertLineBreakCommand.cpp
@@ -35,6 +35,7 @@
 #include "HTMLTableElement.h"
 #include "LocalFrame.h"
 #include "RenderElement.h"
+#include "RenderObjectStyle.h"
 #include "RenderStyleInlines.h"
 #include "RenderText.h"
 #include "Text.h"

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -57,6 +57,7 @@
 #import "LocalizedStrings.h"
 #import "NodeName.h"
 #import "RenderImage.h"
+#import "RenderObjectStyle.h"
 #import "RenderText.h"
 #import "StyleExtractor.h"
 #import "StyleProperties.h"

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -86,6 +86,7 @@
 #include "Range.h"
 #include "RenderBlock.h"
 #include "RenderElementInlines.h"
+#include "RenderObjectStyle.h"
 #include "ScriptWrappableInlines.h"
 #include "Settings.h"
 #include "SocketProvider.h"

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -211,7 +211,6 @@ public:
     virtual bool isVideo() const { return false; }
     bool hasVideo() const override { return false; }
     WEBCORE_EXPORT bool hasAudio() const override;
-    bool hasRenderer() const { return static_cast<bool>(renderer()); }
 
     WEBCORE_EXPORT static HashSet<WeakRef<HTMLMediaElement>>& allMediaElements();
 
@@ -604,7 +603,8 @@ public:
     void allowsMediaDocumentInlinePlaybackChanged();
     void updateShouldPlay();
 
-    RenderMedia* renderer() const;
+    inline bool hasRenderer() const; // Defined in RenderMedia.h.
+    inline RenderMedia* renderer() const; // Defined in RenderMedia.h.
 
     void resetPlaybackSessionState();
     WEBCORE_EXPORT bool isVisibleInViewport() const;

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -120,7 +120,7 @@ public:
     void exitToFullscreenModeWithoutAnimationIfPossible(HTMLMediaElementEnums::VideoFullscreenMode fromMode, HTMLMediaElementEnums::VideoFullscreenMode toMode);
 #endif
 
-    RenderVideo* renderer() const;
+    inline RenderVideo* renderer() const; // Defined in RenderVideo.h.
     void acceleratedRenderingStateChanged();
     bool supportsAcceleratedRendering() const;
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -64,6 +64,7 @@
 #include "PageTimelineAgent.h"
 #include "PlatformStrategies.h"
 #include "RenderObjectInlines.h"
+#include "RenderObjectNode.h"
 #include "RenderView.h"
 #include "ScriptController.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -29,6 +29,7 @@
 #include "CachedResourceRequest.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "ContainerNodeInlines.h"
 #include "CookieJar.h"
 #include "CrossOriginAccessControl.h"
 #include "Document.h"

--- a/Source/WebCore/page/mac/DragControllerMac.mm
+++ b/Source/WebCore/page/mac/DragControllerMac.mm
@@ -38,6 +38,7 @@
 #import "EditorClient.h"
 #import "Element.h"
 #import "File.h"
+#import "FrameDestructionObserverInlines.h"
 #import "HTMLAttachmentElement.h"
 #import "LocalFrame.h"
 #import "LocalFrameView.h"

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -45,7 +45,7 @@
 #import "HTMLIFrameElement.h"
 #import "HandleUserInputEventResult.h"
 #import "KeyboardEvent.h"
-#import "LocalFrame.h"
+#import "LocalFrameInlines.h"
 #import "LocalFrameView.h"
 #import "Logging.h"
 #import "MouseEventWithHitTestResults.h"

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -37,6 +37,7 @@
 #include "FloatRect.h"
 #include "KeyframeEffect.h"
 #include "LayoutSize.h"
+#include "Settings.h"
 #include "StyleInterpolation.h"
 #include "StyleOffsetRotate.h"
 #include "StyleOriginatedAnimation.h"

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -33,6 +33,7 @@
 #include "PathUtilities.h"
 #include "RenderAncestorIterator.h"
 #include "RenderBox.h"
+#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "SimpleRange.h"
 #include "WindRule.h"

--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -81,14 +81,14 @@ void ImageQualityController::removeObject(RenderBoxModelObject* object)
 
 void ImageQualityController::highQualityRepaintTimerFired()
 {
-    if (m_renderView.renderTreeBeingDestroyed())
+    if (m_renderView->renderTreeBeingDestroyed())
         return;
     if (!m_animatedResizeIsActive && !m_liveResizeOptimizationIsActive)
         return;
     m_animatedResizeIsActive = false;
 
     // If the FrameView is in live resize, punt the timer and hold back for now.
-    if (m_renderView.frameView().inLiveResize()) {
+    if (m_renderView->frameView().inLiveResize()) {
         restartTimer();
         return;
     }
@@ -179,7 +179,7 @@ InterpolationQuality ImageQualityController::chooseInterpolationQuality(Graphics
     }
 
     // There is no need to hash scaled images that always use low quality mode when the page demands it. This is the iChat case.
-    if (m_renderView.page().inLowQualityImageInterpolationMode()) {
+    if (m_renderView->page().inLowQualityImageInterpolationMode()) {
         double totalPixels = static_cast<double>(image.width()) * static_cast<double>(image.height());
         if (totalPixels > cInterpolationCutoff)
             return InterpolationQuality::Low;

--- a/Source/WebCore/rendering/ImageQualityController.h
+++ b/Source/WebCore/rendering/ImageQualityController.h
@@ -62,7 +62,7 @@ private:
     void restartTimer();
     void removeObject(RenderBoxModelObject*);
 
-    const RenderView& m_renderView;
+    const CheckedRef<const RenderView> m_renderView;
     ObjectLayerSizeMap m_objectLayerSizeMap;
     DeferrableOneShotTimer m_timer;
     bool m_animatedResizeIsActive { false };

--- a/Source/WebCore/rendering/RenderBlockInlines.h
+++ b/Source/WebCore/rendering/RenderBlockInlines.h
@@ -21,7 +21,6 @@
 
 #include "RenderBlock.h"
 #include "RenderBoxInlines.h"
-#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/RenderBox.h>
 #include <WebCore/RenderBoxModelObjectInlines.h>
 #include <WebCore/RenderElementInlines.h>
-#include <WebCore/RenderObjectInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -19,8 +19,13 @@
 
 #pragma once
 
-#include <WebCore/RenderElement.h>
-#include <WebCore/RenderObjectInlines.h>
+#include <WebCore/PseudoElement.h>
+#include <WebCore/RenderBox.h>
+#include <WebCore/RenderObjectDocument.h>
+#include <WebCore/RenderObjectNode.h>
+#include <WebCore/StyleOpacity.h>
+#include <WebCore/StyleShapeOutside.h>
+#include <WebCore/WillChangeData.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -27,10 +27,9 @@
 
 #if ENABLE(VIDEO)
 
-#include <WebCore/ContainerNodeInlines.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/RenderImage.h>
-#include <WebCore/RenderObjectInlines.h>
+#include <WebCore/RenderObjectNode.h>
 
 namespace WebCore {
 
@@ -62,9 +61,14 @@ private:
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
 };
 
+inline bool HTMLMediaElement::hasRenderer() const
+{
+    return is<RenderMedia>(Node::renderer());
+}
+
 inline RenderMedia* HTMLMediaElement::renderer() const
 {
-    return downcast<RenderMedia>(HTMLElement::renderer());
+    return downcast<RenderMedia>(Node::renderer());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2020,6 +2020,11 @@ PositionWithAffinity RenderObject::createPositionWithAffinity(const Position& po
     return createPositionWithAffinity(0, Affinity::Downstream);
 }
 
+const RenderStyle& RenderObject::outlineStyleForRepaint() const
+{
+    return style();
+}
+
 CursorDirective RenderObject::getCursor(const LayoutPoint&, Cursor&) const
 {
     return SetCursorBasedOnStyle;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -427,7 +427,7 @@ public:
     void outputRegionsInformation(WTF::TextStream&) const;
 #endif
 
-    inline bool isPseudoElement() const; // Defined in RenderObjectInlines.h
+    inline bool isPseudoElement() const; // Defined in RenderObjectNode.h
 
     bool isRenderElement() const { return !isRenderText(); }
     bool isRenderReplaced() const { return m_typeSpecificFlags.kind() == TypeSpecificFlags::Kind::Replaced; }
@@ -437,7 +437,7 @@ public:
     bool isRenderInline() const { return m_typeFlags.contains(TypeFlag::IsRenderInline); }
     bool isRenderLayerModelObject() const { return m_typeFlags.contains(TypeFlag::IsLayerModelObject); }
 
-    inline bool isAtomicInlineLevelBox() const;
+    inline bool isAtomicInlineLevelBox() const; // Defined in RenderObjectStyle.h
     inline bool isNonReplacedAtomicInlineLevelBox() const;
 
     bool isRenderCounter() const { return type() == Type::Counter; }
@@ -499,8 +499,8 @@ public:
     bool isViewTransitionContainingBlock() const { return isRenderBlockFlow() && m_typeSpecificFlags.blockFlowFlags().contains(BlockFlowFlag::IsViewTransitionContainingBlock); }
 
     inline bool isDocumentElementRenderer() const; // Defined in RenderObjectInlines.h
-    inline bool isBody() const; // Defined in RenderObjectInlines.h
-    inline bool isHR() const; // Defined in RenderObjectInlines.h
+    inline bool isBody() const; // Defined in RenderObjectNode.h
+    inline bool isHR() const; // Defined in RenderObjectNode.h
     bool isLegend() const;
 
     bool isHTMLMarquee() const;
@@ -712,8 +712,8 @@ public:
     bool hasNonVisibleOverflow() const { return m_stateBitfields.hasFlag(StateFlag::HasNonVisibleOverflow); }
 
     bool hasTransformRelatedProperty() const { return m_stateBitfields.hasFlag(StateFlag::HasTransformRelatedProperty); } // Transform, perspective or transform-style: preserve-3d.
-    inline bool isTransformed() const;
-    inline bool hasTransformOrPerspective() const;
+    inline bool isTransformed() const; // Defined in RenderObjectStyle.h
+    inline bool hasTransformOrPerspective() const; // Defined in RenderObjectStyle.h
 
     bool capturedInViewTransition() const { return m_stateBitfields.hasFlag(StateFlag::CapturedInViewTransition); }
     bool setCapturedInViewTransition(bool);
@@ -722,7 +722,7 @@ public:
     // instead. Returns the capture state with this adjustment applied.
     bool effectiveCapturedInViewTransition() const;
 
-    inline RenderView& view() const; // Defined in RenderObjectInlines.h
+    inline RenderView& view() const; // Defined in RenderObjectDocument.h
     CheckedRef<RenderView> checkedView() const;
     inline LocalFrameViewLayoutContext& layoutContext() const;
 
@@ -731,13 +731,13 @@ public:
     // Returns true if this renderer is rooted.
     bool isRooted() const;
 
-    inline Node* node() const; // Defined in RenderObjectInlines.h
-    inline RefPtr<Node> protectedNode() const; // Defined in RenderObjectInlines.h
+    inline Node* node() const; // Defined in RenderObjectNode.h
+    inline RefPtr<Node> protectedNode() const; // Defined in RenderObjectNode.h
 
-    inline Node* nonPseudoNode() const; // Defined in RenderObjectInlines.h
+    inline Node* nonPseudoNode() const; // Defined in RenderObjectNode.h
 
-    inline Document& document() const; // Defined in RenderObjectInlines.h
-    inline Ref<Document> protectedDocument() const; // Defined in RenderObjectInlines.h
+    inline Document& document() const; // Defined in RenderObjectDocument.h
+    inline Ref<Document> protectedDocument() const; // Defined in RenderObjectDocument.h
     inline TreeScope& treeScopeForSVGReferences() const; // Defined in RenderObjectInlines.h
     inline Ref<TreeScope> protectedTreeScopeForSVGReferences() const; // Defined in RenderObjectInlines.h
     inline LocalFrame& frame() const; // Defined in RenderObjectInlines.h
@@ -862,16 +862,16 @@ public:
     // the rect that will be painted if this object is passed as the paintingRoot
     WEBCORE_EXPORT LayoutRect paintingRootRect(LayoutRect& topLevelRect);
 
-    const RenderStyle& style() const; // Defined in RenderObjectInlines.h.
-    inline CheckedRef<const RenderStyle> checkedStyle() const; // Defined in RenderObjectInlines.h.
+    inline const RenderStyle& style() const; // Defined in RenderObjectStyle.h.
+    inline CheckedRef<const RenderStyle> checkedStyle() const; // Defined in RenderObjectStyle.h.
     const RenderStyle& firstLineStyle() const;
-    inline WritingMode writingMode() const; // Defined in RenderObjectInlines.h.
+    inline WritingMode writingMode() const; // Defined in RenderObjectStyle.h.
     // writingMode().isHorizontal() is cached by isHorizontalWritingMode() above.
 
     // Anonymous blocks that are part of of a continuation chain will return their inline continuation's outline style instead.
     // This is typically only relevant when repainting.
-    virtual const RenderStyle& outlineStyleForRepaint() const { return style(); }
-    
+    virtual const RenderStyle& outlineStyleForRepaint() const;
+
     virtual CursorDirective getCursor(const LayoutPoint&, Cursor&) const;
 
     // Return the RenderLayerModelObject in the container chain which is responsible for painting this object, or nullptr

--- a/Source/WebCore/rendering/RenderObjectDocument.h
+++ b/Source/WebCore/rendering/RenderObjectDocument.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/Document.h>
+#include <WebCore/Element.h>
+#include <WebCore/LocalFrame.h>
+#include <WebCore/RenderObject.h>
+
+namespace WebCore {
+
+inline Document& RenderObject::document() const { return m_node.get().document(); }
+inline Ref<Document> RenderObject::protectedDocument() const { return document(); }
+
+inline bool RenderObject::isDocumentElementRenderer() const
+{
+    return document().documentElement() == m_node.ptr();
+}
+
+inline RenderView& RenderObject::view() const
+{
+    return *document().renderView();
+}
+
+inline bool RenderObject::renderTreeBeingDestroyed() const
+{
+    return document().renderTreeBeingDestroyed();
+}
+
+}

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -26,49 +26,20 @@
 #include <WebCore/RenderElement.h>
 #include <WebCore/RenderIFrame.h>
 #include <WebCore/RenderObject.h>
+#include <WebCore/RenderObjectDocument.h>
+#include <WebCore/RenderObjectNode.h>
+#include <WebCore/RenderObjectStyle.h>
 #include <WebCore/RenderReplaced.h>
 #include <WebCore/RenderStyleInlines.h>
 #include <WebCore/RenderView.h>
 
 namespace WebCore {
 
-inline Node& RenderObject::nodeForNonAnonymous() const { ASSERT(!isAnonymous()); return m_node.get(); }
 inline bool RenderObject::hasTransformOrPerspective() const { return hasTransformRelatedProperty() && (isTransformed() || style().hasPerspective()); }
 inline bool RenderObject::isAtomicInlineLevelBox() const { return style().isDisplayInlineType() && !(style().display() == DisplayType::Inline && !isBlockLevelReplacedOrAtomicInline()); }
 inline bool RenderObject::isTransformed() const { return hasTransformRelatedProperty() && (style().affectsTransform() || hasSVGTransform()); }
-inline Document& RenderObject::document() const { return m_node.get().document(); }
-inline Ref<Document> RenderObject::protectedDocument() const { return document(); }
 inline LocalFrameViewLayoutContext& RenderObject::layoutContext() const { return view().frameView().layoutContext(); }
-inline bool RenderObject::isBody() const { return node() && node()->hasTagName(HTMLNames::bodyTag); }
-inline bool RenderObject::isHR() const { return node() && node()->hasTagName(HTMLNames::hrTag); }
-inline bool RenderObject::isPseudoElement() const { return node() && node()->isPseudoElement(); }
-inline Node* RenderObject::nonPseudoNode() const { return isPseudoElement() ? nullptr : node(); }
 inline TreeScope& RenderObject::treeScopeForSVGReferences() const { return Ref { m_node.get() }->treeScopeForSVGReferences(); }
-inline WritingMode RenderObject::writingMode() const { return style().writingMode(); }
-
-inline Node* RenderObject::node() const
-{
-    if (isAnonymous())
-        return nullptr;
-    return m_node.ptr();
-}
-
-inline RefPtr<Node> RenderObject::protectedNode() const
-{
-    return node();
-}
-
-inline const RenderStyle& RenderObject::style() const
-{
-    if (isRenderText())
-        return m_parent->style();
-    return downcast<RenderElement>(*this).style();
-}
-
-inline CheckedRef<const RenderStyle> RenderObject::checkedStyle() const
-{
-    return style();
-}
 
 inline const RenderStyle& RenderObject::firstLineStyle() const
 {
@@ -80,16 +51,6 @@ inline const RenderStyle& RenderObject::firstLineStyle() const
 inline Ref<TreeScope> RenderObject::protectedTreeScopeForSVGReferences() const
 {
     return treeScopeForSVGReferences();
-}
-
-inline bool RenderObject::isDocumentElementRenderer() const
-{
-    return document().documentElement() == m_node.ptr();
-}
-
-inline RenderView& RenderObject::view() const
-{
-    return *document().renderView();
 }
 
 inline LocalFrame& RenderObject::frame() const
@@ -118,11 +79,6 @@ inline Ref<Page> RenderObject::protectedPage() const
 inline Settings& RenderObject::settings() const
 {
     return page().settings();
-}
-
-inline bool RenderObject::renderTreeBeingDestroyed() const
-{
-    return document().renderTreeBeingDestroyed();
 }
 
 inline FloatQuad RenderObject::localToAbsoluteQuad(const FloatQuad& quad, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const

--- a/Source/WebCore/rendering/RenderObjectNode.h
+++ b/Source/WebCore/rendering/RenderObjectNode.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/HTMLNames.h>
+#include <WebCore/Node.h>
+#include <WebCore/RenderObject.h>
+
+namespace WebCore {
+
+inline Node& RenderObject::nodeForNonAnonymous() const
+{
+    ASSERT(!isAnonymous());
+    return m_node.get();
+}
+
+inline Node* RenderObject::nonPseudoNode() const
+{
+    if (isPseudoElement())
+        return nullptr;
+    return node();
+}
+
+inline Node* RenderObject::node() const
+{
+    if (isAnonymous())
+        return nullptr;
+    return m_node.ptr();
+}
+
+inline RefPtr<Node> RenderObject::protectedNode() const
+{
+    return node();
+}
+
+inline bool RenderObject::isBody() const { return node() && node()->hasTagName(HTMLNames::bodyTag); }
+inline bool RenderObject::isHR() const { return node() && node()->hasTagName(HTMLNames::hrTag); }
+inline bool RenderObject::isPseudoElement() const { return node() && node()->isPseudoElement(); }
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderObjectStyle.h
+++ b/Source/WebCore/rendering/RenderObjectStyle.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/RenderElement.h>
+#include <WebCore/RenderStyle.h>
+
+namespace WebCore {
+
+inline WritingMode RenderObject::writingMode() const { return style().writingMode(); }
+
+inline const RenderStyle& RenderObject::style() const
+{
+    if (isRenderText())
+        return m_parent->style();
+    return downcast<RenderElement>(*this).style();
+}
+
+inline CheckedRef<const RenderStyle> RenderObject::checkedStyle() const
+{
+    return style();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderTableCellInlines.h
+++ b/Source/WebCore/rendering/RenderTableCellInlines.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderTableCell.h"
 #include "StyleContentAlignmentData.h"

--- a/Source/WebCore/rendering/RenderTableInlines.h
+++ b/Source/WebCore/rendering/RenderTableInlines.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderTable.h"
 

--- a/Source/WebCore/rendering/RenderTableSectionInlines.h
+++ b/Source/WebCore/rendering/RenderTableSectionInlines.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderTableSection.h"
 

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -95,7 +95,7 @@ private:
 
 inline RenderVideo* HTMLVideoElement::renderer() const
 {
-    return downcast<RenderVideo>(HTMLMediaElement::renderer());
+    return downcast<RenderVideo>(Node::renderer());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderWidgetInlines.h
+++ b/Source/WebCore/rendering/RenderWidgetInlines.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/RenderObjectInlines.h>
+#include <WebCore/RenderObjectNode.h>
 #include <WebCore/RenderWidget.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -35,6 +35,7 @@
 #include "Logging.h"
 #include "RenderBlock.h"
 #include "RenderListMarker.h"
+#include "RenderObjectInlines.h"
 #include "RenderText.h"
 #include "RenderTextFragment.h"
 #include "RenderTreeBuilder.h"

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -32,6 +32,7 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "PaintInfo.h"
+#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderText.h"
 #include "RenderTheme.h"

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -36,7 +36,6 @@
 #include "RenderLayer.h"
 #include "RenderLineBreak.h"
 #include "RenderListMarker.h"
-#include "RenderObjectInlines.h"
 #include "RenderSVGInlineText.h"
 #include "RenderTextInlines.h"
 #include "TrailingObjects.h"

--- a/Source/WebCore/rendering/line/LineInlineHeaders.h
+++ b/Source/WebCore/rendering/line/LineInlineHeaders.h
@@ -27,7 +27,6 @@
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderLayer.h"
-#include "RenderObjectInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -38,6 +38,7 @@
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderElement.h"
 #include "RenderIterator.h"
+#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -547,6 +548,12 @@ void RenderMathMLToken::updateMathVariantGlyph()
             m_mathVariantIsMirrored = writingMode().isBidiRTL();
         }
     }
+}
+
+void RenderMathMLToken::setMathVariantGlyphDirty()
+{
+    m_mathVariantGlyphDirty = true;
+    setNeedsLayoutAndPreferredWidthsUpdate();
 }
 
 void RenderMathMLToken::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.h
@@ -30,7 +30,6 @@
 #if ENABLE(MATHML)
 
 #include "RenderMathMLBlock.h"
-#include "RenderObjectInlines.h"
 
 namespace WebCore {
 
@@ -62,11 +61,8 @@ private:
     bool isChildAllowed(const RenderObject&, const RenderStyle&) const final { return true; };
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
     void updateMathVariantGlyph();
-    void setMathVariantGlyphDirty()
-    {
-        m_mathVariantGlyphDirty = true;
-        setNeedsLayoutAndPreferredWidthsUpdate();
-    }
+    void setMathVariantGlyphDirty();
+
     std::optional<char32_t> m_mathVariantCodePoint { std::nullopt };
     bool m_mathVariantIsMirrored { false };
     bool m_mathVariantGlyphDirty { false };

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <WebCore/FontCascade.h>
-#include <WebCore/RenderObjectInlines.h>
+#include <WebCore/RenderObjectNode.h>
 #include <WebCore/RenderText.h>
 #include <WebCore/SVGTextLayoutAttributes.h>
 #include <WebCore/Text.h>

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -43,7 +43,7 @@
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderElementInlines.h"
 #include "RenderIterator.h"
-#include "RenderObjectInlines.h"
+#include "RenderObjectDocument.h"
 #include "RenderSVGBlockInlines.h"
 #include "RenderSVGInline.h"
 #include "RenderSVGInlineText.h"
@@ -63,6 +63,7 @@
 #include "SVGTextLayoutEngine.h"
 #include "SVGURIReference.h"
 #include "SVGVisitedRendererTracking.h"
+#include "Settings.h"
 #include "StyleTextShadow.h"
 #include "TransformState.h"
 #include "VisiblePosition.h"
@@ -801,6 +802,13 @@ PositionWithAffinity RenderSVGText::positionForPoint(const LayoutPoint& pointInC
         return createPositionWithAffinity(0, Affinity::Downstream);
 
     return const_cast<RenderObject&>(closestBox->renderer()).positionForPoint({ pointInContents.x(), LayoutUnit(closestBox->visualRectIgnoringBlockDirection().y()) }, source, fragment);
+}
+
+bool RenderSVGText::requiresLayer() const
+{
+    if (document().settings().layerBasedSVGEngineEnabled())
+        return true;
+    return false;
 }
 
 void RenderSVGText::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "AffineTransform.h"
-#include "RenderObjectInlines.h"
 #include "RenderSVGBlock.h"
 #include "SVGBoundingBoxComputation.h"
 #include "SVGTextChunk.h"
@@ -94,13 +93,7 @@ private:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const final;
     PositionWithAffinity positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
 
-    bool requiresLayer() const override
-    {
-        if (document().settings().layerBasedSVGEngineEnabled())
-            return true;
-        return false;
-    }
-
+    bool requiresLayer() const override;
     void layout() override;
 
     void computePerCharacterLayoutInformation();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -31,6 +31,7 @@
 #include "IntRect.h"
 #include "LegacyRenderSVGResourceFilterInlines.h"
 #include "Logging.h"
+#include "RenderObjectInlines.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGRenderStyle.h"
 #include "SVGRenderingContext.h"

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "LegacyRenderSVGResourceFilterPrimitive.h"
 
+#include "RenderObjectDocument.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGFEDiffuseLightingElement.h"
 #include "SVGFEDropShadowElement.h"

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
@@ -24,6 +24,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "RenderElement.h"
+#include "RenderObjectDocument.h"
 #include "RenderStyle.h"
 #include "RenderView.h"
 #include "SVGRenderStyle.h"

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -38,6 +38,7 @@
 #include "RenderIterator.h"
 #include "RenderLayer.h"
 #include "RenderLayoutState.h"
+#include "RenderObjectInlines.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
 #include "SVGElementTypeHelpers.h"

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -73,7 +73,6 @@
 #include "RenderElementInlines.h"
 #include "RenderGrid.h"
 #include "RenderInline.h"
-#include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "SVGRenderStyle.h"
 #include "ScrollTimeline.h"

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -28,6 +28,7 @@
 #include "ImageBuffer.h"
 #include "LegacyRenderSVGResourceClipper.h"
 #include "RenderElementInlines.h"
+#include "RenderObjectInlines.h"
 #include "RenderSVGResourceClipper.h"
 #include "RenderSVGText.h"
 #include "RenderStyleInlines.h"

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -30,6 +30,7 @@
 #include "LegacyRenderSVGResourceMaskerInlines.h"
 #include "NodeName.h"
 #include "RenderElementInlines.h"
+#include "RenderObjectInlines.h"
 #include "RenderSVGResourceMasker.h"
 #include "SVGElementInlines.h"
 #include "SVGLayerTransformComputation.h"

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -31,7 +31,7 @@
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "FontCache.h"
-#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
 #include "LocaleToScriptMapping.h"
 #include "Page.h"

--- a/Source/WebKit/Shared/EditingRange.cpp
+++ b/Source/WebKit/Shared/EditingRange.cpp
@@ -28,7 +28,7 @@
 
 #include <WebCore/BoundaryPointInlines.h>
 #include <WebCore/FrameSelection.h>
-#include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameInlines.h>
 #include <WebCore/RangeBoundaryPointInlines.h>
 #include <WebCore/TextIterator.h>
 #include <WebCore/VisibleUnits.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -66,7 +66,7 @@
 #include <WebCore/CaptionUserPreferences.h>
 #include <WebCore/CompositionHighlight.h>
 #include <WebCore/FocusController.h>
-#include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameInlines.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageGroup.h>
 #include <WebCore/PageOverlay.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -33,13 +33,14 @@
 #include <WebCore/BoundaryPointInlines.h>
 #include <WebCore/Document.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameInlines.h>
 #include <WebCore/FrameSelection.h>
 #include <WebCore/GeometryUtilities.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/JSRange.h>
-#include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/NodeInlines.h>
 #include <WebCore/Page.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -80,6 +80,7 @@
 #import <WebCore/RenderLayerScrollableArea.h>
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/ScrollAnimator.h>
+#import <WebCore/Settings.h>
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/VoidCallback.h>
 #import <wtf/CheckedArithmetic.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -107,6 +107,7 @@
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ScrollbarTheme.h>
 #include <WebCore/ScrollbarsController.h>
+#include <WebCore/Settings.h>
 #include <WebCore/ShadowRoot.h>
 #include <WebCore/StyleColorOptions.h>
 #include <WebCore/VoidCallback.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/RenderElementInlines.h>
 #include <WebCore/RenderImage.h>
+#include <WebCore/RenderObjectInlines.h>
 #include <WebCore/RenderVideo.h>
 #include <WebCore/ShareableBitmap.h>
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/DocumentFragment.h>
 #include <WebCore/FocusController.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HTMLInputElement.h>
 #include <WebCore/HTMLNames.h>

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -39,7 +39,7 @@
 #include "WebPreferencesKeys.h"
 #include "WebProcess.h"
 #include <WebCore/GraphicsContext.h>
-#include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageOverlayController.h>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -192,6 +192,7 @@
 #include <WebCore/Chrome.h>
 #include <WebCore/CommonVM.h>
 #include <WebCore/ContactsRequestData.h>
+#include <WebCore/ContainerNodeInlines.h>
 #include <WebCore/ContextMenuController.h>
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -76,6 +76,7 @@
 #import <WebCore/AutofillElements.h>
 #import <WebCore/BoundaryPointInlines.h>
 #import <WebCore/Chrome.h>
+#import <WebCore/ContainerNodeInlines.h>
 #import <WebCore/ContentChangeObserver.h>
 #import <WebCore/DOMTimerHoldingTank.h>
 #import <WebCore/DataDetection.h>
@@ -161,6 +162,7 @@
 #import <WebCore/RenderLayer.h>
 #import <WebCore/RenderLayerBacking.h>
 #import <WebCore/RenderLayerScrollableArea.h>
+#import <WebCore/RenderObjectInlines.h>
 #import <WebCore/RenderThemeIOS.h>
 #import <WebCore/RenderVideo.h>
 #import <WebCore/RenderView.h>

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -45,6 +45,7 @@
 #import <WebCore/RemoteFrame.h>
 #import <WebCore/ScrollView.h>
 #import <WebCore/Scrollbar.h>
+#import <WebCore/Settings.h>
 
 namespace ax = WebCore::Accessibility;
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -52,6 +52,7 @@
 #import <WebCore/Quirks.h>
 #import <WebCore/RenderLayer.h>
 #import <WebCore/RenderLayerBacking.h>
+#import <WebCore/RenderObjectInlines.h>
 #import <WebCore/RenderVideo.h>
 #import <WebCore/RenderView.h>
 #import <WebCore/Settings.h>

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -53,6 +53,7 @@
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/Page.h>
 #import <WebCore/RenderBoxInlines.h>
+#import <WebCore/RenderObjectInlines.h>
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/SimpleRange.h>
 #import <WebKitLegacy/DOMPrivate.h>

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -62,6 +62,7 @@
 #import <WebCore/Editor.h>
 #import <WebCore/Event.h>
 #import <WebCore/FloatQuad.h>
+#import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/FrameInlines.h>
 #import <WebCore/HTMLInputElement.h>
 #import <WebCore/HTMLNames.h>

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -109,6 +109,7 @@
 #import <WebCore/RenderLayer.h>
 #import <WebCore/RenderLayerCompositor.h>
 #import <WebCore/RenderLayerScrollableArea.h>
+#import <WebCore/RenderObjectStyle.h>
 #import <WebCore/RenderStyleInlines.h>
 #import <WebCore/RenderTextControl.h>
 #import <WebCore/RenderView.h>

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -167,6 +167,7 @@
 #import <WebCore/FocusController.h>
 #import <WebCore/FontAttributes.h>
 #import <WebCore/FontCache.h>
+#import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/FrameLoader.h>
 #import <WebCore/FrameSelection.h>
 #import <WebCore/FrameTree.h>


### PR DESCRIPTION
#### d804699e453246e9c6d20523003923130a190697
<pre>
[Build Speed] Remove RenderObjectInlines.h from all non-Inlines.h headers
<a href="https://rdar.apple.com/160223115">rdar://160223115</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298613">https://bugs.webkit.org/show_bug.cgi?id=298613</a>

Reviewed by Alex Christensen.

Prior to this patch, RenderObjectInlines.h was included in 8 non-Inlines.h headers. Additionally it
is included 179 times in a WebCore Unified build, and on this machine, each include of that file took the
compiler an average of 1.75s to parse, for a total of 5 CPU minutes of time spent parsing this header.

Three broad categories of definitionions needed from RenderObjectInlines.h were:
- Pulling in node() and related methods
- Pulling in document() and related methods
- Pulling in style() and related methods

Each of these categories of methods have been broken into new headers: RenderObjectNode.h,
RenderObjectDocument.h and RenderObjectStyle.h. Additionally, none of these new headers needs to
include an Inlines.h file itself, as they included only the minimal headers needed for the
definitions included therein.

In many cases, an include of RenderObjectInlines.h could be replaced with one of these new headers.
In others, the include could be removed entirely, and new included added only to implementation files.

In other cases, definitions could be moved out-of-line and into implementation files because they were
either virtual or private.

After this patch, RenderObjectInlines.h was included in 0 non-Inlines.h headers, and is included by
only 1 other Inlines.h header. In a WebCore Unified build, it was only included 110 times, each requiring
only 571ms on average, for a total of 62s of parse time.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXCoreObject.cpp:
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
* Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp:
* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
* Source/WebCore/dom/DocumentMarkerController.cpp:
* Source/WebCore/dom/NodeRenderStyle.h:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/editing/InsertLineBreakCommand.cpp:
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
* Source/WebCore/editing/markup.cpp:
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::hasRenderer const): Deleted.
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
* Source/WebCore/loader/ImageLoader.cpp:
* Source/WebCore/page/mac/DragControllerMac.mm:
* Source/WebCore/page/mac/EventHandlerMac.mm:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
* Source/WebCore/rendering/EventRegion.cpp:
* Source/WebCore/rendering/ImageQualityController.cpp:
(WebCore::ImageQualityController::highQualityRepaintTimerFired):
(WebCore::ImageQualityController::chooseInterpolationQuality):
* Source/WebCore/rendering/ImageQualityController.h:
* Source/WebCore/rendering/RenderBlockInlines.h:
* Source/WebCore/rendering/RenderBoxInlines.h:
* Source/WebCore/rendering/RenderElementInlines.h:
* Source/WebCore/rendering/RenderMedia.h:
(WebCore::HTMLMediaElement::hasRenderer const):
(WebCore::HTMLMediaElement::renderer const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::outlineStyleForRepaint const):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::outlineStyleForRepaint const): Deleted.
* Source/WebCore/rendering/RenderObjectDocument.h:
(WebCore::RenderObject::document const):
(WebCore::RenderObject::protectedDocument const):
(WebCore::RenderObject::isDocumentElementRenderer const):
(WebCore::RenderObject::view const):
(WebCore::RenderObject::renderTreeBeingDestroyed const):
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::isTransformed const):
(WebCore::RenderObject::layoutContext const):
(WebCore::RenderObject::treeScopeForSVGReferences const):
(WebCore::RenderObject::nodeForNonAnonymous const): Deleted.
(WebCore::RenderObject::document const): Deleted.
(WebCore::RenderObject::protectedDocument const): Deleted.
(WebCore::RenderObject::isBody const): Deleted.
(WebCore::RenderObject::isHR const): Deleted.
(WebCore::RenderObject::isPseudoElement const): Deleted.
(WebCore::RenderObject::nonPseudoNode const): Deleted.
(WebCore::RenderObject::writingMode const): Deleted.
(WebCore::RenderObject::node const): Deleted.
(WebCore::RenderObject::protectedNode const): Deleted.
(WebCore::RenderObject::style const): Deleted.
(WebCore::RenderObject::checkedStyle const): Deleted.
(WebCore::RenderObject::isDocumentElementRenderer const): Deleted.
(WebCore::RenderObject::view const): Deleted.
(WebCore::RenderObject::renderTreeBeingDestroyed const): Deleted.
* Source/WebCore/rendering/RenderObjectNode.h:
(WebCore::RenderObject::nodeForNonAnonymous const):
(WebCore::RenderObject::nonPseudoNode const):
(WebCore::RenderObject::node const):
(WebCore::RenderObject::protectedNode const):
(WebCore::RenderObject::isBody const):
(WebCore::RenderObject::isHR const):
(WebCore::RenderObject::isPseudoElement const):
* Source/WebCore/rendering/RenderObjectStyle.h:
(WebCore::RenderObject::writingMode const):
(WebCore::RenderObject::style const):
(WebCore::RenderObject::checkedStyle const):
* Source/WebCore/rendering/RenderTableCellInlines.h:
* Source/WebCore/rendering/RenderTableInlines.h:
* Source/WebCore/rendering/RenderTableSectionInlines.h:
* Source/WebCore/rendering/RenderVideo.h:
(WebCore::HTMLVideoElement::renderer const):
* Source/WebCore/rendering/RenderWidgetInlines.h:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/TextPaintStyle.cpp:
* Source/WebCore/rendering/line/BreakingContext.h:
* Source/WebCore/rendering/line/LineInlineHeaders.h:
* Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
(WebCore::RenderMathMLToken::setMathVariantGlyphDirty):
* Source/WebCore/rendering/mathml/RenderMathMLToken.h:
(WebCore::RenderMathMLToken::setMathVariantGlyphDirty): Deleted.
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::requiresLayer const):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/svg/SVGClipPathElement.cpp:
* Source/WebCore/svg/SVGMaskElement.cpp:
* Source/WebCore/testing/InternalSettings.cpp:
* Source/WebKit/Shared/EditingRange.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
* Source/WebKitLegacy/mac/WebView/WebView.mm:

Canonical link: <a href="https://commits.webkit.org/299817@main">https://commits.webkit.org/299817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a975f8f83dfa6c2d22a3ab2c12abef5aa5c05f63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72383 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0871dbba-6b2f-4bf9-ac09-53967b5137a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48581 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/902ccbcd-fa92-43cc-b841-de3b8951eeda) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71924 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4b48eb9-d873-4916-ae19-5411888a1f9d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25957 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70297 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129564 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47230 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/35834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25339 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23305 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52798 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46561 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48246 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->