### PR TITLE
Address some Safer CPP warnings in Modules

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -102,8 +102,9 @@ void ManagedMediaSource::ensurePrefsRead()
 
     if (m_lowThreshold && m_highThreshold)
         return;
-    m_lowThreshold = scriptExecutionContext()->settingsValues().managedMediaSourceLowThreshold;
-    m_highThreshold = scriptExecutionContext()->settingsValues().managedMediaSourceHighThreshold;
+    RefPtr context = scriptExecutionContext();
+    m_lowThreshold = context->settingsValues().managedMediaSourceLowThreshold;
+    m_highThreshold = context->settingsValues().managedMediaSourceHighThreshold;
 }
 
 void ManagedMediaSource::monitorSourceBuffers()

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -36,12 +36,12 @@ public:
     typedef typename M::value_type value_type;
     bool operator()(const value_type& value, const MediaTime& time)
     {
-        MediaTime presentationEndTime = value.second->presentationTime() + value.second->duration();
+        MediaTime presentationEndTime = Ref { value.second }->presentationTime() + Ref { value.second }->duration();
         return presentationEndTime <= time;
     }
     bool operator()(const MediaTime& time, const value_type& value)
     {
-        MediaTime presentationStartTime = value.second->presentationTime();
+        MediaTime presentationStartTime = Ref { value.second }->presentationTime();
         return time < presentationStartTime;
     }
 };
@@ -52,12 +52,12 @@ public:
     typedef typename M::value_type value_type;
     bool operator()(const value_type& value, const MediaTime& time)
     {
-        MediaTime presentationStartTime = value.second->presentationTime();
+        MediaTime presentationStartTime = Ref { value.second }->presentationTime();
         return presentationStartTime > time;
     }
     bool operator()(const MediaTime& time, const value_type& value)
     {
-        MediaTime presentationEndTime = value.second->presentationTime() + value.second->duration();
+        MediaTime presentationEndTime = Ref { value.second }->presentationTime() + Ref { value.second }->duration();
         return time >= presentationEndTime;
     }
 };
@@ -66,7 +66,7 @@ class SampleIsRandomAccess {
 public:
     bool operator()(DecodeOrderSampleMap::MapType::value_type& value)
     {
-        return value.second->isSync();
+        return Ref { value.second }->isSync();
     }
 };
 
@@ -240,7 +240,7 @@ DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePrior
     reverse_iterator foundSample = findSyncSamplePriorToDecodeIterator(reverseCurrentSampleDTS);
     if (foundSample == rend())
         return rend();
-    if (foundSample->second->presentationTime() < time - threshold)
+    if (Ref { foundSample->second }->presentationTime() < time - threshold)
         return rend();
     return foundSample;
 }
@@ -263,7 +263,7 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresenta
     iterator foundSample = std::find_if(currentSampleDTS, end(), SampleIsRandomAccess());
     if (foundSample == end())
         return end();
-    if (foundSample->second->presentationTime() > upperBound)
+    if (Ref { foundSample->second }->presentationTime() > upperBound)
         return end();
     return foundSample;
 }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -214,6 +214,10 @@ private:
     bool hasAudio() const;
 
     void rangeRemoval(const MediaTime&, const MediaTime&);
+    RefPtr<MediaSource> protectedSource() const;
+    RefPtr<VideoTrackList> protectedVideoTracks() const;
+    RefPtr<AudioTrackList> protectedAudioTracks() const;
+    RefPtr<TextTrackList> protectedTextTracks() const;
 
     friend class Internals;
     using SamplesPromise = NativePromise<Vector<String>, PlatformMediaError>;

--- a/Source/WebCore/Modules/reporting/Report.cpp
+++ b/Source/WebCore/Modules/reporting/Report.cpp
@@ -59,11 +59,6 @@ const String& Report::url() const
     return m_url;
 }
 
-const RefPtr<ReportBody>& Report::body() const
-{
-    return m_body;
-}
-
 Ref<FormData> Report::createReportFormDataForViolation(const String& type, const URL& url, const String& userAgent, const String& destination, NOESCAPE const Function<void(JSON::Object&)>& populateBody)
 {
     auto body = JSON::Object::create();

--- a/Source/WebCore/Modules/reporting/Report.h
+++ b/Source/WebCore/Modules/reporting/Report.h
@@ -43,7 +43,8 @@ public:
 
     WEBCORE_EXPORT const String& type() const;
     WEBCORE_EXPORT const String& url() const;
-    WEBCORE_EXPORT const RefPtr<ReportBody>& body() const;
+    ReportBody* body() const { return m_body.get(); }
+    RefPtr<ReportBody> protectedBody() const { return m_body; }
 
     static Ref<FormData> createReportFormDataForViolation(const String& type, const URL&, const String& userAgent, const String& destination, NOESCAPE const Function<void(JSON::Object&)>& populateBody);
 

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -101,7 +101,7 @@ void ReportingScope::notifyReportObservers(Ref<Report>&& report)
     for (auto& observer : possibleReportObservers)
         observer->appendQueuedReportIfCorrectType(report);
 
-    auto currentReportType = report->body()->reportBodyType();
+    auto currentReportType = report->protectedBody()->reportBodyType();
 
     // Step 4.2.2
     m_queuedReportTypeCounts.add(currentReportType);

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -13,11 +13,7 @@ Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
 Modules/mediasession/MediaSessionCoordinator.cpp
 Modules/mediasession/MediaSessionCoordinator.h
-Modules/mediasource/ManagedMediaSource.cpp
-Modules/mediasource/MediaSource.cpp
 Modules/mediasource/MediaSourceHandle.cpp
-Modules/mediasource/SampleMap.cpp
-Modules/mediasource/SourceBuffer.cpp
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackProcessor.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
@@ -41,8 +37,6 @@ Modules/push-api/PushManager.cpp
 Modules/push-api/PushSubscription.cpp
 Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
 Modules/remoteplayback/RemotePlayback.cpp
-Modules/reporting/ReportingObserver.cpp
-Modules/reporting/ReportingScope.cpp
 Modules/speech/SpeechSynthesis.cpp
 Modules/storage/StorageManager.cpp
 Modules/storage/WorkerStorageConnection.cpp
@@ -203,7 +197,6 @@ bindings/js/JSPopStateEventCustom.cpp
 bindings/js/JSRTCRtpSFrameTransformCustom.cpp
 bindings/js/JSRangeCustom.cpp
 bindings/js/JSReadableStreamSourceCustom.cpp
-bindings/js/JSReportingObserverCustom.cpp
 bindings/js/JSResizeObserverCustom.cpp
 bindings/js/JSSVGViewSpecCustom.cpp
 bindings/js/JSShadowRootCustom.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -3,8 +3,6 @@ Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediasession/MediaMetadata.cpp
-Modules/mediasource/MediaSource.cpp
-Modules/mediasource/SourceBuffer.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/RTCDataChannel.cpp
 Modules/mediastream/RTCPeerConnection.cpp

--- a/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
@@ -35,7 +35,8 @@ namespace WebCore {
 template <typename Visitor>
 void JSReportingObserver::visitAdditionalChildren(Visitor& visitor)
 {
-    wrapped().callbackConcurrently().visitJSFunction(visitor);
+    // Do not ref `wrapped()` here since this function may get called on the GC thread.
+    SUPPRESS_UNCOUNTED_ARG wrapped().callbackConcurrently().visitJSFunction(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReportingObserver);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1536,7 +1536,7 @@ struct WebCore::PushSubscriptionData {
 [RefCounted] class WebCore::Report {
     String type()
     String url()
-    RefPtr<WebCore::ReportBody> body()
+    RefPtr<WebCore::ReportBody> protectedBody()
 };
 
 [RefCounted] class WebCore::TestReportBody {


### PR DESCRIPTION
#### 1850a904ddd6429b923777d028098721b7e16c33
<pre>
Address some Safer CPP warnings in Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=298647">https://bugs.webkit.org/show_bug.cgi?id=298647</a>

Reviewed by Per Arne Vollan.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::ensurePrefsRead):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::MediaSource):
(WebCore::MediaSource::open):
(WebCore::MediaSource::completeSeek):
(WebCore::MediaSource::openIfDeferredOpen):
(WebCore::MediaSource::createSourceBufferPrivate):
(WebCore::MediaSource::updateBufferedIfNeeded):
(WebCore::MediaSource::addAudioTrackMirrorToElement):
(WebCore::MediaSource::addTextTrackMirrorToElement):
(WebCore::MediaSource::addVideoTrackMirrorToElement):
* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::SampleIsLessThanMediaTimeComparator::operator()):
(WebCore::SampleIsGreaterThanMediaTimeComparator::operator()):
(WebCore::SampleIsRandomAccess::operator()):
(WebCore::DecodeOrderSampleMap::findSyncSamplePriorToPresentationTime):
(WebCore::DecodeOrderSampleMap::findSyncSampleAfterPresentationTime):
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::setTimestampOffset):
(WebCore::SourceBuffer::protectedSource const):
(WebCore::SourceBuffer::protectedVideoTracks const):
(WebCore::SourceBuffer::protectedAudioTracks const):
(WebCore::SourceBuffer::protectedTextTracks const):
(WebCore::SourceBuffer::abort):
(WebCore::SourceBuffer::remove):
(WebCore::SourceBuffer::rangeRemoval):
(WebCore::SourceBuffer::changeType):
(WebCore::SourceBuffer::appendBufferInternal):
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveRenderingError):
(WebCore::SourceBuffer::maximumBufferSize const):
(WebCore::SourceBuffer::videoTracks):
(WebCore::SourceBuffer::audioTracks):
(WebCore::SourceBuffer::textTracks):
(WebCore::SourceBuffer::setActive):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::validateInitializationSegment):
(WebCore::SourceBuffer::appendError):
(WebCore::SourceBuffer::hasAudio const):
(WebCore::SourceBuffer::hasVideo const):
(WebCore::SourceBuffer::videoTrackSelectedChanged):
(WebCore::SourceBuffer::videoTrackKindChanged):
(WebCore::SourceBuffer::videoTrackLabelChanged):
(WebCore::SourceBuffer::videoTrackLanguageChanged):
(WebCore::SourceBuffer::audioTrackEnabledChanged):
(WebCore::SourceBuffer::audioTrackKindChanged):
(WebCore::SourceBuffer::audioTrackLabelChanged):
(WebCore::SourceBuffer::audioTrackLanguageChanged):
(WebCore::SourceBuffer::textTrackModeChanged):
(WebCore::SourceBuffer::textTrackKindChanged):
(WebCore::SourceBuffer::textTrackLanguageChanged):
(WebCore::SourceBuffer::sourceBufferPrivateDurationChanged):
(WebCore::SourceBuffer::sourceBufferPrivateDidDropSample):
(WebCore::SourceBuffer::reportExtraMemoryAllocated):
(WebCore::SourceBuffer::setMode):
(WebCore::SourceBuffer::updateBuffered):
(WebCore::SourceBuffer::setBufferedDirty):
(WebCore::SourceBuffer::memoryPressure):
(WebCore::SourceBuffer::sourceBufferPrivateDidAttach):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/reporting/Report.cpp:
(WebCore::Report::body const): Deleted.
* Source/WebCore/Modules/reporting/Report.h:
(WebCore::Report::body const):
(WebCore::Report::protectedBody const):
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::disconnect):
(WebCore::ReportingObserver::observe):
(WebCore::ReportingObserver::appendQueuedReportIfCorrectType):
(WebCore::ReportingObserver::virtualHasPendingActivity const):
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::notifyReportObservers):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/bindings/js/JSReportingObserverCustom.cpp:
(WebCore::JSReportingObserver::visitAdditionalChildren):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/299876@main">https://commits.webkit.org/299876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9002784f474bbfcde9eeadeb2a1a6c90551526f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72409 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9877570-2b3f-455a-bbcd-f74d63fdc811) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91391 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60683 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8167b8d2-506c-4452-90d0-058d0bc0e442) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71944 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d329431-16cd-49c2-b2bc-870268a0a0a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25983 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70323 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129590 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100006 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45297 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43902 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52824 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46587 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->