### PR TITLE
Remove register aliasing from offlineASM

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -279,6 +279,136 @@ const VMTrapAwareSoftStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackMa
 const VMCLoopStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_cloopStackLimit
 const VMSoftStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_softStackLimit
 
+# Registers
+
+if ARMv7
+    const a0 = t0
+    const a1 = t1
+    const a2 = t2
+    const a3 = t3
+    const a4 = invalidGPR
+    const a5 = invalidGPR
+    const a6 = invalidGPR
+    const a7 = invalidGPR
+
+    const wa0 = a0
+    const wa1 = a1
+    const wa2 = a2
+    const wa3 = a3
+    const wa4 = invalidGPR
+    const wa5 = invalidGPR
+    const wa6 = invalidGPR
+    const wa7 = invalidGPR
+
+    const ws0 = csr0 # ws0 must be a non-argument/non-return GPR
+    const ws1 = csr1
+    const ws2 = csr2
+    const ws3 = t7
+
+    const r0 = a0
+    const r1 = a1
+
+    const fa0 = ft0
+    const fa1 = ft1
+    const fa2 = ft2
+    const fa3 = ft3
+
+    const wfa0 = fa0
+    const wfa1 = fa1
+    const wfa2 = fa2
+    const wfa3 = fa3
+    const wfa4 = ft4
+    const wfa5 = ft5
+    const wfa6 = ft6
+    const wfa7 = ft7
+
+    const fr = fa0
+elsif X86_64
+    const a0 = t6
+    const a1 = t1
+    const a2 = t2
+    const a3 = t3
+    const a4 = t4
+    const a5 = t7
+    const a6 = invalidGPR
+    const a7 = invalidGPR
+
+    const wa0 = a0
+    const wa1 = a1
+    const wa2 = a2
+    const wa3 = a3
+    const wa4 = a4
+    const wa5 = a5
+    const wa6 = a6
+    const wa7 = a7
+
+    const ws0 = t0
+    const ws1 = t5
+    const ws2 = invalidGPR
+    const ws3 = invalidGPR
+
+    const r0 = t0
+    const r1 = t2
+
+    const fa0 = ft0
+    const fa1 = ft1
+    const fa2 = ft2
+    const fa3 = ft3
+
+    const wfa0 = fa0
+    const wfa1 = fa1
+    const wfa2 = fa2
+    const wfa3 = fa3
+    const wfa4 = ft4
+    const wfa5 = ft5
+    const wfa6 = ft6
+    const wfa7 = ft7
+
+    const fr = fa0
+else
+    const a0 = t0
+    const a1 = t1
+    const a2 = t2
+    const a3 = t3
+    const a4 = t4
+    const a5 = t5
+    const a6 = t6
+    const a7 = t7
+
+    const wa0 = a0
+    const wa1 = a1
+    const wa2 = a2
+    const wa3 = a3
+    const wa4 = a4
+    const wa5 = a5
+    const wa6 = a6
+    const wa7 = a7
+
+    const ws0 = t9 # ws0 must be a non-argument/non-return GPR
+    const ws1 = t10
+    const ws2 = t11
+    const ws3 = t12
+
+    const r0 = a0
+    const r1 = a1
+
+    const fa0 = ft0
+    const fa1 = ft1
+    const fa2 = ft2
+    const fa3 = ft3
+
+    const wfa0 = fa0
+    const wfa1 = fa1
+    const wfa2 = fa2
+    const wfa3 = fa3
+    const wfa4 = ft4
+    const wfa5 = ft5
+    const wfa6 = ft6
+    const wfa7 = ft7
+
+    const fr = fa0
+end
+
 # Some register conventions.
 # - We use a pair of registers to represent the PC: one register for the
 #   base of the bytecodes, and one register for the index.

--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -155,32 +155,32 @@ ARM64_EXTRA_FPRS = [SpecialRegister.new("q31")]
 class RegisterID
     def arm64Operand(kind)
         case @name
-        when 't0', 'a0', 'r0', 'wa0'
+        when 't0'
             arm64GPRName('x0', kind)
-        when 't1', 'a1', 'r1', 'wa1'
+        when 't1'
             arm64GPRName('x1', kind)
-        when 't2', 'a2', 'wa2'
+        when 't2'
             arm64GPRName('x2', kind)
-        when 't3', 'a3', 'wa3'
+        when 't3'
             arm64GPRName('x3', kind)
-        when 't4', 'a4', 'wa4'
+        when 't4'
             arm64GPRName('x4', kind)
-        when 't5', 'a5', 'wa5'
-          arm64GPRName('x5', kind)
-        when 't6', 'a6', 'wa6'
-          arm64GPRName('x6', kind)
-        when 't7', 'a7', 'wa7'
-          arm64GPRName('x7', kind)
+        when 't5'
+            arm64GPRName('x5', kind)
+        when 't6'
+            arm64GPRName('x6', kind)
+        when 't7'
+            arm64GPRName('x7', kind)
         when 't8'
-          arm64GPRName('x8', kind)
-        when 't9', 'ws0'
-          arm64GPRName('x9', kind)
-        when 't10', 'ws1'
-          arm64GPRName('x10', kind)
-        when 't11', 'ws2'
-          arm64GPRName('x11', kind)
-        when 't12', 'ws3'
-          arm64GPRName('x12', kind)
+            arm64GPRName('x8', kind)
+        when 't9'
+            arm64GPRName('x9', kind)
+        when 't10'
+            arm64GPRName('x10', kind)
+        when 't11'
+            arm64GPRName('x11', kind)
+        when 't12'
+            arm64GPRName('x12', kind)
         when 'cfr'
             arm64GPRName('x29', kind)
         when 'csr0'
@@ -216,21 +216,21 @@ end
 class FPRegisterID
     def arm64Operand(kind)
         case @name
-        when 'ft0', 'fr', 'fa0', 'wfa0'
+        when 'ft0'
             arm64FPRName('q0', kind)
-        when 'ft1', 'fa1', 'wfa1'
+        when 'ft1'
             arm64FPRName('q1', kind)
-        when 'ft2', 'fa2', 'wfa2'
+        when 'ft2'
             arm64FPRName('q2', kind)
-        when 'ft3', 'fa3', 'wfa3'
+        when 'ft3'
             arm64FPRName('q3', kind)
-        when 'ft4', 'wfa4'
+        when 'ft4'
             arm64FPRName('q4', kind)
-        when 'ft5', 'wfa5'
+        when 'ft5'
             arm64FPRName('q5', kind)
-        when 'wfa6'
+        when 'ft6'
             arm64FPRName('q6', kind)
-        when 'wfa7'
+        when 'ft7'
             arm64FPRName('q7', kind)
         when 'csfr0'
             arm64FPRName('q8', kind)

--- a/Source/JavaScriptCore/offlineasm/parser.rb
+++ b/Source/JavaScriptCore/offlineasm/parser.rb
@@ -381,7 +381,7 @@ class Parser
         if isRegister(@tokens[@idx])
             if @tokens[@idx] =~ VEC_PATTERN
                 result = VecRegisterID.forName(@tokens[@idx].codeOrigin, @tokens[@idx].string)
-            elsif @tokens[@idx] =~ FPR_PATTERN || @tokens[@idx] =~ WASM_FPR_PATTERN
+            elsif @tokens[@idx] =~ FPR_PATTERN
                 result = FPRegisterID.forName(@tokens[@idx].codeOrigin, @tokens[@idx].string)
             else
                 result = RegisterID.forName(@tokens[@idx].codeOrigin, @tokens[@idx].string)

--- a/Source/JavaScriptCore/offlineasm/registers.rb
+++ b/Source/JavaScriptCore/offlineasm/registers.rb
@@ -39,20 +39,9 @@ GPRS =
      "t11",
      "t12",
      "cfr",
-     "a0",
-     "a1",
-     "a2",
-     "a3",
-     "a4",
-     "a5",
-     "a6",
-     "a7",
-     "r0",
-     "r1",
      "sp",
      "lr",
      "pc",
-     # 64-bit only registers:
      "csr0",
      "csr1",
      "csr2",
@@ -75,10 +64,8 @@ FPRS =
      "ft3",
      "ft4",
      "ft5",
-     "fa0",
-     "fa1",
-     "fa2",
-     "fa3",
+     "ft6",
+     "ft7",
      "csfr0",
      "csfr1",
      "csfr2",
@@ -91,7 +78,6 @@ FPRS =
      "csfr9",
      "csfr10",
      "csfr11",
-     "fr"
     ]
 
 VECS =
@@ -138,45 +124,10 @@ VECS =
      "v7_q",
     ]
 
-WASM_GPRS =
-    [
-     "wa0",
-     "wa1",
-     "wa2",
-     "wa3",
-     "wa4",
-     "wa5",
-     "wa6",
-     "wa7",
-    ]
-
-WASM_FPRS =
-    [
-     "wfa0",
-     "wfa1",
-     "wfa2",
-     "wfa3",
-     "wfa4",
-     "wfa5",
-     "wfa6",
-     "wfa7",
-    ]
-
-WASM_SCRATCHS =
-    [
-     "ws0",
-     "ws1",
-     # archtecture specific registers:
-     "ws2",
-     "ws3",
-    ]
-
-REGISTERS = GPRS + FPRS + VECS + WASM_GPRS + WASM_FPRS + WASM_SCRATCHS
+REGISTERS = GPRS + FPRS + VECS
 
 GPR_PATTERN = Regexp.new('\\A((' + GPRS.join(')|(') + '))\\Z')
 FPR_PATTERN = Regexp.new('\\A((' + FPRS.join(')|(') + '))\\Z')
 VEC_PATTERN = Regexp.new('\\A((' + VECS.join(')|(') + '))\\Z')
-WASM_GPR_PATTERN = Regexp.new('\\A((' + WASM_GPRS.join(')|(') + '))\\Z')
-WASM_FPR_PATTERN = Regexp.new('\\A((' + WASM_FPRS.join(')|(') + '))\\Z')
 
 REGISTER_PATTERN = Regexp.new('\\A((' + REGISTERS.join(')|(') + '))\\Z')


### PR DESCRIPTION
#### 2925d0ec071ebd69d626921f326ac96f67dc1dfd
<pre>
Remove register aliasing from offlineASM
<a href="https://bugs.webkit.org/show_bug.cgi?id=298622">https://bugs.webkit.org/show_bug.cgi?id=298622</a>

Reviewed by Yusuke Suzuki.

This makes writing future passes in offlineASM much simpler.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/offlineasm/arm.rb:
* Source/JavaScriptCore/offlineasm/arm64.rb:
* Source/JavaScriptCore/offlineasm/parser.rb:
* Source/JavaScriptCore/offlineasm/registers.rb:
* Source/JavaScriptCore/offlineasm/x86.rb:

Canonical link: <a href="https://commits.webkit.org/300113@main">https://commits.webkit.org/300113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ace1c5b2246b41de9e125285a4b695610655534

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92153 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61311 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33305 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108716 "Found 1 new API test failure: TestIPC.ConnectionTest/ConnectionRunLoopTest.SendAsyncAndInvalidate/ClientIsA (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72829 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32323 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26844 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71334 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113445 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130589 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119835 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100752 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100657 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25527 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46059 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44937 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48101 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53814 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149997 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47573 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->