### PR TITLE
[CSS ZOOM] Apply zoom factor when evaluating length values

### DIFF
--- a/Source/WebCore/accessibility/AXTableHelpers.cpp
+++ b/Source/WebCore/accessibility/AXTableHelpers.cpp
@@ -196,8 +196,8 @@ bool isDataTableWithTraversal(HTMLTableElement& tableElement, AXObjectCache& cac
     CheckedPtr<const RenderStyle> tableStyle = safeStyleFrom(tableElement);
     // Store the background color of the table to check against cell's background colors.
     Color tableBackgroundColor = tableStyle ? tableStyle->visitedDependentColor(CSSPropertyBackgroundColor) : Color::white;
-    unsigned tableHorizontalBorderSpacing = tableStyle ? Style::evaluate(tableStyle->borderHorizontalSpacing()) : 0;
-    unsigned tableVerticalBorderSpacing = tableStyle ? Style::evaluate(tableStyle->borderVerticalSpacing()) : 0;
+    unsigned tableHorizontalBorderSpacing = tableStyle ? Style::evaluate(tableStyle->borderHorizontalSpacing(), 1.0f /* FIXME ZOOM EFFECTED? */) : 0;
+    unsigned tableVerticalBorderSpacing = tableStyle ? Style::evaluate(tableStyle->borderVerticalSpacing(), 1.0f /* FIXME ZOOM EFFECTED? */) : 0;
 
     unsigned cellCount = 0;
     unsigned borderedCellCount = 0;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -935,7 +935,7 @@ Path AccessibilityRenderObject::elementPath() const
         if (!needsPath)
             return { };
 
-        float outlineOffset = Style::evaluate(style.outlineOffset());
+        float outlineOffset = Style::evaluate(style.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */);
         float deviceScaleFactor = renderText->document().deviceScaleFactor();
         Vector<FloatRect> pixelSnappedRects;
         for (auto rect : rects) {

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -793,7 +793,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         addAttributeIfNeeded("invisible"_s, style.visibility() == Visibility::Hidden ? "true"_s : "false"_s);
         addAttributeIfNeeded("editable"_s, m_coreObject->canSetValueAttribute() ? "true"_s : "false"_s);
         addAttributeIfNeeded("direction"_s, style.writingMode().isBidiLTR() ? "ltr"_s : "rtl"_s);
-        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate(style.textIndent().length, m_coreObject->size().width())));
+        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate(style.textIndent().length, m_coreObject->size().width(), 1.0f /* FIXME FIND ZOOM */)));
 
         switch (style.textAlign()) {
         case TextAlignMode::Start:

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -322,7 +322,7 @@ float ScrollTimeline::floatValueForOffset(const Length& offset, float maxValue)
 {
     if (offset.isNormal() || offset.isAuto())
         return 0.f;
-    return floatValueForLength(offset, maxValue);
+    return floatValueForLength(offset, maxValue, 1.0f /* FIXME FIND ZOOM */);
 }
 
 Style::SingleAnimationRange ScrollTimeline::defaultRange() const
@@ -352,7 +352,7 @@ std::pair<WebAnimationTime, WebAnimationTime> ScrollTimeline::intervalForAttachm
     auto computedPercentageIfNecessary = [&](const auto& rangeOffset) {
         if (auto percentage = rangeOffset.tryPercentage())
             return percentage->value;
-        return Style::evaluate(rangeOffset, maxScrollOffset) / maxScrollOffset * 100;
+        return Style::evaluate(rangeOffset, maxScrollOffset, 1.0f /* FIXME FIND ZOOM */) / maxScrollOffset * 100;
     };
 
     return {

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -376,14 +376,14 @@ void ViewTimeline::cacheCurrentTime()
         float insetEnd = 0;
 
         if (m_insets.start().isAuto())
-            insetStart = Style::evaluate(scrollPadding(PaddingEdge::Start), scrollContainerSize);
+            insetStart = Style::evaluate(scrollPadding(PaddingEdge::Start), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
         else
-            insetStart = Style::evaluate(m_insets.start(), scrollContainerSize);
+            insetStart = Style::evaluate(m_insets.start(), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
 
         if (m_insets.end().isAuto())
-            insetEnd = Style::evaluate(scrollPadding(PaddingEdge::End), scrollContainerSize);
+            insetEnd = Style::evaluate(scrollPadding(PaddingEdge::End), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
         else
-            insetEnd = Style::evaluate(m_insets.end(), scrollContainerSize);
+            insetEnd = Style::evaluate(m_insets.end(), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
 
         StickinessAdjustmentData stickyData;
         if (auto stickyContainer = dynamicDowncast<RenderBoxModelObject>(this->stickyContainer())) {
@@ -583,7 +583,7 @@ std::pair<double, double> ViewTimeline::offsetIntervalForAttachmentRange(const S
     auto offsetForSingleTimelineRange = [&](const auto& rangeToConvert) {
         auto [conversionRangeStart, conversionRangeEnd] = intervalForTimelineRangeName(data, rangeToConvert.name());
         auto conversionRange = conversionRangeEnd - conversionRangeStart;
-        auto convertedValue = Style::evaluate(rangeToConvert.offset(), conversionRange);
+        auto convertedValue = Style::evaluate(rangeToConvert.offset(), conversionRange, 1.0f /* FIXME FIND ZOOM */);
         auto position = conversionRangeStart + convertedValue;
         return (position - data.rangeStart) / timelineRange;
     };
@@ -604,7 +604,7 @@ std::pair<WebAnimationTime, WebAnimationTime> ViewTimeline::intervalForAttachmen
 
     auto computeTime = [&](const auto& rangeToConvert) {
         auto mappedOffset = mapOffsetToTimelineRange(data, rangeToConvert.name(), [&](const float& subjectRange) {
-            return Style::evaluate(rangeToConvert.offset(), subjectRange);
+            return Style::evaluate(rangeToConvert.offset(), subjectRange, 1.0f /* FIXME FIND ZOOM */);
         });
         return WebAnimationTime::fromPercentage(mappedOffset * 100);
     };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3368,10 +3368,10 @@ void Document::pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int&
 
     // The percentage is calculated with respect to the width even for margin top and bottom.
     // http://www.w3.org/TR/CSS2/box.html#margin-properties
-    marginTop = style->marginTop().isAuto() ? marginTop : Style::evaluate(style->marginTop(), pageSize.width());
-    marginRight = style->marginRight().isAuto() ? marginRight : Style::evaluate(style->marginRight(), pageSize.width());
-    marginBottom = style->marginBottom().isAuto() ? marginBottom : Style::evaluate(style->marginBottom(), pageSize.width());
-    marginLeft = style->marginLeft().isAuto() ? marginLeft : Style::evaluate(style->marginLeft(), pageSize.width());
+    marginTop = style->marginTop().isAuto() ? marginTop : Style::evaluate(style->marginTop(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
+    marginRight = style->marginRight().isAuto() ? marginRight : Style::evaluate(style->marginRight(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
+    marginBottom = style->marginBottom().isAuto() ? marginBottom : Style::evaluate(style->marginBottom(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
+    marginLeft = style->marginLeft().isAuto() ? marginLeft : Style::evaluate(style->marginLeft(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
 }
 
 void Document::fontsNeedUpdate(FontSelector&)

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -190,12 +190,12 @@ static bool outputMismatchingBlockBoxInformationIfNeeded(TextStream& stream, con
         auto marginStart = LayoutUnit { };
         auto& marginStartStyle = layoutBox.style().marginStart();
         if (marginStartStyle.isFixed() || marginStartStyle.isPercent() || marginStartStyle.isCalculated())
-            marginStart = Style::evaluate(marginStartStyle, containingBlockWidth);
+            marginStart = Style::evaluate(marginStartStyle, containingBlockWidth, 1.0f /* FIXME FIND ZOOM */);
 
         auto marginEnd = LayoutUnit { };
         auto& marginEndStyle = layoutBox.style().marginEnd();
         if (marginEndStyle.isFixed() || marginEndStyle.isPercent() || marginEndStyle.isCalculated())
-            marginEnd = Style::evaluate(marginEndStyle, containingBlockWidth);
+            marginEnd = Style::evaluate(marginEndStyle, containingBlockWidth, 1.0f /* FIXME FIND ZOOM */);
 
         auto marginBefore = boxGeometry.marginBefore();
         auto marginAfter = boxGeometry.marginAfter();

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -113,7 +113,7 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
     if (!containingBlockHeight)
         return { };
 
-    return Style::evaluate(height, *containingBlockHeight);
+    return Style::evaluate(height, *containingBlockHeight, 1.0f /* FIXME FIND ZOOM */);
 }
 
 std::optional<LayoutUnit> FormattingGeometry::computedHeight(const Box& layoutBox, std::optional<LayoutUnit> containingBlockHeight) const
@@ -1084,8 +1084,8 @@ BoxGeometry::Edges FormattingGeometry::computedBorder(const Box& layoutBox) cons
     auto& style = layoutBox.style();
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Border] -> layoutBox: " << &layoutBox);
     return {
-        { LayoutUnit(Style::evaluate(style.borderLeftWidth())), LayoutUnit(Style::evaluate(style.borderRightWidth())) },
-        { LayoutUnit(Style::evaluate(style.borderTopWidth())), LayoutUnit(Style::evaluate(style.borderBottomWidth())) },
+        { LayoutUnit(Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */)), LayoutUnit(Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */)) },
+        { LayoutUnit(Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */)), LayoutUnit(Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */)) },
     };
 }
 
@@ -1097,8 +1097,8 @@ BoxGeometry::Edges FormattingGeometry::computedPadding(const Box& layoutBox, con
     auto& style = layoutBox.style();
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Padding] -> layoutBox: " << &layoutBox);
     return {
-        { Style::evaluate(style.paddingStart(), containingBlockWidth), Style::evaluate(style.paddingEnd(), containingBlockWidth) },
-        { Style::evaluate(style.paddingBefore(), containingBlockWidth), Style::evaluate(style.paddingAfter(), containingBlockWidth) }
+        { Style::evaluate(style.paddingStart(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.paddingEnd(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */) },
+        { Style::evaluate(style.paddingBefore(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.paddingAfter(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */) }
     };
 }
 

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -129,7 +129,7 @@ std::optional<LayoutUnit> FormattingGeometry::computedValue(const auto& geometry
 {
     // In general, the computed value resolves the specified value as far as possible without laying out the content.
     if (geometryProperty.isSpecified())
-        return Style::evaluate(geometryProperty, containingBlockWidth);
+        return Style::evaluate(geometryProperty, containingBlockWidth, 1.0f /* FIXME FIND ZOOM */);
     return { };
 }
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
@@ -327,10 +327,10 @@ IntrinsicWidthConstraints BlockFormattingGeometry::intrinsicWidthConstraints(con
     auto fixedMarginBorderAndPadding = [&](auto& layoutBox) {
         auto& style = layoutBox.style();
         return fixedValue(style.marginStart()).value_or(0)
-            + LayoutUnit { Style::evaluate(style.borderLeftWidth()) }
+            + LayoutUnit { Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) }
             + fixedValue(style.paddingLeft()).value_or(0)
             + fixedValue(style.paddingRight()).value_or(0)
-            + LayoutUnit { Style::evaluate(style.borderRightWidth()) }
+            + LayoutUnit { Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */) }
             + fixedValue(style.marginEnd()).value_or(0);
     };
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -93,7 +93,7 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
                 if (auto fixedPropertyValue = propertyValue.tryFixed())
                     return LayoutUnit { fixedPropertyValue->value };
                 if (propertyValue.isSpecified() && availableSize)
-                    return Style::evaluate(propertyValue, *availableSize);
+                    return Style::evaluate(propertyValue, *availableSize, 1.0f /* FIXME FIND ZOOM */);
                 return { };
             };
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -93,7 +93,7 @@ LayoutUnit FlexFormattingUtils::mainAxisGapValue(const ElementBox& flexContainer
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().columnGap() : flexContainer.style().rowGap();
-    return Style::evaluateMinimum(gap, flexContainerContentBoxWidth);
+    return Style::evaluateMinimum(gap, flexContainerContentBoxWidth, 1.0f /* FIXME FIND ZOOM */);
 }
 
 LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContainer, LayoutUnit flexContainerContentBoxHeight)
@@ -102,7 +102,7 @@ LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContaine
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().rowGap() : flexContainer.style().columnGap();
-    return Style::evaluateMinimum(gap, flexContainerContentBoxHeight);
+    return Style::evaluateMinimum(gap, flexContainerContentBoxHeight, 1.0f /* FIXME FIND ZOOM */);
 }
 
 // flex container  direction  flex item    main axis size

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -179,7 +179,7 @@ InlineLayoutUnit InlineFormattingUtils::computedTextIndent(IsIntrinsicWidthMode 
         // https://drafts.csswg.org/css-text/#text-indent-property
         return { };
     }
-    return Style::evaluate(textIndentLength, availableWidth);
+    return Style::evaluate(textIndentLength, availableWidth, 1.0f /* FIXME ZOOM EFFECTED? */);
 }
 
 InlineLayoutUnit InlineFormattingUtils::initialLineHeight(bool isFirstLine) const

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -191,7 +191,7 @@ inline InlineLayoutUnit InlineLevelBox::preferredLineHeight() const
         return primarymetricsOfPrimaryFont().lineSpacing();
 
     if (m_style.lineHeight.isPercentOrCalculated())
-        return minimumValueForLength(m_style.lineHeight, fontSize());
+        return minimumValueForLength(m_style.lineHeight, fontSize(), 1.0f /* FIXME FIND ZOOM */);
     return m_style.lineHeight.value();
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -40,7 +40,7 @@ template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment 
             return keyword;
         },
         [&](const Style::VerticalAlign::Length& length) -> InlineLevelBox::VerticalAlignment {
-            return InlineLayoutUnit { Style::evaluate(length, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor)) };
+            return InlineLayoutUnit { Style::evaluate(length, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), 1.0f /* FIXME FIND ZOOM */) };
         }
     );
 }

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
@@ -42,8 +42,8 @@ static UniqueRef<TableGrid> ensureTableGrid(const ElementBox& tableBox)
     auto tableGrid = makeUniqueRef<TableGrid>();
     auto& tableStyle = tableBox.style();
     auto shouldApplyBorderSpacing = tableStyle.borderCollapse() == BorderCollapse::Separate;
-    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? Style::evaluate(tableStyle.borderHorizontalSpacing()) : 0 });
-    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? Style::evaluate(tableStyle.borderVerticalSpacing()) : 0 });
+    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? Style::evaluate(tableStyle.borderHorizontalSpacing(), 1.0f /* FIXME FIND ZOOM */) : 0 });
+    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? Style::evaluate(tableStyle.borderVerticalSpacing(), 1.0f /* FIXME FIND ZOOM */) : 0 });
 
     auto* firstChild = tableBox.firstChild();
     if (!firstChild) {

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -79,7 +79,7 @@ static LayoutUnit usedValueOrZero(const Style::MarginEdge& marginEdge, std::opti
     if (marginEdge.isAuto() || !availableWidth)
         return { };
 
-    return Style::evaluateMinimum(marginEdge, *availableWidth);
+    return Style::evaluateMinimum(marginEdge, *availableWidth, 1.0f /* FIXME FIND ZOOM */);
 }
 
 static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::optional<LayoutUnit> availableWidth)
@@ -90,7 +90,7 @@ static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::op
     if (!availableWidth)
         return { };
 
-    return Style::evaluateMinimum(paddingEdge, *availableWidth);
+    return Style::evaluateMinimum(paddingEdge, *availableWidth, 1.0f /* FIXME FIND ZOOM */);
 }
 
 static inline void adjustBorderForTableAndFieldset(const RenderBoxModelObject& renderer, RectEdges<LayoutUnit>& borderWidths)
@@ -241,7 +241,7 @@ Layout::BoxGeometry::Edges BoxGeometryUpdater::logicalBorder(const RenderBoxMode
     auto& style = renderer.style();
 
     auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return LayoutUnit { Style::evaluate(width) };
+        return LayoutUnit { Style::evaluate(width, 1.0f /* FIXME ZOOM EFFECTED? */) };
     });
 
     if (!isIntrinsicWidthMode)

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -91,7 +91,7 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
                 return flexContainerRenderer.computePercentageLogicalHeight(*percentageHeight, RenderBox::UpdatePercentageHeightDescendants::No);
 
             if (auto fixedContainingBlockHeight = flexContainerRenderer.containingBlock()->style().height().tryFixed()) {
-                auto value = Style::evaluate(*percentageHeight, fixedContainingBlockHeight->value);
+                auto value = Style::evaluate(*percentageHeight, fixedContainingBlockHeight->value, 1.0f);
                 return LayoutUnit { boxSizingIsContentBox ? value : value - verticalMarginBorderAndPadding };
             }
         }

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -333,7 +333,7 @@ static void expandRootBoundsWithRootMargin(FloatRect& rootBounds, const Intersec
 {
     auto zoomAdjustedLength = [](const IntersectionObserverMarginEdge& edge, float maximumValue, float zoomFactor) {
         if (auto percentage = edge.tryPercentage())
-            return Style::evaluate(*percentage, maximumValue);
+            return Style::evaluate(*percentage, maximumValue, 1.0f /* FIXME FIND ZOOM */);
         return edge.tryFixed()->value * zoomFactor;
     };
 
@@ -372,11 +372,12 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
         return absoluteClippedRect;
 
     auto frameRect = renderer->view().frameView().layoutViewportRect();
+    float zoom = 1.0f; /* FIXME FIND ZOOM */
     auto scrollMarginEdges = LayoutBoxExtent {
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.top(), frameRect.height()))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.right(), frameRect.width()))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.bottom(), frameRect.height()))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.left(), frameRect.width())))
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.top(), frameRect.height(), zoom))),
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.right(), frameRect.width(), zoom))),
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.bottom(), frameRect.height(), zoom))),
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.left(), frameRect.width(), zoom)))
     };
     frameRect.expand(scrollMarginEdges);
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -681,7 +681,7 @@ void LocalFrameView::applyPaginationToViewport()
         if (!columnGap.isNormal()) {
             auto* renderBox = dynamicDowncast<RenderBox>(documentOrBodyRenderer);
             if (auto* containerForPaginationGap = renderBox ? renderBox : documentOrBodyRenderer->containingBlock())
-                pagination.gap = Style::evaluate(columnGap, containerForPaginationGap->contentBoxLogicalWidth()).toUnsigned();
+                pagination.gap = Style::evaluate(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */).toUnsigned();
         }
     }
     setPagination(pagination);
@@ -2467,7 +2467,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         if (!border->isVisible())
             return samplingRect;
 
-        auto borderWidth = Style::evaluate(border->width());
+        auto borderWidth = Style::evaluate(border->width(), 1.0f /* FIXME FIND ZOOM */);
         if (borderWidth > thinBorderWidth)
             return samplingRect;
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -523,9 +523,9 @@ LayoutRect nodeRectInAbsoluteCoordinates(const ContainerNode& containerNode, boo
         // the rect of the focused element.
         if (ignoreBorder) {
             auto& style = renderer->style();
-            rect.move(Style::evaluate(style.borderLeftWidth()), Style::evaluate(style.borderTopWidth()));
-            rect.setWidth(rect.width() - Style::evaluate(style.borderLeftWidth()) - Style::evaluate(style.borderRightWidth()));
-            rect.setHeight(rect.height() - Style::evaluate(style.borderTopWidth()) - Style::evaluate(style.borderBottomWidth()));
+            rect.move(Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
+            rect.setWidth(rect.width() - Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) - Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */));
+            rect.setHeight(rect.height() - Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */) - Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */));
         }
         return rect;
     }

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -255,7 +255,7 @@ static std::pair<LayoutType, std::optional<unsigned>> closestSnapOffsetWithInfoA
 static LayoutRect computeScrollSnapPortRect(const Style::ScrollPaddingBox& padding, const LayoutRect& rect)
 {
     auto result = rect;
-    result.contract(Style::extentForRect(padding, rect));
+    result.contract(Style::extentForRect(padding, rect, 1.0f /* FIXME ZOOM EFFECTED? */));
     return result;
 }
 

--- a/Source/WebCore/platform/Length.h
+++ b/Source/WebCore/platform/Length.h
@@ -148,7 +148,12 @@ public:
     CalculationValue& calculationValue() const;
     Ref<CalculationValue> protectedCalculationValue() const;
 
-    struct Fixed { float value; };
+    struct Fixed {
+        constexpr Fixed(float value) : value(value) { }
+        constexpr auto evaluate(float zoom) const { return value * zoom; }
+        private:
+            float value;
+    };
     std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { value() }) : std::nullopt; }
 
     struct Percentage { float value; };

--- a/Source/WebCore/platform/LengthFunctions.cpp
+++ b/Source/WebCore/platform/LengthFunctions.cpp
@@ -31,39 +31,43 @@
 
 namespace WebCore {
 
-int intValueForLength(const Length& length, LayoutUnit maximumValue)
+int intValueForLength(const Length& length, LayoutUnit maximumValue, float zoom)
 {
-    return static_cast<int>(valueForLength(length, maximumValue));
+    return static_cast<int>(valueForLength(length, maximumValue, zoom));
 }
 
-LayoutUnit valueForLength(const Length& length, LayoutUnit maximumValue)
+LayoutUnit valueForLength(const Length& length, LayoutUnit maximumValue, float zoom)
 {
-    return valueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(length, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+    return valueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(length, [&] ALWAYS_INLINE_LAMBDA {
+        return maximumValue;
+    }, zoom);
 }
 
-float floatValueForLength(const Length& length, float maximumValue)
+float floatValueForLength(const Length& length, float maximumValue, float zoom)
 {
-    return valueForLengthWithLazyMaximum<float, float>(length, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+    return valueForLengthWithLazyMaximum<float, float>(length, [&] ALWAYS_INLINE_LAMBDA {
+        return maximumValue;
+    }, zoom);
 }
 
-LayoutSize sizeForLengthSize(const LengthSize& length, const LayoutSize& maximumValue)
+LayoutSize sizeForLengthSize(const LengthSize& length, const LayoutSize& maximumValue, float zoom)
 {
-    return { valueForLength(length.width, maximumValue.width()), valueForLength(length.height, maximumValue.height()) };
+    return { valueForLength(length.width, maximumValue.width(), zoom), valueForLength(length.height, maximumValue.height(), zoom) };
 }
 
-LayoutPoint pointForLengthPoint(const LengthPoint& lengthPoint, const LayoutSize& maximumValue)
+LayoutPoint pointForLengthPoint(const LengthPoint& lengthPoint, const LayoutSize& maximumValue, float zoom)
 {
-    return { valueForLength(lengthPoint.x, maximumValue.width()), valueForLength(lengthPoint.y, maximumValue.height()) };
+    return { valueForLength(lengthPoint.x, maximumValue.width(), zoom), valueForLength(lengthPoint.y, maximumValue.height(), zoom) };
 }
 
-FloatSize floatSizeForLengthSize(const LengthSize& lengthSize, const FloatSize& boxSize)
+FloatSize floatSizeForLengthSize(const LengthSize& lengthSize, const FloatSize& boxSize, float zoom)
 {
-    return { floatValueForLength(lengthSize.width, boxSize.width()), floatValueForLength(lengthSize.height, boxSize.height()) };
+    return { floatValueForLength(lengthSize.width, boxSize.width(), zoom), floatValueForLength(lengthSize.height, boxSize.height(), zoom) };
 }
 
-FloatPoint floatPointForLengthPoint(const LengthPoint& lengthPoint, const FloatSize& boxSize)
+FloatPoint floatPointForLengthPoint(const LengthPoint& lengthPoint, const FloatSize& boxSize, float zoom)
 {
-    return { floatValueForLength(lengthPoint.x, boxSize.width()), floatValueForLength(lengthPoint.y, boxSize.height()) };
+    return { floatValueForLength(lengthPoint.x, boxSize.width(), zoom), floatValueForLength(lengthPoint.y, boxSize.height(), zoom) };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/LengthFunctions.h
+++ b/Source/WebCore/platform/LengthFunctions.h
@@ -37,22 +37,22 @@ struct Length;
 struct LengthSize;
 struct LengthPoint;
 
-int intValueForLength(const Length&, LayoutUnit maximumValue);
-WEBCORE_EXPORT float floatValueForLength(const Length&, float maximumValue);
-WEBCORE_EXPORT LayoutUnit valueForLength(const Length&, LayoutUnit maximumValue);
+int intValueForLength(const Length&, LayoutUnit maximumValue, float zoom);
+WEBCORE_EXPORT float floatValueForLength(const Length&, float maximumValue, float zoom);
+WEBCORE_EXPORT LayoutUnit valueForLength(const Length&, LayoutUnit maximumValue, float zoom);
 
-LayoutSize sizeForLengthSize(const LengthSize&, const LayoutSize& maximumValue);
-FloatSize floatSizeForLengthSize(const LengthSize&, const FloatSize& maximumValue);
+LayoutSize sizeForLengthSize(const LengthSize&, const LayoutSize& maximumValue, float zoom);
+FloatSize floatSizeForLengthSize(const LengthSize&, const FloatSize& maximumValue, float zoom);
 
-LayoutPoint pointForLengthPoint(const LengthPoint&, const LayoutSize& maximumValue);
-FloatPoint floatPointForLengthPoint(const LengthPoint&, const FloatSize& maximumValue);
+LayoutPoint pointForLengthPoint(const LengthPoint&, const LayoutSize& maximumValue, float zoom);
+FloatPoint floatPointForLengthPoint(const LengthPoint&, const FloatSize& maximumValue, float zoom);
 
 template<typename ReturnType, typename MaximumType>
-ReturnType minimumValueForLengthWithLazyMaximum(const Length& length, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor)
+ReturnType minimumValueForLengthWithLazyMaximum(const Length& length, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom)
 {
     switch (length.type()) {
     case LengthType::Fixed:
-        return ReturnType(length.value());
+        return ReturnType(length.value() * zoom);
     case LengthType::Percent:
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * length.percent() / 100.0f));
     case LengthType::Calculated:
@@ -76,11 +76,11 @@ ReturnType minimumValueForLengthWithLazyMaximum(const Length& length, NOESCAPE c
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType valueForLengthWithLazyMaximum(const Length& length, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor)
+ReturnType valueForLengthWithLazyMaximum(const Length& length, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom)
 {
     switch (length.type()) {
     case LengthType::Fixed:
-        return ReturnType(length.value());
+        return ReturnType(length.value() * zoom);
     case LengthType::Percent:
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * length.percent() / 100.0f));
     case LengthType::Calculated:
@@ -103,34 +103,38 @@ ReturnType valueForLengthWithLazyMaximum(const Length& length, NOESCAPE const In
     return ReturnType(0);
 }
 
-inline float floatValueForLengthWithLazyLayoutUnitMaximum(const Length& length, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
+inline float floatValueForLengthWithLazyLayoutUnitMaximum(const Length& length, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor, float zoom)
 {
-    return valueForLengthWithLazyMaximum<float, LayoutUnit>(length, lazyMaximumValueFunctor);
+    return valueForLengthWithLazyMaximum<float, LayoutUnit>(length, lazyMaximumValueFunctor, zoom);
 }
 
-inline float floatValueForLengthWithLazyFloatMaximum(const Length& length, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor)
+inline float floatValueForLengthWithLazyFloatMaximum(const Length& length, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor, float zoom)
 {
-    return valueForLengthWithLazyMaximum<float, float>(length, lazyMaximumValueFunctor);
+    return valueForLengthWithLazyMaximum<float, float>(length, lazyMaximumValueFunctor, zoom);
 }
 
-inline LayoutUnit minimumValueForLength(const Length& length, LayoutUnit maximumValue)
+inline LayoutUnit minimumValueForLength(const Length& length, LayoutUnit maximumValue, float zoom)
 {
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(length, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(length, [&] ALWAYS_INLINE_LAMBDA {
+        return maximumValue;
+    }, zoom);
 }
 
-inline int minimumIntValueForLength(const Length& length, LayoutUnit maximumValue)
+inline int minimumIntValueForLength(const Length& length, LayoutUnit maximumValue, float zoom)
 {
-    return minimumValueForLengthWithLazyMaximum<int, LayoutUnit>(length, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+    return minimumValueForLengthWithLazyMaximum<int, LayoutUnit>(length, [&] ALWAYS_INLINE_LAMBDA {
+        return maximumValue;
+    }, zoom);
 }
 
-inline LayoutUnit valueForLength(const Length& length, auto maximumValue)
+inline LayoutUnit valueForLength(const Length& length, auto maximumValue, float zoom)
 {
-    return valueForLength(length, LayoutUnit(maximumValue));
+    return valueForLength(length, LayoutUnit(maximumValue), zoom);
 }
 
-inline LayoutUnit minimumValueForLength(const Length& length, auto maximumValue)
+inline LayoutUnit minimumValueForLength(const Length& length, auto maximumValue, float zoom)
 {
-    return minimumValueForLength(length, LayoutUnit(maximumValue));
+    return minimumValueForLength(length, LayoutUnit(maximumValue), zoom);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -101,8 +101,8 @@ static LengthPoint resolveCalculateValuesFor(const LengthPoint& lengthPoint, Int
     if (!lengthPoint.x.isCalculated() && !lengthPoint.y.isCalculated())
         return lengthPoint;
     return {
-        { floatValueForLength(lengthPoint.x, borderBoxSize.width()), LengthType::Fixed },
-        { floatValueForLength(lengthPoint.y, borderBoxSize.height()), LengthType::Fixed }
+        { floatValueForLength(lengthPoint.x, borderBoxSize.width(), 1.0f /* FIXME FIND ZOOM */), LengthType::Fixed },
+        { floatValueForLength(lengthPoint.y, borderBoxSize.height(), 1.0f /* FIXME FIND ZOOM */), LengthType::Fixed }
     };
 }
 
@@ -134,9 +134,9 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
     offsetRotate = style.offsetRotate();
     offsetDistance = Style::toPlatform(style.offsetDistance());
     if (offsetDistance.isCalculated() && offsetPath) {
-        auto anchor = borderBoxRect.location() + floatPointForLengthPoint(transformOrigin, borderBoxSize);
+        auto anchor = borderBoxRect.location() + floatPointForLengthPoint(transformOrigin, borderBoxSize, 1.0f /* FIXME FIND ZOOM */);
         if (!offsetAnchor.x.isAuto())
-            anchor = floatPointForLengthPoint(offsetAnchor, borderBoxRect.size()) + borderBoxRect.location();
+            anchor = floatPointForLengthPoint(offsetAnchor, borderBoxRect.size(), 1.0f /* FIXME FIND ZOOM */) + borderBoxRect.location();
 
         auto path = offsetPath->getPath(TransformOperationData(FloatRect(borderBoxRect)));
         offsetDistance = { path ? path->length() : 0.0f, LengthType:: Fixed };
@@ -170,7 +170,7 @@ TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const
 
     // 6. Translate and rotate by the transform specified by offset.
     if (transformOperationData && offsetPath) {
-        auto computedTransformOrigin = boundingBox.location() + floatPointForLengthPoint(transformOrigin, boundingBox.size());
+        auto computedTransformOrigin = boundingBox.location() + floatPointForLengthPoint(transformOrigin, boundingBox.size(), 1.0f /* FIXME FIND ZOOM */);
         MotionPath::applyMotionPathTransform(matrix, *transformOperationData, computedTransformOrigin, Style::OffsetPath { *offsetPath }, Style::OffsetAnchor { offsetAnchor }, Style::OffsetDistance { offsetDistance }, offsetRotate, transformBox);
     }
 

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -506,7 +506,7 @@ Path PathUtilities::pathWithShrinkWrappedRectsForOutline(const Vector<FloatRect>
     float outlineOffset, WritingMode writingMode, float deviceScaleFactor)
 {
     auto roundedRect = [radii, outlineOffset, deviceScaleFactor](const FloatRect& rect) {
-        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate(radii, rect.size()), outlineOffset);
+        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate(radii, rect.size(), 1.0f /* FIXME FIND ZOOM */), outlineOffset);
         adjustedRadii.scale(calcBorderRadiiConstraintScaleFor(rect, adjustedRadii));
 
         LayoutRoundedRect roundedRect(
@@ -543,8 +543,8 @@ Path PathUtilities::pathWithShrinkWrappedRectsForOutline(const Vector<FloatRect>
     auto firstLineRect = isLeftToRight ? rects.at(0) : rects.at(rects.size() - 1);
     auto lastLineRect = isLeftToRight ? rects.at(rects.size() - 1) : rects.at(0);
     // Adjust radius so that it matches the box border.
-    auto firstLineRadii = Style::evaluate(radii, firstLineRect.size());
-    auto lastLineRadii = Style::evaluate(radii, lastLineRect.size());
+    auto firstLineRadii = Style::evaluate(radii, firstLineRect.size(), 1.0f /* FIXME FIND ZOOM */);
+    auto lastLineRadii = Style::evaluate(radii, lastLineRect.size(), 1.0f /* FIXME FIND ZOOM */);
     firstLineRadii.scale(calcBorderRadiiConstraintScaleFor(firstLineRect, firstLineRadii));
     lastLineRadii.scale(calcBorderRadiiConstraintScaleFor(lastLineRect, lastLineRadii));
 

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
@@ -49,9 +49,9 @@ public:
 
     Ref<TransformOperation> selfOrCopyWithResolvedCalculatedValues(const FloatSize&) const override;
 
-    float xAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_x, borderBoxSize.width()); }
-    float yAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_y, borderBoxSize.height()); }
-    float zAsFloat() const { return floatValueForLength(m_z, 1); }
+    float xAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_x, borderBoxSize.width(), 1.0f /* FIXME FIND ZOOM */); }
+    float yAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_y, borderBoxSize.height(), 1.0f /* FIXME FIND ZOOM */); }
+    float zAsFloat() const { return floatValueForLength(m_z, 1, 1.0f /* FIXME FIND ZOOM */); }
 
     Length x() const { return m_x; }
     Length y() const { return m_y; }
@@ -69,7 +69,7 @@ public:
         return m_x.isPercent() || m_y.isPercent();
     }
 
-    bool isIdentity() const final { return !floatValueForLength(m_x, 1) && !floatValueForLength(m_y, 1) && !floatValueForLength(m_z, 1); }
+    bool isIdentity() const final { return !floatValueForLength(m_x, 1, 1.0f /* FIXME FIND ZOOM */) && !floatValueForLength(m_y, 1, 1.0f /* FIXME FIND ZOOM */) && !floatValueForLength(m_z, 1, 1.0f /* FIXME FIND ZOOM */); }
 
     bool operator==(const TranslateTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const final;

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -578,7 +578,7 @@ void AutoTableLayout::layout()
         for (size_t i = 0; i < nEffCols; ++i) {
             auto& logicalWidth = m_layoutStruct[i].effectiveLogicalWidth;
             if (logicalWidth.isPercentOrCalculated()) {
-                float cellLogicalWidth = std::max<float>(m_layoutStruct[i].effectiveMinLogicalWidth, Style::evaluateMinimum(logicalWidth, tableLogicalWidth));
+                float cellLogicalWidth = std::max<float>(m_layoutStruct[i].effectiveMinLogicalWidth, Style::evaluateMinimum(logicalWidth, tableLogicalWidth, 1.0f /* FIXME FIND ZOOM */));
                 available += m_layoutStruct[i].computedLogicalWidth - cellLogicalWidth;
                 m_layoutStruct[i].computedLogicalWidth = cellLogicalWidth;
             }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -679,7 +679,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
 
     LayoutSize spaceSize;
     LayoutSize phase;
-    auto computedXPosition = Style::evaluate(fillLayer.xPosition(), availableWidth);
+    auto computedXPosition = Style::evaluate(fillLayer.xPosition(), availableWidth, 1.0f /* FIXME FIND ZOOM */);
     if (backgroundRepeatX == FillRepeat::Round && positioningAreaSize.width() > 0 && tileSize.width() > 0) {
         int numTiles = std::max(1, roundToInt(positioningAreaSize.width() / tileSize.width()));
         if (!fillLayer.size().specifiedHeight() && backgroundRepeatY != FillRepeat::Round)
@@ -689,7 +689,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
         phase.setWidth(tileSize.width() ? tileSize.width() - fmodf((computedXPosition + left), tileSize.width()) : 0);
     }
 
-    auto computedYPosition = Style::evaluate(fillLayer.yPosition(), availableHeight);
+    auto computedYPosition = Style::evaluate(fillLayer.yPosition(), availableHeight, 1.0f /* FIXME FIND ZOOM */);
     if (backgroundRepeatY == FillRepeat::Round && positioningAreaSize.height() > 0 && tileSize.height() > 0) {
         int numTiles = std::max(1, roundToInt(positioningAreaSize.height() / tileSize.height()));
         if (!fillLayer.size().specifiedWidth() && backgroundRepeatX != FillRepeat::Round)
@@ -705,7 +705,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
     } else if (backgroundRepeatX == FillRepeat::Space && tileSize.width() > 0) {
         if (auto space = getSpace(positioningAreaSize.width(), tileSize.width())) {
             LayoutUnit actualWidth = tileSize.width() + *space;
-            computedXPosition = minimumValueForLength(Length(), availableWidth);
+            computedXPosition = minimumValueForLength(Length(), availableWidth, 1.0f /* FIXME FIND ZOOM */);
             spaceSize.setWidth(*space);
             spaceSize.setHeight(0);
             phase.setWidth(actualWidth ? actualWidth - fmodf((computedXPosition + left), actualWidth) : 0);
@@ -729,7 +729,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
     } else if (backgroundRepeatY == FillRepeat::Space && tileSize.height() > 0) {
         if (auto space = getSpace(positioningAreaSize.height(), tileSize.height())) {
             LayoutUnit actualHeight = tileSize.height() + *space;
-            computedYPosition = minimumValueForLength(Length(), availableHeight);
+            computedYPosition = minimumValueForLength(Length(), availableHeight, 1.0f /* FIXME FIND ZOOM */);
             spaceSize.setHeight(*space);
             phase.setHeight(actualHeight ? actualHeight - fmodf((computedYPosition + top), actualHeight) : 0);
         } else
@@ -801,7 +801,7 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
             if (auto fixed = layerWidth.tryFixed())
                 tileSize.setWidth(fixed->value);
             else if (layerWidth.isPercentOrCalculated()) {
-                auto resolvedWidth = Style::evaluate(layerWidth, positioningAreaSize.width());
+                auto resolvedWidth = Style::evaluate(layerWidth, positioningAreaSize.width(), 1.0f /* FIXME FIND ZOOM */);
                 // Non-zero resolved value should always produce some content.
                 tileSize.setWidth(!resolvedWidth ? resolvedWidth : std::max(devicePixelSize, resolvedWidth));
             }
@@ -809,7 +809,7 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
             if (auto fixed = layerHeight.tryFixed())
                 tileSize.setHeight(fixed->value);
             else if (layerHeight.isPercentOrCalculated()) {
-                auto resolvedHeight = Style::evaluate(layerHeight, positioningAreaSize.height());
+                auto resolvedHeight = Style::evaluate(layerHeight, positioningAreaSize.height(), 1.0f /* FIXME FIND ZOOM */);
                 // Non-zero resolved value should always produce some content.
                 tileSize.setHeight(!resolvedHeight ? resolvedHeight : std::max(devicePixelSize, resolvedHeight));
             }

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -51,7 +51,7 @@ BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectE
 {
     auto constructBorderEdge = [&](Style::LineWidth width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
         auto color = setColorsToBlack ? Color::black : style.visitedDependentColorWithColorFilter(borderColorProperty);
-        auto evaluatedWidth = Style::evaluate(width);
+        auto evaluatedWidth = Style::evaluate(width, 1.0f /* FIXME FIND ZOOM */);
         auto inflatedWidth = evaluatedWidth ? evaluatedWidth + inflation : evaluatedWidth;
         return BorderEdge(inflatedWidth, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
     };
@@ -68,7 +68,7 @@ BorderEdges borderEdgesForOutline(const RenderStyle& style, BorderStyle borderSt
 {
     auto color = style.visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
     auto isTransparent = color.isValid() && !color.isVisible();
-    auto size = Style::evaluate(style.outlineWidth());
+    auto size = Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */);
     return {
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -309,8 +309,8 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
     if (!borderStyle || *borderStyle == BorderStyle::None)
         return;
 
-    auto outlineWidth = LayoutUnit { Style::evaluate(styleToUse.outlineWidth()) };
-    auto outlineOffset = LayoutUnit { Style::evaluate(styleToUse.outlineOffset()) };
+    auto outlineWidth = LayoutUnit { Style::evaluate(styleToUse.outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */) };
+    auto outlineOffset = LayoutUnit { Style::evaluate(styleToUse.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */) };
 
     auto outerRect = paintRect;
     outerRect.inflate(outlineOffset + outlineWidth);
@@ -351,8 +351,8 @@ void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<La
     }
 
     auto& styleToUse = m_renderer->style();
-    auto outlineOffset = Style::evaluate(styleToUse.outlineOffset());
-    auto outlineWidth = Style::evaluate(styleToUse.outlineWidth());
+    auto outlineOffset = Style::evaluate(styleToUse.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */);
+    auto outlineWidth = Style::evaluate(styleToUse.outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */);
     auto deviceScaleFactor = document().deviceScaleFactor();
 
     Vector<FloatRect> pixelSnappedRects;

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
 {
     auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return LayoutUnit { Style::evaluate(width) };
+        return LayoutUnit { Style::evaluate(width, 1.0f /* FIXME ZOOM EFFECTED? */) };
     });
     return shapeForBorderRect(style, borderRect, borderWidths, closedEdges);
 }
@@ -59,7 +59,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
     };
 
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size());
+        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), 1.0f/* FIXME ZOOM EFFECTED? */);
         radii.scale(calcBorderRadiiConstraintScaleFor(borderRect, radii));
 
         if (!closedEdges.top()) {
@@ -99,7 +99,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
     };
 
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size());
+        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), 1.0f /* FIXME ZOOM EFFECTED? */);
 
         auto leftOutset = std::max(borderRect.x() - outlineBoxRect.x(), 0_lu);
         auto topOutset = std::max(borderRect.y() - outlineBoxRect.y(), 0_lu);
@@ -138,7 +138,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
 BorderShape BorderShape::shapeForInsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& insetRect)
 {
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size());
+        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), 1.0f /* FIXME ZOOM EFFECTED? */);
 
         auto leftInset = std::max(insetRect.x() - borderRect.x(), 0_lu);
         auto topInset = std::max(insetRect.y()- borderRect.y(), 0_lu);

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -263,7 +263,7 @@ LayoutUnit GridTrackSizingAlgorithm::initialBaseSize(const Style::GridTrackSize&
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0));
+        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), 1.0f /* FIXME ZOOM EFFECTED? */);
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return 0;
@@ -277,7 +277,7 @@ LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const Style::GridTrackSi
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0));
+        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), 1.0f /* FIXME ZOOM EFFECTED? */);
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return infinity;
@@ -300,7 +300,7 @@ void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSp
     else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
         auto growthLimit = masonryIndefiniteItems.maxContentSize;
         if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0)));
+            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), 1.0f /* FIXME ZOOM EFFECTED? */));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -323,7 +323,7 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
     } else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
         LayoutUnit growthLimit = m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState);
         if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0)));
+            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), 1.0f /* FIXME ZOOM EFFECTED? */));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -828,7 +828,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForG
         if (maxTrackSize.isContentSized() || maxTrackSize.isFlex() || GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(maxTrackSize, availableSpace(direction)))
             gridAreaIsIndefinite = true;
         else
-            gridAreaSize += Style::evaluate(maxTrackSize.length(), availableSize.value_or(0_lu));
+            gridAreaSize += Style::evaluate(maxTrackSize.length(), availableSize.value_or(0_lu), 1.0f /* FIXME ZOOM EFFECTED? */);
     }
 
     gridAreaSize += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSize);
@@ -1193,7 +1193,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContributionForGridItem(RenderBo
             if (!trackSize.hasFixedMaxTrackBreadth())
                 allFixed = false;
             else if (allFixed)
-                maxBreadth += Style::evaluate(trackSize.maxTrackBreadth().length(), availableSpace().value_or(0_lu));
+                maxBreadth += Style::evaluate(trackSize.maxTrackBreadth().length(), availableSpace().value_or(0_lu), 1.0f /* FIXME ZOOM EFFECTED? */);
         }
         if (!allFixed)
             return minSize;
@@ -1647,7 +1647,7 @@ void GridTrackSizingAlgorithm::initializeTrackSizes()
         track.setInfinitelyGrowable(false);
 
         if (trackSize.isFitContent())
-            track.setGrowthLimitCap(Style::evaluate(trackSize.fitContentTrackLength(), maxSize));
+            track.setGrowthLimitCap(Style::evaluate(trackSize.fitContentTrackLength(), maxSize, 1.0f /* FIXME ZOOM EFFECTED? */));
         if (trackSize.isContentSized())
             m_contentSizedTracksIndex.append(i);
         if (trackSize.maxTrackBreadth().isFlex())
@@ -2041,7 +2041,7 @@ void GridTrackSizingAlgorithm::setup(Style::GridTrackSizingDirection direction, 
             const auto subgridSpan = m_renderGrid->gridSpanForGridItem(subgrid, Style::GridTrackSizingDirection::Columns);
             auto& subgridRowStartMargin = subgrid.style().marginBefore(m_renderGrid->writingMode());
             if (!subgridRowStartMargin.isAuto())
-                m_renderGrid->setMarginBeforeForChild(subgrid, Style::evaluateMinimum(subgridRowStartMargin, computeGridSpanSize(tracks(Style::GridTrackSizingDirection::Columns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(Style::GridTrackSizingDirection::Columns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(Style::GridTrackSizingDirection::Columns)))));
+                m_renderGrid->setMarginBeforeForChild(subgrid, Style::evaluateMinimum(subgridRowStartMargin, computeGridSpanSize(tracks(Style::GridTrackSizingDirection::Columns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(Style::GridTrackSizingDirection::Columns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(Style::GridTrackSizingDirection::Columns))), 1.0f /* FIXME ZOOM EFFECTED? */));
         }
     };
     if (m_direction == Style::GridTrackSizingDirection::Rows && (m_sizingState == SizingState::RowSizingFirstIteration || m_sizingState == SizingState::RowSizingSecondIteration))

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -102,7 +102,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
                 return offsetFromContainer(renderer, container, referenceRect);
             },
             [&](const Style::Position& position) -> FloatPoint {
-                return Style::evaluate(position, referenceRect.size());
+                return Style::evaluate(position, referenceRect.size(), 1.0f /* FIXME ZOOM EFFECTED? */);
             }
         );
     };
@@ -124,7 +124,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
         [&](const Style::RayPath& offsetPath) {
             auto startingPosition = offsetPath.ray()->position;
             data.usedStartingPosition = startingPosition
-                ? Style::evaluate(*startingPosition, data.containingBlockBoundingRect.rect().size())
+                ? Style::evaluate(*startingPosition, data.containingBlockBoundingRect.rect().size(), 1.0f /* FIXME ZOOM EFFECTED? */)
                 : startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container);
         },
         [&](const auto&) { }
@@ -136,7 +136,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 static PathTraversalState traversalStateAtDistance(const Path& path, const Style::OffsetDistance& distance)
 {
     auto pathLength = path.length();
-    auto distanceValue = Style::evaluate(distance, pathLength);
+    auto distanceValue = Style::evaluate(distance, pathLength, 1.0f /* FIXME ZOOM EFFECTED? */);
 
     float resolvedLength = 0;
     if (path.isClosed()) {
@@ -158,7 +158,7 @@ void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const Tr
     auto anchor = transformOrigin;
     WTF::switchOn(offsetAnchor,
         [&](const Style::Position& position) {
-            anchor = Style::evaluate(position, boundingBox.size()) + boundingBox.location();
+            anchor = Style::evaluate(position, boundingBox.size(), 1.0f /* FIXME ZOOM EFFECTED? */) + boundingBox.location();
         },
         [&](const CSS::Keyword::Auto&) { }
     );

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -78,7 +78,7 @@ static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, Layou
 {
     return WTF::switchOn(length,
         [&](const typename WidthValue::LengthPercentage& value) {
-            return Style::evaluate(value, extent);
+            return Style::evaluate(value, extent, 1.0f /* FIXME ZOOM EFFECTED? */);
         },
         [&](const typename WidthValue::Number& value) {
             return LayoutUnit { value.value * width };
@@ -104,10 +104,10 @@ template<typename SliceValues>
 static LayoutBoxExtent computeSlices(const LayoutSize& size, const SliceValues& slices, int scaleFactor)
 {
     return {
-        std::min(size.height(),  Style::evaluate(slices.values.top(),    size.height())) * scaleFactor,
-        std::min(size.width(),   Style::evaluate(slices.values.right(),  size.width()))  * scaleFactor,
-        std::min(size.height(),  Style::evaluate(slices.values.bottom(), size.height())) * scaleFactor,
-        std::min(size.width(),   Style::evaluate(slices.values.left(),   size.width()))  * scaleFactor,
+        std::min(size.height(),  Style::evaluate(slices.values.top(),    size.height(), 1.0f /* FIXME ZOOM EFFECTED? */)) * scaleFactor,
+        std::min(size.width(),   Style::evaluate(slices.values.right(),  size.width(), 1.0f /* FIXME ZOOM EFFECTED? */))  * scaleFactor,
+        std::min(size.height(),  Style::evaluate(slices.values.bottom(), size.height(), 1.0f /* FIXME ZOOM EFFECTED? */)) * scaleFactor,
+        std::min(size.width(),   Style::evaluate(slices.values.left(),   size.width(), 1.0f /* FIXME ZOOM EFFECTED? */))  * scaleFactor,
     };
 }
 
@@ -229,7 +229,7 @@ static void paintNinePieceImage(const T& ninePieceImage, GraphicsContext& graphi
     ASSERT(styleImage->isLoaded(renderer));
 
     auto sourceSlices      = computeSlices(source, ninePieceImage.slice(), styleImage->imageScaleFactor());
-    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate(style.borderWidth()), sourceSlices);
+    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate(style.borderWidth(), 1.0f /* FIXME ZOOM EFFECTED? */), sourceSlices);
 
     scaleSlicesIfNeeded(destination.size(), destinationSlices, deviceScaleFactor);
 

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -75,10 +75,10 @@ public:
     Style::MarginEdge marginAfter() const { return m_marginAfter; }
     Style::InsetEdge insetBefore() const { return m_insetBefore; }
     Style::InsetEdge insetAfter() const { return m_insetAfter; }
-    LayoutUnit marginBeforeValue() const { return Style::evaluateMinimum(m_marginBefore, m_containingInlineSize); }
-    LayoutUnit marginAfterValue() const { return Style::evaluateMinimum(m_marginAfter, m_containingInlineSize); }
-    LayoutUnit insetBeforeValue() const { return Style::evaluateMinimum(m_insetBefore, containingSize()); }
-    LayoutUnit insetAfterValue() const { return Style::evaluateMinimum(m_insetAfter, containingSize()); }
+    LayoutUnit marginBeforeValue() const { return Style::evaluateMinimum(m_marginBefore, m_containingInlineSize, 1.0f /* FIXME ZOOM EFFECTED? */); }
+    LayoutUnit marginAfterValue() const { return Style::evaluateMinimum(m_marginAfter, m_containingInlineSize, 1.0f /* FIXME ZOOM EFFECTED? */); }
+    LayoutUnit insetBeforeValue() const { return Style::evaluateMinimum(m_insetBefore, containingSize(), 1.0f /* FIXME ZOOM EFFECTED? */); }
+    LayoutUnit insetAfterValue() const { return Style::evaluateMinimum(m_insetAfter, containingSize(), 1.0f /* FIXME ZOOM EFFECTED? */); }
 
     LayoutUnit insetModifiedContainingSize() const { return m_insetModifiedContainingRange.size(); }
     LayoutRange insetModifiedContainingRange() const { return m_insetModifiedContainingRange; }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1842,7 +1842,7 @@ LayoutUnit RenderBlock::textIndentOffset() const
     LayoutUnit cw;
     if (style().textIndent().length.isPercentOrCalculated())
         cw = contentBoxLogicalWidth();
-    return Style::evaluate(style().textIndent().length, cw);
+    return Style::evaluate(style().textIndent().length, cw, 1.0f /* FIXME ZOOM EFFECTED? */);
 }
 
 LayoutUnit RenderBlock::logicalLeftOffsetForContent() const

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -291,7 +291,7 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
         LayoutUnit colGap = columnGap();
         LayoutUnit gapExtra = (columnCount - 1) * colGap;
         if (auto columnWidthLength = style().columnWidth().tryLength()) {
-            columnWidth = Style::evaluate(*columnWidthLength);
+            columnWidth = Style::evaluate(*columnWidthLength, 1.0f /* FIXME ZOOM EFFECTED? */);
             minLogicalWidth = std::min(minLogicalWidth, columnWidth);
         } else
             minLogicalWidth = minLogicalWidth * columnCount + gapExtra;
@@ -355,7 +355,7 @@ LayoutUnit RenderBlockFlow::columnGap() const
 {
     if (style().columnGap().isNormal())
         return LayoutUnit(style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate(style().columnGap(), contentBoxLogicalWidth());
+    return Style::evaluate(style().columnGap(), contentBoxLogicalWidth(), 1.0f /* FIXME ZOOM EFFECTED? */);
 }
 
 void RenderBlockFlow::computeColumnCountAndWidth()
@@ -373,7 +373,7 @@ void RenderBlockFlow::computeColumnCountAndWidth()
 
     LayoutUnit availWidth = desiredColumnWidth;
     LayoutUnit colGap = columnGap();
-    LayoutUnit colWidth = std::max(1_lu, LayoutUnit(Style::evaluate(style().columnWidth().tryLength().value_or(0_css_px))));
+    LayoutUnit colWidth = std::max(1_lu, LayoutUnit(Style::evaluate(style().columnWidth().tryLength().value_or(0_css_px), 1.0f /* FIXME ZOOM EFFECTED? */)));
     unsigned colCount = std::max<unsigned>(1, style().columnCount().tryValue().value_or(1).value);
 
     if (style().columnWidth().isAuto() && !style().columnCount().isAuto()) {
@@ -4574,7 +4574,7 @@ static inline std::optional<LayoutUnit> textIndentForBlockContainer(const Render
         if (auto containingBlockFixedLogicalWidth = containingBlock->style().logicalWidth().tryFixed()) {
             // At this point of the shrink-to-fit computation, we don't have a used value for the containing block width
             // (that's exactly to what we try to contribute here) unless the computed value is fixed.
-            indentValue = Style::evaluate(style.textIndent().length, containingBlockFixedLogicalWidth->value);
+            indentValue = Style::evaluate(style.textIndent().length, containingBlockFixedLogicalWidth->value, 1.0f /* FIXME ZOOM EFFECTED? */);
         }
     }
     return indentValue ? std::make_optional(indentValue) : std::nullopt;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -403,11 +403,11 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         };
         if (!left.isAuto()) {
             if (!right.isAuto() && !containingBlock->writingMode().isAnyLeftToRight())
-                offset.setWidth(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu));
+                offset.setWidth(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
             else
-                offset.expand(Style::evaluate(left, !left.isFixed() ? availableWidth() : 0_lu), 0_lu);
+                offset.expand(Style::evaluate(left, !left.isFixed() ? availableWidth() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */), 0_lu);
         } else if (!right.isAuto())
-            offset.expand(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu), 0_lu);
+            offset.expand(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */), 0_lu);
     }
 
     // If the containing block of a relatively positioned element does not
@@ -438,10 +438,10 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         // FIXME: The computation of the available height is repeated later for "bottom".
         // We could refactor this and move it to some common code for both ifs, however moving it outside of the ifs
         // is not possible as it'd cause performance regressions.
-        offset.expand(0_lu, Style::evaluate(top, !top.isFixed() ? availableHeight() : 0_lu));
+        offset.expand(0_lu, Style::evaluate(top, !top.isFixed() ? availableHeight() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
     } else if (!bottom.isAuto() && (!bottom.isPercentOrCalculated() || containingBlockHasDefiniteHeight)) {
         // FIXME: Check comment above for "top", it applies here too.
-        offset.expand(0_lu, -Style::evaluate(bottom, !bottom.isFixed() ? availableHeight() : 0_lu));
+        offset.expand(0_lu, -Style::evaluate(bottom, !bottom.isFixed() ? availableHeight() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
     }
     return offset;
 }
@@ -550,10 +550,10 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     // Sticky positioned element ignore any override logical width on the containing block (as they don't call
     // containingBlockLogicalWidthForContent). It's unclear whether this is totally fine.
     LayoutBoxExtent minMargin(
-        Style::evaluateMinimum(style().marginTop(), maxWidth),
-        Style::evaluateMinimum(style().marginRight(), maxWidth),
-        Style::evaluateMinimum(style().marginBottom(), maxWidth),
-        Style::evaluateMinimum(style().marginLeft(), maxWidth)
+        Style::evaluateMinimum(style().marginTop(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
+        Style::evaluateMinimum(style().marginRight(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
+        Style::evaluateMinimum(style().marginBottom(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
+        Style::evaluateMinimum(style().marginLeft(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */)
     );
 
     // Compute the container-relative area within which the sticky element is allowed to move.
@@ -603,22 +603,22 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     constraints.setStickyBoxRect(stickyBoxRelativeToScrollingAncestor);
 
     if (!style().left().isAuto()) {
-        constraints.setLeftOffset(Style::evaluate(style().left(), constrainingRect.width()));
+        constraints.setLeftOffset(Style::evaluate(style().left(), constrainingRect.width(), 1.0f /* FIXME ZOOM EFFECTED? */));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeLeft);
     }
 
     if (!style().right().isAuto()) {
-        constraints.setRightOffset(Style::evaluate(style().right(), constrainingRect.width()));
+        constraints.setRightOffset(Style::evaluate(style().right(), constrainingRect.width(), 1.0f /* FIXME ZOOM EFFECTED? */));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeRight);
     }
 
     if (!style().top().isAuto()) {
-        constraints.setTopOffset(Style::evaluate(style().top(), constrainingRect.height()));
+        constraints.setTopOffset(Style::evaluate(style().top(), constrainingRect.height(), 1.0f /* FIXME ZOOM EFFECTED? */));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeTop);
     }
 
     if (!style().bottom().isAuto()) {
-        constraints.setBottomOffset(Style::evaluate(style().bottom(), constrainingRect.height()));
+        constraints.setBottomOffset(Style::evaluate(style().bottom(), constrainingRect.height(), 1.0f /* FIXME ZOOM EFFECTED? */));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeBottom);
     }
 }

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -25,7 +25,7 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderBoxModelObject::borderAfter() const { return LayoutUnit(Style::evaluate(style().borderAfterWidth())); }
+inline LayoutUnit RenderBoxModelObject::borderAfter() const { return LayoutUnit(Style::evaluate(style().borderAfterWidth(), 1.0f /* FIXME FIND ZOOM */)); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingAfter() const { return borderAfter() + paddingAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingBefore() const { return borderBefore() + paddingBefore(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalHeight() const { return borderAndPaddingBefore() + borderAndPaddingAfter(); }
@@ -34,17 +34,17 @@ inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalLeft() const { re
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalRight() const { return writingMode().isHorizontal() ? borderRight() + paddingRight() : borderBottom() + paddingBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingStart() const { return borderStart() + paddingStart(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingEnd() const { return borderEnd() + paddingEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderBefore() const { return LayoutUnit(Style::evaluate(style().borderBeforeWidth())); }
-inline LayoutUnit RenderBoxModelObject::borderBottom() const { return LayoutUnit(Style::evaluate(style().borderBottomWidth())); }
-inline LayoutUnit RenderBoxModelObject::borderEnd() const { return LayoutUnit(Style::evaluate(style().borderEndWidth())); }
-inline LayoutUnit RenderBoxModelObject::borderLeft() const { return LayoutUnit(Style::evaluate(style().borderLeftWidth())); }
+inline LayoutUnit RenderBoxModelObject::borderBefore() const { return LayoutUnit(Style::evaluate(style().borderBeforeWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderBottom() const { return LayoutUnit(Style::evaluate(style().borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderEnd() const { return LayoutUnit(Style::evaluate(style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderLeft() const { return LayoutUnit(Style::evaluate(style().borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */)); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalHeight() const { return borderBefore() + borderAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalLeft() const { return writingMode().isHorizontal() ? borderLeft() : borderTop(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalRight() const { return writingMode().isHorizontal() ? borderRight() : borderBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalWidth() const { return borderStart() + borderEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderRight() const { return LayoutUnit(Style::evaluate(style().borderRightWidth())); }
-inline LayoutUnit RenderBoxModelObject::borderStart() const { return LayoutUnit(Style::evaluate(style().borderStartWidth())); }
-inline LayoutUnit RenderBoxModelObject::borderTop() const { return LayoutUnit(Style::evaluate(style().borderTopWidth())); }
+inline LayoutUnit RenderBoxModelObject::borderRight() const { return LayoutUnit(Style::evaluate(style().borderRightWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderStart() const { return LayoutUnit(Style::evaluate(style().borderStartWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderTop() const { return LayoutUnit(Style::evaluate(style().borderTopWidth(), 1.0f /* FIXME FIND ZOOM */)); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingAfter() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingAfter()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBefore() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBefore()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBottom() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBottom()); }
@@ -80,8 +80,8 @@ inline LayoutUnit RenderBoxModelObject::verticalBorderExtent() const { return bo
 
 inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
 {
-    return RectEdges<LayoutUnit>::map(style().borderWidth(), [](auto width) {
-        return LayoutUnit { Style::evaluate(width) };
+    return RectEdges<LayoutUnit>::map(style().borderWidth(), [&](auto width) {
+        return LayoutUnit { Style::evaluate(width, 1.0f /* FIXME FIND ZOOM */) };
     });
 }
 
@@ -100,7 +100,7 @@ inline LayoutUnit RenderBoxModelObject::resolveLengthPercentageUsingContainerLog
     LayoutUnit containerWidth;
     if (value.isPercentOrCalculated())
         containerWidth = containingBlockLogicalWidthForContent();
-    return Style::evaluateMinimum(value, containerWidth);
+    return Style::evaluateMinimum(value, containerWidth, 1.0f /* FIXME ZOOM EFFECTED? */);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1510,12 +1510,12 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxWidth = renderBox->width();
                 return std::max({
                     renderBox->borderRight(),
-                    Style::evaluate(style.borderTopRightRadius().width(), borderBoxWidth),
-                    Style::evaluate(style.borderBottomRightRadius().width(), borderBoxWidth),
+                    Style::evaluate(style.borderTopRightRadius().width(), borderBoxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
+                    Style::evaluate(style.borderBottomRightRadius().width(), borderBoxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
                 });
             };
             auto outlineRightInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset()) };
+                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */) };
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowRightInsetExtent = [&] {
@@ -1554,12 +1554,12 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxHeight = renderBox->height();
                 return std::max({
                     renderBox->borderBottom(),
-                    Style::evaluate(style.borderBottomLeftRadius().height(), borderBoxHeight),
-                    Style::evaluate(style.borderBottomRightRadius().height(), borderBoxHeight),
+                    Style::evaluate(style.borderBottomLeftRadius().height(), borderBoxHeight, 1.0f /* FIXME ZOOM EFFECTED? */),
+                    Style::evaluate(style.borderBottomRightRadius().height(), borderBoxHeight, 1.0f /* FIXME ZOOM EFFECTED? */),
                 });
             };
             auto outlineBottomInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset()) };
+                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), 1.0f /* FIXME FIND ZOOM */) };
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowBottomInsetExtent = [&]() -> LayoutUnit {
@@ -2120,22 +2120,22 @@ static bool useShrinkWrappedFocusRingForOutlineStyleAuto()
 
 static void drawFocusRing(GraphicsContext& context, const Path& path, const RenderStyle& style, const Color& color)
 {
-    context.drawFocusRing(path, Style::evaluate(style.outlineWidth()), color);
+    context.drawFocusRing(path, Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */), color);
 }
 
 static void drawFocusRing(GraphicsContext& context, Vector<FloatRect> rects, const RenderStyle& style, const Color& color)
 {
 #if PLATFORM(MAC)
-    context.drawFocusRing(rects, 0, Style::evaluate(style.outlineWidth()), color);
+    context.drawFocusRing(rects, 0, Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */), color);
 #else
-    context.drawFocusRing(rects, Style::evaluate(style.outlineOffset()), Style::evaluate(style.outlineWidth()), color);
+    context.drawFocusRing(rects, Style::evaluate(style.outlineOffset(), 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */), color);
 #endif
 }
 
 void RenderElement::paintFocusRing(const PaintInfo& paintInfo, const RenderStyle& style, const Vector<LayoutRect>& focusRingRects) const
 {
     ASSERT(style.outlineStyle() == OutlineStyle::Auto);
-    float outlineOffset = Style::evaluate(style.outlineOffset());
+    float outlineOffset = Style::evaluate(style.outlineOffset(), 1.0f /* FIXME FIND ZOOM */);
     Vector<FloatRect> pixelSnappedFocusRingRects;
     float deviceScaleFactor = document().deviceScaleFactor();
     for (auto rect : focusRingRects) {

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -296,7 +296,7 @@ void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogic
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1117,12 +1117,12 @@ template<typename SizeType> LayoutUnit RenderFlexibleBox::computeMainSizeFromAsp
         [&](const SizeType::Percentage& percentageCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
                 ? flexItem.computePercentageLogicalHeight(percentageCrossSizeLength)
-                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(percentageCrossSizeLength, contentBoxWidth()));
+                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(percentageCrossSizeLength, contentBoxWidth(), 1.0f /* FIXME FIND ZOOM */));
         },
         [&](const SizeType::Calc& calcCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
                 ? flexItem.computePercentageLogicalHeight(calcCrossSizeLength)
-                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(calcCrossSizeLength, contentBoxWidth()));
+                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(calcCrossSizeLength, contentBoxWidth(), 1.0f /* FIXME FIND ZOOM */));
         },
         [&](const CSS::Keyword::Auto&) -> std::optional<LayoutUnit> {
             ASSERT(flexItemCrossSizeShouldUseContainerCrossSize(flexItem));
@@ -1650,7 +1650,7 @@ LayoutUnit RenderFlexibleBox::computeFlexItemMarginValue(const Style::MarginEdge
 {
     // When resolving the margins, we use the content size for resolving percent and calc (for percents in calc expressions) margins.
     // Fortunately, percent margins are always computed with respect to the block's width, even for margin-top and margin-bottom.
-    return Style::evaluateMinimum(margin, contentBoxLogicalWidth());
+    return Style::evaluateMinimum(margin, contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */);
 }
 
 void RenderFlexibleBox::prepareOrderIteratorAndMargins()
@@ -2785,7 +2785,7 @@ LayoutUnit RenderFlexibleBox::computeGap(RenderFlexibleBox::GapType gapType) con
         return { };
 
     auto availableSize = usesRowGap ? availableLogicalHeightForPercentageComputation().value_or(0_lu) : contentBoxLogicalWidth();
-    return Style::evaluateMinimum(gap, availableSize);
+    return Style::evaluateMinimum(gap, availableSize, 1.0f /* FIXME FIND ZOOM */);
 }
 
 bool RenderFlexibleBox::layoutUsingFlexFormattingContext()

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -696,7 +696,7 @@ LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction, std::o
         return downcast<RenderGrid>(parent())->gridGap(parentDirection);
     }
 
-    return Style::evaluate(gap, availableSize.value_or(0_lu));
+    return Style::evaluate(gap, availableSize.value_or(0_lu), 1.0f /* FIXME FIND ZOOM */);
 }
 
 LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction) const
@@ -895,13 +895,13 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
             },
             [&](const Style::MaximumSize::Percentage& percentageMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = Style::evaluate(percentageMaxSize, containingBlockAvailableSize());
+                auto maxSizeValue = Style::evaluate(percentageMaxSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
             },
             [&](const Style::MaximumSize::Calc& calcMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = Style::evaluate(calcMaxSize, containingBlockAvailableSize());
+                auto maxSizeValue = Style::evaluate(calcMaxSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
@@ -927,13 +927,13 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
             },
             [&](const Style::MinimumSize::Percentage& percentageMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = Style::evaluate(percentageMinSize, containingBlockAvailableSize());
+                auto minSizeValue = Style::evaluate(percentageMinSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
             },
             [&](const Style::MinimumSize::Calc& calcMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = Style::evaluate(calcMinSize, containingBlockAvailableSize());
+                auto minSizeValue = Style::evaluate(calcMinSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
@@ -966,8 +966,8 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
 
         auto contributingTrackSize = [&] {
             if (hasDefiniteMaxTrackSizingFunction && hasDefiniteMinTrackSizingFunction)
-                return std::max(Style::evaluate(minTrackSizingFunction.length(), *availableSize), Style::evaluate(maxTrackSizingFunction.length(), *availableSize));
-            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate(maxTrackSizingFunction.length(), *availableSize) : Style::evaluate(minTrackSizingFunction.length(), *availableSize);
+                return std::max(Style::evaluate(minTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */), Style::evaluate(maxTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */));
+            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate(maxTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */) : Style::evaluate(minTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */);
         };
         autoRepeatTracksSize += contributingTrackSize();
     }
@@ -982,7 +982,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
     for (const auto& track : trackSizes) {
         bool hasDefiniteMaxTrackBreadth = track.maxTrackBreadth().isLength() && !track.maxTrackBreadth().isContentSized();
         ASSERT(hasDefiniteMaxTrackBreadth || (track.minTrackBreadth().isLength() && !track.minTrackBreadth().isContentSized()));
-        tracksSize += Style::evaluate(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value());
+        tracksSize += Style::evaluate(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value(), 1.0f /* FIXME FIND ZOOM */);
     }
 
     // Add gutters as if auto repeat tracks were only repeated once. Gaps between different repetitions will be added later when

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -688,7 +688,7 @@ void RenderImage::paintAreaElementFocusRing(PaintInfo& paintInfo, const LayoutPo
     if (!areaElementStyle)
         return;
 
-    float outlineWidth = Style::evaluate(areaElementStyle->outlineWidth());
+    float outlineWidth = Style::evaluate(areaElementStyle->outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */);
     if (!outlineWidth)
         return;
 

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -349,7 +349,9 @@ LayoutPoint RenderInline::firstInlineBoxTopLeft() const
 
 static LayoutUnit computeMargin(const RenderInline* renderer, const Style::MarginEdge& margin)
 {
-    return Style::evaluateMinimum(margin, [&] ALWAYS_INLINE_LAMBDA { return std::max<LayoutUnit>(0, renderer->containingBlock()->contentBoxLogicalWidth()); });
+    return Style::evaluateMinimum(margin, [&] ALWAYS_INLINE_LAMBDA {
+        return std::max<LayoutUnit>(0, renderer->containingBlock()->contentBoxLogicalWidth());
+    }, 1.0f /* FIXME FIND ZOOM */);
 }
 
 LayoutUnit RenderInline::marginLeft() const

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2292,7 +2292,7 @@ FloatPoint RenderLayer::perspectiveOrigin() const
 {
     if (!renderer().hasTransformRelatedProperty())
         return { };
-    return Style::evaluate(renderer().style().perspectiveOrigin(), renderer().transformReferenceBoxRect(renderer().style()).size());
+    return Style::evaluate(renderer().style().perspectiveOrigin(), renderer().transformReferenceBoxRect(renderer().style()).size(), 1.0f /* FIXME FIND ZOOM */);
 }
 
 static inline bool isContainerForPositioned(RenderLayer& layer, PositionType position, bool establishesTopLayer)
@@ -2975,8 +2975,8 @@ LayoutSize RenderLayer::minimumSizeForResizing(float zoomFactor) const
 {
     // Use the resizer size as the strict minimum size
     auto resizerRect = overflowControlsRects().resizer;
-    LayoutUnit minWidth = Style::evaluateMinimum(renderer().style().minWidth(), renderer().containingBlock()->width());
-    LayoutUnit minHeight = Style::evaluateMinimum(renderer().style().minHeight(), renderer().containingBlock()->height());
+    LayoutUnit minWidth = Style::evaluateMinimum(renderer().style().minWidth(), renderer().containingBlock()->width(), 1.0f /* FIXME FIND ZOOM */);
+    LayoutUnit minHeight = Style::evaluateMinimum(renderer().style().minHeight(), renderer().containingBlock()->height(), 1.0f /* FIXME FIND ZOOM */);
     minWidth = std::max(LayoutUnit(minWidth / zoomFactor), LayoutUnit(resizerRect.width()));
     minHeight = std::max(LayoutUnit(minHeight / zoomFactor), LayoutUnit(resizerRect.height()));
     return LayoutSize(minWidth, minHeight);

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -235,7 +235,7 @@ void RenderListBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, L
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -297,7 +297,7 @@ void RenderMarquee::timerFired()
         }
         bool positive = range > 0;
         int clientSize = (isHorizontal() ? roundToInt(renderBox->clientWidth()) : roundToInt(renderBox->clientHeight()));
-        int increment = std::abs(Style::evaluate(m_layer->renderer().style().marqueeIncrement(), clientSize));
+        int increment = std::abs(Style::evaluate(m_layer->renderer().style().marqueeIncrement(), clientSize, 1.0f /* FIXME FIND ZOOM */));
         int currentPos = (isHorizontal() ? scrollableArea->scrollOffset().x() : scrollableArea->scrollOffset().y());
         newPos =  currentPos + (addIncrement ? increment : -increment);
         if (positive)

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -230,7 +230,7 @@ void RenderMenuList::updateOptionsWidth()
             // Add in the option's text indent.  We can't calculate percentage values for now.
             float optionWidth = 0;
             if (auto* optionStyle = option->computedStyleForEditability())
-                optionWidth += Style::evaluate(optionStyle->textIndent().length, 0);
+                optionWidth += Style::evaluate(optionStyle->textIndent().length, 0, 1.0f /* FIXME FIND ZOOM */);
             if (!text.isEmpty()) {
                 const FontCascade& font = style().fontCascade();
                 TextRun run = RenderBlock::constructTextRun(text, style());
@@ -350,7 +350,7 @@ void RenderMenuList::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, 
     }
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -445,7 +445,7 @@ LayoutUnit RenderMultiColumnSet::columnGap() const
     auto& parentBlockGap = parentBlock.style().columnGap();
     if (parentBlockGap.isNormal())
         return LayoutUnit(parentBlock.style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate(parentBlockGap, parentBlock.contentBoxLogicalWidth());
+    return Style::evaluate(parentBlockGap, parentBlock.contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */);
 }
 
 unsigned RenderMultiColumnSet::columnCount() const
@@ -632,7 +632,7 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     const Color& ruleColor = blockStyle.visitedDependentColorWithColorFilter(CSSPropertyColumnRuleColor);
     bool ruleTransparent = blockStyle.columnRuleIsTransparent();
     BorderStyle ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
-    LayoutUnit ruleThickness { Style::evaluate(blockStyle.columnRuleWidth()) };
+    LayoutUnit ruleThickness { Style::evaluate(blockStyle.columnRuleWidth(), 1.0f /* FIXME FIND ZOOM */) };
     LayoutUnit colGap = columnGap();
     bool renderRule = ruleStyle > BorderStyle::Hidden && !ruleTransparent;
     if (!renderRule)

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -556,8 +556,8 @@ LayoutRect RenderReplaced::replacedContentRect(const LayoutSize& intrinsicSize) 
 
     auto& objectPosition = style().objectPosition();
 
-    LayoutUnit xOffset = Style::evaluate(objectPosition.x, contentRect.width() - finalRect.width());
-    LayoutUnit yOffset = Style::evaluate(objectPosition.y, contentRect.height() - finalRect.height());
+    LayoutUnit xOffset = Style::evaluate(objectPosition.x, contentRect.width() - finalRect.width(), 1.0f /* FIXME FIND ZOOM */);
+    LayoutUnit yOffset = Style::evaluate(objectPosition.y, contentRect.height() - finalRect.height(), 1.0f /* FIXME FIND ZOOM */);
 
     finalRect.move(xOffset, yOffset);
 
@@ -613,8 +613,8 @@ LayoutUnit RenderReplaced::computeConstrainedLogicalWidth() const
     LayoutUnit logicalWidth = isOutOfFlowPositioned() ? containingBlock()->clientLogicalWidth() : containingBlock()->contentBoxLogicalWidth();
 
     // This solves above equation for 'width' (== logicalWidth).
-    LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), logicalWidth);
-    LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), logicalWidth);
+    LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), logicalWidth, 1.0f /* FIXME FIND ZOOM */);
+    LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), logicalWidth, 1.0f /* FIXME FIND ZOOM */);
 
     return std::max(0_lu, (logicalWidth - (marginStart + marginEnd + borderLeft() + borderRight() + paddingLeft() + paddingRight())));
 }

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -87,21 +87,21 @@ void RenderScrollbarPart::layoutVerticalPart()
 static int calcScrollbarThicknessUsing(const Style::PreferredSize& preferredSize)
 {
     if (!preferredSize.isPercentOrCalculated() && !preferredSize.isIntrinsicOrLegacyIntrinsicOrAuto())
-        return Style::evaluateMinimum(preferredSize, 0_lu);
+        return Style::evaluateMinimum(preferredSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MinimumSize& minimumSize)
 {
     if ((!minimumSize.isPercentOrCalculated() && !minimumSize.isIntrinsicOrLegacyIntrinsicOrAuto()) || minimumSize.isAuto())
-        return Style::evaluateMinimum(minimumSize, 0_lu);
+        return Style::evaluateMinimum(minimumSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MaximumSize& maximumSize)
 {
     if (!maximumSize.isPercentOrCalculated() && !maximumSize.isIntrinsic() && !maximumSize.isLegacyIntrinsic())
-        return Style::evaluateMinimum(maximumSize, 0_lu);
+        return Style::evaluateMinimum(maximumSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
@@ -115,8 +115,8 @@ void RenderScrollbarPart::computeScrollbarWidth()
     setWidth(std::max(minWidth, std::min(maxWidth, width)));
     
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setLeft(Style::evaluateMinimum(style().marginLeft(), 0_lu));
-    m_marginBox.setRight(Style::evaluateMinimum(style().marginRight(), 0_lu));
+    m_marginBox.setLeft(Style::evaluateMinimum(style().marginLeft(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
+    m_marginBox.setRight(Style::evaluateMinimum(style().marginRight(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
 }
 
 void RenderScrollbarPart::computeScrollbarHeight()
@@ -129,8 +129,8 @@ void RenderScrollbarPart::computeScrollbarHeight()
     setHeight(std::max(minHeight, std::min(maxHeight, height)));
 
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setTop(Style::evaluateMinimum(style().marginTop(), 0_lu));
-    m_marginBox.setBottom(Style::evaluateMinimum(style().marginBottom(), 0_lu));
+    m_marginBox.setTop(Style::evaluateMinimum(style().marginTop(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
+    m_marginBox.setBottom(Style::evaluateMinimum(style().marginBottom(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
 }
 
 void RenderScrollbarPart::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -84,7 +84,7 @@ void RenderSlider::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, La
     maxLogicalWidth = defaultTrackLength * style().usedZoom();
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -157,8 +157,8 @@ void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldSty
     bool oldFixedTableLayout = oldStyle ? oldStyle->isFixedTableLayout() : false;
 
     // In the collapsed border model, there is no cell spacing.
-    m_hSpacing = collapseBorders() ? 0 : Style::evaluate(style().borderHorizontalSpacing());
-    m_vSpacing = collapseBorders() ? 0 : Style::evaluate(style().borderVerticalSpacing());
+    m_hSpacing = collapseBorders() ? 0 : Style::evaluate(style().borderHorizontalSpacing(), 1.0f /* FIXME FIND ZOOM */);
+    m_vSpacing = collapseBorders() ? 0 : Style::evaluate(style().borderVerticalSpacing(), 1.0f /* FIXME FIND ZOOM */);
     ASSERT(m_hSpacing >= 0);
     ASSERT(m_vSpacing >= 0);
 
@@ -307,8 +307,8 @@ void RenderTable::updateLogicalWidth()
         setLogicalWidth(convertStyleLogicalWidthToComputedWidth(styleLogicalWidth, containerWidthInInlineDirection));
     else {
         // Subtract out any fixed margins from our available width for auto width tables.
-        LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), availableLogicalWidth);
-        LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), availableLogicalWidth);
+        LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), availableLogicalWidth, 1.0f /* FIXME FIND ZOOM */);
+        LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), availableLogicalWidth, 1.0f /* FIXME FIND ZOOM */);
         LayoutUnit marginTotal = marginStart + marginEnd;
 
         // Subtract out our margins to get the available content width.
@@ -360,8 +360,8 @@ void RenderTable::updateLogicalWidth()
         setMarginStart(marginValues.m_start);
         setMarginEnd(marginValues.m_end);
     } else {
-        setMarginStart(Style::evaluateMinimum(style().marginStart(), availableLogicalWidth));
-        setMarginEnd(Style::evaluateMinimum(style().marginEnd(), availableLogicalWidth));
+        setMarginStart(Style::evaluateMinimum(style().marginStart(), availableLogicalWidth, 1.0f /* FIXME FIND ZOOM */));
+        setMarginEnd(Style::evaluateMinimum(style().marginEnd(), availableLogicalWidth, 1.0f /* FIXME FIND ZOOM */));
     }
 }
 
@@ -378,7 +378,7 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalWidthToCo
     if (isCSSTable && styleLogicalWidth.isSpecified() && styleLogicalWidth.isPositive() && style().boxSizing() == BoxSizing::ContentBox)
         borders = borderStart() + borderEnd() + (collapseBorders() ? 0_lu : paddingStart() + paddingEnd());
 
-    return Style::evaluateMinimum(styleLogicalWidth, availableWidth) + borders;
+    return Style::evaluateMinimum(styleLogicalWidth, availableWidth, 1.0f /* FIXME FIND ZOOM */) + borders;
 }
 
 template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToComputedHeight(const SizeType& styleLogicalHeight)
@@ -1287,7 +1287,7 @@ LayoutUnit RenderTable::calcBorderStart() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth), document().deviceScaleFactor(), writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 }
 
 LayoutUnit RenderTable::calcBorderEnd() const
@@ -1342,7 +1342,7 @@ LayoutUnit RenderTable::calcBorderEnd() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 }
 
 void RenderTable::recalcBordersInRowDirection()
@@ -1384,7 +1384,7 @@ LayoutUnit RenderTable::outerBorderBefore() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit(Style::evaluate(tb.width()) / 2));
+        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit(Style::evaluate(tb.width(), 1.0f /* FIXME FIND ZOOM */) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, document().deviceScaleFactor());
     }
     return borderWidth;
@@ -1406,7 +1406,7 @@ LayoutUnit RenderTable::outerBorderAfter() const
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
         float deviceScaleFactor = document().deviceScaleFactor();
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit((Style::evaluate(tb.width()) + (1 / deviceScaleFactor)) / 2));
+        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit((Style::evaluate(tb.width(), 1.0f /* FIXME FIND ZOOM */) + (1 / deviceScaleFactor)) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, deviceScaleFactor);
     }
     return borderWidth;
@@ -1423,7 +1423,7 @@ LayoutUnit RenderTable::outerBorderStart() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(tb.width()), document().deviceScaleFactor(), writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(tb.width(), 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 
     bool allHidden = true;
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {
@@ -1450,7 +1450,7 @@ LayoutUnit RenderTable::outerBorderEnd() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(tb.width()), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(tb.width(), 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 
     bool allHidden = true;
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -367,7 +367,7 @@ LayoutUnit RenderTableCell::logicalHeightForRowSizing() const
     auto specifiedSize = !isOrthogonal() ? style().logicalHeight() : style().logicalWidth();
     if (!specifiedSize.isSpecified())
         return usedLogicalSize;
-    auto computedLogicaSize = Style::evaluate(specifiedSize, 0_lu);
+    auto computedLogicaSize = Style::evaluate(specifiedSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
     // In strict mode, box-sizing: content-box do the right thing and actually add in the border and padding.
     // Call computedCSSPadding* directly to avoid including implicitPadding.
     if (!document().inQuirksMode() && style().boxSizing() != BoxSizing::BorderBox)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -221,7 +221,7 @@ static LayoutUnit resolveLogicalHeightForRow(const Style::PreferredSize& rowLogi
     if (auto fixedRowLogicalHeight = rowLogicalHeight.tryFixed())
         return LayoutUnit(fixedRowLogicalHeight->value);
     if (rowLogicalHeight.isCalculated())
-        return LayoutUnit(Style::evaluate(rowLogicalHeight, 0));
+        return LayoutUnit(Style::evaluate(rowLogicalHeight, 0, 1.0f /* FIXME FIND ZOOM */));
     return 0;
 }
 
@@ -787,7 +787,7 @@ LayoutUnit RenderTableSection::calcBlockDirectionOuterBorder(BlockBorderSide sid
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
 }
 
 LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide side) const
@@ -841,7 +841,7 @@ LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide s
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
 }
 
 void RenderTableSection::recalcOuterBorder()
@@ -1144,18 +1144,18 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
     switch (borderSide) {
     case BoxSide::Top:
         paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderTop().width()))), BoxSide::Top, CSSPropertyBorderTopColor, style.borderTopStyle(), table()->style().borderTopStyle());
+            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderTop().width(), 1.0f /* FIXME FIND ZOOM */))), BoxSide::Top, CSSPropertyBorderTopColor, style.borderTopStyle(), table()->style().borderTopStyle());
         break;
     case BoxSide::Bottom:
         paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y() + rowGroupRect.height(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderBottom().width()))), BoxSide::Bottom, CSSPropertyBorderBottomColor, style.borderBottomStyle(), table()->style().borderBottomStyle());
+            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderBottom().width(), 1.0f /* FIXME FIND ZOOM */))), BoxSide::Bottom, CSSPropertyBorderBottomColor, style.borderBottomStyle(), table()->style().borderBottomStyle());
         break;
     case BoxSide::Left:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderLeft().width())),
+        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderLeft().width(), 1.0f /* FIXME FIND ZOOM */)),
             verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Left, CSSPropertyBorderLeftColor, style.borderLeftStyle(), table()->style().borderLeftStyle());
         break;
     case BoxSide::Right:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x() + rowGroupRect.width(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderRight().width())),
+        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x() + rowGroupRect.width(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderRight().width(), 1.0f /* FIXME FIND ZOOM */)),
             verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Right, CSSPropertyBorderRightColor, style.borderRightStyle(), table()->style().borderRightStyle());
         break;
     default:

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -195,7 +195,7 @@ void RenderTextControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderTextInlines.h
+++ b/Source/WebCore/rendering/RenderTextInlines.h
@@ -26,8 +26,8 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum(style().marginLeft(), 0_lu); }
-inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum(style().marginRight(), 0_lu); }
+inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum(style().marginLeft(), 0_lu, 1.0f /* FIXME FIND ZOOM */); }
+inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum(style().marginRight(), 0_lu, 1.0f /* FIXME FIND ZOOM */); }
 
 template <typename MeasureTextCallback>
 float RenderText::measureTextConsideringPossibleTrailingSpace(bool currentCharacterIsSpace, unsigned startIndex, unsigned wordLength, WordTrailingSpace& wordTrailingSpace, SingleThreadWeakHashSet<const Font>& fallbackFonts, MeasureTextCallback&& callback)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -837,7 +837,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderObject& ren
         style->usedZoom(),
         style->usedAccentColor(renderObject.styleColorOptions()),
         style->visitedDependentColorWithColorFilter(CSSPropertyColor),
-        Style::evaluate(style->borderWidth())
+        Style::evaluate(style->borderWidth(), 1.0f /* FIXME FIND ZOOM */)
     };
 }
 
@@ -1394,26 +1394,27 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     if (!style.writingMode().isHorizontal() && supportsVerticalWritingMode(appearance))
         borderBox = Style::LineWidthBox { borderBox.left(), borderBox.top(), borderBox.right(), borderBox.bottom() };
 
-    if (Style::evaluate(borderBox.top()) != static_cast<int>(Style::evaluate(style.borderTopWidth()))) {
+    /* FIXME: FIND ZOOM */
+    if (Style::evaluate(borderBox.top(), 1.0f) != static_cast<int>(Style::evaluate(style.borderTopWidth(), 1.0f))) {
         if (!borderBox.top().isZero())
             style.setBorderTopWidth(borderBox.top());
         else
             style.resetBorderTop();
     }
-    if (Style::evaluate(borderBox.right()) != static_cast<int>(Style::evaluate(style.borderRightWidth()))) {
+    if (Style::evaluate(borderBox.right(), 1.0f) != static_cast<int>(Style::evaluate(style.borderRightWidth(), 1.0f))) {
         if (!borderBox.right().isZero())
             style.setBorderRightWidth(borderBox.right());
         else
             style.resetBorderRight();
     }
-    if (Style::evaluate(borderBox.bottom()) != static_cast<int>(Style::evaluate(style.borderBottomWidth()))) {
+    if (Style::evaluate(borderBox.bottom(), 1.0f) != static_cast<int>(Style::evaluate(style.borderBottomWidth(), 1.0f))) {
         style.setBorderBottomWidth(borderBox.bottom());
         if (!borderBox.bottom().isZero())
             style.setBorderBottomWidth(borderBox.bottom());
         else
             style.resetBorderBottom();
     }
-    if (Style::evaluate(borderBox.left()) != static_cast<int>(Style::evaluate(style.borderLeftWidth()))) {
+    if (Style::evaluate(borderBox.left(), 1.0f) != static_cast<int>(Style::evaluate(style.borderLeftWidth(), 1.0f))) {
         style.setBorderLeftWidth(borderBox.left());
         if (!borderBox.left().isZero())
             style.setBorderLeftWidth(borderBox.left());

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -275,7 +275,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
                 ts << " [textStrokeColor="_s << serializationForRenderTreeAsText(textStrokeColor) << ']';
 
             if (renderElement->parent()->style().textStrokeWidth() != renderElement->style().textStrokeWidth() && renderElement->style().textStrokeWidth().isPositive())
-                ts << " [textStrokeWidth="_s << Style::evaluate(renderElement->style().textStrokeWidth()) << ']';
+                ts << " [textStrokeWidth="_s << Style::evaluate(renderElement->style().textStrokeWidth(), 1.0f /* FIXME FIND ZOOM */) << ']';
         }
 
         auto* box = dynamicDowncast<RenderBoxModelObject>(o);

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -153,7 +153,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
 
         int specifiedLineHeight;
         if (lineHeightLength.isPercent())
-            specifiedLineHeight = minimumValueForLength(lineHeightLength, fontDescription.specifiedSize());
+            specifiedLineHeight = minimumValueForLength(lineHeightLength, fontDescription.specifiedSize(), 1.0f /* FIXME FIND ZOOM */);
         else
             specifiedLineHeight = lineHeightLength.value();
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -128,7 +128,7 @@ static void drawFocusRingForPathForVectorBasedControls(const RenderObject& box, 
     // macOS controls have never honored outline offset.
 #if PLATFORM(IOS_FAMILY)
     auto deviceScaleFactor = box.document().deviceScaleFactor();
-    auto outlineOffset = floorToDevicePixel(Style::evaluate(box.style().outlineOffset()), deviceScaleFactor);
+    auto outlineOffset = floorToDevicePixel(Style::evaluate(box.style().outlineOffset(), 1.0f /* FIXME FIND ZOOM */), deviceScaleFactor);
 
     if (outlineOffset > 0) {
         const auto center = rect.center();
@@ -2583,9 +2583,9 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
     }
 
     if (!style->writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth()) - glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME ZOOM EFFECTED? */) - glyphPaddingEnd);
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth()) + glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME ZOOM EFFECTED? */) + glyphPaddingEnd);
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -383,7 +383,7 @@ Style::PaddingBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& sty
     auto padding = emSize->resolveAsLength<float>({ style, nullptr, nullptr, nullptr });
 
     if (style.usedAppearance() == StyleAppearance::MenulistButton) {
-        auto value = toTruncatedPaddingEdge(padding + Style::evaluate(style.borderTopWidth()));
+        auto value = toTruncatedPaddingEdge(padding + Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
         if (style.writingMode().isBidiRTL())
             return { 0_css_px, 0_css_px, 0_css_px, value };
         return { 0_css_px, value, 0_css_px, 0_css_px };
@@ -610,9 +610,9 @@ void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const 
     FloatPoint glyphOrigin;
     glyphOrigin.setY(logicalRect.center().y() - glyphSize.height() / 2.0f);
     if (!style.writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth()) - Style::evaluate(box.style().paddingEnd(), logicalRect.width()));
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) - Style::evaluate(box.style().paddingEnd(), logicalRect.width(), 1.0f/* FIXME FIND ZOOM */));
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth()) + Style::evaluate(box.style().paddingEnd(), logicalRect.width()));
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) + Style::evaluate(box.style().paddingEnd(), logicalRect.width(), 1.0f /* FIXME FIND ZOOM */));
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();
@@ -1744,10 +1744,10 @@ bool RenderThemeIOS::paintListButton(const RenderObject& box, const PaintInfo& p
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
-    float paddingTop = Style::evaluate(style.paddingTop(), rect.height());
-    float paddingRight = Style::evaluate(style.paddingRight(), rect.width());
-    float paddingBottom = Style::evaluate(style.paddingBottom(), rect.height());
-    float paddingLeft = Style::evaluate(style.paddingLeft(), rect.width());
+    float paddingTop = Style::evaluate(style.paddingTop(), rect.height(), 1.0f /* FIXME FIND ZOOM */);
+    float paddingRight = Style::evaluate(style.paddingRight(), rect.width(), 1.0f /* FIXME FIND ZOOM */);
+    float paddingBottom = Style::evaluate(style.paddingBottom(), rect.height(), 1.0f /* FIXME FIND ZOOM */);
+    float paddingLeft = Style::evaluate(style.paddingLeft(), rect.width(), 1.0f /* FIXME FIND ZOOM */);
 
     FloatRect indicatorRect = rect;
     indicatorRect.move(paddingLeft, paddingTop);

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -121,14 +121,14 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
             return createEllipseShape(logicalCenter, radii, logicalBoxSize.width());
         },
         [&](const Style::InsetFunction& inset) -> Ref<LayoutShape> {
-            float left = Style::evaluate(inset->insets.left(), boxWidth);
-            float top = Style::evaluate(inset->insets.top(), boxHeight);
+            float left = Style::evaluate(inset->insets.left(), boxWidth, 1.0f /* FIXME FIND ZOOM */);
+            float top = Style::evaluate(inset->insets.top(), boxHeight, 1.0f /* FIXME FIND ZOOM */);
 
             FloatRect rect {
                 left,
                 top,
-                std::max<float>(boxWidth - left - Style::evaluate(inset->insets.right(), boxWidth), 0),
-                std::max<float>(boxHeight - top - Style::evaluate(inset->insets.bottom(), boxHeight), 0)
+                std::max<float>(boxWidth - left - Style::evaluate(inset->insets.right(), boxWidth, 1.0f /* FIXME FIND ZOOM */), 0),
+                std::max<float>(boxHeight - top - Style::evaluate(inset->insets.bottom(), boxHeight, 1.0f /* FIXME FIND ZOOM */), 0)
             };
 
             auto logicalRect = physicalRectToLogical(rect, logicalBoxSize.height(), writingMode);
@@ -136,10 +136,10 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
 
             auto boxSize = FloatSize(boxWidth, boxHeight);
             auto isBlockLeftToRight = writingMode.isBlockLeftToRight();
-            auto topLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize), writingMode);
-            auto topRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize), writingMode);
-            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize), writingMode);
-            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize), writingMode);
+            auto topLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
+            auto topRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
+            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
+            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
             auto cornerRadii = FloatRoundedRect::Radii(topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius);
             if (shouldFlipStartAndEndPoints(writingMode))
                 cornerRadii = { cornerRadii.topRight(), cornerRadii.topLeft(), cornerRadii.bottomRight(), cornerRadii.bottomLeft() };
@@ -151,7 +151,7 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
             auto boxSize = FloatSize { boxWidth, boxHeight };
 
             auto vertices = polygon->vertices.value.map([&](const auto& vertex) {
-                return physicalPointToLogical(Style::evaluate(vertex, boxSize) + borderBoxOffset, logicalBoxSize.height(), writingMode);
+                return physicalPointToLogical(Style::evaluate(vertex, boxSize, 1.0f /* FIXME FIND ZOOM */) + borderBoxOffset, logicalBoxSize.height(), writingMode);
             });
 
             return createPolygonShape(WTFMove(vertices), logicalBoxSize.width());

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -255,7 +255,7 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
     auto boxSize = computeLogicalBoxSize(renderer, isHorizontalWritingMode);
 
     auto logicalMargin = [&] {
-        auto shapeMargin = Style::evaluate(style.shapeMargin(), containingBlock.contentBoxLogicalWidth()).toFloat();
+        auto shapeMargin = Style::evaluate(style.shapeMargin(), containingBlock.contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */).toFloat();
         return isnan(shapeMargin) ? 0.0f : shapeMargin;
     }();
 

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -39,7 +39,7 @@ public:
     }
 
     CollapsedBorderValue(const BorderValue& border, const Color& color, BorderPrecedence precedence)
-        : m_width(LayoutUnit(border.nonZero() ? Style::evaluate(border.width()) : 0))
+        : m_width(LayoutUnit(border.nonZero() ? Style::evaluate(border.width(), 1.0f /* FIXME ZOOM EFFECTED? */) : 0))
         , m_color(color)
         , m_style(static_cast<unsigned>(border.style()))
         , m_precedence(static_cast<unsigned>(precedence))

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -86,7 +86,7 @@ std::optional<FloatRect> SVGRenderSupport::computeFloatVisibleRectInContainer(co
         return FloatRect();
 
     FloatRect adjustedRect = rect;
-    adjustedRect.inflate(Style::evaluate(renderer.style().outlineWidth()));
+    adjustedRect.inflate(Style::evaluate(renderer.style().outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */));
 
     // Translate to coords in our parent renderer, and then call computeFloatVisibleRectInContainer() on our parent.
     adjustedRect = renderer.localToParentTransform().mapRect(adjustedRect);

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -50,7 +50,7 @@ float SVGTextLayoutEngineBaseline::calculateBaselineShift(const SVGRenderStyle& 
             return m_font->metricsOfPrimaryFont().height() / 2;
         },
         [&](const Style::SVGBaselineShift::Length& length) -> float {
-            return Style::evaluate(length, m_font->size());
+            return Style::evaluate(length, m_font->size(), 1.0f /* FIXME ZOOM EFFECTED? */);
         }
     );
 }

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -389,7 +389,7 @@ template<CSSPropertyID propertyID, typename InsetEdgeApplier, typename NumberAsP
                     : box->containingBlockLogicalWidthForContent();
             }
         }
-        return numberAsPixelsApplier(Style::evaluate(inset, containingBlockSize));
+        return numberAsPixelsApplier(Style::evaluate(inset, containingBlockSize, 1.0f /* FIXME FIND ZOOM */));
     }
 
     // Return a "computed value" length.
@@ -1300,7 +1300,7 @@ inline Ref<CSSValue> ExtractorCustom::extractLineHeight(ExtractorState& state)
         // that here either.
         return ExtractorConverter::convertNumberAsPixels(state, static_cast<double>(length.percent() * state.style.fontDescription().computedSize()) / 100);
     }
-    return ExtractorConverter::convertNumberAsPixels(state, floatValueForLength(length, 0));
+    return ExtractorConverter::convertNumberAsPixels(state, floatValueForLength(length, 0, 1.0f /* FIXME FIND ZOOM */));
 }
 
 inline void ExtractorCustom::extractLineHeightSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
@@ -1327,7 +1327,7 @@ inline void ExtractorCustom::extractLineHeightSerialization(ExtractorState& stat
         return;
     }
 
-    ExtractorSerializer::serializeNumberAsPixels(state, builder, context, floatValueForLength(length, 0));
+    ExtractorSerializer::serializeNumberAsPixels(state, builder, context, floatValueForLength(length, 0, 1.0f /* FIX ME FIND ZOOM */));
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractFontFamily(ExtractorState& state)
@@ -1662,7 +1662,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginRight(ExtractorState& state)
         // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
         // and the right-edge of the containing box, when display == DisplayType::Block. Let's calculate the absolute
         // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent());
+        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), 1.0f /* FIXME FIND ZOOM */);
     } else
         value = box->marginRight();
     return ExtractorConverter::convertNumberAsPixels(state, value);
@@ -1687,7 +1687,7 @@ inline void ExtractorCustom::extractMarginRightSerialization(ExtractorState& sta
         // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
         // and the right-edge of the containing box, when display == DisplayType::Block. Let's calculate the absolute
         // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent());
+        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), 1.0f /* FIXME FIND ZOOM */);
     } else
         value = box->marginRight();
 
@@ -2803,8 +2803,8 @@ inline RefPtr<CSSValue> ExtractorCustom::extractPerspectiveOriginShorthand(Extra
     CSSValueListBuilder list;
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginX(), box.width())));
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginY(), box.height())));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */)));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */)));
     } else {
         list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginX()));
         list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginY()));
@@ -2816,9 +2816,9 @@ inline void ExtractorCustom::extractPerspectiveOriginShorthandSerialization(Extr
 {
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginX(), box.width()));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */));
         builder.append(' ');
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginY(), box.height()));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */));
     } else {
         ExtractorSerializer::serializeStyleType(state, builder, context, state.style.perspectiveOriginX());
         builder.append(' ');
@@ -3048,8 +3048,8 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTransformOriginShorthand(Extract
     CSSValueListBuilder list;
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginX(), box.width())));
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginY(), box.height())));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */)));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */)));
         if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value)
             list.append(ExtractorConverter::convertStyleType(state, transformOriginZ));
     } else {
@@ -3065,9 +3065,9 @@ inline void ExtractorCustom::extractTransformOriginShorthandSerialization(Extrac
 {
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginX(), box.width()));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */));
         builder.append(' ');
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginY(), box.height()));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */));
         if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value) {
             builder.append(' ');
             ExtractorSerializer::serializeStyleType(state, builder, context, transformOriginZ);

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -331,7 +331,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                     return CSS::switchOnUnitType(lengthPercentage.unit,
                         [&](CSS::PercentageUnit) -> ResolvedFontSize {
                             return {
-                                .size = Style::evaluate(Style::Percentage<> { narrowPrecisionToFloat(lengthPercentage.value) }, parentSize),
+                                .size = Style::evaluate(Style::Percentage<> { narrowPrecisionToFloat(lengthPercentage.value) }, parentSize, 1.0f /* FIXME FIND ZOOM */),
                                 .keyword = CSSValueInvalid
                             };
                         },
@@ -360,7 +360,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                         return { .size = 0.0f, .keyword = CSSValueInvalid };
 
                     return {
-                        .size = Style::evaluate(Style::toStyleNoConversionDataRequired(calc), parentSize),
+                        .size = Style::evaluate(Style::toStyleNoConversionDataRequired(calc), parentSize, 1.0f /* FIXME FIND ZOOM */),
                         .keyword = CSSValueInvalid
                     };
                 }

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -30,6 +30,7 @@
 #include "RenderStyleInlines.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 namespace Style {
@@ -73,13 +74,13 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
 
 // MARK: - Evaluate
 
-FloatBoxExtent Evaluation<LineWidthBox>::operator()(const LineWidthBox& value)
+FloatBoxExtent Evaluation<LineWidthBox>::operator()(const LineWidthBox& value, float zoom)
 {
     return {
-        evaluate(value.top()),
-        evaluate(value.right()),
-        evaluate(value.bottom()),
-        evaluate(value.left()),
+        evaluate(value.top(), zoom),
+        evaluate(value.right(), zoom),
+        evaluate(value.bottom(), zoom),
+        evaluate(value.left(), zoom),
     };
 }
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -65,8 +65,16 @@ template<> struct CSSValueConversion<LineWidth> { auto operator()(BuilderState&,
 
 // MARK: - Evaluate
 
-template<> struct Evaluation<LineWidth> { constexpr auto operator()(const LineWidth& value) -> float { return value.value.value; } };
-template<> struct Evaluation<LineWidthBox> { FloatBoxExtent operator()(const LineWidthBox&); };
+template<> struct Evaluation<LineWidth> {
+    constexpr auto operator()(const LineWidth& value) -> float
+    {
+        return value.value.evaluate(1.0f /* FIXME FIND ZOOM */);
+    }
+};
+
+template<> struct Evaluation<LineWidthBox> {
+    FloatBoxExtent operator()(const LineWidthBox&, float zoom);
+};
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
@@ -85,23 +85,23 @@ auto CSSValueConversion<BorderRadiusValue>::operator()(BuilderState& state, cons
 
 // MARK: - Evaluation
 
-auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, FloatSize referenceSize) -> FloatRoundedRect::Radii
+auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, FloatSize referenceSize, float zoom) -> FloatRoundedRect::Radii
 {
     return {
-        evaluate(value.topLeft(), referenceSize),
-        evaluate(value.topRight(), referenceSize),
-        evaluate(value.bottomLeft(), referenceSize),
-        evaluate(value.bottomRight(), referenceSize),
+        evaluate(value.topLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.topRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.bottomLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.bottomRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
     };
 }
 
-auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, LayoutSize referenceSize) -> LayoutRoundedRect::Radii
+auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, LayoutSize referenceSize, float zoom) -> LayoutRoundedRect::Radii
 {
     return {
-        evaluate(value.topLeft(), referenceSize),
-        evaluate(value.topRight(), referenceSize),
-        evaluate(value.bottomLeft(), referenceSize),
-        evaluate(value.bottomRight(), referenceSize),
+        evaluate(value.topLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.topRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.bottomLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.bottomRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
     };
 }
 

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.h
@@ -80,8 +80,8 @@ template<> struct CSSValueConversion<BorderRadiusValue> { auto operator()(Builde
 // MARK: - Evaluation
 
 template<> struct Evaluation<BorderRadius> {
-    auto operator()(const BorderRadius&, FloatSize) -> FloatRoundedRect::Radii;
-    auto operator()(const BorderRadius&, LayoutSize) -> LayoutRoundedRect::Radii;
+    auto operator()(const BorderRadius&, FloatSize, float zoom) -> FloatRoundedRect::Radii;
+    auto operator()(const BorderRadius&, LayoutSize, float zoom) -> LayoutRoundedRect::Radii;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -644,7 +644,7 @@ template<typename GradientAdapter, typename StyleGradient> GradientColorStops co
 
 static inline float positionFromValue(LengthWrapperBaseDerived auto const& coordinate, float widthOrHeight)
 {
-    return evaluate(coordinate, widthOrHeight);
+    return evaluate(coordinate, widthOrHeight, 1.0f /* FIXME ZOOM EFFECTED? */);
 }
 
 static inline float positionFromValue(const NumberOrPercentage<>& coordinate, float widthOrHeight)
@@ -722,7 +722,7 @@ static std::pair<FloatPoint, FloatPoint> endPointsFromAngleForPrefixedVariants(f
 
 static float resolveRadius(const LengthPercentage<CSS::Nonnegative>& radius, float widthOrHeight)
 {
-    return evaluate(radius, widthOrHeight);
+    return evaluate(radius, widthOrHeight, 1.0f /* FIXME ZOOM EFFECTED? */);
 }
 
 struct DistanceToCorner {

--- a/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
@@ -53,7 +53,11 @@ template<> struct CSSValueConversion<WebkitTextStrokeWidth> { auto operator()(Bu
 
 // MARK: - Evaluate
 
-template<> struct Evaluation<WebkitTextStrokeWidth> { constexpr auto operator()(const WebkitTextStrokeWidth& value) -> float { return value.value.value; } };
+template<> struct Evaluation<WebkitTextStrokeWidth> {
+    constexpr auto operator()(const WebkitTextStrokeWidth& value, float zoom) -> float {
+        return value.value.value * zoom;
+    }
+};
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -282,41 +282,41 @@ template<typename T> concept LengthWrapperBaseDerived = WTF::IsBaseOfTemplate<Le
 // MARK: - Evaluation
 
 template<LengthWrapperBaseDerived T> struct Evaluation<T> {
-    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor) -> LayoutUnit
+    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor, float zoom) -> LayoutUnit
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor) -> float
+    auto operator()(const T& value, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor, float zoom) -> float
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), lazyMaximumValueFunctor);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, LayoutUnit maximumValue) -> LayoutUnit
+    auto operator()(const T& value, LayoutUnit maximumValue, float zoom) -> LayoutUnit
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
     }
-    auto operator()(const T& value, float maximumValue) -> float
+    auto operator()(const T& value, float maximumValue, float zoom) -> float
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
     }
 };
 
-template<typename StyleType, typename Reference> decltype(auto) evaluateMinimum(const StyleType& value, NOESCAPE Reference&& reference)
+template<typename StyleType, typename Reference> decltype(auto) evaluateMinimum(const StyleType& value, NOESCAPE Reference&& reference, float zoom)
 {
-    return MinimumEvaluation<StyleType>{}(value, std::forward<Reference>(reference));
+    return MinimumEvaluation<StyleType> { }(value, std::forward<Reference>(reference), zoom);
 }
 
 template<LengthWrapperBaseDerived T> struct MinimumEvaluation<T> {
-    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor) -> LayoutUnit
+    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor, float zoom) -> LayoutUnit
     {
-        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor);
+        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, LayoutUnit maximumValue) -> LayoutUnit
+    auto operator()(const T& value, LayoutUnit maximumValue, float zoom) -> LayoutUnit
     {
-        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
     }
-    auto operator()(const T& value, float maximumValue) -> float
+    auto operator()(const T& value, float maximumValue, float zoom) -> float
     {
-        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); });
+        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); }, zoom);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -85,9 +85,9 @@ struct LengthWrapperData {
     bool isNegative() const;
 
     template<typename ReturnType, typename MaximumType>
-    ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor) const;
+    ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const;
     template<typename ReturnType, typename MaximumType>
-    ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor) const;
+    ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const;
 
 private:
     WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue) const;
@@ -246,12 +246,12 @@ inline bool LengthWrapperData::isZero() const
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor) const
+ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
-        return ReturnType(m_floatValue);
+        return ReturnType(m_floatValue * zoom);
     case LengthWrapperDataEvaluationKind::Percentage:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));
@@ -267,12 +267,12 @@ ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(Le
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor) const
+ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
-        return ReturnType(m_floatValue);
+        return ReturnType(m_floatValue * zoom);
     case LengthWrapperDataEvaluationKind::Percentage:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -310,11 +310,11 @@ auto CSSValueConversion<PositionY>::operator()(BuilderState& state, const CSSVal
 
 // MARK: - Evaluation
 
-auto Evaluation<Position>::operator()(const Position& position, FloatSize referenceBox) -> FloatPoint
+auto Evaluation<Position>::operator()(const Position& position, FloatSize referenceBox, float zoom) -> FloatPoint
 {
     return {
-        evaluate(position.x, referenceBox.width()),
-        evaluate(position.y, referenceBox.height())
+        evaluate(position.x, referenceBox.width(), zoom),
+        evaluate(position.y, referenceBox.height(), zoom)
     };
 }
 

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -139,7 +139,9 @@ template<> struct CSSValueConversion<PositionY> { auto operator()(BuilderState&,
 
 // MARK: - Evaluation
 
-template<> struct Evaluation<Position> { auto operator()(const Position&, FloatSize) -> FloatPoint; };
+template<> struct Evaluation<Position> {
+    auto operator()(const Position&, FloatSize, float zoom) -> FloatPoint;
+};
 
 // MARK: - Platform
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -68,6 +68,11 @@ template<CSS::Numeric CSSType> struct PrimitiveNumeric {
     {
     }
 
+    constexpr auto evaluate(float zoom) const
+    {
+        return value * zoom;
+    }
+
     constexpr bool isZero() const { return !value; }
     constexpr bool isPositive() const { return value > 0; }
     constexpr bool isNegative() const { return value < 0; }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -39,6 +39,21 @@ namespace Style {
 
 using namespace CSS::Literals;
 
+// MARK: - Length
+
+template<auto R, typename V> struct Evaluation<Length<R, V>> {
+    using StyleType = Length<R, V>;
+
+    constexpr double operator()(const StyleType& value, float zoom)
+    {
+        return static_cast<double>(value.evaluate(zoom));
+    }
+    template<typename Reference> constexpr auto operator()(const StyleType& value, Reference, float zoom) -> Reference
+    {
+        return static_cast<Reference>(value.evaluate(zoom));
+    }
+};
+
 // MARK: - Percentage
 
 template<auto R, typename V> struct Evaluation<Percentage<R, V>> {
@@ -90,18 +105,18 @@ template<Calc Calculation> struct Evaluation<Calculation> {
 // MARK: - SpaceSeparatedPoint
 
 template<typename T> struct Evaluation<SpaceSeparatedPoint<T>> {
-    FloatPoint operator()(const SpaceSeparatedPoint<T>& value, FloatSize referenceBox)
+    FloatPoint operator()(const SpaceSeparatedPoint<T>& value, FloatSize referenceBox, float zoom)
     {
         return {
-            evaluate(value.x(), referenceBox.width()),
-            evaluate(value.y(), referenceBox.height())
+            evaluate(value.x(), referenceBox.width(), zoom),
+            evaluate(value.y(), referenceBox.height(), zoom)
         };
     }
-    LayoutPoint operator()(const SpaceSeparatedPoint<T>& value, LayoutSize referenceBox)
+    LayoutPoint operator()(const SpaceSeparatedPoint<T>& value, LayoutSize referenceBox, float zoom)
     {
         return {
-            evaluate(value.x(), referenceBox.width()),
-            evaluate(value.y(), referenceBox.height())
+            evaluate(value.x(), referenceBox.width(), zoom),
+            evaluate(value.y(), referenceBox.height(), zoom)
         };
     }
 };
@@ -109,18 +124,18 @@ template<typename T> struct Evaluation<SpaceSeparatedPoint<T>> {
 // MARK: - SpaceSeparatedSize
 
 template<typename T> struct Evaluation<SpaceSeparatedSize<T>> {
-    FloatSize operator()(const SpaceSeparatedSize<T>& value, FloatSize referenceBox)
+    FloatSize operator()(const SpaceSeparatedSize<T>& value, FloatSize referenceBox, float zoom)
     {
         return {
-            evaluate(value.width(), referenceBox.width()),
-            evaluate(value.height(), referenceBox.height())
+            evaluate(value.width(), referenceBox.width(), zoom),
+            evaluate(value.height(), referenceBox.height(), zoom)
         };
     }
-    LayoutSize operator()(const SpaceSeparatedSize<T>& value, LayoutSize referenceBox)
+    LayoutSize operator()(const SpaceSeparatedSize<T>& value, LayoutSize referenceBox, float zoom)
     {
         return {
-            evaluate(value.width(), referenceBox.width()),
-            evaluate(value.height(), referenceBox.height())
+            evaluate(value.width(), referenceBox.width(), zoom),
+            evaluate(value.height(), referenceBox.height(), zoom)
         };
     }
 };
@@ -128,18 +143,18 @@ template<typename T> struct Evaluation<SpaceSeparatedSize<T>> {
 // MARK: - MinimallySerializingSpaceSeparatedSize
 
 template<typename T> struct Evaluation<MinimallySerializingSpaceSeparatedSize<T>> {
-    FloatSize operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, FloatSize referenceBox)
+    FloatSize operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, FloatSize referenceBox, float zoom)
     {
         return {
-            evaluate(value.width(), referenceBox.width()),
-            evaluate(value.height(), referenceBox.height())
+            evaluate(value.width(), referenceBox.width(), zoom),
+            evaluate(value.height(), referenceBox.height(), zoom)
         };
     }
-    LayoutSize operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, LayoutSize referenceBox)
+    LayoutSize operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, LayoutSize referenceBox, float zoom)
     {
         return {
-            evaluate(value.width(), referenceBox.width()),
-            evaluate(value.height(), referenceBox.height())
+            evaluate(value.width(), referenceBox.width(), zoom),
+            evaluate(value.height(), referenceBox.height(), zoom)
         };
     }
 };

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -33,14 +33,14 @@
 namespace WebCore {
 namespace Style {
 
-LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit)
+LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit, float zoom)
 {
-    return LayoutUnit(edge.m_value.value);
+    return LayoutUnit(edge.m_value.value * zoom);
 }
 
-float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float)
+float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float, float zoom)
 {
-    return edge.m_value.value;
+    return edge.m_value.value * zoom;
 }
 
 auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollMarginEdge
@@ -51,10 +51,10 @@ auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const
 LayoutBoxExtent extentForRect(const ScrollMarginBox& margin, const LayoutRect& rect)
 {
     return LayoutBoxExtent {
-        Style::evaluate(margin.top(), rect.height()),
-        Style::evaluate(margin.right(), rect.width()),
-        Style::evaluate(margin.bottom(), rect.height()),
-        Style::evaluate(margin.left(), rect.width()),
+        Style::evaluate(margin.top(), rect.height(), 1.0f /* FIXME ZOOM EFFECTED? */),
+        Style::evaluate(margin.right(), rect.width(), 1.0f/* FIXME ZOOM EFFECTED? */),
+        Style::evaluate(margin.bottom(), rect.height(), 1.0f /* FIXME ZOOM EFFECTED? */),
+        Style::evaluate(margin.left(), rect.width(), 1.0f /* FIXME ZOOM EFFECTED? */),
     };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -75,8 +75,8 @@ template<> struct CSSValueConversion<ScrollMarginEdge> { auto operator()(Builder
 // MARK: - Evaluation
 
 template<> struct Evaluation<ScrollMarginEdge> {
-    auto operator()(const ScrollMarginEdge&, LayoutUnit referenceLength) -> LayoutUnit;
-    auto operator()(const ScrollMarginEdge&, float referenceLength) -> float;
+    auto operator()(const ScrollMarginEdge&, LayoutUnit referenceLength, float zoom) -> LayoutUnit;
+    auto operator()(const ScrollMarginEdge&, float referenceLength, float zoom) -> float;
 };
 
 // MARK: - Extent

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -31,17 +31,17 @@
 namespace WebCore {
 namespace Style {
 
-LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength)
+LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength, float zoom)
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
             return LayoutUnit(fixed.value);
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
-            return Style::evaluate(percentage, referenceLength);
+            return Style::evaluate(percentage, referenceLength, zoom /* FIXME ZOOM EFFECTED? */);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return Style::evaluate(calculated, referenceLength);
+            return Style::evaluate(calculated, referenceLength, zoom /* FIXME FIND ZOOM */);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0_lu;
@@ -49,17 +49,17 @@ LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& ed
     );
 }
 
-float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, float referenceLength)
+float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, float referenceLength, float zoom)
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
             return fixed.value;
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
-            return Style::evaluate(percentage, referenceLength);
+            return Style::evaluate(percentage, referenceLength, zoom /* FIXME ZOOM EFFECTED? */);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return Style::evaluate(calculated, referenceLength);
+            return Style::evaluate(calculated, referenceLength, zoom /* FIXME ZOOM EFFECTED? */);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0.0f;
@@ -67,13 +67,13 @@ float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, f
     );
 }
 
-LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect)
+LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect, float zoom)
 {
     return LayoutBoxExtent {
-        Style::evaluate(padding.top(), rect.height()),
-        Style::evaluate(padding.right(), rect.width()),
-        Style::evaluate(padding.bottom(), rect.height()),
-        Style::evaluate(padding.left(), rect.width()),
+        Style::evaluate(padding.top(), rect.height(), zoom),
+        Style::evaluate(padding.right(), rect.width(), zoom),
+        Style::evaluate(padding.bottom(), rect.height(), zoom),
+        Style::evaluate(padding.left(), rect.width(), zoom),
     };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -46,13 +46,13 @@ using ScrollPaddingBox = MinimallySerializingSpaceSeparatedRectEdges<ScrollPaddi
 // MARK: - Evaluation
 
 template<> struct Evaluation<ScrollPaddingEdge> {
-    auto operator()(const ScrollPaddingEdge&, LayoutUnit referenceLength) -> LayoutUnit;
-    auto operator()(const ScrollPaddingEdge&, float referenceLength) -> float;
+    auto operator()(const ScrollPaddingEdge&, LayoutUnit referenceLength, float zoom) -> LayoutUnit;
+    auto operator()(const ScrollPaddingEdge&, float referenceLength, float zoom) -> float;
 };
 
 // MARK: - Extent
 
-LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&);
+LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&, float zoom);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -64,14 +64,14 @@ static const WebCore::Path& cachedCirclePath(const FloatRect& rect)
 
 FloatPoint resolvePosition(const Circle& value, FloatSize boundingBox)
 {
-    return value.position ? evaluate(*value.position, boundingBox) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
+    return value.position ? evaluate(*value.position, boundingBox, 1.0f /* FIXME ZOOM EFFECTED? */) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
 }
 
 float resolveRadius(const Circle& value, FloatSize boxSize, FloatPoint center)
 {
     return WTF::switchOn(value.radius,
         [&](const Circle::Length& length) -> float {
-            return evaluate(length, boxSize.diagonalLength() / std::numbers::sqrt2_v<float>);
+            return evaluate(length, boxSize.diagonalLength() / std::numbers::sqrt2_v<float>, 1.0f /* FIXME ZOOM EFFECTED? */);
         },
         [&](const Circle::Extent& extent) -> float {
             return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
@@ -65,7 +65,7 @@ static const WebCore::Path& cachedEllipsePath(const FloatRect& rect)
 
 FloatPoint resolvePosition(const Ellipse& value, FloatSize boundingBox)
 {
-    return value.position ? evaluate(*value.position, boundingBox) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
+    return value.position ? evaluate(*value.position, boundingBox, 1.0f /* FIXME ZOOM EFFECTED? */) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
 }
 
 FloatSize resolveRadii(const Ellipse& value, FloatSize boxSize, FloatPoint center)
@@ -73,7 +73,7 @@ FloatSize resolveRadii(const Ellipse& value, FloatSize boxSize, FloatPoint cente
     auto sizeForAxis = [&](const Ellipse::RadialSize& radius, float centerValue, float dimensionSize) {
         return WTF::switchOn(radius,
             [&](const Ellipse::Length& length) -> float {
-                return evaluate(length, std::abs(dimensionSize));
+                return evaluate(length, std::abs(dimensionSize), 1.0f /* FIXME FIND ZOOM */);
             },
             [&](const Ellipse::Extent& extent) -> float {
                 return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
@@ -63,16 +63,16 @@ WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const Float
 {
     auto boundingSize = boundingBox.size();
 
-    auto left = evaluate(value.insets.left(), boundingSize.width());
-    auto top = evaluate(value.insets.top(), boundingSize.height());
+    auto left = evaluate(value.insets.left(), boundingSize.width(), 1.0f /* FIXME ZOOM EFFECTED? */);
+    auto top = evaluate(value.insets.top(), boundingSize.height(), 1.0f /* FIXME ZOOM EFFECTED? */);
     auto rect = FloatRect {
         left + boundingBox.x(),
         top + boundingBox.y(),
-        std::max<float>(boundingSize.width() - left - evaluate(value.insets.right(), boundingSize.width()), 0),
-        std::max<float>(boundingSize.height() - top - evaluate(value.insets.bottom(), boundingSize.height()), 0)
+        std::max<float>(boundingSize.width() - left - evaluate(value.insets.right(), boundingSize.width(), 1.0f /* FIXME ZOOM EFFECTED? */), 0),
+        std::max<float>(boundingSize.height() - top - evaluate(value.insets.bottom(), boundingSize.height(), 1.0f /* FIXME ZOOM EFFECTED? */), 0)
     };
 
-    auto radii = evaluate(value.radii, boundingSize);
+    auto radii = evaluate(value.radii, boundingSize, 1.0f /* FIXME FIND ZOOM */);
     radii.scale(calcBorderRadiiConstraintScaleFor(rect, radii));
 
     return cachedRoundedInsetPath(FloatRoundedRect { rect, radii });

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
@@ -63,7 +63,7 @@ WebCore::Path PathComputation<Polygon>::operator()(const Polygon& value, const F
     auto boundingLocation = boundingBox.location();
     auto boundingSize = boundingBox.size();
     auto points = value.vertices.value.map([&](const auto& vertex) {
-        return evaluate(vertex, boundingSize) + boundingLocation;
+        return evaluate(vertex, boundingSize, 1.0f /* FIXME FIND ZOOM */) + boundingLocation;
     });
     return cachedPolygonPath(points);
 }

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -52,7 +52,7 @@ template<typename ControlPoint> static ControlPointAnchor evaluateControlPointAn
 
 template<typename ControlPoint> static FloatPoint evaluateControlPointOffset(const ControlPoint& value, const FloatSize& boxSize)
 {
-    return evaluate(value.offset, boxSize);
+    return evaluate(value.offset, boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
 }
 
 template<typename ControlPoint> static FloatPoint resolveControlPoint(CommandAffinity affinity, FloatPoint currentPosition, FloatPoint segmentOffset, const ControlPoint& controlPoint, const FloatSize& boxSize)
@@ -118,32 +118,32 @@ private:
     std::optional<MoveToSegment> parseMoveToSegment(FloatPoint) override
     {
         if (!m_nextIndex)
-            return MoveToSegment { evaluate(m_start, m_boxSize) };
+            return MoveToSegment { evaluate(m_start, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */) };
 
         auto& moveCommand = currentValue<MoveCommand>();
 
-        return MoveToSegment { evaluate(moveCommand.toBy, m_boxSize) };
+        return MoveToSegment { evaluate(moveCommand.toBy, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */) };
     }
 
     std::optional<LineToSegment> parseLineToSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<LineCommand>();
 
-        return LineToSegment { evaluate(lineCommand.toBy, m_boxSize) };
+        return LineToSegment { evaluate(lineCommand.toBy, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */) };
     }
 
     std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<HLineCommand>();
 
-        return LineToHorizontalSegment { evaluate(lineCommand.toBy, m_boxSize.width()) };
+        return LineToHorizontalSegment { evaluate(lineCommand.toBy, m_boxSize.width(), 1.0f /* FIXME ZOOM EFFECTED? */) };
     }
 
     std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<VLineCommand>();
 
-        return LineToVerticalSegment { evaluate(lineCommand.toBy, m_boxSize.height()) };
+        return LineToVerticalSegment { evaluate(lineCommand.toBy, m_boxSize.height(), 1.0f /* FIXME ZOOM EFFECTED? */) };
     }
 
     std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint currentPosition) override
@@ -152,7 +152,7 @@ private:
 
         return WTF::switchOn(curveCommand.toBy,
             [&](const auto& value) {
-                auto offset = evaluate(value.offset, m_boxSize);
+                auto offset = evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
                 return CurveToCubicSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint1, m_boxSize),
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint2.value(), m_boxSize),
@@ -168,7 +168,7 @@ private:
 
         return WTF::switchOn(curveCommand.toBy,
             [&](const auto& value) {
-                auto offset = evaluate(value.offset, m_boxSize);
+                auto offset = evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
                 return CurveToQuadraticSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint1, m_boxSize),
                     offset
@@ -184,7 +184,7 @@ private:
         return WTF::switchOn(smoothCommand.toBy,
             [&](const auto& value) {
                 ASSERT(value.controlPoint);
-                auto offset = evaluate(value.offset, m_boxSize);
+                auto offset = evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
                 return CurveToCubicSmoothSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint.value(), m_boxSize),
                     offset
@@ -200,7 +200,7 @@ private:
         return WTF::switchOn(smoothCommand.toBy,
             [&](const auto& value) {
                 return CurveToQuadraticSmoothSegment {
-                    evaluate(value.offset, m_boxSize)
+                    evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */)
                 };
             }
         );
@@ -210,14 +210,14 @@ private:
     {
         auto& arcCommand = currentValue<ArcCommand>();
 
-        auto radius = evaluate(arcCommand.size, m_boxSize);
+        auto radius = evaluate(arcCommand.size, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
         return ArcToSegment {
             .rx = radius.width(),
             .ry = radius.height(),
             .angle = narrowPrecisionToFloat(arcCommand.rotation.value),
             .largeArc = std::holds_alternative<CSS::Keyword::Large>(arcCommand.arcSize),
             .sweep = std::holds_alternative<CSS::Keyword::Cw>(arcCommand.arcSweep),
-            .targetPoint = evaluate(arcCommand.toBy, m_boxSize)
+            .targetPoint = evaluate(arcCommand.toBy, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */)
         };
     }
 

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
@@ -49,7 +49,7 @@ float TextDecorationThickness::resolve(const RenderStyle& style) const
             return style.metricsOfPrimaryFont().underlineThickness().value_or(0);
         },
         [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate(length, style.computedFontSize());
+            return Style::evaluate(length, style.computedFontSize(), 1.0f /* FIXME FIND ZOOM */);
         }
     );
 }
@@ -64,7 +64,7 @@ float TextDecorationThickness::resolve(float fontSize, const FontMetrics& metric
             return metrics.underlineThickness().value_or(0);
         },
         [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate(length, fontSize);
+            return Style::evaluate(length, fontSize, 1.0f /* FIXME FIND ZOOM */);
         }
     );
 }

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
@@ -40,7 +40,7 @@ float TextUnderlineOffset::resolve(const RenderStyle& style, float autoValue) co
             return autoValue;
         },
         [&](const Fixed& fixed) -> float {
-            return fixed.value;
+            return fixed.evaluate(1.0f /* FIXME FIND ZOOM */);
         },
         [&](const auto& percentage) -> float {
             return Style::evaluate(percentage, style.computedFontSize());
@@ -55,7 +55,7 @@ float TextUnderlineOffset::resolve(float fontSize, float autoValue) const
             return autoValue;
         },
         [&](const Fixed& fixed) -> float {
-            return fixed.value;
+            return fixed.evaluate(1.0f /* FIXME FIND ZOOM */);
         },
         [&](const auto& percentage) -> float {
             return Style::evaluate(percentage, fontSize);

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -124,7 +124,7 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
         },
         [&](const typename SizeType::Calc& calc) -> float {
             auto viewportSize = this->viewportSize().value_or(FloatSize { });
-            return Style::evaluate(calc, dimensionForLengthMode(lengthMode, viewportSize));
+            return Style::evaluate(calc, dimensionForLengthMode(lengthMode, viewportSize), 1.0f /* FIXME FIND ZOOM */);
         },
         [&](const auto&) -> float {
             return 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -142,12 +142,12 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
             if (m_popupClient->menuStyle().textDirection() == TextDirection::LTR) {
                 textX = std::max<float>(0, m_popupClient->clientPaddingLeft() - m_popupClient->clientInsetLeft());
                 if (RenderTheme::singleton().popupOptionSupportsTextIndent())
-                    textX += minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()));
+                    textX += minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()), 1.0f /* FIXME FIND ZOOM */);
             } else {
                 textX = itemRect.width() - m_popupClient->menuStyle().font().width(textRun);
                 textX = std::min<float>(textX, textX - m_popupClient->clientPaddingRight() + m_popupClient->clientInsetRight());
                 if (RenderTheme::singleton().popupOptionSupportsTextIndent())
-                    textX -= minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()));
+                    textX -= minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()), 1.0f /* FIXME FIND ZOOM */);
             }
             float textY = itemRect.y() + itemFontCascade.metricsOfPrimaryFont().intAscent() + (itemRect.height() - itemFontCascade.metricsOfPrimaryFont().intHeight()) / 2;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2060,9 +2060,9 @@ IntRect WebPage::absoluteInteractionBounds(const Node& node)
     auto& style = renderer->style();
     FloatRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
     // This is wrong. It's subtracting borders after converting to absolute coords on something that probably doesn't represent a rectangular element.
-    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth()), WebCore::Style::evaluate(style.borderTopWidth()));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth()) - WebCore::Style::evaluate(style.borderRightWidth()));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth()) - WebCore::Style::evaluate(style.borderTopWidth()));
+    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */), WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
     return enclosingIntRect(boundingBox);
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -448,9 +448,9 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto& style = renderer->style();
     IntRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
 
-    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth()), WebCore::Style::evaluate(style.borderTopWidth()));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth()) - WebCore::Style::evaluate(style.borderRightWidth()));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth()) - WebCore::Style::evaluate(style.borderTopWidth()));
+    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */), WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
 
     // FIXME: This function advertises returning a quad, but it actually returns a bounding box (so there is no rotation, for instance).
     return wkQuadFromFloatQuad(FloatQuad(boundingBox));


### PR DESCRIPTION
#### c7062e578f499388f90c57f83a582c61140344a4
<pre>
[CSS ZOOM] Apply zoom factor when evaluating length values
<a href="https://bugs.webkit.org/show_bug.cgi?id=298621">https://bugs.webkit.org/show_bug.cgi?id=298621</a>
<a href="https://rdar.apple.com/problem/160233917">rdar://problem/160233917</a>

Reviewed by Antti Koivisto.

When evaluating lengths, we use valueForLength and related functions.
For strongly typed length values, we use Style::evaluate and
Style::evaluateMinimum.

Since CSS zoom is a layout concern that applies to all length values,
we pass zoom information to these evaluations so that the computed
lengths include the zoom factor.

A few caveats:
- We are currently hardcoding zoom values to 1.0f, effectively making
it a no-op in this PR so that we don&apos;t break any current behavior
- Zoom is not applied to auto or percentage length types

As a follow-up, we will pass actual zoom values to these evaluations
for specific properties, with tests verifying the changes.
We should also remove zoom from style build time in a future
PR to avoid double zooming.

* Source/WebCore/accessibility/AXTableHelpers.cpp:
(WebCore::AXTableHelpers::isDataTableWithTraversal):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::elementPath const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::floatValueForOffset):
(WebCore::ScrollTimeline::intervalForAttachmentRange const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::ViewTimeline::offsetIntervalForAttachmentRange const):
(WebCore::ViewTimeline::intervalForAttachmentRange const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::pageSizeAndMarginsInPixels):
* Source/WebCore/layout/Verification.cpp:
(WebCore::Layout::outputMismatchingBlockBoxInformationIfNeeded):
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
(WebCore::Layout::FormattingGeometry::computedHeightValue const):
(WebCore::Layout::FormattingGeometry::computedBorder const):
(WebCore::Layout::FormattingGeometry::computedPadding const):
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
(WebCore::Layout::FormattingGeometry::computedValue const):
* Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp:
(WebCore::Layout::BlockFormattingGeometry::intrinsicWidthConstraints const):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
(WebCore::Layout::FlexFormattingContext::convertFlexItemsToLogicalSpace):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
(WebCore::Layout::FlexFormattingUtils::mainAxisGapValue):
(WebCore::Layout::FlexFormattingUtils::crossAxisGapValue):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::computedTextIndent const):
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
(WebCore::Layout::InlineLevelBox::preferredLineHeight const):
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
(WebCore::Layout::toInlineBoxLevelVerticalAlign):
* Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp:
(WebCore::Layout::ensureTableGrid):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::usedValueOrZero):
(WebCore::LayoutIntegration::BoxGeometryUpdater::logicalBorder):
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::constraintsForFlexContent):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::expandRootBoundsWithRootMargin):
(WebCore::computeClippedRectInRootContentsSpace):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::applyPaginationToViewport):
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::nodeRectInAbsoluteCoordinates):
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::computeScrollSnapPortRect):
* Source/WebCore/platform/Length.h:
(WebCore::Length::Fixed::Fixed):
(WebCore::Length::Fixed::evaluate const):
* Source/WebCore/platform/LengthFunctions.cpp:
(WebCore::intValueForLength):
(WebCore::valueForLength):
(WebCore::floatValueForLength):
(WebCore::sizeForLengthSize):
(WebCore::pointForLengthPoint):
(WebCore::floatSizeForLengthSize):
(WebCore::floatPointForLengthPoint):
* Source/WebCore/platform/LengthFunctions.h:
(WebCore::minimumValueForLengthWithLazyMaximum):
(WebCore::valueForLengthWithLazyMaximum):
(WebCore::floatValueForLengthWithLazyLayoutUnitMaximum):
(WebCore::floatValueForLengthWithLazyFloatMaximum):
(WebCore::minimumValueForLength):
(WebCore::minimumIntValueForLength):
(WebCore::valueForLength):
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::resolveCalculateValuesFor):
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
(WebCore::AcceleratedEffectValues::computedTransformationMatrix const):
* Source/WebCore/platform/graphics/PathUtilities.cpp:
(WebCore::PathUtilities::pathWithShrinkWrappedRectsForOutline):
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h:
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::layout):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::calculateFillLayerImageGeometryImpl):
(WebCore::BackgroundPainter::calculateFillTileSize):
* Source/WebCore/rendering/BorderEdge.cpp:
(WebCore::borderEdges):
(WebCore::borderEdgesForOutline):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintOutline const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForBorderRect):
(WebCore::BorderShape::shapeForOutsetRect):
(WebCore::BorderShape::shapeForInsetRect):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::initialBaseSize const):
(WebCore::GridTrackSizingAlgorithm::initialGrowthLimit const):
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup):
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem):
(WebCore::GridTrackSizingAlgorithm::estimatedGridAreaBreadthForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::minContributionForGridItem const):
(WebCore::GridTrackSizingAlgorithm::initializeTrackSizes):
(WebCore::GridTrackSizingAlgorithm::setup):
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::motionPathDataForRenderer):
(WebCore::traversalStateAtDistance):
(WebCore::MotionPath::applyMotionPathTransform):
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
(WebCore::computeSlice):
(WebCore::computeSlices):
(WebCore::paintNinePieceImage):
* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::PositionedLayoutConstraints::marginBeforeValue const):
(WebCore::PositionedLayoutConstraints::marginAfterValue const):
(WebCore::PositionedLayoutConstraints::insetBeforeValue const):
(WebCore::PositionedLayoutConstraints::insetAfterValue const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::textIndentOffset const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns const):
(WebCore::RenderBlockFlow::columnGap const):
(WebCore::RenderBlockFlow::computeColumnCountAndWidth):
(WebCore::textIndentForBlockContainer):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::constrainContentBoxLogicalHeightByMinMax const):
(WebCore::RenderBox::reflectionOffset const):
(WebCore::RenderBox::applyCachedClipAndScrollPosition const):
(WebCore::RenderBox::computeLogicalWidth const):
(WebCore::RenderBox::fillAvailableMeasure const):
(WebCore::RenderBox::computeLogicalWidthUsingGeneric const):
(WebCore::RenderBox::computeInlineDirectionMargins const):
(WebCore::RenderBox::computePercentageLogicalHeightGeneric const):
(WebCore::RenderBox::computeReplacedLogicalWidthUsingGeneric const):
(WebCore::RenderBox::computeReplacedLogicalHeightUsingGeneric const):
(WebCore::RenderBox::availableLogicalHeightUsing const):
(WebCore::RenderBox::constrainBlockMarginInAvailableSpaceOrTrim const):
(WebCore::RenderBox::computePositionedLogicalWidthUsing const):
(WebCore::RenderBox::computePositionedLogicalHeightUsing const):
(WebCore::RenderBox::scrollPaddingForViewportRect):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::relativePositionOffset const):
(WebCore::RenderBoxModelObject::computeStickyPositionConstraints const):
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
(WebCore::RenderBoxModelObject::borderAfter const):
(WebCore::RenderBoxModelObject::borderBefore const):
(WebCore::RenderBoxModelObject::borderBottom const):
(WebCore::RenderBoxModelObject::borderEnd const):
(WebCore::RenderBoxModelObject::borderLeft const):
(WebCore::RenderBoxModelObject::borderRight const):
(WebCore::RenderBoxModelObject::borderStart const):
(WebCore::RenderBoxModelObject::borderTop const):
(WebCore::RenderBoxModelObject::borderWidths const):
(WebCore::RenderBoxModelObject::resolveLengthPercentageUsingContainerLogicalWidth const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
(WebCore::drawFocusRing):
(WebCore::RenderElement::paintFocusRing const):
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeMainSizeFromAspectRatioUsing const):
(WebCore::RenderFlexibleBox::computeFlexItemMarginValue):
(WebCore::RenderFlexibleBox::computeGap const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridGap const):
(WebCore::RenderGrid::computeAutoRepeatTracksCount const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintAreaElementFocusRing):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::computeMargin):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::perspectiveOrigin const):
(WebCore::RenderLayer::minimumSizeForResizing const):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::RenderMarquee::timerFired):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::updateOptionsWidth):
(RenderMenuList::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::columnGap const):
(WebCore::RenderMultiColumnSet::paintColumnRules):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(WebCore::calcScrollbarThicknessUsing):
(WebCore::RenderScrollbarPart::computeScrollbarWidth):
(WebCore::RenderScrollbarPart::computeScrollbarHeight):
* Source/WebCore/rendering/RenderSlider.cpp:
(WebCore::RenderSlider::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::styleDidChange):
(WebCore::RenderTable::updateLogicalWidth):
(WebCore::RenderTable::convertStyleLogicalWidthToComputedWidth):
(WebCore::RenderTable::calcBorderStart const):
(WebCore::RenderTable::calcBorderEnd const):
(WebCore::RenderTable::outerBorderBefore const):
(WebCore::RenderTable::outerBorderAfter const):
(WebCore::RenderTable::outerBorderStart const):
(WebCore::RenderTable::outerBorderEnd const):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::logicalHeightForRowSizing const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::resolveLogicalHeightForRow):
(WebCore::RenderTableSection::calcBlockDirectionOuterBorder const):
(WebCore::RenderTableSection::calcInlineDirectionOuterBorder const):
(WebCore::RenderTableSection::paintRowGroupBorderIfRequired):
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderTextInlines.h:
(WebCore::RenderText::marginLeft const):
(WebCore::RenderText::marginRight const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::extractControlStyleForRenderer const):
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::TextAutoSizingValue::adjustTextNodeSizes):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::drawFocusRingForPathForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::popupInternalPaddingBox const):
(WebCore::RenderThemeIOS::paintMenuListButtonDecorations):
(WebCore::RenderThemeIOS::paintListButton):
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
(WebCore::LayoutShape::createShape):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::makeShapeForShapeOutside):
* Source/WebCore/rendering/style/CollapsedBorderValue.h:
(WebCore::CollapsedBorderValue::CollapsedBorderValue):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::hashForTextAutosizing const):
(WebCore::RenderStyle::computePerspectiveOrigin const):
(WebCore::RenderStyle::computeTransformOrigin const):
(WebCore::RenderStyle::computeLineHeight const):
(WebCore::RenderStyle::imageOutsets const):
(WebCore::RenderStyle::outlineWidth const):
(WebCore::RenderStyle::outlineOffset const):
(WebCore::RenderStyle::outlineSize const):
(WebCore::RenderStyle::computedStrokeWidth const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeFloatVisibleRectInContainer):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::calculateBaselineShift const):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::extractZoomAdjustedInset):
(WebCore::Style::ExtractorCustom::extractLineHeight):
(WebCore::Style::ExtractorCustom::extractLineHeightSerialization):
(WebCore::Style::ExtractorCustom::extractMarginRight):
(WebCore::Style::ExtractorCustom::extractMarginRightSerialization):
(WebCore::Style::ExtractorCustom::extractPerspectiveOriginShorthand):
(WebCore::Style::ExtractorCustom::extractPerspectiveOriginShorthandSerialization):
(WebCore::Style::ExtractorCustom::extractTransformOriginShorthand):
(WebCore::Style::ExtractorCustom::extractTransformOriginShorthandSerialization):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontSizeFromUnresolvedFontSize):
* Source/WebCore/style/values/StyleValueTypes.h:
(WebCore::Style::evaluate):
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
(WebCore::Style::Evaluation&lt;LineWidthBox&gt;::operator):
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
(WebCore::Style::Evaluation&lt;LineWidth&gt;::operator()):
* Source/WebCore/style/values/borders/StyleBorderRadius.cpp:
(WebCore::Style::Evaluation&lt;BorderRadius&gt;::operator):
* Source/WebCore/style/values/borders/StyleBorderRadius.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
(WebCore::Style::positionFromValue):
(WebCore::Style::resolveRadius):
* Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h:
(WebCore::Style::Evaluation&lt;WebkitTextStrokeWidth&gt;::operator()):
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
(WebCore::Style::Evaluation&lt;T&gt;::operator()):
(WebCore::Style::evaluateMinimum):
(WebCore::Style::MinimumEvaluation&lt;T&gt;::operator()):
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
(WebCore::Style::LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum const):
(WebCore::Style::LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum const):
* Source/WebCore/style/values/primitives/StylePosition.cpp:
(WebCore::Style::Evaluation&lt;Position&gt;::operator):
* Source/WebCore/style/values/primitives/StylePosition.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
(WebCore::Style::PrimitiveNumeric::evaluate const):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
(WebCore::Style::Evaluation&lt;SpaceSeparatedPoint&lt;T&gt;&gt;::operator()):
(WebCore::Style::Evaluation&lt;SpaceSeparatedSize&lt;T&gt;&gt;::operator()):
(WebCore::Style::Evaluation&lt;MinimallySerializingSpaceSeparatedSize&lt;T&gt;&gt;::operator()):
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp:
(WebCore::Style::Evaluation&lt;ScrollMarginEdge&gt;::operator):
(WebCore::Style::extentForRect):
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
(WebCore::Style::Evaluation&lt;ScrollPaddingEdge&gt;::operator):
(WebCore::Style::extentForRect):
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
(WebCore::Style::resolvePosition):
(WebCore::Style::resolveRadius):
* Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp:
(WebCore::Style::resolvePosition):
(WebCore::Style::resolveRadii):
* Source/WebCore/style/values/shapes/StyleInsetFunction.cpp:
(WebCore::Style::PathComputation&lt;Inset&gt;::operator):
* Source/WebCore/style/values/shapes/StylePolygonFunction.cpp:
(WebCore::Style::PathComputation&lt;Polygon&gt;::operator):
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
(WebCore::Style::evaluateControlPointOffset):
* Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp:
(WebCore::Style::TextDecorationThickness::resolve const):
* Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp:
(WebCore::Style::TextUnderlineOffset::resolve const):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::valueForSizeType):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::absoluteInteractionBounds):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMNode innerFrameQuad]):
* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:
(WebKit::WebPopupMenu::setUpPlatformData):

Canonical link: <a href="https://commits.webkit.org/300279@main">https://commits.webkit.org/300279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e7d75793bf088720b9223955cec94768e5b8370

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74098 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/034a2a20-72b2-4676-9b84-60555211c7be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92724 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d984b0d5-613f-4a65-ad02-6b926bd3c5e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73378 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1725442-ddfe-4642-a742-4910adcfbd03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32837 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72062 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131329 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101283 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24641 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45651 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54535 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51621 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->