### PR TITLE
Update availability declarations for API/SPIs shipped in 26.0

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, _WKLegacyErrorCode) {
     _WKErrorCodeCannotShowURL WK_API_AVAILABLE(macos(13.3), ios(16.4)) = 101,
     _WKErrorCodeFrameLoadInterruptedByPolicyChange WK_API_AVAILABLE(macos(10.11), ios(9.0)) = 102,
     _WKErrorCodeFrameLoadBlockedByContentBlocker WK_API_AVAILABLE(macos(13.3), ios(16.4)) = 104,
-    _WKErrorCodeFrameLoadBlockedByContentFilter WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) = 105,
+    _WKErrorCodeFrameLoadBlockedByContentFilter WK_API_AVAILABLE(macos(26.0), ios(26.0)) = 105,
     _WKErrorCodeFrameLoadBlockedByRestrictions WK_API_AVAILABLE(macos(10.15), ios(13.0)) = 106,
     _WKErrorCodeHTTPSUpgradeRedirectLoop WK_API_AVAILABLE(macos(14.0), ios(17.0)) = 304,
     _WKErrorCodeHTTPNavigationWithHTTPSOnly WK_API_AVAILABLE(macos(14.0), ios(17.0)) = 305,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGSize _contentSize WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, readonly) CGSize _visibleContentSize WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, readonly) CGSize _visibleContentSizeExcludingScrollbars WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
-@property (nonatomic, readonly, nullable) SecTrustRef _serverTrust WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly, nullable) SecTrustRef _serverTrust WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 - (BOOL)_isSameFrame:(WKFrameInfo *)frame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
@@ -67,7 +67,7 @@ WK_SWIFT_UI_ACTOR
  @param cookies An array of cookies to set.
  @param completionHandler A block to invoke once the cookies have been stored.
 */
-- (void)setCookies:(NSArray<NSHTTPCookie *> *)cookies completionHandler:(nullable WK_SWIFT_UI_ACTOR void (^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)setCookies:(NSArray<NSHTTPCookie *> *)cookies completionHandler:(nullable WK_SWIFT_UI_ACTOR void (^)(void))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 /*! @abstract Delete the specified cookie.
  @param completionHandler A block to invoke once the cookie has been deleted.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStorePrivate.h
@@ -32,6 +32,6 @@
 
 #if !TARGET_OS_IPHONE
 // FIXME: Promote this to API (rdar://147591774).
-- (void)_setCookies:(NSArray<NSHTTPCookie *> *)cookies completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_setCookies:(NSArray<NSHTTPCookie *> *)cookies completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(26.0));
 #endif
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -64,9 +64,9 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierTranslate WK_API_AVAILABLE(macos
 WK_EXTERN NSString * const _WKMenuItemIdentifierCopySubject WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierWritingTools WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
-WK_EXTERN NSString * const _WKMenuItemIdentifierProofread WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierRewrite WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-WK_EXTERN NSString * const _WKMenuItemIdentifierSummarize WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierProofread WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierRewrite WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSummarize WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierSpellingMenu WK_API_AVAILABLE(macos(13.0), ios(16.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierShowSpellingPanel WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
@@ -203,7 +203,7 @@ WK_SWIFT_UI_ACTOR
  In the case where the normal webpage loading process takes place, additional navigation delegate calls will continue to happen for this
  navigation starting with `decidePolicyForNavigationAction`
 */
-- (void)webView:(WKWebView *)webView shouldGoToBackForwardListItem:(WKBackForwardListItem *)backForwardListItem willUseInstantBack:(BOOL)willUseInstantBack completionHandler:(void (^)(BOOL shouldGoToItem))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView shouldGoToBackForwardListItem:(WKBackForwardListItem *)backForwardListItem willUseInstantBack:(BOOL)willUseInstantBack completionHandler:(void (^)(BOOL shouldGoToItem))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h
@@ -30,7 +30,7 @@
 
 @interface WKNavigation (WKPrivate)
 @property (nonatomic, readonly, copy) NSURLRequest *_request;
-@property (nonatomic, readonly, copy) WKFrameInfo *_initiatingFrame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly, copy) WKFrameInfo *_initiatingFrame WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 @property (nonatomic, readonly, getter=_isUserInitiated) BOOL _userInitiated;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponsePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponsePrivate.h
@@ -29,8 +29,8 @@
 
 @interface WKNavigationResponse (WKPrivate)
 @property (nonatomic, readonly) WKFrameInfo *_frame;
-@property (nonatomic, readonly) WKFrameInfo *_navigationInitiatingFrame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) WKNavigation *_navigation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) WKFrameInfo *_navigationInitiatingFrame WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
+@property (nonatomic, readonly) WKNavigation *_navigation WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 @property (nonatomic, readonly) NSURLRequest *_request;
 @property (nonatomic, readonly) NSString *_downloadAttribute WK_API_AVAILABLE(macos(10.15), ios(13.0));
 @property (nonatomic, readonly) BOOL _wasPrivateRelayed WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -201,7 +201,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setModelProcessEnabled:) BOOL _modelProcessEnabled WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, setter=_setModelNoPortalAttributeEnabled:) BOOL _modelNoPortalAttributeEnabled WK_API_AVAILABLE(visionos(2.4));
 @property (nonatomic, setter=_setRequiresPageVisibilityForVideoToBeNowPlayingForTesting:) BOOL _requiresPageVisibilityForVideoToBeNowPlayingForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
-@property (nonatomic, setter=_setSiteIsolationEnabled:) BOOL _siteIsolationEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setSiteIsolationEnabled:) BOOL _siteIsolationEnabled WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setWebGLEnabled:) BOOL _webGLEnabled WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -194,6 +194,6 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 
 @interface WKProcessPool (WKPrivateMac)
 
-- (void)_registerAdditionalFonts:(NSArray<NSString *> *)fontNames WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_registerAdditionalFonts:(NSArray<NSString *> *)fontNames WK_API_AVAILABLE(macos(26.0));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -148,7 +148,7 @@ struct UIEdgeInsets;
 
 - (void)_webViewClose:(WKWebView *)webView;
 - (void)_webViewFullscreenMayReturnToInline:(WKWebView *)webView;
-- (void)_webViewWillEnterFullscreen:(WKWebView *)webView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_webViewWillEnterFullscreen:(WKWebView *)webView WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 - (void)_webViewDidEnterFullscreen:(WKWebView *)webView WK_API_AVAILABLE(macos(10.11), ios(8.3));
 - (void)_webViewDidExitFullscreen:(WKWebView *)webView WK_API_AVAILABLE(macos(10.11), ios(8.3));
 - (void)_webViewRequestPointerLock:(WKWebView *)webView WK_API_AVAILABLE(macos(10.12.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h
@@ -26,7 +26,7 @@
 #import <WebKit/WKWebExtensionPermission.h>
 
 /*! @abstract The `bookmarks` permission requests access to the `browser.bookmarks` APIs. */
-WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0))
 WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionBookmarks NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `notifications` permission requests access to the `browser.notifications` APIs. */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -543,7 +543,7 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
 
 /*! @abstract A Boolean value indicating whether Screen Time blocking has occurred.
  */
-@property (nonatomic, readonly) BOOL isBlockedByScreenTime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly) BOOL isBlockedByScreenTime WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
 /*! @abstract Sets the webpage contents from the passed data as if it was the
  response to the supplied request. The request is never actually sent to the
@@ -687,19 +687,19 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
 */
 typedef NS_OPTIONS(NSUInteger, WKWebViewDataType) {
     WKWebViewDataTypeSessionStorage = 1 << 0
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 /* @abstract Called when the client wants to fetch WKWebView data.
    @param dataTypes The option set of WKWebView data types whose data the client wants to fetch.
    @param completionHandler The completion handler that should be invoked with the retrieved data and possibly an error. The retrieved data will be a serialized blob. If an error occurred, the retrieved data will be nil. An error may occur if the data cannot be retrieved for some reason (such as a crash).
 */
-- (void)fetchDataOfTypes:(WKWebViewDataType)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData * _Nullable data, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(fetchData(of:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)fetchDataOfTypes:(WKWebViewDataType)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData * _Nullable data, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(fetchData(of:completionHandler:)) WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 /* @abstract Called when the client wants to restore WKWebView data.
    @param data The serialized blob containing the data that the client wants to restore.
    @param completionHandler The completion handler that may be invoked with an error if the data is in an invalid format or if the data cannot be restored for some other reason (such as a crash).
  */
-- (void)restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(restoreData(_:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(restoreData(_:completionHandler:)) WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 /*! @abstract Edge insets on all sides, relative to the web view's coordinate space, which shrink
  * the bounds of the layout viewport. Obscured content areas (that is, parts of the web view that

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
@@ -143,7 +143,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 /*! @abstract A Boolean value indicating whether the System Screen Time blocking view should be shown.
  @discussion The default value is YES.
  */
-@property (nonatomic) BOOL showsSystemScreenTimeBlockingView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic) BOOL showsSystemScreenTimeBlockingView WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
 /*! @abstract A Boolean value indicating whether HTTP requests to servers known to support HTTPS should be automatically upgraded to HTTPS requests.
  @discussion The default value is YES.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -95,7 +95,7 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, setter=_setIncompleteImageBorderEnabled:) BOOL _incompleteImageBorderEnabled WK_API_AVAILABLE(macos(10.14), ios(12.0));
 @property (nonatomic, setter=_setDrawsBackground:) BOOL _drawsBackground WK_API_AVAILABLE(macos(10.14), ios(12.0));
 @property (nonatomic, setter=_setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad:) BOOL _shouldDeferAsynchronousScriptsUntilAfterDocumentLoad WK_API_AVAILABLE(macos(10.14), ios(12.0));
-@property (nonatomic, setter=_setShowsSystemScreenTimeBlockingView:) BOOL _showsSystemScreenTimeBlockingView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setShowsSystemScreenTimeBlockingView:) BOOL _showsSystemScreenTimeBlockingView WK_API_AVAILABLE(macos(26.0), ios(26.0));
 @property (nonatomic, setter=_setOverrideReferrerForAllRequests:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setAllowPostingLegacySynchronousMessages:) BOOL _allowPostingLegacySynchronousMessages WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setShouldSendConsoleLogsToUIProcessForTesting:) BOOL _shouldSendConsoleLogsToUIProcessForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -412,9 +412,9 @@ for this property.
 @property (nonatomic, readonly) BOOL _isSuspended;
 
 #if TARGET_OS_IPHONE
-@property (nonatomic, readonly) UIColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) UIColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(ios(26.0), visionos(26.0));
 #else
-@property (nonatomic, readonly) NSColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readonly) NSColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(macos(26.0));
 #endif
 
 @property (nonatomic, readonly) BOOL _canTogglePictureInPicture;
@@ -435,8 +435,8 @@ for this property.
 
 - (void)_nowPlayingMediaTitleAndArtist:(void (^)(NSString *, NSString *))completionHandler;
 
-- (void)_convertPoint:(CGPoint)point fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGPoint, NSError *error))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-- (void)_convertRect:(CGRect)rect fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGRect, NSError *error))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_convertPoint:(CGPoint)point fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGPoint, NSError *error))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
+- (void)_convertRect:(CGRect)rect fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGRect, NSError *error))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 // If frame is nil, the main frame will be used if there is a main frame.
 // If frame is non-nil, not only will frame's coordinate space be used, but frame's subtree will be searched,
@@ -465,7 +465,7 @@ for this property.
 - (void)_addAppHighlight WK_API_AVAILABLE(macos(12.0), ios(15.0));
 - (void)_addAppHighlightInNewGroup:(BOOL)newGroup originatedInApp:(BOOL)originatedInApp WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
-- (void)_textFragmentDirectiveFromSelectionWithCompletionHandler:(void(^)(NSURL *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_textFragmentDirectiveFromSelectionWithCompletionHandler:(void(^)(NSURL *))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 #if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 - (void)_targetedPreviewForElementWithID:(NSString *)elementID completionHandler:(WK_SWIFT_UI_ACTOR void (^)(UITargetedPreview *))completionHandler WK_API_AVAILABLE(ios(18.2), visionos(2.2));
@@ -480,7 +480,7 @@ for this property.
 @property (nonatomic, readonly) NSColor *_sampledPageTopColor WK_API_AVAILABLE(macos(12.0));
 #endif
 
-@property (nonatomic, readonly) _WKSpatialBackdropSource *_spatialBackdropSource WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) _WKSpatialBackdropSource *_spatialBackdropSource WK_API_AVAILABLE(visionos(26.0));
 
 - (void)_grantAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));
 - (void)_revokeAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));
@@ -628,7 +628,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 @property (nonatomic) audit_token_t presentingApplicationAuditToken WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
-@property (nonatomic, setter=_setShouldSuppressTopColorExtensionView:) BOOL _shouldSuppressTopColorExtensionView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setShouldSuppressTopColorExtensionView:) BOOL _shouldSuppressTopColorExtensionView WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
 #if TARGET_OS_OSX
 - (NSUInteger)accessibilityRemoteChildTokenHash;
@@ -779,8 +779,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 @interface WKWebView (WKPrivateVision)
 @property (copy, setter=_setDefaultSTSLabel:) NSString *_defaultSTSLabel;
 
-- (void)_enterExternalPlaybackForNowPlayingMediaSessionWithEnterCompletionHandler:(void (^)(UIViewController *nowPlayingViewController, NSError *error))enterHandler exitCompletionHandler:(void (^)(NSError *error))exitHandler WK_API_AVAILABLE(visionos(WK_XROS_TBA));
-- (void)_exitExternalPlayback WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)_enterExternalPlaybackForNowPlayingMediaSessionWithEnterCompletionHandler:(void (^)(UIViewController *nowPlayingViewController, NSError *error))enterHandler exitCompletionHandler:(void (^)(NSError *error))exitHandler WK_API_AVAILABLE(visionos(26.0));
+- (void)_exitExternalPlayback WK_API_AVAILABLE(visionos(26.0));
 @end
 #endif
 
@@ -875,7 +875,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_setCustomSwipeViews:(NSArray *)customSwipeViews WK_API_AVAILABLE(macos(10.13.4));
 - (void)_setDidMoveSwipeSnapshotCallback:(void(^)(CGRect))callback WK_API_AVAILABLE(macos(10.13.4));
 - (void)_setCustomSwipeViewsTopContentInset:(float)topContentInset WK_API_AVAILABLE(macos(10.13.4));
-- (void)_setCustomSwipeViewsObscuredContentInsets:(NSEdgeInsets)contentInsets WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_setCustomSwipeViewsObscuredContentInsets:(NSEdgeInsets)contentInsets WK_API_AVAILABLE(macos(26.0));
 
 - (NSView *)_fullScreenPlaceholderView WK_API_AVAILABLE(macos(10.13.4));
 - (NSWindow *)_fullScreenWindow WK_API_AVAILABLE(macos(10.13.4));
@@ -902,11 +902,11 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_setFont:(NSFont *)font sender:(id)sender WK_API_AVAILABLE(macos(13.3));
 
 - (void)_setTopContentInset:(CGFloat)topContentInset immediate:(BOOL)immediate WK_API_AVAILABLE(macos(15.4));
-- (void)_setObscuredContentInsets:(NSEdgeInsets)insets immediate:(BOOL)immediate WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, readonly) NSEdgeInsets _obscuredContentInsets WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, setter=_setUsesAutomaticContentInsetBackgroundFill:) BOOL _usesAutomaticContentInsetBackgroundFill WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, copy, setter=_setOverrideTopScrollEdgeEffectColor:) NSColor *_overrideTopScrollEdgeEffectColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, setter=_setOverflowHeightForTopScrollEdgeEffect:) CGFloat _overflowHeightForTopScrollEdgeEffect WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_setObscuredContentInsets:(NSEdgeInsets)insets immediate:(BOOL)immediate WK_API_AVAILABLE(macos(26.0));
+@property (nonatomic, readonly) NSEdgeInsets _obscuredContentInsets WK_API_AVAILABLE(macos(26.0));
+@property (nonatomic, setter=_setUsesAutomaticContentInsetBackgroundFill:) BOOL _usesAutomaticContentInsetBackgroundFill WK_API_AVAILABLE(macos(26.0));
+@property (nonatomic, copy, setter=_setOverrideTopScrollEdgeEffectColor:) NSColor *_overrideTopScrollEdgeEffectColor WK_API_AVAILABLE(macos(26.0));
+@property (nonatomic, setter=_setOverflowHeightForTopScrollEdgeEffect:) CGFloat _overflowHeightForTopScrollEdgeEffect WK_API_AVAILABLE(macos(26.0));
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
 @property (nonatomic, readonly) NSScrollPocket *_topScrollPocket WK_API_AVAILABLE(macos(26.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -158,7 +158,7 @@ struct WKAppPrivacyReportTestingData {
 
 - (void)_setMediaVolumeForTesting:(float)volume;
 
-- (void)_textFragmentRangesWithCompletionHandlerForTesting:(void(^)(NSArray<NSValue *> *fragmentRanges))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_textFragmentRangesWithCompletionHandlerForTesting:(void(^)(NSArray<NSValue *> *fragmentRanges))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 @property (nonatomic, readonly) _WKRectEdge _fixedContainerEdges;
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -85,8 +85,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
     _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry WK_API_AVAILABLE(macos(14.0), ios(17.0)) = 1 << 6,
     _WKWebsiteNetworkConnectionIntegrityPolicyRequestValidation WK_API_AVAILABLE(macos(14.0), ios(17.0)) = 1 << 7,
     _WKWebsiteNetworkConnectionIntegrityPolicySanitizeLookalikeCharacters WK_API_AVAILABLE(macos(14.0), ios(17.0)) = 1 << 8,
-    _WKWebsiteNetworkConnectionIntegrityPolicyFailClosedForAllHosts WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 9,
-    _WKWebsiteNetworkConnectionIntegrityPolicyStrictFailClosed WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 10,
+    _WKWebsiteNetworkConnectionIntegrityPolicyFailClosedForAllHosts WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0)) = 1 << 9,
+    _WKWebsiteNetworkConnectionIntegrityPolicyStrictFailClosed WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0)) = 1 << 10,
 } WK_API_AVAILABLE(macos(13.3), ios(16.4));
 
 @class _WKCustomHeaderFields;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
@@ -72,7 +72,7 @@ WK_EXTERN NSString * const WKWebsiteDataTypeMediaKeys WK_API_AVAILABLE(macos(14.
 WK_EXTERN NSString * const WKWebsiteDataTypeHashSalt WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 /*! @constant WKWebsiteDataTypeScreenTime Screen Time information */
-WK_EXTERN NSString * const WKWebsiteDataTypeScreenTime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+WK_EXTERN NSString * const WKWebsiteDataTypeScreenTime WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
 /*! A WKWebsiteDataRecord represents website data, grouped by domain name using the public suffix list. */
 WK_SWIFT_UI_ACTOR

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -93,13 +93,13 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
    @param dataTypes The set of WKWebsiteDataStore data types whose data the client wants to fetch.
    @param completionHandler The completion handler that should be invoked with the retrieved data and possibly an error. The retrieved data will be a serialized blob. If an error occurred, the retrieved data will be nil. An error may occur if a requested data type is not supported or if the data cannot be retrieved for some other reason (such as a crash).
  */
-- (void)fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData * _Nullable data, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(fetchData(of:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData * _Nullable data, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(fetchData(of:completionHandler:)) WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 /* @abstract Called when the client wants to restore WKWebsiteDataStore data.
    @param data The serialized blob containing the data that the client wants to restore.
    @param completionHandler The completion handler that may be invoked with an error if the data is in an invalid format or if the data cannot be restored for some other reason (such as a crash).
  */
-- (void)restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(restoreData(_:completionHandler:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(restoreData(_:completionHandler:)) WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 /*! @abstract Get a persistent data store.
  @param identifier An identifier that is used to uniquely identify the data store.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
@@ -69,8 +69,8 @@ typedef NS_ENUM(NSInteger, _WKAutomationSessionWebExtensionResourceOptions) {
 - (void)_automationSession:(_WKAutomationSession *)automationSession dismissCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (void)_automationSession:(_WKAutomationSession *)automationSession acceptCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession messageOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
-- (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession userInputOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-- (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession defaultTextOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession userInputOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
+- (nullable NSString *)_automationSession:(_WKAutomationSession *)automationSession defaultTextOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 - (void)_automationSession:(_WKAutomationSession *)automationSession setUserInput:(NSString *)value forCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (_WKAutomationSessionJavaScriptDialogType)_automationSession:(_WKAutomationSession *)automationSession typeOfCurrentJavaScriptDialogForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.14), ios(12.0));
 - (_WKAutomationSessionBrowsingContextPresentation)_automationSession:(_WKAutomationSession *)automationSession currentPresentationForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
@@ -37,8 +37,8 @@ WK_CLASS_AVAILABLE(macos(10.12))
 @property (nonatomic, readonly, copy) _WKHitTestResult *hitTestResult WK_API_AVAILABLE(macos(13.3));
 @property (nonatomic, readonly, copy, nullable) NSString *qrCodePayloadString WK_API_AVAILABLE(macos(14.0));
 @property (nonatomic, readonly) BOOL hasEntireImage WK_API_AVAILABLE(macos(14.0));
-@property (nonatomic, readonly) BOOL allowsFollowingLink WK_API_AVAILABLE(macos(WK_MAC_TBA));
-@property (nonatomic, readonly) BOOL allowsFollowingImageURL WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readonly) BOOL allowsFollowingLink WK_API_AVAILABLE(macos(26.0));
+@property (nonatomic, readonly) BOOL allowsFollowingImageURL WK_API_AVAILABLE(macos(26.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFocusedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFocusedElementInfo.h
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSInteger, WKInputType) {
 @property (nonatomic, readonly, copy) NSString *label;
 
 /* The frame containing the element */
-@property (nonatomic, readonly, copy) WKFrameInfo *frame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly, copy) WKFrameInfo *frame WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 /**
  * Whether the element was focused due to user interaction. NO indicates that

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.h
@@ -28,12 +28,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-WK_CLASS_AVAILABLE(visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(visionos(26.0))
 @interface _WKSpatialBackdropSource : NSObject
 
-@property (nonatomic, readonly) NSURL *sourceURL WK_API_AVAILABLE(visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) NSURL *modelURL WK_API_AVAILABLE(visionos(WK_XROS_TBA));
-@property (nonatomic, readonly, nullable) NSURL *environmentMapURL WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) NSURL *sourceURL WK_API_AVAILABLE(visionos(26.0));
+@property (nonatomic, readonly) NSURL *modelURL WK_API_AVAILABLE(visionos(26.0));
+@property (nonatomic, readonly, nullable) NSURL *environmentMapURL WK_API_AVAILABLE(visionos(26.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h
@@ -44,7 +44,7 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 
 + (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithRPIDAndAccessGroup:(NSString *)accessGroup rpID:(NSString *)rpID WK_API_AVAILABLE(macos(13.0), ios(16.0));
 + (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithCredentialIDAndAccessGroup:(NSString *)accessGroup credentialID:(NSData *)credentialID WK_API_AVAILABLE(macos(13.0), ios(16.0));
-+ (NSData *) encodeMakeCredentialCommandWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability authenticatorSupportedCredentialParameters:(NSArray<_WKPublicKeyCredentialParameters *> *)credentialParameters WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
++ (NSData *) encodeMakeCredentialCommandWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability authenticatorSupportedCredentialParameters:(NSArray<_WKPublicKeyCredentialParameters *> *)credentialParameters WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
 // For details of configuration, refer to MockWebAuthenticationConfiguration.h.
 @property (nonatomic, copy) NSDictionary *mockConfiguration;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -104,7 +104,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) BOOL isDeclarativeWebPushEnabled WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));
 @property (nonatomic, nullable, copy) NSNumber *defaultTrackingPreventionEnabledOverride WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 @property (nonatomic, copy, setter=_setResourceMonitorThrottlerDirectory:) NSURL *_resourceMonitorThrottlerDirectory WK_API_AVAILABLE(macos(15.0), ios(18.0));
-@property (nonatomic, nullable, copy) NSURL *webContentRestrictionsConfigurationURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, nullable, copy) NSURL *webContentRestrictionsConfigurationURL WK_API_AVAILABLE(macos(26.0), ios(26.0));
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));


### PR DESCRIPTION
#### ed6dc7d8e3a5e1cf4332cbeb55ded19391dacbf6
<pre>
Update availability declarations for API/SPIs shipped in 26.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=298635">https://bugs.webkit.org/show_bug.cgi?id=298635</a>
<a href="https://rdar.apple.com/160160926">rdar://160160926</a>

Reviewed by Aditya Keerthi.

Update availability declarations for APIs and SPIs that shipped in iOS, macOS and visionOS 26, now
that `WK_*_TBA` no longer tracks 26.0.

* Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStorePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponsePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFocusedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKSpatialBackdropSource.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/299794@main">https://commits.webkit.org/299794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f54e0722d565b20f15469272af63d5aa924ddb93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72272 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11d430e8-4107-4120-9b04-37bdeedd89bf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91279 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60573 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a0316e7-2bf9-4b3d-b684-c529632b58e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71832 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/831db30f-9868-4b5b-9937-5937c1ddfa0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31450 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129453 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99899 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99741 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25322 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45196 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23220 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52687 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->