### PR TITLE
[Smart Lists] When converting HTML to an NSAttributedString, unordered lists may sometimes be converted to ordered lists

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -4367,17 +4367,17 @@ TEST(WritingToolsContextGeneration, ContextWithNestedLists)
     DecomposedAttributedText expected { {
         DecomposedAttributedText::OrderedList { {
             DecomposedAttributedText::UnorderedList { DecomposedAttributedText::ListMarker::Circle, {
-                "T"_s,
+                "T\n"_s,
                 DecomposedAttributedText::OrderedList { {
-                    "I\nJ\nK"_s
+                    "I\nJ\nK\n"_s
                 } },
-                "U"_s,
+                "U\n"_s,
             } },
-            "B"_s,
+            "B\n"_s,
             DecomposedAttributedText::OrderedList { {
-                "V\nW"_s,
+                "V\nW\n"_s,
             } },
-            "C"_s,
+            "C\n"_s,
         } },
         "Z"_s,
     } };
@@ -4401,11 +4401,11 @@ TEST(WritingToolsContextGeneration, ContextWithDiscontiguousLists)
     )"""_s;
 
     DecomposedAttributedText expected { {
-        "Hello"_s,
+        "Hello\n"_s,
         DecomposedAttributedText::OrderedList { {
-            "A\nB\nC"_s,
+            "A\nB\nC\n"_s,
         } },
-        "World"_s,
+        "World\n"_s,
         DecomposedAttributedText::UnorderedList { {
             "X\nY\nZ"_s,
         } },
@@ -4451,15 +4451,15 @@ TEST(WritingToolsContextGeneration, ContextWithStyledContentChildrenInList)
 
     DecomposedAttributedText expected { {
         DecomposedAttributedText::UnorderedList { {
-            "The"_s,
+            "The "_s,
             DecomposedAttributedText::Italic { {
                 "quick"_s,
             } },
-            "brown fox\njumped"_s,
+            "\nbrown fox\njumped "_s,
             DecomposedAttributedText::Bold { {
                 "over"_s,
             } },
-            "the dog"_s,
+            " the dog"_s,
         } },
     } };
 

--- a/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h
+++ b/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h
@@ -39,11 +39,27 @@ struct _DecomposedAttributedTextOrderedList;
 struct _DecomposedAttributedTextUnorderedList;
 
 struct DecomposedAttributedText {
-    enum class ListMarker: uint8_t {
-        Circle,
-        Decimal,
-        Disc,
-        LowercaseRoman,
+    struct ListMarker {
+        enum class Type: uint8_t {
+            Circle,
+            Decimal,
+            Disc,
+            LowercaseRoman,
+        };
+
+        using enum Type;
+
+        ListMarker(Type type)
+            : data(type)
+        {
+        }
+
+        explicit ListMarker(String&& string)
+            : data(string)
+        {
+        }
+
+        Variant<Type, String> data;
     };
 
     enum class ListIDTag { };
@@ -135,6 +151,8 @@ TextStream& operator<<(TextStream&, const DecomposedAttributedText::OrderedList&
 TextStream& operator<<(TextStream&, const DecomposedAttributedText::UnorderedList&);
 
 TextStream& operator<<(TextStream&, const DecomposedAttributedText&);
+
+bool operator==(const DecomposedAttributedText::ListMarker&, const DecomposedAttributedText::ListMarker&);
 
 bool operator==(const DecomposedAttributedText::Bold&, const DecomposedAttributedText::Bold&);
 


### PR DESCRIPTION
#### e314d3e1d7fc5ac9a78cd5b79655a8387b76d25a
<pre>
[Smart Lists] When converting HTML to an NSAttributedString, unordered lists may sometimes be converted to ordered lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=298643">https://bugs.webkit.org/show_bug.cgi?id=298643</a>
<a href="https://rdar.apple.com/160259938">rdar://160259938</a>

Reviewed by Abrar Rahman Protyasha.

Fix a correctness issue when converting HTML with lists to NSAttributedString; specifically, if a &lt;ul&gt; list uses a custom
list style type, the NSTextList created from it would have the incorrect marker format, marker, and would incorrectly be considered
to be ordered.

This is because the NodeHTMLConverter algorithm was trivially just creating the marker format via `{&lt;value&gt;}` where `&lt;value&gt;` is
the CSS text list style specified. This works for the standard NSTextList marker formats, and for ordered lists. However, the system
expects marker formats for unordered lists to just be `&lt;value&gt;`, which the conversion does not take into account.

Fix by replacing the ad-hoc list creation in NodeHTMLConverter with the established `TextList` type; consequently, also fix a correctness
issue with `TextList` for its marker conversion, since it did not accept custom list style types, even though the system accepts them.

Also adds a test for all affected configurations, and enhances the DecomposedAttributedText test helper type with more flexibility.

* Source/WebCore/editing/cocoa/FontAttributesCocoa.mm:
(WebCore::cocoaTextListMarkerName):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_processElement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TestWebKitAPI::TEST(WKWebView, AttributedStringFromListWithCustomListStyleTypes)):
* Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h:
(DecomposedAttributedText::ListMarker::ListMarker):
* Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.mm:
(operator==):
(operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/299820@main">https://commits.webkit.org/299820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13616b8870d746e3165c558df59ea32fb3b62ec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120323 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72396 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/baf0bd6e-236f-4a6c-862b-aea45eb998ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91379 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60670 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c0cb93e-fb26-463e-bf82-146423d57d43) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71933 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4755a305-7c54-4bb4-b4fc-98b62a4ba9fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129577 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35844 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25341 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23317 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52811 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46574 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49920 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->