### PR TITLE
Remove ipint argumINT pointer instructions, and extract a constant for ipint alignment.

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -58,6 +58,11 @@
 # Finally, we provide four "sc" (safe for call) registers which are guaranteed to not overlap with argument
 # registers (sc0, sc1, sc2, sc3)
 
+const alignIPInt = constexpr JSC::IPInt::alignIPInt
+const alignArgumInt = constexpr JSC::IPInt::alignArgumInt
+const alignUInt = constexpr JSC::IPInt::alignUInt
+const alignMInt = constexpr JSC::IPInt::alignMInt
+
 if ARM64 or ARM64E
     const PC = csr7
     const MC = csr6
@@ -280,13 +285,13 @@ end
 # causes all kinds of problems.
 
 macro instructionLabel(instrname)
-    aligned _ipint%instrname%_validate 256
+    aligned _ipint%instrname%_validate alignIPInt
     _ipint%instrname%_validate:
     _ipint%instrname%:
 end
 
 macro slowPathLabel(instrname)
-    aligned _ipint%instrname%_slow_path_validate 256
+    aligned _ipint%instrname%_slow_path_validate alignIPInt
     _ipint%instrname%_slow_path_validate:
     _ipint%instrname%_slow_path:
 end
@@ -490,19 +495,19 @@ end
 ################################
 
 macro argumINTAlign(instrname)
-    aligned _ipint_argumINT%instrname%_validate 64
+    aligned _ipint_argumINT%instrname%_validate alignArgumInt
     _ipint_argumINT%instrname%_validate:
     _argumINT%instrname%:
 end
 
 macro mintAlign(instrname)
-    aligned _ipint_mint%instrname%_validate 64
+    aligned _ipint_mint%instrname%_validate alignMInt
     _ipint_mint%instrname%_validate:
     _mint%instrname%:
 end
 
 macro uintAlign(instrname)
-    aligned _ipint_uint%instrname%_validate 64
+    aligned _ipint_uint%instrname%_validate alignUInt
     _ipint_uint%instrname%_validate:
     _uint%instrname%:
 end

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -48,16 +48,16 @@ do { \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * width, #name); \
 } while (false);
 
-#define VALIDATE_IPINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_unreachable_validate, 256, opcode, name)
-#define VALIDATE_IPINT_GC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_struct_new_validate, 256, opcode, name)
-#define VALIDATE_IPINT_CONVERSION_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_i32_trunc_sat_f32_s_validate, 256, opcode, name)
-#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_simd_v128_load_mem_validate, 256, opcode, name)
-#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_memory_atomic_notify_validate, 256, opcode, name)
-#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_argumINT_a0_validate, 64, opcode, name)
-#define VALIDATE_IPINT_SLOW_PATH(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_local_get_slow_path_validate, 256, opcode, name)
-#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_a0_validate, 64, opcode, name)
-#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_r0_validate, 64, opcode, name)
-#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_uint_r0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_unreachable_validate, alignIPInt, opcode, name)
+#define VALIDATE_IPINT_GC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_struct_new_validate, alignIPInt, opcode, name)
+#define VALIDATE_IPINT_CONVERSION_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_i32_trunc_sat_f32_s_validate, alignIPInt, opcode, name)
+#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_simd_v128_load_mem_validate, alignIPInt, opcode, name)
+#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_memory_atomic_notify_validate, alignIPInt, opcode, name)
+#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_argumINT_a0_validate, alignArgumInt, opcode, name)
+#define VALIDATE_IPINT_SLOW_PATH(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_local_get_slow_path_validate, alignIPInt, opcode, name)
+#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_a0_validate, alignMInt, opcode, name)
+#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_r0_validate, alignMInt, opcode, name)
+#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_uint_r0_validate, alignUInt, opcode, name)
 
 #define FOR_EACH_IPINT_BASE_POINTER(v) \
     v(ipint_dispatch_base, ipint_unreachable_validate) \

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -792,6 +792,12 @@ FOR_EACH_IPINT_UINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 
 namespace JSC { namespace IPInt {
 
+constexpr uint64_t alignIPInt = 256;
+constexpr uint64_t alignArgumInt = 64;
+constexpr uint64_t alignUInt = 64;
+constexpr uint64_t alignMInt = 64;
+
+
 void initialize();
 void verifyInitialization();
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -66,7 +66,7 @@ macro nextIPIntInstruction()
 # .fine:
     loadb [PC], t0
 if ARMv7
-    lshiftp 8, t0
+    lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
     leap (_ipint_unreachable + 1), t1
     addp t1, t0
     emit "bx r0"
@@ -251,7 +251,7 @@ macro argumINTDispatch()
     loadb [MC], argumINTTmp
     addp 1, MC
     bbgteq argumINTTmp, (constexpr IPInt::ArgumINTBytecode::NumOpcodes), .err
-    lshiftp 6, argumINTTmp
+    lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignArgumInt))), argumINTTmp
     leap (_argumINT_begin + 1), argumINTDsp
     addp argumINTTmp, argumINTDsp
     jmp argumINTDsp
@@ -393,7 +393,7 @@ macro uintDispatch()
     bilt csr1, (constexpr IPInt::UIntBytecode::NumOpcodes), .safe
     break
 .safe:
-    lshiftp 6, csr1
+    lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignUInt))), csr1
     addp csr1, sc1, t7
     # t7 = r9
     emit "bx r9"
@@ -4104,7 +4104,7 @@ macro mintArgDispatch()
     bilt sc0, (constexpr IPInt::CallArgumentBytecode::NumOpcodes), .safe
     break
 .safe:
-    lshiftp 6, sc0
+    lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
     leap (_mint_begin + 1), t7
     addp sc0, t7
     # t7 = r9
@@ -4117,7 +4117,7 @@ macro mintRetDispatch()
     bilt sc0, (constexpr IPInt::CallResultBytecode::NumOpcodes), .safe
     break
 .safe:
-    lshiftp 6, sc0
+    lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
     leap (_mint_begin_return + 1), t7
     addp sc0, t7
     # t7 = r9

--- a/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
+++ b/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/InPlaceInterpreter.h>
 #include <JavaScriptCore/LLIntCommon.h>
 #include <JavaScriptCore/StructureID.h>
 #include <wtf/Assertions.h>

--- a/Source/JavaScriptCore/offlineasm/asm.rb
+++ b/Source/JavaScriptCore/offlineasm/asm.rb
@@ -391,7 +391,8 @@ File.open(outputFlnm, "w") {
             end
 
             lowLevelAST = lowLevelAST.demacroify({})
-            lowLevelAST = lowLevelAST.resolve(buildOffsetsMap(lowLevelAST, offsetsList))
+            mapping = buildOffsetsMap(lowLevelAST, offsetsList)
+            lowLevelAST = lowLevelAST.resolve(mapping)
             lowLevelAST.validate
             emitCodeInConfiguration(concreteSettings, lowLevelAST, backend) {
                 $currentSettings = concreteSettings

--- a/Source/JavaScriptCore/offlineasm/ast.rb
+++ b/Source/JavaScriptCore/offlineasm/ast.rb
@@ -896,7 +896,7 @@ class BaseIndex < Node
     end
     
     def dump
-        "#{offset.dump}[#{base.dump}, #{index.dump}, #{scale.value}]"
+        "#{offset.dump}[#{base.dump}, #{index.dump}, #{scale.dump}]"
     end
     
     def address?
@@ -1085,7 +1085,7 @@ end
 $labelMapping = {}
 $referencedExternLabels = Array.new
 
-class Label < NoChildren
+class Label < Node
     def initialize(codeOrigin, name, definedInFile = false)
         super(codeOrigin)
         @name = name
@@ -1096,7 +1096,21 @@ class Label < NoChildren
         @alignTo = false
         @export = false
     end
+
+    def children
+        if aligned? and @alignTo
+            [@alignTo]
+        else
+            []
+        end
+    end
     
+    def mapChildren
+        # This is mutable, since labels are unique.
+        @alignTo = yield @alignTo if aligned? and @alignTo
+        self
+    end
+
     def self.forName(codeOrigin, name, definedInFile = false)
         if $labelMapping[name]
             raise "Label name collision: #{name}" unless $labelMapping[name].is_a? Label

--- a/Source/JavaScriptCore/offlineasm/backends.rb
+++ b/Source/JavaScriptCore/offlineasm/backends.rb
@@ -135,7 +135,7 @@ end
 class Label
     def lower(name)
         $asm.debugAnnotation codeOrigin.debugDirective if $enableDebugAnnotations
-        $asm.putsLabel(self.name[1..-1], @global, @export, @aligned, @alignTo)
+        $asm.putsLabel(self.name[1..-1], @global, @export, @aligned, @alignTo ? @alignTo.dump : @alignTo)
     end
 end
 

--- a/Source/JavaScriptCore/offlineasm/cloop.rb
+++ b/Source/JavaScriptCore/offlineasm/cloop.rb
@@ -773,7 +773,7 @@ class Instruction
             $asm.putc "#{operands[1].clLValue(:int32)} = #{operands[0].clValue(:int8)};"
         when "sxh2i"
             $asm.putc "#{operands[1].clLValue(:int32)} = #{operands[0].clValue(:int16)};"
-        when "sxb2q"
+        when "sxb2q", "sxb2p"
             $asm.putc "#{operands[1].clLValue(:int64)} = #{operands[0].clValue(:int8)};"
         when "sxh2q"
             $asm.putc "#{operands[1].clLValue(:int64)} = #{operands[0].clValue(:int16)};"

--- a/Source/JavaScriptCore/offlineasm/instructions.rb
+++ b/Source/JavaScriptCore/offlineasm/instructions.rb
@@ -153,6 +153,7 @@ MACRO_INSTRUCTIONS =
      "sxb2i",
      "sxh2i",
      "sxb2q",
+     "sxb2p",
      "sxh2q",
      "nop",
      "bieq",
@@ -454,13 +455,16 @@ ARM64_INSTRUCTIONS =
      "atomicloadi",
      "atomicloadq",
      "loadpairq",
+     "loadpairp",
      "loadpairi",
      "storepairq",
+     "storepairp",
      "storepairi",
      "loadpaird",
      "storepaird",
      "loadpairv",
      "storepairv",
+     "addlshiftp"
     ]
 
 ARM64_SIMD_INSTRUCTIONS =

--- a/Source/JavaScriptCore/offlineasm/parser.rb
+++ b/Source/JavaScriptCore/offlineasm/parser.rb
@@ -762,6 +762,7 @@ class Parser
                 name = @tokens[@idx].string
                 @idx += 1
                 align = @tokens[@idx].string
+                align = Variable.forName(codeOrigin, align) if align !=~ /[0-9]+/
                 @idx += 1
                 Label.setAsAligned(codeOrigin, name, align)
             elsif @tokens[@idx] == "unalignedglobalexport"

--- a/Source/JavaScriptCore/offlineasm/transform.rb
+++ b/Source/JavaScriptCore/offlineasm/transform.rb
@@ -256,7 +256,7 @@ end
 
 class Label
     def freshVariables(mapping)
-        if @name =~ $concatenation
+        if @name =~ $concatenation or @alignTo.is_a? Variable
             name = @name.gsub($concatenation) { |match|
                 var = Variable.forName(codeOrigin, match[1...-1])
                 if mapping[var]
@@ -268,7 +268,7 @@ class Label
             result = Label.forName(codeOrigin, name, @definedInFile)
             result.setGlobal() if global?
             result.setUnalignedGlobal() unless aligned?
-            result.setAligned(@alignTo) if aligned? and @alignTo
+            result.setAligned(@alignTo.freshVariables(mapping)) if aligned? and @alignTo
             result.clearExtern unless extern?
             result
         else
@@ -277,7 +277,7 @@ class Label
     end
 
     def substitute(mapping)
-        if @name =~ $concatenation
+        if @name =~ $concatenation or @alignTo.is_a? Variable
             name = @name.gsub($concatenation) { |match|
                 var = Variable.forName(codeOrigin, match[1...-1])
                 if mapping[var]
@@ -289,7 +289,7 @@ class Label
             result = Label.forName(codeOrigin, name, @definedInFile)
             result.setGlobal() if global?
             result.setUnalignedGlobal() unless aligned?
-            result.setAligned(@alignTo) if aligned? and @alignTo
+            result.setAligned(@alignTo.substitute(mapping)) if aligned? and @alignTo
             result.clearExtern unless extern?
             result
         else

--- a/Source/JavaScriptCore/offlineasm/x86.rb
+++ b/Source/JavaScriptCore/offlineasm/x86.rb
@@ -1329,7 +1329,7 @@ class Instruction
             $asm.puts "movsbl #{operands[0].x86Operand(:byte)}, #{operands[1].x86Operand(:int)}"
         when "sxh2i"
             $asm.puts "movswl #{operands[0].x86Operand(:half)}, #{operands[1].x86Operand(:int)}"
-        when "sxb2q"
+        when "sxb2q", "sxb2p"
             $asm.puts "movsbq #{operands[0].x86Operand(:byte)}, #{operands[1].x86Operand(:quad)}"
         when "sxh2q"
             $asm.puts "movswq #{operands[0].x86Operand(:half)}, #{operands[1].x86Operand(:quad)}"


### PR DESCRIPTION
#### 843ed902cf37cb4ac3e6e2790d56987be89c6f55
<pre>
Remove ipint argumINT pointer instructions, and extract a constant for ipint alignment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298625">https://bugs.webkit.org/show_bug.cgi?id=298625</a>

Reviewed by Yusuke Suzuki.

This helpful for local builds of the armv7 port, and in general for debug
patches that instrument these opcodes. This way, if the size is ever
too large after instrumentation, it is easy to adjust the alignment globally.

We also add offlineASM support for constexpr align values, to let the
align directives use these constants too.

Canonical link: <a href="https://commits.webkit.org/300304@main">https://commits.webkit.org/300304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46372ba8f7ce969fb4f9ffe45184030770760f13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74169 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92788 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61671 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72134 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114223 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131399 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120601 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101351 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25663 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24704 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45752 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54605 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150759 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48341 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38577 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->