### PR TITLE
[JSC] Fix `ToIndex(value)` to Align with TC39

### DIFF
--- a/JSTests/stress/bigint-asintn.js
+++ b/JSTests/stress/bigint-asintn.js
@@ -107,3 +107,12 @@ shouldBe(BigInt.asIntN(63, -0x800000000000001n), -576460752303423489n);
 shouldBe(BigInt.asIntN(64, -0x800000000000001n), -576460752303423489n);
 shouldBe(BigInt.asIntN(65, -0x800000000000001n), -576460752303423489n);
 shouldBe(BigInt.asIntN(66, -0x800000000000001n), -576460752303423489n);
+
+shouldBe(BigInt.asIntN(2 ** 32 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asIntN(2 ** 32, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asIntN(2 ** 32 + 1, 2n ** 64n - 1n), 18446744073709551615n);
+
+shouldBe(BigInt.asIntN(2 ** 53 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldThrow(() => {
+    BigInt.asIntN(2 ** 53, 2n ** 64n - 1n)
+}, `RangeError: number of bits larger than (2 ** 53) - 1`);

--- a/JSTests/stress/bigint-asuintn.js
+++ b/JSTests/stress/bigint-asuintn.js
@@ -131,3 +131,12 @@ shouldBe(BigInt.asUintN(64, -0xffffffffffffffffn), 1n);
 shouldBe(BigInt.asUintN(65, -0xffffffffffffffffn), 18446744073709551617n);
 shouldBe(BigInt.asUintN(66, -0xffffffffffffffffn), 55340232221128654849n);
 shouldBe(BigInt.asUintN(67, -0xffffffffffffffffn), 129127208515966861313n);
+
+shouldBe(BigInt.asUintN(2 ** 32 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asUintN(2 ** 32, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asUintN(2 ** 32 + 1, 2n ** 64n - 1n), 18446744073709551615n);
+
+shouldBe(BigInt.asUintN(2 ** 53 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldThrow(() => {
+    BigInt.asUintN(2 ** 53, 2n ** 64n - 1n)
+}, `RangeError: number of bits larger than (2 ** 53) - 1`);

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -321,7 +321,7 @@ public:
     double toIntegerOrInfinity(JSGlobalObject*) const;
     int32_t toInt32(JSGlobalObject*) const;
     uint32_t toUInt32(JSGlobalObject*) const;
-    uint32_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const;
+    uint64_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const;
     size_t toTypedArrayIndex(JSGlobalObject*, ASCIILiteral) const;
     uint64_t toLength(JSGlobalObject*) const;
 


### PR DESCRIPTION
#### 92134253a5d4eb3789d9276c0c59d70bbd711c56
<pre>
[JSC] Fix `ToIndex(value)` to Align with TC39
<a href="https://bugs.webkit.org/show_bug.cgi?id=298629">https://bugs.webkit.org/show_bug.cgi?id=298629</a>

Reviewed by Yusuke Suzuki.

This patch fixes `ToIndex(value)` implementation to align with TC39 [1].
This fix indirectly corrects functions that rely on `ToIndex(value)`,
such as `BigInt.asUintN`[2], `BigInt.asIntN`[3] and more.

[1]: <a href="https://tc39.es/ecma262/#sec-toindex">https://tc39.es/ecma262/#sec-toindex</a>
[2]: <a href="https://tc39.es/ecma262/#sec-bigint.asuintn">https://tc39.es/ecma262/#sec-bigint.asuintn</a>
[3]: <a href="https://tc39.es/ecma262/#sec-bigint.asintn">https://tc39.es/ecma262/#sec-bigint.asintn</a>

* JSTests/stress/bigint-asintn.js:
(shouldThrow):
* JSTests/stress/bigint-asuintn.js:
(shouldThrow):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toIndex const):

Canonical link: <a href="https://commits.webkit.org/299946@main">https://commits.webkit.org/299946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcf21f14b6a258fd1f1b7dadcc3f88b7bb064870

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72935 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49130 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61042 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70861 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112985 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130127 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119375 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36292 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100315 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45708 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23755 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44463 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53347 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47113 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->