### PR TITLE
Address remaining Safer CPP warnings in IndexedDB code

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -38,6 +38,12 @@
 
 namespace WTF {
 
+#define USING_CAN_MAKE_CHECKEDPTR(BASE) \
+    using BASE::checkedPtrCount; \
+    using BASE::checkedPtrCountWithoutThreadCheck; \
+    using BASE::incrementCheckedPtrCount; \
+    using BASE::decrementCheckedPtrCount
+
 template<typename T, typename PtrTraits>
 class CheckedRef {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CheckedRef);

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.h
@@ -55,10 +55,12 @@ public:
     const Source& source() const;
     IDBCursorDirection direction() const;
 
-    IDBKey* key() { return m_key.get(); };
-    IDBKey* primaryKey() { return m_primaryKey.get(); };
-    IDBValue value() { return m_value; };
-    const std::optional<IDBKeyPath>& primaryKeyPath() { return m_keyPath; };
+    IDBKey* key() { return m_key.get(); }
+    RefPtr<IDBKey> protectedKey() { return m_key; }
+    IDBKey* primaryKey() { return m_primaryKey.get(); }
+    RefPtr<IDBKey> protectedPrimaryKey() { return m_primaryKey; }
+    IDBValue value() { return m_value; }
+    const std::optional<IDBKeyPath>& primaryKeyPath() { return m_keyPath; }
     JSValueInWrappedObject& keyWrapper() { return m_keyWrapper; }
     JSValueInWrappedObject& primaryKeyWrapper() { return m_primaryKeyWrapper; }
     JSValueInWrappedObject& valueWrapper() { return m_valueWrapper; }

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -119,6 +119,11 @@ Ref<DOMStringList> IDBDatabase::objectStoreNames() const
     return objectStoreNames;
 }
 
+RefPtr<IDBTransaction> IDBDatabase::protectedVersionChangeTransaction() const
+{
+    return m_versionChangeTransaction;
+}
+
 void IDBDatabase::renameObjectStore(IDBObjectStore& objectStore, const String& newName)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
@@ -127,7 +132,7 @@ void IDBDatabase::renameObjectStore(IDBObjectStore& objectStore, const String& n
 
     m_info.renameObjectStore(objectStore.info().identifier(), newName);
 
-    m_versionChangeTransaction->renameObjectStore(objectStore, newName);
+    protectedVersionChangeTransaction()->renameObjectStore(objectStore, newName);
 }
 
 void IDBDatabase::renameIndex(IDBIndex& index, const String& newName)
@@ -139,7 +144,7 @@ void IDBDatabase::renameIndex(IDBIndex& index, const String& newName)
 
     m_info.infoForExistingObjectStore(index.objectStore().info().name())->infoForExistingIndex(index.info().identifier())->rename(newName);
 
-    m_versionChangeTransaction->renameIndex(index, newName);
+    protectedVersionChangeTransaction()->renameIndex(index, newName);
 }
 
 ScriptExecutionContext* IDBDatabase::scriptExecutionContext() const
@@ -154,10 +159,11 @@ ExceptionOr<Ref<IDBObjectStore>> IDBDatabase::createObjectStore(const String& na
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
     ASSERT(!m_versionChangeTransaction || m_versionChangeTransaction->isVersionChange());
 
-    if (!m_versionChangeTransaction)
+    RefPtr versionChangeTransaction = m_versionChangeTransaction;
+    if (!versionChangeTransaction)
         return Exception { ExceptionCode::InvalidStateError, "Failed to execute 'createObjectStore' on 'IDBDatabase': The database is not running a version change transaction."_s };
 
-    if (!m_versionChangeTransaction->isActive())
+    if (!versionChangeTransaction->isActive())
         return Exception { ExceptionCode::TransactionInactiveError };
 
     auto& keyPath = parameters.keyPath;
@@ -174,7 +180,7 @@ ExceptionOr<Ref<IDBObjectStore>> IDBDatabase::createObjectStore(const String& na
     auto info = m_info.createNewObjectStore(name, WTFMove(keyPath), parameters.autoIncrement);
 
     // Create the actual IDBObjectStore from the transaction, which also schedules the operation server side.
-    return m_versionChangeTransaction->createObjectStore(info);
+    return versionChangeTransaction->createObjectStore(info);
 }
 
 ExceptionOr<Ref<IDBTransaction>> IDBDatabase::transaction(StringOrVectorOfStrings&& storeNames, IDBTransactionMode mode, TransactionOptions options)
@@ -227,17 +233,18 @@ ExceptionOr<void> IDBDatabase::deleteObjectStore(const String& objectStoreName)
 
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    if (!m_versionChangeTransaction)
+    RefPtr versionChangeTransaction = m_versionChangeTransaction;
+    if (!versionChangeTransaction)
         return Exception { ExceptionCode::InvalidStateError, "Failed to execute 'deleteObjectStore' on 'IDBDatabase': The database is not running a version change transaction."_s };
 
-    if (!m_versionChangeTransaction->isActive())
+    if (!versionChangeTransaction->isActive())
         return Exception { ExceptionCode::TransactionInactiveError };
 
     if (!m_info.hasObjectStore(objectStoreName))
         return Exception { ExceptionCode::NotFoundError, "Failed to execute 'deleteObjectStore' on 'IDBDatabase': The specified object store was not found."_s };
 
     m_info.deleteObjectStore(objectStoreName);
-    m_versionChangeTransaction->deleteObjectStore(objectStoreName);
+    versionChangeTransaction->deleteObjectStore(objectStoreName);
 
     return { };
 }

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -126,6 +126,8 @@ private:
 
     void maybeCloseInServer();
 
+    RefPtr<IDBTransaction> protectedVersionChangeTransaction() const;
+
     const Ref<IDBClient::IDBConnectionProxy> m_connectionProxy;
     IDBDatabaseInfo m_info;
     IDBDatabaseConnectionIdentifier m_databaseConnectionIdentifier;

--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -117,7 +117,7 @@ std::weak_ordering IDBKey::compare(const IDBKey& other) const
         auto& array = std::get<IDBKeyVector>(m_value);
         auto& otherArray = std::get<IDBKeyVector>(other.m_value);
         for (size_t i = 0; i < array.size() && i < otherArray.size(); ++i) {
-            if (auto result = array[i]->compare(*otherArray[i]); is_neq(result))
+            if (auto result = Ref { *array[i] }->compare(Ref { *otherArray[i] }); is_neq(result))
                 return result;
         }
         return array.size() <=> otherArray.size();

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
@@ -68,8 +68,8 @@ public:
 private:
     IDBKeyRange(RefPtr<IDBKey>&& lower, RefPtr<IDBKey>&& upper, bool isLowerOpen, bool isUpperOpen);
 
-    RefPtr<IDBKey> m_lower;
-    RefPtr<IDBKey> m_upper;
+    const RefPtr<IDBKey> m_lower;
+    const RefPtr<IDBKey> m_upper;
     bool m_isLowerOpen;
     bool m_isUpperOpen;
 };

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -119,7 +119,7 @@ public:
     void ref() const final;
     void deref() const final;
 
-    template<typename Visitor> void visitReferencedIndexes(Visitor&) const;
+    template<typename Visitor> void visitReferencedIndexesConcurrently(Visitor&) const;
     void renameReferencedIndex(IDBIndex&, const String& newName);
 
 private:

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.h
@@ -60,6 +60,8 @@ private:
 
     void cancelForStop() final;
 
+    EventTargetInterfaceType eventTargetInterface() const final;
+
     void onError(const IDBResultData&);
     void onSuccess(const IDBResultData&);
     void onUpgradeNeeded(const IDBResultData&);
@@ -75,3 +77,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::IDBOpenDBRequest)
+    static bool isType(const WebCore::EventTarget& eventTarget) { return eventTarget.eventTargetInterface() == WebCore::EventTargetInterfaceType::IDBOpenDBRequest; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/Strong.h>
 #include <WebCore/EventTarget.h>
+#include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/IDBActiveDOMObject.h>
 #include <WebCore/IDBError.h>
 #include <WebCore/IDBGetAllResult.h>
@@ -153,7 +154,7 @@ private:
     IDBRequest(ScriptExecutionContext&, IDBObjectStore&, IndexedDB::ObjectStoreRecordType, IDBTransaction&);
     IDBRequest(ScriptExecutionContext&, IDBIndex&, IndexedDB::IndexRecordType, IDBTransaction&);
 
-    enum EventTargetInterfaceType eventTargetInterface() const override;
+    EventTargetInterfaceType eventTargetInterface() const override;
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
@@ -174,6 +175,8 @@ private:
     void clearWrappers();
 
 protected:
+    RefPtr<IDBTransaction> protectedTransaction() const;
+
     // FIXME: Protected data members aren't great for maintainability.
     // Consider adding protected helper functions and making these private.
     RefPtr<IDBTransaction> m_transaction;
@@ -211,3 +214,7 @@ private:
 WebCoreOpaqueRoot root(IDBRequest*);
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::IDBRequest)
+    static bool isType(const WebCore::EventTarget& eventTarget) { return eventTarget.eventTargetInterface() == WebCore::EventTargetInterfaceType::IDBRequest; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -355,15 +355,6 @@ void IDBTransaction::stop()
     abortInternal();
 }
 
-bool IDBTransaction::isFinishedOrFinishing() const
-{
-    ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
-
-    return m_state == IndexedDB::TransactionState::Committing
-        || m_state == IndexedDB::TransactionState::Aborting
-        || m_state == IndexedDB::TransactionState::Finished;
-}
-
 void IDBTransaction::addRequest(IDBRequest& request)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -308,4 +308,12 @@ inline bool IDBTransaction::isActive() const
     return m_state == IndexedDB::TransactionState::Active;
 }
 
+inline bool IDBTransaction::isFinishedOrFinishing() const
+{
+    assertCurrentThreadAccessThreadLocalData();
+    return m_state == IndexedDB::TransactionState::Committing
+        || m_state == IndexedDB::TransactionState::Aborting
+        || m_state == IndexedDB::TransactionState::Finished;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
@@ -51,6 +51,7 @@ public:
 
 private:
     static ASCIILiteral supplementName() { return "DOMWindowIndexedDatabase"_s; }
+    bool isDOMWindowIndexedDatabase() const final { return true; }
 
     RefPtr<IDBFactory> m_idbFactory;
 };
@@ -63,6 +64,7 @@ public:
 
     static WorkerGlobalScopeIndexedDatabase* from(WorkerGlobalScope&);
     IDBFactory* indexedDB();
+    bool isWorkerGlobalScopeIndexedDatabase() const final { return true; }
 
 private:
     static ASCIILiteral supplementName() { return "WorkerGlobalScopeIndexedDatabase"_s; }
@@ -70,6 +72,18 @@ private:
     RefPtr<IDBFactory> m_idbFactory;
     const Ref<IDBClient::IDBConnectionProxy> m_connectionProxy;
 };
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DOMWindowIndexedDatabase)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isDOMWindowIndexedDatabase(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WorkerGlobalScopeIndexedDatabase)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isWorkerGlobalScopeIndexedDatabase(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+namespace WebCore {
 
 // DOMWindowIndexedDatabase supplement.
 
@@ -82,7 +96,7 @@ DOMWindowIndexedDatabase::DOMWindowIndexedDatabase(LocalDOMWindow& window)
 
 DOMWindowIndexedDatabase* DOMWindowIndexedDatabase::from(LocalDOMWindow& window)
 {
-    auto* supplement = static_cast<DOMWindowIndexedDatabase*>(Supplement<LocalDOMWindow>::from(&window, supplementName()));
+    auto* supplement = downcast<DOMWindowIndexedDatabase>(Supplement<LocalDOMWindow>::from(&window, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<DOMWindowIndexedDatabase>(window);
         supplement = newSupplement.get();
@@ -129,7 +143,7 @@ WorkerGlobalScopeIndexedDatabase::WorkerGlobalScopeIndexedDatabase(IDBClient::ID
 
 WorkerGlobalScopeIndexedDatabase* WorkerGlobalScopeIndexedDatabase::from(WorkerGlobalScope& scope)
 {
-    auto* supplement = static_cast<WorkerGlobalScopeIndexedDatabase*>(Supplement<WorkerGlobalScope>::from(&scope, supplementName()));
+    auto* supplement = downcast<WorkerGlobalScopeIndexedDatabase>(Supplement<WorkerGlobalScope>::from(&scope, supplementName()));
     if (!supplement) {
         RefPtr connectionProxy = scope.idbConnectionProxy();
         if (!connectionProxy)

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -399,7 +399,7 @@ void IDBServer::establishTransaction(IDBDatabaseConnectionIdentifier databaseCon
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto* databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
+    RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)
         return;
 
@@ -431,11 +431,8 @@ void IDBServer::didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionI
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto* connection = m_databaseConnections.get(databaseConnectionIdentifier);
-    if (!connection)
-        return;
-
-    connection->didFinishHandlingVersionChange(transactionIdentifier);
+    if (RefPtr connection = m_databaseConnections.get(databaseConnectionIdentifier))
+        connection->didFinishHandlingVersionChange(transactionIdentifier);
 }
 
 void IDBServer::databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
@@ -444,7 +441,7 @@ void IDBServer::databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier d
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
+    RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)
         return;
 
@@ -457,7 +454,7 @@ void IDBServer::databaseConnectionClosed(IDBDatabaseConnectionIdentifier databas
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto* databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
+    RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)
         return;
 
@@ -478,7 +475,7 @@ void IDBServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier databa
             transaction->abortWithoutCallback();
     }
 
-    auto databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
+    RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)
         return;
 
@@ -491,7 +488,7 @@ void IDBServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier databa
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    if (auto databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier))
+    if (RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier))
         databaseConnection->didFireVersionChangeEvent(requestIdentifier, connectionClosed);
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -168,7 +168,7 @@ void MemoryBackingStoreTransaction::abort()
 
     // Restore renamed indexes.
     for (const auto& iterator : m_originalIndexNames) {
-        auto* index = iterator.key;
+        RefPtr index = iterator.key;
         auto originalName = iterator.value;
         auto identifier = index->info().identifier();
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
@@ -272,7 +272,7 @@ IDBError MemoryIDBBackingStore::renameIndex(const IDBResourceIdentifier& transac
     if (!objectStore)
         return IDBError { ExceptionCode::ConstraintError };
 
-    auto* index = objectStore->indexForIdentifier(indexIdentifier);
+    RefPtr index = objectStore->indexForIdentifier(indexIdentifier);
     ASSERT(index);
     if (!index)
         return IDBError { ExceptionCode::ConstraintError };
@@ -393,7 +393,7 @@ IDBError MemoryIDBBackingStore::getAllRecords(const IDBResourceIdentifier& trans
         return IDBError { ExceptionCode::UnknownError, "No backing store object store found"_s };
 
     if (getAllRecordsData.indexIdentifier) {
-        auto* index = objectStore->indexForIdentifier(*getAllRecordsData.indexIdentifier);
+        RefPtr index = objectStore->indexForIdentifier(*getAllRecordsData.indexIdentifier);
         if (!index)
             return IDBError { ExceptionCode::UnknownError, "No backing store index found"_s };
 
@@ -523,7 +523,7 @@ IDBError MemoryIDBBackingStore::openCursor(const IDBResourceIdentifier& transact
             return IDBError { ExceptionCode::UnknownError, "No backing store object store found"_s };
 
         auto identifier = std::get<IDBIndexIdentifier>(info.sourceIdentifier());
-        auto* index = objectStore->indexForIdentifier(identifier);
+        RefPtr index = objectStore->indexForIdentifier(identifier);
         if (!index)
             return IDBError { ExceptionCode::UnknownError, "No backing store index found"_s };
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
@@ -51,7 +51,7 @@ MemoryIndexCursor::MemoryIndexCursor(MemoryIndex& index, const IDBCursorInfo& cu
 {
     LOG(IndexedDB, "MemoryIndexCursor::MemoryIndexCursor %s", cursorInfo.range().loggingString().utf8().data());
 
-    auto* valueStore = index.valueStore();
+    CheckedPtr valueStore = index.valueStore();
     if (!valueStore)
         return;
 
@@ -99,7 +99,7 @@ void MemoryIndexCursor::iterate(const IDBKeyData& key, const IDBKeyData& primary
         // Cannot iterate by both a count and to a key
         ASSERT(!count);
 
-        auto* valueStore = index->valueStore();
+        CheckedPtr valueStore = index->valueStore();
         if (!valueStore) {
             m_currentKey = { };
             m_currentPrimaryKey = { };
@@ -144,7 +144,7 @@ void MemoryIndexCursor::iterate(const IDBKeyData& key, const IDBKeyData& primary
         count = 1;
 
     if (!m_currentIterator.isValid()) {
-        auto* valueStore = index->valueStore();
+        CheckedPtr valueStore = index->valueStore();
         if (!valueStore) {
             m_currentKey = { };
             m_currentPrimaryKey = { };

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -167,6 +167,8 @@ private:
     enum class DidCreateIndexInBackingStore : bool { No, Yes };
     void didCreateIndexAsyncForTransaction(UniqueIDBDatabaseTransaction&, const IDBIndexInfo&, const IDBError&, DidCreateIndexInBackingStore = DidCreateIndexInBackingStore::Yes);
 
+    CheckedPtr<IDBBackingStore> checkedBackingStore() const;
+
     WeakPtr<UniqueIDBDatabaseManager> m_manager;
     IDBDatabaseIdentifier m_identifier;
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -102,8 +102,8 @@ void UniqueIDBDatabaseTransaction::abortWithoutCallback()
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::abortWithoutCallback");
 
-    if (m_databaseConnection)
-        m_databaseConnection->abortTransactionWithoutCallback(*this);
+    if (RefPtr databaseConnection = m_databaseConnection.get())
+        databaseConnection->abortTransactionWithoutCallback(*this);
 }
 
 UniqueIDBDatabase* UniqueIDBDatabaseTransaction::database() const
@@ -169,13 +169,17 @@ void UniqueIDBDatabaseTransaction::createObjectStore(const IDBRequestData& reque
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createObjectStore (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->didCreateObjectStore(IDBResultData::createObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection->didCreateObjectStore(IDBResultData::createObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            protectedThis->m_databaseConnection->didCreateObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->didCreateObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -194,15 +198,19 @@ void UniqueIDBDatabaseTransaction::deleteObjectStore(const IDBRequestData& reque
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteObjectStore (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->didDeleteObjectStore(IDBResultData::deleteObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection->didDeleteObjectStore(IDBResultData::deleteObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            protectedThis->m_databaseConnection->didDeleteObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->didDeleteObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -221,13 +229,17 @@ void UniqueIDBDatabaseTransaction::renameObjectStore(const IDBRequestData& reque
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameObjectStore (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->didRenameObjectStore(IDBResultData::renameObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection->didRenameObjectStore(IDBResultData::renameObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            protectedThis->m_databaseConnection->didRenameObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->didRenameObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -245,15 +257,19 @@ void UniqueIDBDatabaseTransaction::clearObjectStore(const IDBRequestData& reques
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::clearObjectStore (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->didClearObjectStore(IDBResultData::clearObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection->didClearObjectStore(IDBResultData::clearObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            protectedThis->m_databaseConnection->didClearObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->didClearObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -272,13 +288,17 @@ void UniqueIDBDatabaseTransaction::deleteIndex(const IDBRequestData& requestData
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteIndex (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->didDeleteIndex(IDBResultData::deleteIndexSuccess(requestData.requestIdentifier()));
+            databaseConnection->didDeleteIndex(IDBResultData::deleteIndexSuccess(requestData.requestIdentifier()));
         else
-            protectedThis->m_databaseConnection->didDeleteIndex(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->didDeleteIndex(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -297,13 +317,17 @@ void UniqueIDBDatabaseTransaction::renameIndex(const IDBRequestData& requestData
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameIndex (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->didRenameIndex(IDBResultData::renameIndexSuccess(requestData.requestIdentifier()));
+            databaseConnection->didRenameIndex(IDBResultData::renameIndexSuccess(requestData.requestIdentifier()));
         else
-            protectedThis->m_databaseConnection->didRenameIndex(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->didRenameIndex(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -323,15 +347,19 @@ void UniqueIDBDatabaseTransaction::putOrAdd(const IDBRequestData& requestData, c
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::putOrAdd (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didPutOrAdd(IDBResultData::putOrAddSuccess(requestData.requestIdentifier(), key));
+            databaseConnection->protectedConnectionToClient()->didPutOrAdd(IDBResultData::putOrAddSuccess(requestData.requestIdentifier(), key));
         else
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didPutOrAdd(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->protectedConnectionToClient()->didPutOrAdd(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -349,15 +377,19 @@ void UniqueIDBDatabaseTransaction::getRecord(const IDBRequestData& requestData, 
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getRecord (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result));
+            databaseConnection->protectedConnectionToClient()->didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result));
         else
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didGetRecord(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->protectedConnectionToClient()->didGetRecord(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -375,15 +407,19 @@ void UniqueIDBDatabaseTransaction::getAllRecords(const IDBRequestData& requestDa
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getAllRecords (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result));
+            databaseConnection->protectedConnectionToClient()->didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result));
         else
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didGetAllRecords(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->protectedConnectionToClient()->didGetAllRecords(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -401,15 +437,19 @@ void UniqueIDBDatabaseTransaction::getCount(const IDBRequestData& requestData, c
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getCount (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didGetCount(IDBResultData::getCountSuccess(requestData.requestIdentifier(), count));
+            databaseConnection->protectedConnectionToClient()->didGetCount(IDBResultData::getCountSuccess(requestData.requestIdentifier(), count));
         else
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didGetCount(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->protectedConnectionToClient()->didGetCount(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -427,15 +467,19 @@ void UniqueIDBDatabaseTransaction::deleteRecord(const IDBRequestData& requestDat
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteRecord (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didDeleteRecord(IDBResultData::deleteRecordSuccess(requestData.requestIdentifier()));
+            databaseConnection->protectedConnectionToClient()->didDeleteRecord(IDBResultData::deleteRecordSuccess(requestData.requestIdentifier()));
         else
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didDeleteRecord(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->protectedConnectionToClient()->didDeleteRecord(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -453,15 +497,19 @@ void UniqueIDBDatabaseTransaction::openCursor(const IDBRequestData& requestData,
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::openCursor (callback)");
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result));
+            databaseConnection->protectedConnectionToClient()->didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result));
         else
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didOpenCursor(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->protectedConnectionToClient()->didOpenCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -482,15 +530,19 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
             return;
 
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_databaseConnection)
+        if (!protectedThis)
+            return;
+
+        RefPtr databaseConnection = protectedThis->m_databaseConnection.get();
+        if (!databaseConnection)
             return;
 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result));
+            databaseConnection->protectedConnectionToClient()->didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result));
         else
-            protectedThis->m_databaseConnection->protectedConnectionToClient()->didIterateCursor(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection->protectedConnectionToClient()->didIterateCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -10,7 +10,6 @@ Modules/contact-picker/NavigatorContacts.cpp
 Modules/credentialmanagement/NavigatorCredentials.cpp
 Modules/encryptedmedia/MediaKeySystemController.cpp
 Modules/geolocation/NavigatorGeolocation.cpp
-Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
 Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
 Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
 Modules/mediasession/NavigatorMediaSession.cpp
@@ -82,7 +81,6 @@ html/NavigatorUserActivation.cpp
 html/track/TextTrackCueGeneric.cpp
 inspector/CommandLineAPIModule.cpp
 inspector/agents/InspectorCSSAgent.cpp
-inspector/agents/InspectorIndexedDBAgent.cpp
 layout/layouttree/LayoutIterator.h
 layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,6 +1,5 @@
 Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
-Modules/indexeddb/server/UniqueIDBDatabase.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediasession/MediaMetadata.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,6 +1,3 @@
-Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
-Modules/indexeddb/server/MemoryIDBBackingStore.cpp
-Modules/indexeddb/server/MemoryIndexCursor.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/UserMediaRequest.cpp
@@ -191,7 +188,6 @@ inspector/agents/InspectorCanvasAgent.cpp
 inspector/agents/InspectorDOMAgent.cpp
 inspector/agents/InspectorDOMDebuggerAgent.cpp
 inspector/agents/InspectorDOMStorageAgent.cpp
-inspector/agents/InspectorIndexedDBAgent.cpp
 inspector/agents/InspectorLayerTreeAgent.cpp
 inspector/agents/InspectorNetworkAgent.cpp
 inspector/agents/InspectorPageAgent.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -8,14 +8,6 @@ Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/filesystem/FileSystemFileHandle.cpp
 Modules/filesystem/WorkerFileSystemStorageConnection.cpp
 Modules/identity/CredentialRequestCoordinator.cpp
-Modules/indexeddb/IDBDatabase.cpp
-Modules/indexeddb/IDBKey.cpp
-Modules/indexeddb/IDBKeyRange.cpp
-Modules/indexeddb/IDBObjectStore.cpp
-Modules/indexeddb/IDBOpenDBRequest.cpp
-Modules/indexeddb/IDBRequest.cpp
-Modules/indexeddb/server/UniqueIDBDatabase.cpp
-Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
@@ -559,7 +551,6 @@ inspector/agents/InspectorCanvasAgent.cpp
 inspector/agents/InspectorDOMAgent.cpp
 inspector/agents/InspectorDOMDebuggerAgent.cpp
 inspector/agents/InspectorDOMStorageAgent.cpp
-inspector/agents/InspectorIndexedDBAgent.cpp
 inspector/agents/InspectorLayerTreeAgent.cpp
 inspector/agents/InspectorMemoryAgent.cpp
 inspector/agents/InspectorNetworkAgent.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,10 +1,5 @@
 Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/indexeddb/IDBActiveDOMObjectInlines.h
-Modules/indexeddb/IDBObjectStore.cpp
-Modules/indexeddb/server/IDBServer.cpp
-Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
-Modules/indexeddb/server/MemoryIDBBackingStore.cpp
-Modules/indexeddb/server/UniqueIDBDatabase.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
@@ -272,7 +267,6 @@ inspector/agents/InspectorCanvasAgent.cpp
 inspector/agents/InspectorDOMAgent.cpp
 inspector/agents/InspectorDOMDebuggerAgent.cpp
 inspector/agents/InspectorDOMStorageAgent.cpp
-inspector/agents/InspectorIndexedDBAgent.cpp
 inspector/agents/InspectorLayerTreeAgent.cpp
 inspector/agents/InspectorNetworkAgent.cpp
 inspector/agents/InspectorPageAgent.cpp

--- a/Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp
@@ -38,7 +38,7 @@ using namespace JSC;
 template<typename Visitor>
 void JSIDBObjectStore::visitAdditionalChildren(Visitor& visitor)
 {
-    static_cast<IDBObjectStore&>(wrapped()).visitReferencedIndexes(visitor);
+    static_cast<IDBObjectStore&>(wrapped()).visitReferencedIndexesConcurrently(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIDBObjectStore);

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
@@ -64,6 +64,8 @@ public:
     void clearObjectStore(const String& securityOrigin, const String& databaseName, const String& objectStoreName, Ref<ClearObjectStoreCallback>&&);
 
 private:
+    Ref<Page> protectedInspectedPage() const;
+
     Inspector::InjectedScriptManager& m_injectedScriptManager;
     const Ref<Inspector::IndexedDBBackendDispatcher> m_backendDispatcher;
 

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -81,6 +81,7 @@ public:
     // specialization can be implemented here and overridden in the base class.
 
     virtual bool isDOMWindowCaches() const { return false; }
+    virtual bool isDOMWindowIndexedDatabase() const { return false; }
     virtual bool isNavigatorClipboard() const { return false; }
     virtual bool isNavigatorCookieConsent() const { return false; }
     virtual bool isNavigatorGamepad() const { return false; }
@@ -89,6 +90,7 @@ public:
     virtual bool isLocalDOMWindowMediaControls() const { return false; }
     virtual bool isDocumentMediaElement() const { return false; }
     virtual bool isGeolocationController() const { return false; }
+    virtual bool isWorkerGlobalScopeIndexedDatabase() const { return false; }
 };
 
 template<typename T>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -148,16 +148,12 @@ class NetworkConnectionToWebProcess final
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkConnectionToWebProcess);
 public:
     USING_CAN_MAKE_WEAKPTR(MessageReceiver);
+    USING_CAN_MAKE_CHECKEDPTR(IPC::Connection::Client);
 
     using RegistrableDomain = WebCore::RegistrableDomain;
 
     static Ref<NetworkConnectionToWebProcess> create(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier&&);
     virtual ~NetworkConnectionToWebProcess();
-
-    using IPC::Connection::Client::checkedPtrCount;
-    using IPC::Connection::Client::checkedPtrCountWithoutThreadCheck;
-    using IPC::Connection::Client::incrementCheckedPtrCount;
-    using IPC::Connection::Client::decrementCheckedPtrCount;
 
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }


### PR DESCRIPTION
#### b24b56d1816e1cad17b9cb685be8f4cbebe024a0
<pre>
Address remaining Safer CPP warnings in IndexedDB code
<a href="https://bugs.webkit.org/show_bug.cgi?id=298641">https://bugs.webkit.org/show_bug.cgi?id=298641</a>

Reviewed by Ryosuke Niwa and Sihui Liu.

* Source/WTF/wtf/CheckedRef.h:
* Source/WebCore/Modules/indexeddb/IDBCursor.h:
(WebCore::IDBCursor::key):
(WebCore::IDBCursor::protectedKey):
(WebCore::IDBCursor::primaryKey):
(WebCore::IDBCursor::protectedPrimaryKey):
(WebCore::IDBCursor::value):
(WebCore::IDBCursor::primaryKeyPath):
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::protectedVersionChangeTransaction const):
(WebCore::IDBDatabase::renameObjectStore):
(WebCore::IDBDatabase::renameIndex):
(WebCore::IDBDatabase::createObjectStore):
(WebCore::IDBDatabase::deleteObjectStore):
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBKey.cpp:
(WebCore::IDBKey::compare const):
* Source/WebCore/Modules/indexeddb/IDBKeyRange.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::virtualHasPendingActivity const):
(WebCore::IDBObjectStore::doOpenCursor):
(WebCore::IDBObjectStore::doOpenKeyCursor):
(WebCore::IDBObjectStore::putOrAdd):
(WebCore::IDBObjectStore::index):
(WebCore::IDBObjectStore::doGetAll):
(WebCore::IDBObjectStore::doGetAllKeys):
(WebCore::IDBObjectStore::visitReferencedIndexesConcurrently const):
(WebCore::IDBObjectStore::visitReferencedIndexes const):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp:
(WebCore::IDBOpenDBRequest::eventTargetInterface const):
(WebCore::IDBOpenDBRequest::fireSuccessAfterVersionChangeCommit):
(WebCore::IDBOpenDBRequest::fireErrorAfterVersionChangeCompletion):
(WebCore::IDBOpenDBRequest::dispatchEvent):
(WebCore::IDBOpenDBRequest::onSuccess):
(WebCore::IDBOpenDBRequest::onUpgradeNeeded):
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.h:
(isType):
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::eventTargetInterface const):
(WebCore::IDBRequest::dispatchEvent):
(WebCore::IDBRequest::uncaughtExceptionInEventHandler):
(WebCore::IDBRequest::didOpenOrIterateCursor):
(WebCore::IDBRequest::protectedTransaction const):
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
(isType):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::isFinishedOrFinishing const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
(WebCore::IDBTransaction::isFinishedOrFinishing const):
* Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp:
(isType):
(WebCore::DOMWindowIndexedDatabase::from):
(WebCore::WorkerGlobalScopeIndexedDatabase::from):
* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::establishTransaction):
(WebCore::IDBServer::IDBServer::didFinishHandlingVersionChangeTransaction):
(WebCore::IDBServer::IDBServer::databaseConnectionPendingClose):
(WebCore::IDBServer::IDBServer::databaseConnectionClosed):
(WebCore::IDBServer::IDBServer::abortOpenAndUpgradeNeeded):
(WebCore::IDBServer::IDBServer::didFireVersionChangeEvent):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::renameIndex):
(WebCore::IDBServer::MemoryIDBBackingStore::getAllRecords):
(WebCore::IDBServer::MemoryIDBBackingStore::openCursor):
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp:
(WebCore::IDBServer::MemoryIndexCursor::MemoryIndexCursor):
(WebCore::IDBServer::MemoryIndexCursor::iterate):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::performCurrentOpenOperationAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::startVersionChangeTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::openDBRequestCancelled):
(WebCore::IDBServer::UniqueIDBDatabase::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::deleteObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::clearObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::createIndexAsyncAfterQuotaCheck):
(WebCore::IDBServer::UniqueIDBDatabase::didGenerateIndexKeyForRecord):
(WebCore::IDBServer::UniqueIDBDatabase::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabase::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAddAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::getRecord):
(WebCore::IDBServer::UniqueIDBDatabase::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabase::getCount):
(WebCore::IDBServer::UniqueIDBDatabase::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabase::openCursor):
(WebCore::IDBServer::UniqueIDBDatabase::iterateCursor):
(WebCore::IDBServer::UniqueIDBDatabase::commitTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::abortTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::activateTransactionInBackingStore):
(WebCore::IDBServer::UniqueIDBDatabase::takeNextRunnableTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::immediateClose):
(WebCore::IDBServer::UniqueIDBDatabase::checkedBackingStore const):
(WebCore::IDBServer::UniqueIDBDatabase::abortActiveTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::close):
(WebCore::IDBServer::UniqueIDBDatabase::tryClose):
(WebCore::IDBServer::UniqueIDBDatabase::hasDataInMemory const):
(WebCore::IDBServer::UniqueIDBDatabase::filePath const):
(WebCore::IDBServer::UniqueIDBDatabase::handleLowMemoryWarning):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::abortWithoutCallback):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::clearObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getCount):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::openCursor):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::iterateCursor):
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp:
(WebCore::JSIDBObjectStore::visitAdditionalChildren):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::InspectorIndexedDBAgent::InspectorIndexedDBAgent):
(WebCore::InspectorIndexedDBAgent::protectedInspectedPage const):
(WebCore::documentFromFrame):
(WebCore::IDBFactoryFromDocument):
(WebCore::getDocumentAndIDBFactoryFromFrameOrSendFailure):
(WebCore::InspectorIndexedDBAgent::requestDatabaseNames):
(WebCore::InspectorIndexedDBAgent::requestDatabase):
(WebCore::InspectorIndexedDBAgent::requestData):
(WebCore::InspectorIndexedDBAgent::clearObjectStore):
(): Deleted.
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h:
* Source/WebCore/platform/Supplementable.h:
(WebCore::SupplementBase::isDOMWindowIndexedDatabase const):
(WebCore::SupplementBase::isWorkerGlobalScopeIndexedDatabase const):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:

Canonical link: <a href="https://commits.webkit.org/299842@main">https://commits.webkit.org/299842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5192cb2382d652750f60b2319de623f9a133d454

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72457 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1839baf-8481-4df1-8cd3-41cc7d8fc7c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60723 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e43f1409-e9f2-4876-bb5e-a7250ac14e3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71982 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2464775d-b098-4f65-9c74-8723ff4e75af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26025 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70369 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112508 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129638 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118898 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47303 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35895 "Found 1 new test failure: http/tests/websocket/tests/hybi/alert-in-event-handler.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100053 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99895 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52870 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147597 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46633 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37916 "Found 1 new JSC binary failure: testapi, Found 18665 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_length.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49980 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->