### PR TITLE
[Tables] Fix baseline handling by skipping adjustments when cell has no inflow children

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6734,7 +6734,6 @@ imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-si
 imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-children-006.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/min-max-size-table-content-box.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/rules-groups.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-tables/table-cell-baseline-static-position.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/table-has-box-sizing-border-box-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/tentative/paint/background-image-column-collapsed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/tentative/paint/background-image-column.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/table/table-insert-before-non-anonymous-block-expected.txt
+++ b/LayoutTests/fast/table/table-insert-before-non-anonymous-block-expected.txt
@@ -53,4 +53,4 @@ layer at (0,0) size 800x466
             RenderTableCell (anonymous) at (0,0) size 50x100 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (0,0) size 50x50 [bgcolor=#0000FF]
               RenderBlock {DIV} at (0,50) size 50x50 [bgcolor=#0000FF]
-            RenderTableCell {DIV} at (50,50) size 50x0 [bgcolor=#0000FF] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {DIV} at (50,0) size 50x0 [bgcolor=#0000FF] [r=0 c=1 rs=1 cs=1]

--- a/LayoutTests/platform/glib/fast/css/acid2-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/acid2-expected.txt
@@ -33,10 +33,10 @@ layer at (36,2638) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,2842) size 740x10 scrollHeight 276

--- a/LayoutTests/platform/glib/fast/css/acid2-pixel-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/acid2-pixel-expected.txt
@@ -33,10 +33,10 @@ layer at (36,72) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,276) size 740x10 scrollHeight 276

--- a/LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
+++ b/LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
@@ -40,7 +40,7 @@ layer at (0,0) size 800x600
           RenderTable at (39,0) size 104x18
             RenderTableSection (anonymous) at (0,0) size 103x18
               RenderTableRow (anonymous) at (0,0) size 103x18
-                RenderTableCell {TD} at (0,14) size 0x0 [r=0 c=0 rs=1 cs=1]
+                RenderTableCell {TD} at (0,0) size 0x0 [r=0 c=0 rs=1 cs=1]
                 RenderTableCell {DIV} at (0,0) size 103x18 [r=0 c=1 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"

--- a/LayoutTests/platform/glib/http/tests/misc/acid2-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/misc/acid2-expected.txt
@@ -33,10 +33,10 @@ layer at (36,2638) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,2842) size 740x10 scrollHeight 276

--- a/LayoutTests/platform/glib/http/tests/misc/acid2-pixel-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/misc/acid2-pixel-expected.txt
@@ -33,10 +33,10 @@ layer at (36,72) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,276) size 740x10 scrollHeight 276

--- a/LayoutTests/platform/ios/fast/css/acid2-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/acid2-expected.txt
@@ -33,10 +33,10 @@ layer at (36,2640) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,2844) size 740x10 scrollHeight 277

--- a/LayoutTests/platform/ios/fast/css/acid2-pixel-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/acid2-pixel-expected.txt
@@ -33,10 +33,10 @@ layer at (36,72) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,276) size 740x10 scrollHeight 277

--- a/LayoutTests/platform/ios/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
+++ b/LayoutTests/platform/ios/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
@@ -40,7 +40,7 @@ layer at (0,0) size 800x600
           RenderTable at (40,0) size 106x20
             RenderTableSection (anonymous) at (0,0) size 105x20
               RenderTableRow (anonymous) at (0,0) size 105x20
-                RenderTableCell {TD} at (0,15) size 0x0 [r=0 c=0 rs=1 cs=1]
+                RenderTableCell {TD} at (0,0) size 0x0 [r=0 c=0 rs=1 cs=1]
                 RenderTableCell {DIV} at (0,0) size 105x20 [r=0 c=1 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"

--- a/LayoutTests/platform/ios/http/tests/misc/acid2-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/misc/acid2-expected.txt
@@ -33,10 +33,10 @@ layer at (36,2640) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,2844) size 740x10 scrollHeight 277

--- a/LayoutTests/platform/ios/http/tests/misc/acid2-pixel-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/misc/acid2-pixel-expected.txt
@@ -33,10 +33,10 @@ layer at (36,72) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,276) size 740x10 scrollHeight 277

--- a/LayoutTests/platform/mac/fast/css/acid2-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/acid2-expected.txt
@@ -33,10 +33,10 @@ layer at (36,2638) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,2842) size 740x10 scrollHeight 276

--- a/LayoutTests/platform/mac/fast/css/acid2-pixel-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/acid2-pixel-expected.txt
@@ -33,10 +33,10 @@ layer at (36,72) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,276) size 740x10 scrollHeight 276

--- a/LayoutTests/platform/mac/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
+++ b/LayoutTests/platform/mac/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
@@ -40,7 +40,7 @@ layer at (0,0) size 800x600
           RenderTable at (40,0) size 106x18
             RenderTableSection (anonymous) at (0,0) size 105x18
               RenderTableRow (anonymous) at (0,0) size 105x18
-                RenderTableCell {TD} at (0,14) size 0x0 [r=0 c=0 rs=1 cs=1]
+                RenderTableCell {TD} at (0,0) size 0x0 [r=0 c=0 rs=1 cs=1]
                 RenderTableCell {DIV} at (0,0) size 105x18 [r=0 c=1 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"

--- a/LayoutTests/platform/mac/http/tests/misc/acid2-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/misc/acid2-expected.txt
@@ -33,10 +33,10 @@ layer at (36,2638) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,2842) size 740x10 scrollHeight 276

--- a/LayoutTests/platform/mac/http/tests/misc/acid2-pixel-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/misc/acid2-pixel-expected.txt
@@ -33,10 +33,10 @@ layer at (36,72) size 764x226
     RenderTable {UL} at (96,192) size 48x12 [bgcolor=#FF0000]
       RenderTableSection (anonymous) at (0,0) size 48x12
         RenderTableRow (anonymous) at (0,0) size 48x12
-          RenderTableCell {LI} at (0,12) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
+          RenderTableCell {LI} at (0,0) size 12x0 [bgcolor=#000000] [r=0 c=0 rs=1 cs=1]
           RenderTableCell (anonymous) at (12,0) size 12x12 [r=0 c=1 rs=1 cs=1]
             RenderTable {LI} at (0,0) size 12x12 [bgcolor=#000000]
-          RenderTableCell {LI} at (24,12) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
+          RenderTableCell {LI} at (24,0) size 12x0 [bgcolor=#000000] [r=0 c=2 rs=1 cs=1]
           RenderTableCell (anonymous) at (36,0) size 12x12 [r=0 c=3 rs=1 cs=1]
             RenderListItem {LI} at (0,0) size 12x12 [bgcolor=#000000]
 layer at (48,276) size 740x10 scrollHeight 276

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2016-2017 Google Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
@@ -288,6 +288,12 @@ bool RenderTableCell::computeIntrinsicPadding(LayoutUnit heightConstraint)
 
     auto applyStandard = [&] {
         auto baseline = cellBaselinePosition();
+        if (!firstInFlowChild() && baseline == borderAndPaddingBefore()) {
+            // If baseline equals borderAndPaddingBefore(), there is no real content.
+            intrinsicPaddingBefore = 0;
+            return;
+        }
+
         auto needsIntrinsicPadding = baseline > borderAndPaddingBefore() || !borderBoxLogicalHeight;
         if (needsIntrinsicPadding)
             intrinsicPaddingBefore = section()->rowBaseline(rowIndex()) - (baseline - oldIntrinsicPaddingBefore);


### PR DESCRIPTION
#### 46e34443b1ae64a65ea99957cd01ecf467700d32
<pre>
[Tables] Fix baseline handling by skipping adjustments when cell has no inflow children
<a href="https://bugs.webkit.org/show_bug.cgi?id=298659">https://bugs.webkit.org/show_bug.cgi?id=298659</a>
<a href="https://rdar.apple.com/problem/160774504">rdar://problem/160774504</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Inspired by: <a href="https://chromium.googlesource.com/chromium/src/+/ca5380c68d5805f2e7ae6914620723fed797685c">https://chromium.googlesource.com/chromium/src/+/ca5380c68d5805f2e7ae6914620723fed797685c</a>

According to Web Specification [1], the baseline of a table cell is the
baseline of the first in-flow line box or table-row, whichever comes first.
If none exist, the baseline falls back to the bottom content edge of the
cell box.

WebKit previously always attempted to adjust intrinsic padding during baseline
alignment, even for cells containing only out-of-flow (OOF) children. However,
the specification distinguishes between:

- Baseline determination (always produced, falling back to content edge if needed)
- Baseline alignment adjustments (only applied when in-flow children exist)

This patch adds an in-flow child check in `applyStandard` to ensure that
intrinsic padding adjustments are skipped for cells with only OOF children.
In such cases, the baseline defaults to the content edge without applying
any padding shift. The check uses `firstInFlowChild()` for efficiency, and
the baseline computation is deferred until after this check to avoid
unnecessary calculations when early-returning.

This patch fixes WebKit&apos;s behavior and makes it consistent with other browsers
and closer to the web specification.

[1] <a href="https://www.w3.org/TR/CSS21/tables.html#height-layout">https://www.w3.org/TR/CSS21/tables.html#height-layout</a>

* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::computeIntrinsicPadding):

&gt; Progression:
* LayoutTests/TestExpectations:

&gt; Rebaselines:
* LayoutTests/fast/table/table-insert-before-non-anonymous-block-expected.txt:
* LayoutTests/platform/glib/fast/css/acid2-expected.txt:
* LayoutTests/platform/glib/fast/css/acid2-pixel-expected.txt:
* LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt:
* LayoutTests/platform/glib/http/tests/misc/acid2-expected.txt:
* LayoutTests/platform/glib/http/tests/misc/acid2-pixel-expected.txt:
* LayoutTests/platform/ios/fast/css/acid2-expected.txt:
* LayoutTests/platform/ios/fast/css/acid2-pixel-expected.txt:
* LayoutTests/platform/ios/fast/dynamic/insert-before-table-part-in-continuation-expected.txt:
* LayoutTests/platform/ios/http/tests/misc/acid2-expected.txt:
* LayoutTests/platform/ios/http/tests/misc/acid2-pixel-expected.txt:
* LayoutTests/platform/mac/fast/css/acid2-expected.txt:
* LayoutTests/platform/mac/fast/css/acid2-pixel-expected.txt:
* LayoutTests/platform/mac/fast/dynamic/insert-before-table-part-in-continuation-expected.txt:
* LayoutTests/platform/mac/http/tests/misc/acid2-expected.txt:
* LayoutTests/platform/mac/http/tests/misc/acid2-pixel-expected.txt:

Canonical link: <a href="https://commits.webkit.org/304477@main">https://commits.webkit.org/304477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da7951fd962ac1298b41deef4dd28ea19a9c9e98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143397 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8ac6a52f-198f-4a5c-ae0a-30057be7ea4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7900 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8567c5ba-7856-4d85-9274-d0b17553016f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6271 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ced69a78-6174-442c-9061-9980ca26145c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4003 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146145 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40382 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112427 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5901 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117927 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7788 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->