### PR TITLE
SVGAElement's rel attribute was never utilised

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy-expected.txt
@@ -1,3 +1,10 @@
 
-PASS No Opener policy attribute on svg anchor element is applied
+PASS SVG Anchor element with target=_blank with rel=noopener
+PASS SVG Anchor element with target=_blank with rel=opener
+PASS SVG Anchor element with target=_blank with implicit rel=noopener
+PASS SVG Anchor element with target=_blank with rel=opener+noopener
+PASS SVG Anchor element with target=_blank with rel=noopener+opener
+PASS SVG Anchor element with target=_blank with rel=noreferrer
+PASS SVG Anchor element with target=_blank with rel=opener+noreferrer
+PASS SVG Anchor element with target=_blank with rel=noopener+opener+noreferrer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noopener-policy.html
@@ -1,22 +1,47 @@
 <!DOCTYPE html>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
-<title> Rel attribute with noopener value </title>
-<svg>
-  <a id="test" href="resources/a.rel-noopener-policy-target.html" rel="noopener"></a>
+<html>
+<head>
+  <meta charset=utf-8>
+  <meta name="timeout" content="long">
+  <title>Test behavior of target=_blank links</title>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+</head>
+<body>
+  <svg>
+    <a href="resources/a.rel-noopener-policy-target.html?a1" id="a1" rel="noopener" target="_blank">Click me</a>
+    <a href="resources/a.rel-noopener-policy-target.html?a2" id="a2" rel="opener" target="_blank">Click me</a>
+    <a href="resources/a.rel-noopener-policy-target.html?a3" id="a3" target="_blank">Click me</a>
+    <a href="resources/a.rel-noopener-policy-target.html?a4" id="a4" rel="opener noopener" target="_blank">Click me</a>
+    <a href="resources/a.rel-noopener-policy-target.html?a5" id="a5" rel="noopener opener" target="_blank">Click me</a>
+    <a href="resources/a.rel-noopener-policy-target.html?a6" id="a6" rel="noreferrer" target="_blank">Click me</a>
+    <a href="resources/a.rel-noopener-policy-target.html?a7" id="a7" rel="opener noreferrer" target="_blank">Click me</a>
+    <a href="resources/a.rel-noopener-policy-target.html?a8" id="a8" rel="noopener opener noreferrer" target="_blank">Click me</a>
+  </svg>
   <script>
-    var anchorElement = document.getElementById('test');
 
-    // Simulate a click event
-    var event = new MouseEvent('click', {
-      view: window,
-      bubbles: true,
-      cancelable: true
-    });
+  let tests = [
+    { id: "a1", hasOpener: false, name: "SVG Anchor element with target=_blank with rel=noopener" },
+    { id: "a2", hasOpener: true, name: "SVG Anchor element with target=_blank with rel=opener" },
+    { id: "a3", hasOpener: false, name: "SVG Anchor element with target=_blank with implicit rel=noopener" },
+    { id: "a4", hasOpener: false, name: "SVG Anchor element with target=_blank with rel=opener+noopener" },
+    { id: "a5", hasOpener: false, name: "SVG Anchor element with target=_blank with rel=noopener+opener" },
+    { id: "a6", hasOpener: false, name: "SVG Anchor element with target=_blank with rel=noreferrer" },
+    { id: "a7", hasOpener: false, name: "SVG Anchor element with target=_blank with rel=opener+noreferrer" },
+    { id: "a8", hasOpener: false, name: "SVG Anchor element with target=_blank with rel=noopener+opener+noreferrer" },
+  ];
 
-    // Dispatch the event to the anchor element
-    anchorElement.dispatchEvent(event);
+  tests.forEach(data => {
+    async_test(
+      test => {
+        let bc = new BroadcastChannel(data.id);
+        bc.addEventListener("message", test.step_func_done(e => {
+          assert_equals(e.data.hasOpener, data.hasOpener);
+        }), {once: true});
+
+        document.getElementById(data.id).dispatchEvent(new MouseEvent('click'));
+      }, data.name);
+  });
   </script>
-</svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL No Referrer policy attribute on svg anchor element is applied assert_equals: expected "http://localhost:8800/svg/linking/scripted/a.rel-noreferrer-policy.html" but got ""
+PASS No Referrer policy attribute on svg anchor element is applied
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/rellist-feature-detection.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/rellist-feature-detection.svg
@@ -11,7 +11,7 @@
     let link_support_table = {};
     // https://html.spec.whatwg.org/multipage/links.html#linkTypes
     link_support_table['a'] =  {
-    supported : ['noreferrer', 'noopener'],
+    supported : ['noreferrer', 'noopener', 'opener'],
     unsupported : ['author', 'bookmark', 'external', 'help', 'license',
                     'nofollow', 'pingback', 'prev', 'search', 'tag',
                     'modulepreload', 'preload', 'preconnect', 'dns-prefetch',

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noopener-policy-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/scripted/resources/a.rel-noopener-policy-target.html
@@ -1,10 +1,6 @@
 <!DOCTYPE html>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
-<link rel="help" href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">
 <script>
-  test(function () {
-    assert_equals(true,window.opener == null);
-  }, "No Opener policy attribute on svg anchor element is applied");
+  let bc = new BroadcastChannel(window.location.search.substring(1));
+  bc.postMessage({ hasOpener: opener !== null });
+  window.close();
 </script>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/linking/scripted/a.rel-noreferrer-policy-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL No Referrer policy attribute on svg anchor element is applied assert_equals: expected "http://web-platform.test:8800/svg/linking/scripted/a.rel-noreferrer-policy.html" but got ""
-

--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -31,6 +31,8 @@ namespace WebCore {
 
 class DOMTokenList;
 
+enum class Relation : uint8_t;
+
 class SVGAElement final : public SVGGraphicsElement, public SVGURIReference {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGAElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAElement);
@@ -59,6 +61,8 @@ private:
     bool isValid() const final { return SVGTests::isValid(); }
     String title() const final;
     void defaultEventHandler(Event&) final;
+
+    bool hasRel(Relation) const;
     
     bool supportsFocus() const final;
     bool isMouseFocusable() const final;
@@ -70,6 +74,8 @@ private:
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 
     Ref<SVGAnimatedString> m_target { SVGAnimatedString::create(this) };
+
+    OptionSet<Relation> m_linkRelations;
 
     // This is computed only once and must not be affected by subsequent URL changes.
     mutable std::optional<SharedStringHash> m_storedVisitedLinkHash;


### PR DESCRIPTION
#### 233383991cd38c0e0dde2bee50898e5b687899e7
<pre>
SVGAElement&apos;s rel attribute was never utilised
<a href="https://bugs.webkit.org/show_bug.cgi?id=298620">https://bugs.webkit.org/show_bug.cgi?id=298620</a>

Reviewed by Anne van Kesteren.

SVGAElement had rel and relList added in 227520@main.
However, it was never actually used inside of defaultEventHandler()
to change the behaviour of the navigation.

This is now done, alongside the addition of the &quot;opener&quot; value.

SVGAElement now follows the same behaviour as HTMLAnchorElement including the
implicit noopener when target=&quot;_blank&quot;.

Canonical link: <a href="https://commits.webkit.org/300462@main">https://commits.webkit.org/300462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/598f49963372735f89c5b20e24391e27dbd6640f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91630 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60889 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26250 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70642 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129906 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100251 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100092 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25802 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44226 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53133 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->