### PR TITLE
`getElementsByClassName` should be case-insensitive under certain conditions

### DIFF
--- a/LayoutTests/fast/dom/getElementsByClassName/ASCII-case-insensitive-expected.txt
+++ b/LayoutTests/fast/dom/getElementsByClassName/ASCII-case-insensitive-expected.txt
@@ -1,9 +1,8 @@
-FAIL getByClassName('a') should be a A. Was a.
-FAIL getByClassName('A') should be a A. Was A.
+PASS getByClassName('a') is "a A"
+PASS getByClassName('A') is "a A"
 PASS getByClassName('ä') is "ä"
 PASS getByClassName('Ä') is "Ä"
 PASS successfullyParsed is true
-Some tests failed.
 
 TEST COMPLETE
 

--- a/Source/WebCore/dom/ClassCollection.h
+++ b/Source/WebCore/dom/ClassCollection.h
@@ -31,8 +31,10 @@
 
 #include "CachedHTMLCollection.h"
 #include "Document.h"
+#include "DocumentType.h"
 #include "Element.h"
 #include "SpaceSplitString.h"
+#include "TextResourceDecoder.h"
 
 namespace WebCore {
 
@@ -54,9 +56,14 @@ private:
 
 inline ClassCollection::ClassCollection(ContainerNode& rootNode, CollectionType type, const AtomString& classNames)
     : CachedHTMLCollection(rootNode, type)
-    , m_classNames(classNames, rootNode.document().inQuirksMode() ? SpaceSplitString::ShouldFoldCase::Yes : SpaceSplitString::ShouldFoldCase::No)
     , m_originalClassNames(classNames)
 {
+    auto& document = rootNode.document();
+    bool shouldUseCaseInsensitive = document.decoder() && document.decoder()->encoding().name() == "UTF-8"_s
+        && document.doctype() && document.doctype()->publicId().isEmpty()
+        && document.doctype()->systemId().isEmpty();
+
+    m_classNames = SpaceSplitString(classNames, rootNode.document().inQuirksMode() || shouldUseCaseInsensitive ? SpaceSplitString::ShouldFoldCase::Yes : SpaceSplitString::ShouldFoldCase::No);
 }
 
 inline bool ClassCollection::elementMatches(Element& element) const

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -50,6 +50,7 @@
 #include "DocumentFullscreen.h"
 #include "DocumentInlines.h"
 #include "DocumentSharedObjectPool.h"
+#include "DocumentType.h"
 #include "Editing.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementAnimationRareData.h"
@@ -2585,19 +2586,24 @@ void Element::classAttributeChanged(const AtomString& newClassString, AttributeM
             classList->associatedAttributeValueChanged();
     }
 
+    bool shouldUseCaseInsensitive = document().decoder() && document().decoder()->encoding().name() == "UTF-8"_s
+        && document().doctype()
+        && document().doctype()->publicId().isEmpty()
+        && document().doctype()->systemId().isEmpty();
+
     if (reason == AttributeModificationReason::Parser) {
         // If ElementData is ShareableElementData created in parserSetAttributes,
         // it is possible that SpaceSplitString is already created and set.
         // We also do not need to invalidate caches / styles since it is not inserted to the tree yet.
         if (elementData()->classNames().keyString() == newClassString)
             return;
-        auto shouldFoldCase = document().inQuirksMode() ? SpaceSplitString::ShouldFoldCase::Yes : SpaceSplitString::ShouldFoldCase::No;
+        auto shouldFoldCase = document().inQuirksMode() || shouldUseCaseInsensitive ? SpaceSplitString::ShouldFoldCase::Yes : SpaceSplitString::ShouldFoldCase::No;
         SpaceSplitString newClassNames(newClassString, shouldFoldCase);
         elementData()->setClassNames(WTFMove(newClassNames));
         return;
     }
 
-    auto shouldFoldCase = document().inQuirksMode() ? SpaceSplitString::ShouldFoldCase::Yes : SpaceSplitString::ShouldFoldCase::No;
+    auto shouldFoldCase = document().inQuirksMode() || shouldUseCaseInsensitive ? SpaceSplitString::ShouldFoldCase::Yes : SpaceSplitString::ShouldFoldCase::No;
     SpaceSplitString newClassNames(newClassString, shouldFoldCase);
     Style::ClassChangeInvalidation styleInvalidation(*this, elementData()->classNames(), newClassNames);
     document().invalidateQuerySelectorAllResultsForClassAttributeChange(*this, elementData()->classNames(), newClassNames);


### PR DESCRIPTION
#### 1f2e050262e67fa9cc55f238932f08944a46b587
<pre>
`getElementsByClassName` should be case-insensitive under certain conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=298637">https://bugs.webkit.org/show_bug.cgi?id=298637</a>

Reviewed by NOBODY (OOPS!).

Fix the failing test case when using getElementsByClassName,
it should in some cases be case-insensitive when document in quirks mode,
or when the document is in HTML5 mode with a UTF-8 charset for ASCII.

* LayoutTests/fast/dom/getElementsByClassName/ASCII-case-insensitive-expected.txt:
* Source/WebCore/dom/ClassCollection.h:
(WebCore::ClassCollection::ClassCollection):
(WebCore::ClassCollection::elementMatches const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::classAttributeChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2e050262e67fa9cc55f238932f08944a46b587

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48600 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91385 "Failure limit exceed. At least found 442 new test failures: css3/calc/transitions-dependent.html css3/unicode-bidi-isolate-basic.html fast/css/text-overflow-ellipsis-bidi.html fast/css/text-overflow-ellipsis-strict.html fast/dom/HTMLElement/attr-dir-auto-change-before-text-node.html fast/dom/HTMLElement/attr-dir-auto-change-child-node.html fast/dom/HTMLElement/attr-dir-auto-change-text-form-control.html fast/dom/HTMLElement/attr-dir-auto-change-text.html fast/dom/HTMLElement/attr-dir-auto-children.html fast/dom/HTMLElement/attr-dir-auto-remove-add-children.html ... (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60677 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123281 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32516 "Found 20 new test failures: css3/unicode-bidi-isolate-basic.html editing/selection/ios/scroll-overflow-container-with-selection.html fast/css/appearance-apple-pay-button-default-corners.html fast/css/text-overflow-ellipsis-bidi.html fast/css/text-overflow-ellipsis-strict.html fast/dom/HTMLElement/attr-dir-auto-change-before-text-node.html fast/dom/HTMLElement/attr-dir-auto-change-child-node.html fast/dom/HTMLElement/attr-dir-auto-change-text-form-control.html fast/dom/HTMLElement/attr-dir-auto-change-text.html fast/dom/HTMLElement/attr-dir-auto-children.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107871 "Found 1 new API test failure: TestWebKitAPI.TextManipulation.StartTextManipulationExcludesTextRenderedAsIcons (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71938 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31550 "Found 60 new test failures: imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-with-transparent-pixels.html imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-blended-with-3D-transform.html imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-3D-transform.html imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-sibling-with-3D-transform.html imported/w3c/web-platform-tests/css/css-align/content-distribution/parse-align-content-001.html imported/w3c/web-platform-tests/css/css-align/content-distribution/parse-justify-content-001.html imported/w3c/web-platform-tests/css/css-align/default-alignment/parse-align-items-001.html imported/w3c/web-platform-tests/css/css-align/default-alignment/parse-justify-items-001.html imported/w3c/web-platform-tests/css/css-align/gaps/column-gap-parsing-001.html imported/w3c/web-platform-tests/css/css-align/gaps/gap-parsing-001.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25977 "Found 60 new test failures: css3/unicode-bidi-isolate-basic.html fast/css/appearance-apple-pay-button-default-corners.html fast/css/text-overflow-ellipsis-bidi.html fast/css/text-overflow-ellipsis-strict.html fast/dom/HTMLElement/attr-dir-auto-change-before-text-node.html fast/dom/HTMLElement/attr-dir-auto-change-child-node.html fast/dom/HTMLElement/attr-dir-auto-change-text-form-control.html fast/dom/HTMLElement/attr-dir-auto-change-text.html fast/dom/HTMLElement/attr-dir-auto-children.html fast/dom/HTMLElement/attr-dir-auto-remove-add-children.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70316 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101995 "Found 1 new API test failure: TestWebKitAPI.TextManipulation.StartTextManipulationExcludesTextRenderedAsIcons (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26161 "Found 60 new test failures: css3/unicode-bidi-isolate-basic.html fast/css/appearance-apple-pay-button-default-corners.html fast/css/text-overflow-ellipsis-bidi.html fast/css/text-overflow-ellipsis-strict.html fast/dom/HTMLElement/attr-dir-auto-change-before-text-node.html fast/dom/HTMLElement/attr-dir-auto-change-child-node.html fast/dom/HTMLElement/attr-dir-auto-change-text-form-control.html fast/dom/HTMLElement/attr-dir-auto-change-text.html fast/dom/HTMLElement/attr-dir-auto-children.html fast/dom/HTMLElement/attr-dir-auto-remove-add-children.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129583 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47250 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35849 "Found 60 new test failures: css3/unicode-bidi-isolate-basic.html fast/css/appearance-apple-pay-button-default-corners.html fast/css/text-overflow-ellipsis-bidi.html fast/css/text-overflow-ellipsis-strict.html fast/dom/HTMLElement/attr-dir-auto-change-before-text-node.html fast/dom/HTMLElement/attr-dir-auto-change-child-node.html fast/dom/HTMLElement/attr-dir-auto-change-text-form-control.html fast/dom/HTMLElement/attr-dir-auto-change-text.html fast/dom/HTMLElement/attr-dir-auto-children.html fast/dom/HTMLElement/attr-dir-auto-remove-add-children.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100001 "Failure limit exceed. At least found 439 new test failures: css3/calc/transitions-dependent.html css3/unicode-bidi-isolate-basic.html fast/css/text-overflow-ellipsis-bidi.html fast/css/text-overflow-ellipsis-strict.html fast/dom/HTMLElement/attr-dir-auto-change-before-text-node.html fast/dom/HTMLElement/attr-dir-auto-change-child-node.html fast/dom/HTMLElement/attr-dir-auto-change-text-form-control.html fast/dom/HTMLElement/attr-dir-auto-change-text.html fast/dom/HTMLElement/attr-dir-auto-children.html fast/dom/HTMLElement/attr-dir-auto-remove-add-children.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99843 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45291 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23322 "Found 60 new test failures: css3/filters/backdrop/backdrop-filter-uneven-corner-radii.html css3/filters/change-filter-style.html css3/filters/drop-shadow-current-color.html css3/unicode-bidi-isolate-basic.html fast/css/appearance-apple-pay-button-default-corners.html fast/css/text-overflow-ellipsis-bidi.html fast/css/text-overflow-ellipsis-strict.html fast/dom/HTMLElement/attr-dir-auto-change-before-text-node.html fast/dom/HTMLElement/attr-dir-auto-change-child-node.html fast/dom/HTMLElement/attr-dir-auto-change-text-form-control.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43894 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47112 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52817 "Found 2 new failures in dom/ClassCollection.h") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46580 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->