### PR TITLE
AudioVideoRenderer should only complete the seek once it has received data for all tracks, not just the video

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -131,6 +131,10 @@ private:
     MediaTime clampTimeToLastSeekTime(const MediaTime&) const;
     void maybeCompleteSeek();
     bool shouldBePlaying() const;
+    bool allRenderersHaveAvailableSamples() const { return m_allRenderersHaveAvailableSamples; }
+    void updateAllRenderersHaveAvailableSamples();
+    void setHasAvailableVideoFrame(bool);
+    void setHasAvailableAudioSample(TrackIdentifier, bool);
 
     std::optional<TrackType> typeOf(TrackIdentifier) const;
 
@@ -228,11 +232,17 @@ private:
     RetainPtr<id> m_timeJumpedObserver;
     bool m_isSynchronizerSeeking { false };
     bool m_hasAvailableVideoFrame { false };
+    bool m_allRenderersHaveAvailableSamples { false };
+
+    struct AudioTrackProperties {
+        bool hasAudibleSample { false };
+    };
+    HashMap<TrackIdentifier, AudioTrackProperties> m_audioTracksMap;
+    bool m_readyToRequestVideoData { true };
+    bool m_readyToRequestAudioData { true };
 
     HashMap<TrackIdentifier, TrackType> m_trackTypes;
     HashMap<TrackIdentifier, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
-    bool m_readyToRequestVideoData { true };
-    bool m_readyToRequestAudioData { true };
     RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;
     RefPtr<VideoMediaSampleRenderer> m_videoRenderer;


### PR DESCRIPTION
#### 894d5299b3bea8cc2e041c897b450bac339c4ef8
<pre>
AudioVideoRenderer should only complete the seek once it has received data for all tracks, not just the video
<a href="https://bugs.webkit.org/show_bug.cgi?id=298640">https://bugs.webkit.org/show_bug.cgi?id=298640</a>
<a href="https://rdar.apple.com/160257202">rdar://160257202</a>

Reviewed by Youenn Fablet.

We adopt the same heuristic as the one in use in the MediaPlayerPrivateMediaSourceAVFObjC.
When seeking, we will only resolve the seek promise once we have decoded a video frame
and an audio sample has been queued on all active audio track.

* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
(WebCore::AudioVideoRendererAVFObjC::allRenderersHaveAvailableSamples const):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::enqueueSample):
(WebCore::AudioVideoRendererAVFObjC::seekTo):
(WebCore::AudioVideoRendererAVFObjC::maybeCompleteSeek):
(WebCore::AudioVideoRendererAVFObjC::shouldBePlaying const):
(WebCore::AudioVideoRendererAVFObjC::setHasAvailableAudioSample):
(WebCore::AudioVideoRendererAVFObjC::updateAllRenderersHaveAvailableSamples):
(WebCore::AudioVideoRendererAVFObjC::setHasAvailableVideoFrame):
(WebCore::AudioVideoRendererAVFObjC::setVideoRenderer):
(WebCore::AudioVideoRendererAVFObjC::flushVideo):
(WebCore::AudioVideoRendererAVFObjC::flushAudio):
(WebCore::AudioVideoRendererAVFObjC::flushAudioTrack):

Canonical link: <a href="https://commits.webkit.org/299808@main">https://commits.webkit.org/299808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd3f6238c0ac38588ab5eb87f6ded7d9a869053c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72328 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91326 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60620 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107813 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71878 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25919 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70240 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129509 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99942 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99784 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25336 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23268 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43808 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52743 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46506 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49852 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->