### PR TITLE
window.opener should persist after navigating a site-isolated iframe after window.open

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-cross-site-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-cross-site-iframe.html
@@ -1,0 +1,5 @@
+window-opener-persists-after-iframe-navigation-cross-site-iframe
+<script>
+   window.open("http://127.0.0.1:8000/site-isolation/resources/window-opener-persists-after-iframe-navigation-pop-up.html");
+   window.location = "http://localhost:8000/site-isolation/resources/window-opener-persists-after-iframe-navigation-new-iframe.html"
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-iframe.html
@@ -1,0 +1,5 @@
+window-opener-persists-after-iframe-navigation-iframe
+<script>
+   window.open("http://127.0.0.1:8000/site-isolation/resources/window-opener-persists-after-iframe-navigation-pop-up.html");
+   window.location = "http://127.0.0.1:8000/site-isolation/resources/window-opener-persists-after-iframe-navigation-new-iframe.html"
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-new-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-new-iframe.html
@@ -1,0 +1,8 @@
+window-opener-persists-after-iframe-navigation-new-iframe
+<script>
+  window.addEventListener("message", event => {
+    if (event.data == "ping") {
+      window.parent.postMessage("success", "*");
+    }
+  });
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-pop-up.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-pop-up.html
@@ -1,0 +1,6 @@
+window-opener-persists-after-iframe-navigation-pop-up
+<script>
+  setTimeout(() => {
+    window.opener.postMessage('ping', '*');
+}, 1000);
+</script>

--- a/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-cross-site-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-cross-site-expected.txt
@@ -1,0 +1,10 @@
+Verifies window.opener persists after a cross-site iframe navigation
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS received message from iframe prompted by its pop-up, after a navigation
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-cross-site.html
+++ b/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-cross-site.html
@@ -1,0 +1,20 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies window.opener persists after a cross-site iframe navigation");
+jsTestIsAsync = true;
+
+
+addEventListener("message", (event) => {
+    if (event.data === "success") {
+        testPassed("received message from iframe prompted by its pop-up, after a navigation");
+        finishJSTest();
+    }
+});
+
+</script>
+
+<body>
+<iframe src='http://127.0.0.1:8000/site-isolation/resources/window-opener-persists-after-iframe-navigation-cross-site-iframe.html'></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-expected.txt
@@ -1,0 +1,10 @@
+Verifies window.opener persists after an iframe navigation
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS received message from iframe prompted by its pop-up, after a navigation
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies window.opener persists after an iframe navigation");
+jsTestIsAsync = true;
+
+addEventListener("message", (event) => {
+    if (event.data === "success") {
+        testPassed("received message from iframe prompted by its pop-up, after a navigation");
+        finishJSTest();
+    }
+});
+
+</script>
+
+<body>
+<iframe src='http://127.0.0.1:8000/site-isolation/resources/window-opener-persists-after-iframe-navigation-iframe.html'></iframe>
+</body>

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -191,6 +191,7 @@ void Frame::takeWindowProxyAndOpenerFrom(Frame& frame)
         opened->m_opener = *this;
         m_openedFrames.add(opened);
     }
+    frame.m_openedFrames.clear();
 }
 
 Ref<WindowProxy> Frame::protectedWindowProxy() const


### PR DESCRIPTION
#### 9a4da7c7037d5f3ed082f6ce11373c4569b34dc3
<pre>
window.opener should persist after navigating a site-isolated iframe after window.open
<a href="https://bugs.webkit.org/show_bug.cgi?id=298633">https://bugs.webkit.org/show_bug.cgi?id=298633</a>
<a href="https://rdar.apple.com/117269418">rdar://117269418</a>

Reviewed by Per Arne Vollan and Sihui Liu.

We had observed that when an iframe&apos;s pop-up navigates to a different site, the opener relationship between the iframe&apos;s
pop-up and the iframe itself is severed. The pop-up&apos;s window.opener is null.

The root-cause is that window.opener is incorrectly set to null during provisional navigation. When an iframe
navigates to a new site, frame assets are migrated from the original local frame to a new remote frame.
This process updates the original local frame&apos;s opened/children frames so that their openers now point to the new
remote frame. The original local frame is then destroyed - it is no longer needed because it has been replaced by the
new remote frame. However, during destruction, the local frame&apos;s opened/children frames will have their openers set
to null even though their openers had already been migrated prior).

To fix this, we clear out the original local frame&apos;s opened/children frames when we migrate frame assets so
 that the only owner is the new remote frame and not the stale local frame. Now when the frame destructor executes,
the stale local frame will not accidentally sever opener relationships of its stale opened/children frames.

Tests: http/tests/site-isolation/window-opener-persists-after-iframe-navigation-cross-site.html
       http/tests/site-isolation/window-opener-persists-after-iframe-navigation.html
* LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-cross-site-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-new-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/window-opener-persists-after-iframe-navigation-pop-up.html: Added.
* LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-cross-site-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-cross-site.html: Added.
* LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-opener-persists-after-iframe-navigation.html: Added.
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::takeWindowProxyAndOpenerFrom):

Canonical link: <a href="https://commits.webkit.org/299924@main">https://commits.webkit.org/299924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2b965982a8b23a15228a98fb8b964c0eef3db50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72761 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4784d960-bade-40d9-83d0-a10ab4a77c3d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91667 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60924 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7871f22d-ceb7-4d20-a56f-c83a4d37780e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72217 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b40885de-7a5b-4964-ad9c-e8473bd7d541) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26287 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70684 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129947 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100286 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100125 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23604 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44267 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19156 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53174 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->