### PR TITLE
[VideoMediaSampleRenderer] Take into account the amount on in-flight compressed samples when determining if we have reached enough data.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -158,6 +158,7 @@ private:
 
     void assignResourceOwner(const MediaSample&);
     bool areSamplesQueuesReadyForMoreMediaData(size_t waterMark) const;
+    size_t compressedSamplesCount() const;
     void maybeBecomeReadyForMoreMediaData();
     bool shouldDecodeSample(const MediaSample&);
 
@@ -192,6 +193,7 @@ private:
     std::atomic<FlushId> m_flushId { 0 };
     Deque<std::tuple<Ref<const MediaSample>, MediaTime, FlushId, bool>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
     std::atomic<uint32_t> m_compressedSamplesCount { 0 };
+    std::atomic<uint32_t> m_pendingSamplesCount { 0 };
     MediaSampleReorderQueue m_decodedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
     RefPtr<WebCoreDecompressionSession> m_decompressionSession WTF_GUARDED_BY_LOCK(m_lock);
     bool m_decompressionSessionBlocked WTF_GUARDED_BY_CAPABILITY(mainThread) { false };


### PR DESCRIPTION
#### 8f1f856797a83cee30108eb6d40698879f445285
<pre>
[VideoMediaSampleRenderer] Take into account the amount on in-flight compressed samples when determining if we have reached enough data.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298639">https://bugs.webkit.org/show_bug.cgi?id=298639</a>
<a href="https://rdar.apple.com/160256931">rdar://160256931</a>

Reviewed by Youenn Fablet.

The calculation of how many compressed samples were pending was racy,
as soon as we decoded the first frame, it would be reset to the actual number
of frames in the compressed queue, which at the time is always 1.
The next read would then not take into account any of the in-flight waiting
for the tasks to run.

As a consequence, we would enqueue a high number of compressed frames.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::areSamplesQueuesReadyForMoreMediaData const):
(WebCore::VideoMediaSampleRenderer::compressedSamplesCount const):
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):
(WebCore::VideoMediaSampleRenderer::flushCompressedSampleQueue):

Canonical link: <a href="https://commits.webkit.org/299798@main">https://commits.webkit.org/299798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/488c822ee66cb2c24b8449f0a91b539bf7e3f8ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126576 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72294 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91296 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60594 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71850 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70201 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129475 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99917 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23239 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43772 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52709 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46471 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48155 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->