### PR TITLE
[css-pseudo] ::first-letter and ::first-line should reject some properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt
@@ -31,8 +31,8 @@ PASS textTransform should be applied to first-letter pseudo elements.
 PASS textUnderlinePosition should be applied to first-letter pseudo elements.
 PASS verticalAlign should be applied to first-letter pseudo elements.
 PASS wordSpacing should be applied to first-letter pseudo elements.
-FAIL position should not be applied to first-letter pseudo elements. assert_equals: expected "static" but got "absolute"
-FAIL transition should not be applied to first-letter pseudo elements. assert_equals: expected "all" but got "transform 1s"
+PASS position should not be applied to first-letter pseudo elements.
+PASS transition should not be applied to first-letter pseudo elements.
 PASS transform should not be applied to first-letter pseudo elements.
-FAIL wordBreak should not be applied to first-letter pseudo elements. assert_equals: expected "normal" but got "break-all"
+PASS wordBreak should not be applied to first-letter pseudo elements.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt
@@ -31,8 +31,17 @@ PASS textTransform should be applied to first-letter pseudo elements.
 PASS textUnderlinePosition should be applied to first-letter pseudo elements.
 PASS verticalAlign should be applied to first-letter pseudo elements.
 PASS wordSpacing should be applied to first-letter pseudo elements.
-FAIL position should not be applied to first-letter pseudo elements. assert_equals: expected "static" but got "absolute"
-FAIL transition should not be applied to first-letter pseudo elements. assert_equals: expected "all" but got "transform 1s"
+PASS animationName should be applied to first-letter pseudo elements.
+PASS animationDuration should be applied to first-letter pseudo elements.
+PASS animationTimingFunction should be applied to first-letter pseudo elements.
+PASS animationDelay should be applied to first-letter pseudo elements.
+PASS animationIterationCount should be applied to first-letter pseudo elements.
+PASS animationDirection should be applied to first-letter pseudo elements.
+PASS animationFillMode should be applied to first-letter pseudo elements.
+PASS animationPlayState should be applied to first-letter pseudo elements.
+PASS animationComposition should be applied to first-letter pseudo elements.
+PASS position should not be applied to first-letter pseudo elements.
+PASS transition should not be applied to first-letter pseudo elements.
 PASS transform should not be applied to first-letter pseudo elements.
-FAIL wordBreak should not be applied to first-letter pseudo elements. assert_equals: expected "normal" but got "break-all"
+PASS wordBreak should not be applied to first-letter pseudo elements.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html
@@ -52,7 +52,16 @@ var validProperties = {
   textTransform: 'capitalize',
   textUnderlinePosition: 'under',
   verticalAlign: '12%',
-  wordSpacing: '12px'
+  wordSpacing: '12px',
+  animationName: 'foo',
+  animationDuration: '1s',
+  animationTimingFunction: 'ease-in-out',
+  animationDelay: '2s',
+  animationIterationCount: '3',
+  animationDirection: 'alternate',
+  animationFillMode: 'forwards',
+  animationPlayState: 'paused',
+  animationComposition: 'add'
 };
 
 var invalidProperties = {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-animate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-animate-expected.txt
@@ -1,0 +1,5 @@
+
+PASS 'color' animation
+PASS 'transform' animation
+PASS 'color' + 'transform' animation
+first letter

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-animate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-animate.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: Animating ::first-letter</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-letter-styling">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/">
+<meta name="assert" content="This test checks that ::first-letter can be animated with Web Animations, but only the supported properties." />
+<style>
+  /* A ::first-letter rule is required for the pseudo-element (and thus its
+     animations) to be resolved; unlike ::marker it is not auto-generated. */
+  #target::first-letter { color: black; }
+</style>
+<div id="log"></div>
+<p id="target">first letter</p>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const target = document.getElementById("target");
+const cs = getComputedStyle(target, "::first-letter");
+const options = {
+  pseudoElement: "::first-letter",
+  duration: 2,
+  delay: -1,
+};
+
+// 'color' applies to ::first-letter so it should be animatable
+test(function() {
+  const anim = target.animate([
+    {color: "rgb(0, 100, 200)"},
+    {color: "rgb(200, 0, 100)"},
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+}, "'color' animation");
+
+// 'transform' doesn't apply to ::first-letter so it shouldn't be animatable
+test(function() {
+  const anim = target.animate([
+    {transform: "translateX(0px)"},
+    {transform: "translateX(100px)"},
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.transform, "none", "transform");
+}, "'transform' animation");
+
+// When both 'color' and 'transform' are specified, only the former should be animated.
+test(function() {
+  const anim = target.animate([
+    {
+      color: "rgb(0, 100, 200)",
+      transform: "translateX(0px)",
+    },
+    {
+      color: "rgb(200, 0, 100)",
+      transform: "translateX(100px)",
+    },
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+  assert_equals(cs.transform, "none", "transform");
+}, "'color' + 'transform' animation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt
@@ -28,13 +28,13 @@ PASS textTransform should be applied to first-line pseudo elements.
 PASS textUnderlinePosition should be applied to first-line pseudo elements.
 PASS verticalAlign should be applied to first-line pseudo elements.
 PASS wordSpacing should be applied to first-line pseudo elements.
-FAIL border should not be applied to first-line pseudo elements. assert_equals: expected "0px none rgb(0, 0, 0)" but got "40px dotted rgb(10, 20, 30)"
-FAIL borderImage should not be applied to first-line pseudo elements. assert_equals: expected "none" but got "linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 10% / 20 / 30px repeat"
-FAIL borderRadius should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px"
-FAIL margin should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px 30px 40px"
-FAIL padding should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px 30px 40px"
-FAIL position should not be applied to first-line pseudo elements. assert_equals: expected "static" but got "absolute"
-FAIL transition should not be applied to first-line pseudo elements. assert_equals: expected "all" but got "transform 1s"
+PASS border should not be applied to first-line pseudo elements.
+PASS borderImage should not be applied to first-line pseudo elements.
+PASS borderRadius should not be applied to first-line pseudo elements.
+PASS margin should not be applied to first-line pseudo elements.
+PASS padding should not be applied to first-line pseudo elements.
+PASS position should not be applied to first-line pseudo elements.
+PASS transition should not be applied to first-line pseudo elements.
 PASS transform should not be applied to first-line pseudo elements.
-FAIL wordBreak should not be applied to first-line pseudo elements. assert_equals: expected "normal" but got "break-all"
+PASS wordBreak should not be applied to first-line pseudo elements.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt
@@ -28,13 +28,22 @@ PASS textTransform should be applied to first-line pseudo elements.
 PASS textUnderlinePosition should be applied to first-line pseudo elements.
 PASS verticalAlign should be applied to first-line pseudo elements.
 PASS wordSpacing should be applied to first-line pseudo elements.
-FAIL border should not be applied to first-line pseudo elements. assert_equals: expected "0px none rgb(0, 0, 0)" but got "40px dotted rgb(10, 20, 30)"
-FAIL borderImage should not be applied to first-line pseudo elements. assert_equals: expected "none" but got "linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 10% / 20 / 30px repeat"
-FAIL borderRadius should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px"
-FAIL margin should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px 30px 40px"
-FAIL padding should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px 30px 40px"
-FAIL position should not be applied to first-line pseudo elements. assert_equals: expected "static" but got "absolute"
-FAIL transition should not be applied to first-line pseudo elements. assert_equals: expected "all" but got "transform 1s"
+PASS animationName should be applied to first-line pseudo elements.
+PASS animationDuration should be applied to first-line pseudo elements.
+PASS animationTimingFunction should be applied to first-line pseudo elements.
+PASS animationDelay should be applied to first-line pseudo elements.
+PASS animationIterationCount should be applied to first-line pseudo elements.
+PASS animationDirection should be applied to first-line pseudo elements.
+PASS animationFillMode should be applied to first-line pseudo elements.
+PASS animationPlayState should be applied to first-line pseudo elements.
+PASS animationComposition should be applied to first-line pseudo elements.
+PASS border should not be applied to first-line pseudo elements.
+PASS borderImage should not be applied to first-line pseudo elements.
+PASS borderRadius should not be applied to first-line pseudo elements.
+PASS margin should not be applied to first-line pseudo elements.
+PASS padding should not be applied to first-line pseudo elements.
+PASS position should not be applied to first-line pseudo elements.
+PASS transition should not be applied to first-line pseudo elements.
 PASS transform should not be applied to first-line pseudo elements.
-FAIL wordBreak should not be applied to first-line pseudo elements. assert_equals: expected "normal" but got "break-all"
+PASS wordBreak should not be applied to first-line pseudo elements.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html
@@ -47,7 +47,16 @@
     textTransform: "capitalize",
     textUnderlinePosition: "under",
     verticalAlign: "12%",
-    wordSpacing: "12px"
+    wordSpacing: "12px",
+    animationName: "foo",
+    animationDuration: "1s",
+    animationTimingFunction: "ease-in-out",
+    animationDelay: "2s",
+    animationIterationCount: "3",
+    animationDirection: "alternate",
+    animationFillMode: "forwards",
+    animationPlayState: "paused",
+    animationComposition: "add"
   };
 
   const invalidProperties = {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-animate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-animate-expected.txt
@@ -1,0 +1,5 @@
+
+PASS 'color' animation
+PASS 'transform' animation
+PASS 'color' + 'transform' animation
+first line

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-animate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-animate.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: Animating ::first-line</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-line-styling">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/">
+<meta name="assert" content="This test checks that ::first-line can be animated with Web Animations, but only the supported properties." />
+<style>
+  /* A ::first-line rule is required for the pseudo-element (and thus its
+     animations) to be resolved; unlike ::marker it is not auto-generated. */
+  #target::first-line { color: black; }
+</style>
+<div id="log"></div>
+<p id="target">first line</p>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const target = document.getElementById("target");
+const cs = getComputedStyle(target, "::first-line");
+const options = {
+  pseudoElement: "::first-line",
+  duration: 2,
+  delay: -1,
+};
+
+// 'color' applies to ::first-line so it should be animatable
+test(function() {
+  const anim = target.animate([
+    {color: "rgb(0, 100, 200)"},
+    {color: "rgb(200, 0, 100)"},
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+}, "'color' animation");
+
+// 'transform' doesn't apply to ::first-line so it shouldn't be animatable
+test(function() {
+  const anim = target.animate([
+    {transform: "translateX(0px)"},
+    {transform: "translateX(100px)"},
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.transform, "none", "transform");
+}, "'transform' animation");
+
+// When both 'color' and 'transform' are specified, only the former should be animated.
+test(function() {
+  const anim = target.animate([
+    {
+      color: "rgb(0, 100, 200)",
+      transform: "translateX(0px)",
+    },
+    {
+      color: "rgb(200, 0, 100)",
+      transform: "translateX(100px)",
+    },
+  ], options);
+  this.add_cleanup(() => anim.cancel());
+  assert_equals(cs.color, "rgb(100, 50, 150)", "color");
+  assert_equals(cs.transform, "none", "transform");
+}, "'color' + 'transform' animation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-first-letter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-first-letter-expected.txt
@@ -8,7 +8,7 @@ CSS variable referencing another CSS variable that defines 'position' property s
 PASS color
 PASS font-size
 PASS font-weight
-FAIL position assert_equals: expected "absolute" but got "static"
+PASS position
 PASS nested color
-FAIL abspos assert_equals: expected "absolute" but got "static"
+PASS abspos
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-first-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-first-line-expected.txt
@@ -13,7 +13,7 @@ CSS variable referencing another CSS variable that defines 'position' property s
 PASS color
 PASS font-size
 PASS font-weight
-FAIL position assert_equals: expected "absolute" but got "static"
+PASS position
 PASS nested color
-FAIL abspos assert_equals: expected "absolute" but got "static"
+PASS abspos
 

--- a/LayoutTests/inspector/layers/layers-anonymous.html
+++ b/LayoutTests/inspector/layers/layers-anonymous.html
@@ -65,7 +65,7 @@ function test()
         }
 
         logTestName("Check node");
-        
+
         assert("Node was found", !!node, true);
         assert("Node has expected localName", node.localName, "p");
         assert("Node has id", node.attributes[0], "id");
@@ -127,7 +127,7 @@ window.addEventListener("DOMContentLoaded", function()
 
     #first-letter::first-letter {
         float: left;
-        -webkit-transform: translateZ(0);
+        opacity: 0.99;
     }
 
 </style>

--- a/LayoutTests/inspector/layers/layers-anonymous.html
+++ b/LayoutTests/inspector/layers/layers-anonymous.html
@@ -125,9 +125,22 @@ window.addEventListener("DOMContentLoaded", function()
 </script>
 <style type="text/css">
 
+    /*
+     * ::first-letter no longer accepts transform (typographic pseudo-elements
+     * reject box-level properties), so force the anonymous first-letter layer
+     * to composite with a running accelerated opacity animation instead. Unlike
+     * overlap or will-change compositing, animation-driven compositing is not
+     * suppressed under the Conservative compositing policy, so this stays
+     * deterministic under memory pressure on the stress-test bots.
+     */
+    @keyframes first-letter-fade {
+        from { opacity: 1; }
+        to { opacity: 0.5; }
+    }
+
     #first-letter::first-letter {
         float: left;
-        -webkit-transform: translateZ(0);
+        animation: first-letter-fade 1s infinite alternate;
     }
 
 </style>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1686,6 +1686,23 @@ bool KeyframeEffect::isAboutToRunAccelerated() const
     return m_acceleratedPropertiesState != AcceleratedProperties::None && m_lastRecordedAcceleratedAction != AcceleratedAction::Stop;
 }
 
+static bool isPropertyValidForPseudoElement(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, CSSPropertyID property)
+{
+    if (!pseudoElementIdentifier)
+        return true;
+
+    switch (pseudoElementIdentifier->type) {
+    case PseudoElementType::Marker:
+        return Style::isValidMarkerStyleProperty(property);
+    case PseudoElementType::FirstLetter:
+        return Style::isValidFirstLetterStyleProperty(property);
+    case PseudoElementType::FirstLine:
+        return Style::isValidFirstLineStyleProperty(property);
+    default:
+        return true;
+    }
+}
+
 bool KeyframeEffect::isCurrentlyAffectingProperty(CSSPropertyID property, Accelerated accelerated) const
 {
     if (accelerated == Accelerated::Yes && !isRunningAccelerated() && !isAboutToRunAccelerated())
@@ -1694,7 +1711,7 @@ bool KeyframeEffect::isCurrentlyAffectingProperty(CSSPropertyID property, Accele
     if (!m_blendingKeyframes.properties().contains(property))
         return false;
 
-    if (m_pseudoElementIdentifier && m_pseudoElementIdentifier->type == PseudoElementType::Marker && !Style::isValidMarkerStyleProperty(property))
+    if (!isPropertyValidForPseudoElement(m_pseudoElementIdentifier, property))
         return false;
 
     return m_phaseAtLastApplication == AnimationEffectPhase::Active;
@@ -1727,10 +1744,9 @@ void KeyframeEffect::computeAcceleratedPropertiesState()
 
     if (RefPtr document = this->document()) {
         auto& settings = document->settings();
-        auto isMarker = m_pseudoElementIdentifier && m_pseudoElementIdentifier->type == PseudoElementType::Marker;
 
         auto isAcceleratedProperty = [&](AnimatableCSSProperty property) {
-            if (isMarker && std::holds_alternative<CSSPropertyID>(property) && !Style::isValidMarkerStyleProperty(std::get<CSSPropertyID>(property)))
+            if (std::holds_alternative<CSSPropertyID>(property) && !isPropertyValidForPseudoElement(m_pseudoElementIdentifier, std::get<CSSPropertyID>(property)))
                 return false;
             return Style::Interpolation::isAccelerated(property, settings);
         };

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -33,11 +33,14 @@ PropertyAllowlist propertyAllowlistForPseudoElement(PseudoElementType type)
 {
     if (type == PseudoElementType::Marker)
         return PropertyAllowlist::Marker;
+    if (type == PseudoElementType::FirstLetter)
+        return PropertyAllowlist::FirstLetter;
+    if (type == PseudoElementType::FirstLine)
+        return PropertyAllowlist::FirstLine;
     return PropertyAllowlist::None;
 }
 
-// https://drafts.csswg.org/css-lists-3/#marker-properties (Editor's Draft, 14 July 2021)
-// FIXME: this is outdated, see https://bugs.webkit.org/show_bug.cgi?id=218791.
+// https://drafts.csswg.org/css-lists-3/#marker-properties
 bool isValidMarkerStyleProperty(CSSPropertyID id)
 {
     switch (id) {
@@ -111,6 +114,199 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     case CSSPropertyTransitionTimingFunction:
     case CSSPropertyTransitionDelay:
     case CSSPropertyTransitionProperty:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+// https://drafts.csswg.org/css-pseudo/#first-letter-styling
+bool isValidFirstLetterStyleProperty(CSSPropertyID id)
+{
+    switch (id) {
+    case CSSPropertyBackgroundAttachment:
+    case CSSPropertyBackgroundBlendMode:
+    case CSSPropertyBackgroundClip:
+    case CSSPropertyBackgroundColor:
+    case CSSPropertyBackgroundImage:
+    case CSSPropertyBackgroundOrigin:
+    case CSSPropertyBackgroundPositionX:
+    case CSSPropertyBackgroundPositionY:
+    case CSSPropertyBackgroundRepeat:
+    case CSSPropertyBackgroundSize:
+    case CSSPropertyBorderBottomColor:
+    case CSSPropertyBorderBottomStyle:
+    case CSSPropertyBorderBottomWidth:
+    case CSSPropertyBorderLeftColor:
+    case CSSPropertyBorderLeftStyle:
+    case CSSPropertyBorderLeftWidth:
+    case CSSPropertyBorderRightColor:
+    case CSSPropertyBorderRightStyle:
+    case CSSPropertyBorderRightWidth:
+    case CSSPropertyBorderTopColor:
+    case CSSPropertyBorderTopStyle:
+    case CSSPropertyBorderTopWidth:
+    case CSSPropertyBorderBottomLeftRadius:
+    case CSSPropertyBorderBottomRightRadius:
+    case CSSPropertyBorderTopLeftRadius:
+    case CSSPropertyBorderTopRightRadius:
+    case CSSPropertyBorderBlockStyle:
+    case CSSPropertyBorderImageSource:
+    case CSSPropertyBorderImageWidth:
+    case CSSPropertyBorderImageOutset:
+    case CSSPropertyBorderImageRepeat:
+    case CSSPropertyBorderImageSlice:
+    case CSSPropertyBorderInlineStartColor:
+    case CSSPropertyBorderInlineStartStyle:
+    case CSSPropertyBorderInlineStartWidth:
+    case CSSPropertyBorderInlineEndColor:
+    case CSSPropertyBorderInlineEndStyle:
+    case CSSPropertyBorderInlineEndWidth:
+    case CSSPropertyBorderBlockStartColor:
+    case CSSPropertyBorderBlockStartStyle:
+    case CSSPropertyBorderBlockStartWidth:
+    case CSSPropertyBorderBlockEndColor:
+    case CSSPropertyBorderBlockEndStyle:
+    case CSSPropertyBorderBlockEndWidth:
+    case CSSPropertyBorderStartStartRadius:
+    case CSSPropertyBorderStartEndRadius:
+    case CSSPropertyBorderEndStartRadius:
+    case CSSPropertyBorderEndEndRadius:
+    case CSSPropertyWebkitBorderImage:
+    case CSSPropertyBoxShadow:
+    case CSSPropertyCornerStartStartShape:
+    case CSSPropertyCornerStartEndShape:
+    case CSSPropertyCornerEndStartShape:
+    case CSSPropertyCornerEndEndShape:
+    case CSSPropertyCornerBottomLeftShape:
+    case CSSPropertyCornerBottomRightShape:
+    case CSSPropertyCornerTopLeftShape:
+    case CSSPropertyCornerTopRightShape:
+    case CSSPropertyColor:
+    case CSSPropertyCustom:
+    case CSSPropertyFloat:
+    case CSSPropertyFontFamily:
+    case CSSPropertyFontFeatureSettings:
+    case CSSPropertyFontKerning:
+    case CSSPropertyFontSize:
+    case CSSPropertyFontSizeAdjust:
+    case CSSPropertyFontPalette:
+    case CSSPropertyFontStyle:
+    case CSSPropertyFontSynthesisWeight:
+    case CSSPropertyFontSynthesisStyle:
+    case CSSPropertyFontSynthesisSmallCaps:
+    case CSSPropertyFontVariantAlternates:
+    case CSSPropertyFontVariantCaps:
+    case CSSPropertyFontVariantEastAsian:
+    case CSSPropertyFontVariantLigatures:
+    case CSSPropertyFontVariantNumeric:
+    case CSSPropertyFontVariantEmoji:
+    case CSSPropertyFontVariantPosition:
+    case CSSPropertyFontWeight:
+#if ENABLE(VARIATION_FONTS)
+    case CSSPropertyFontOpticalSizing:
+    case CSSPropertyFontVariationSettings:
+#endif
+    case CSSPropertyLetterSpacing:
+    case CSSPropertyLineHeight:
+    case CSSPropertyMarginBottom:
+    case CSSPropertyMarginLeft:
+    case CSSPropertyMarginRight:
+    case CSSPropertyMarginTop:
+    case CSSPropertyMarginBlockEnd:
+    case CSSPropertyMarginBlockStart:
+    case CSSPropertyMarginInlineEnd:
+    case CSSPropertyMarginInlineStart:
+    case CSSPropertyOpacity:
+    case CSSPropertyPaddingTop:
+    case CSSPropertyPaddingRight:
+    case CSSPropertyPaddingBottom:
+    case CSSPropertyPaddingLeft:
+    case CSSPropertyTextDecorationStyle:
+    case CSSPropertyTextDecorationColor:
+    case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextDecorationSkipInk:
+    case CSSPropertyTextDecorationThickness:
+    case CSSPropertyTextJustify:
+    case CSSPropertyTextShadow:
+    case CSSPropertyTextTransform:
+    case CSSPropertyTextUnderlinePosition:
+    case CSSPropertyTextUnderlineOffset:
+    case CSSPropertyVerticalAlign:
+    case CSSPropertyVisibility:
+    case CSSPropertyWebkitBorderHorizontalSpacing:
+    case CSSPropertyWebkitBorderVerticalSpacing:
+    case CSSPropertyWebkitFontSmoothing:
+    case CSSPropertyWebkitInitialLetter:
+    case CSSPropertyWebkitLineBoxContain:
+    case CSSPropertyWordSpacing:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+// https://drafts.csswg.org/css-pseudo/#first-line-styling
+bool isValidFirstLineStyleProperty(CSSPropertyID id)
+{
+    switch (id) {
+    case CSSPropertyBackgroundAttachment:
+    case CSSPropertyBackgroundBlendMode:
+    case CSSPropertyBackgroundClip:
+    case CSSPropertyBackgroundColor:
+    case CSSPropertyBackgroundImage:
+    case CSSPropertyBackgroundOrigin:
+    case CSSPropertyBackgroundPosition:
+    case CSSPropertyBackgroundPositionX:
+    case CSSPropertyBackgroundPositionY:
+    case CSSPropertyBackgroundRepeat:
+    case CSSPropertyBackgroundSize:
+    case CSSPropertyBoxShadow:
+    case CSSPropertyColor:
+    case CSSPropertyCustom:
+    case CSSPropertyFontFamily:
+    case CSSPropertyFontFeatureSettings:
+    case CSSPropertyFontKerning:
+    case CSSPropertyFontSize:
+    case CSSPropertyFontSizeAdjust:
+    case CSSPropertyFontPalette:
+    case CSSPropertyFontStyle:
+    case CSSPropertyFontSynthesis:
+    case CSSPropertyFontSynthesisWeight:
+    case CSSPropertyFontSynthesisStyle:
+    case CSSPropertyFontSynthesisSmallCaps:
+    case CSSPropertyFontVariantAlternates:
+    case CSSPropertyFontVariantCaps:
+    case CSSPropertyFontVariantEastAsian:
+    case CSSPropertyFontVariantLigatures:
+    case CSSPropertyFontVariantNumeric:
+    case CSSPropertyFontVariantEmoji:
+    case CSSPropertyFontVariantPosition:
+    case CSSPropertyFontWeight:
+#if ENABLE(VARIATION_FONTS)
+    case CSSPropertyFontOpticalSizing:
+    case CSSPropertyFontVariationSettings:
+#endif
+    case CSSPropertyLetterSpacing:
+    case CSSPropertyLineHeight:
+    case CSSPropertyOpacity:
+    case CSSPropertyRubyPosition:
+    case CSSPropertyTextDecorationStyle:
+    case CSSPropertyTextDecorationColor:
+    case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextDecorationSkipInk:
+    case CSSPropertyTextDecorationThickness:
+    case CSSPropertyTextJustify:
+    case CSSPropertyTextShadow:
+    case CSSPropertyTextTransform:
+    case CSSPropertyTextUnderlinePosition:
+    case CSSPropertyTextUnderlineOffset:
+    case CSSPropertyVerticalAlign:
+    case CSSPropertyVisibility:
+    case CSSPropertyWebkitFontSmoothing:
+    case CSSPropertyWordSpacing:
         return true;
     default:
         break;

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -40,6 +40,10 @@ PropertyAllowlist propertyAllowlistForPseudoElement(PseudoElementType type)
         return PropertyAllowlist::Highlight;
     case PseudoElementType::Marker:
         return PropertyAllowlist::Marker;
+    case PseudoElementType::FirstLetter:
+        return PropertyAllowlist::FirstLetter;
+    case PseudoElementType::FirstLine:
+        return PropertyAllowlist::FirstLine;
     default:
         return PropertyAllowlist::None;
     }
@@ -73,8 +77,7 @@ bool isValidHighlightStyleProperty(CSSPropertyID id)
     return false;
 }
 
-// https://drafts.csswg.org/css-lists-3/#marker-properties (Editor's Draft, 14 July 2021)
-// FIXME: this is outdated, see https://bugs.webkit.org/show_bug.cgi?id=218791.
+// https://drafts.csswg.org/css-lists-3/#marker-properties
 bool isValidMarkerStyleProperty(CSSPropertyID id)
 {
     switch (id) {
@@ -149,6 +152,223 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     case CSSPropertyTransitionTimingFunction:
     case CSSPropertyTransitionDelay:
     case CSSPropertyTransitionProperty:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+// https://drafts.csswg.org/css-pseudo/#first-letter-styling
+bool isValidFirstLetterStyleProperty(CSSPropertyID id)
+{
+    switch (id) {
+    case CSSPropertyBackgroundAttachment:
+    case CSSPropertyBackgroundBlendMode:
+    case CSSPropertyBackgroundClip:
+    case CSSPropertyBackgroundColor:
+    case CSSPropertyBackgroundImage:
+    case CSSPropertyBackgroundOrigin:
+    case CSSPropertyBackgroundPositionX:
+    case CSSPropertyBackgroundPositionY:
+    case CSSPropertyBackgroundRepeat:
+    case CSSPropertyBackgroundSize:
+    case CSSPropertyBorderBottomColor:
+    case CSSPropertyBorderBottomStyle:
+    case CSSPropertyBorderBottomWidth:
+    case CSSPropertyBorderLeftColor:
+    case CSSPropertyBorderLeftStyle:
+    case CSSPropertyBorderLeftWidth:
+    case CSSPropertyBorderRightColor:
+    case CSSPropertyBorderRightStyle:
+    case CSSPropertyBorderRightWidth:
+    case CSSPropertyBorderTopColor:
+    case CSSPropertyBorderTopStyle:
+    case CSSPropertyBorderTopWidth:
+    case CSSPropertyBorderBottomLeftRadius:
+    case CSSPropertyBorderBottomRightRadius:
+    case CSSPropertyBorderTopLeftRadius:
+    case CSSPropertyBorderTopRightRadius:
+    case CSSPropertyBorderBlockStyle:
+    case CSSPropertyBorderImageSource:
+    case CSSPropertyBorderImageWidth:
+    case CSSPropertyBorderImageOutset:
+    case CSSPropertyBorderImageRepeat:
+    case CSSPropertyBorderImageSlice:
+    case CSSPropertyBorderInlineStartColor:
+    case CSSPropertyBorderInlineStartStyle:
+    case CSSPropertyBorderInlineStartWidth:
+    case CSSPropertyBorderInlineEndColor:
+    case CSSPropertyBorderInlineEndStyle:
+    case CSSPropertyBorderInlineEndWidth:
+    case CSSPropertyBorderBlockStartColor:
+    case CSSPropertyBorderBlockStartStyle:
+    case CSSPropertyBorderBlockStartWidth:
+    case CSSPropertyBorderBlockEndColor:
+    case CSSPropertyBorderBlockEndStyle:
+    case CSSPropertyBorderBlockEndWidth:
+    case CSSPropertyBorderStartStartRadius:
+    case CSSPropertyBorderStartEndRadius:
+    case CSSPropertyBorderEndStartRadius:
+    case CSSPropertyBorderEndEndRadius:
+    case CSSPropertyWebkitBorderImage:
+    case CSSPropertyBoxShadow:
+    case CSSPropertyCornerStartStartShape:
+    case CSSPropertyCornerStartEndShape:
+    case CSSPropertyCornerEndStartShape:
+    case CSSPropertyCornerEndEndShape:
+    case CSSPropertyCornerBottomLeftShape:
+    case CSSPropertyCornerBottomRightShape:
+    case CSSPropertyCornerTopLeftShape:
+    case CSSPropertyCornerTopRightShape:
+    case CSSPropertyColor:
+    case CSSPropertyCustom:
+    case CSSPropertyFloat:
+    case CSSPropertyFontFamily:
+    case CSSPropertyFontFeatureSettings:
+    case CSSPropertyFontKerning:
+    case CSSPropertyFontSize:
+    case CSSPropertyFontSizeAdjust:
+    case CSSPropertyFontPalette:
+    case CSSPropertyFontStyle:
+    case CSSPropertyFontSynthesisWeight:
+    case CSSPropertyFontSynthesisStyle:
+    case CSSPropertyFontSynthesisSmallCaps:
+    case CSSPropertyFontVariantAlternates:
+    case CSSPropertyFontVariantCaps:
+    case CSSPropertyFontVariantEastAsian:
+    case CSSPropertyFontVariantLigatures:
+    case CSSPropertyFontVariantNumeric:
+    case CSSPropertyFontVariantEmoji:
+    case CSSPropertyFontVariantPosition:
+    case CSSPropertyFontWeight:
+#if ENABLE(VARIATION_FONTS)
+    case CSSPropertyFontOpticalSizing:
+    case CSSPropertyFontVariationSettings:
+#endif
+    case CSSPropertyLetterSpacing:
+    case CSSPropertyLineHeight:
+    case CSSPropertyMarginBottom:
+    case CSSPropertyMarginLeft:
+    case CSSPropertyMarginRight:
+    case CSSPropertyMarginTop:
+    case CSSPropertyMarginBlockEnd:
+    case CSSPropertyMarginBlockStart:
+    case CSSPropertyMarginInlineEnd:
+    case CSSPropertyMarginInlineStart:
+    case CSSPropertyOpacity:
+    case CSSPropertyPaddingTop:
+    case CSSPropertyPaddingRight:
+    case CSSPropertyPaddingBottom:
+    case CSSPropertyPaddingLeft:
+    case CSSPropertyTextDecorationStyle:
+    case CSSPropertyTextDecorationColor:
+    case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextDecorationSkipInk:
+    case CSSPropertyTextDecorationThickness:
+    case CSSPropertyTextJustify:
+    case CSSPropertyTextShadow:
+    case CSSPropertyTextTransform:
+    case CSSPropertyTextUnderlinePosition:
+    case CSSPropertyTextUnderlineOffset:
+    case CSSPropertyVerticalAlign:
+    case CSSPropertyVisibility:
+    case CSSPropertyWebkitBorderHorizontalSpacing:
+    case CSSPropertyWebkitBorderVerticalSpacing:
+    case CSSPropertyWebkitFontSmoothing:
+    case CSSPropertyWebkitInitialLetter:
+    case CSSPropertyWebkitLineBoxContain:
+    case CSSPropertyWordSpacing:
+    case CSSPropertyAnimationComposition:
+    case CSSPropertyAnimationDelay:
+    case CSSPropertyAnimationDirection:
+    case CSSPropertyAnimationDuration:
+    case CSSPropertyAnimationFillMode:
+    case CSSPropertyAnimationIterationCount:
+    case CSSPropertyAnimationName:
+    case CSSPropertyAnimationPlayState:
+    case CSSPropertyAnimationRangeEnd:
+    case CSSPropertyAnimationRangeStart:
+    case CSSPropertyAnimationTimeline:
+    case CSSPropertyAnimationTimingFunction:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+// https://drafts.csswg.org/css-pseudo/#first-line-styling
+bool isValidFirstLineStyleProperty(CSSPropertyID id)
+{
+    switch (id) {
+    case CSSPropertyBackgroundAttachment:
+    case CSSPropertyBackgroundBlendMode:
+    case CSSPropertyBackgroundClip:
+    case CSSPropertyBackgroundColor:
+    case CSSPropertyBackgroundImage:
+    case CSSPropertyBackgroundOrigin:
+    case CSSPropertyBackgroundPosition:
+    case CSSPropertyBackgroundPositionX:
+    case CSSPropertyBackgroundPositionY:
+    case CSSPropertyBackgroundRepeat:
+    case CSSPropertyBackgroundSize:
+    case CSSPropertyBoxShadow:
+    case CSSPropertyColor:
+    case CSSPropertyCustom:
+    case CSSPropertyFontFamily:
+    case CSSPropertyFontFeatureSettings:
+    case CSSPropertyFontKerning:
+    case CSSPropertyFontSize:
+    case CSSPropertyFontSizeAdjust:
+    case CSSPropertyFontPalette:
+    case CSSPropertyFontStyle:
+    case CSSPropertyFontSynthesis:
+    case CSSPropertyFontSynthesisWeight:
+    case CSSPropertyFontSynthesisStyle:
+    case CSSPropertyFontSynthesisSmallCaps:
+    case CSSPropertyFontVariantAlternates:
+    case CSSPropertyFontVariantCaps:
+    case CSSPropertyFontVariantEastAsian:
+    case CSSPropertyFontVariantLigatures:
+    case CSSPropertyFontVariantNumeric:
+    case CSSPropertyFontVariantEmoji:
+    case CSSPropertyFontVariantPosition:
+    case CSSPropertyFontWeight:
+#if ENABLE(VARIATION_FONTS)
+    case CSSPropertyFontOpticalSizing:
+    case CSSPropertyFontVariationSettings:
+#endif
+    case CSSPropertyLetterSpacing:
+    case CSSPropertyLineHeight:
+    case CSSPropertyOpacity:
+    case CSSPropertyRubyPosition:
+    case CSSPropertyTextDecorationStyle:
+    case CSSPropertyTextDecorationColor:
+    case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextDecorationSkipInk:
+    case CSSPropertyTextDecorationThickness:
+    case CSSPropertyTextJustify:
+    case CSSPropertyTextShadow:
+    case CSSPropertyTextTransform:
+    case CSSPropertyTextUnderlinePosition:
+    case CSSPropertyTextUnderlineOffset:
+    case CSSPropertyVerticalAlign:
+    case CSSPropertyVisibility:
+    case CSSPropertyWebkitFontSmoothing:
+    case CSSPropertyWordSpacing:
+    case CSSPropertyAnimationComposition:
+    case CSSPropertyAnimationDelay:
+    case CSSPropertyAnimationDirection:
+    case CSSPropertyAnimationDuration:
+    case CSSPropertyAnimationFillMode:
+    case CSSPropertyAnimationIterationCount:
+    case CSSPropertyAnimationName:
+    case CSSPropertyAnimationPlayState:
+    case CSSPropertyAnimationRangeEnd:
+    case CSSPropertyAnimationRangeStart:
+    case CSSPropertyAnimationTimeline:
+    case CSSPropertyAnimationTimingFunction:
         return true;
     default:
         break;

--- a/Source/WebCore/style/PropertyAllowlist.h
+++ b/Source/WebCore/style/PropertyAllowlist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,8 @@ namespace Style {
 enum class PropertyAllowlist : uint8_t {
     None,
     Marker,
+    FirstLetter,
+    FirstLine,
 #if ENABLE(VIDEO)
     Cue,
     CueSelector,
@@ -45,6 +47,8 @@ enum class PropertyAllowlist : uint8_t {
 PropertyAllowlist NODELETE propertyAllowlistForPseudoElement(PseudoElementType);
 
 bool NODELETE isValidMarkerStyleProperty(CSSPropertyID);
+bool NODELETE isValidFirstLetterStyleProperty(CSSPropertyID);
+bool NODELETE isValidFirstLineStyleProperty(CSSPropertyID);
 #if ENABLE(VIDEO)
 bool NODELETE isValidCueStyleProperty(CSSPropertyID);
 bool NODELETE isValidCueSelectorStyleProperty(CSSPropertyID);

--- a/Source/WebCore/style/PropertyAllowlist.h
+++ b/Source/WebCore/style/PropertyAllowlist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,12 +41,16 @@ enum class PropertyAllowlist : uint8_t {
     CueBackground,
 #endif
     Highlight,
+    FirstLetter,
+    FirstLine
 };
 
 PropertyAllowlist NODELETE propertyAllowlistForPseudoElement(PseudoElementType);
 
 bool NODELETE isValidHighlightStyleProperty(CSSPropertyID);
 bool NODELETE isValidMarkerStyleProperty(CSSPropertyID);
+bool NODELETE isValidFirstLetterStyleProperty(CSSPropertyID);
+bool NODELETE isValidFirstLineStyleProperty(CSSPropertyID);
 #if ENABLE(VIDEO)
 bool NODELETE isValidCueStyleProperty(CSSPropertyID);
 bool NODELETE isValidCueSelectorStyleProperty(CSSPropertyID);

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -291,6 +291,12 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
                 return false;
 #endif
             if (propertyAllowlist == PropertyAllowlist::Marker && !isValidMarkerStyleProperty(propertyID))
+                return false;
+
+            if (propertyAllowlist == PropertyAllowlist::FirstLetter && !isValidFirstLetterStyleProperty(propertyID))
+                return false;
+
+            if (propertyAllowlist == PropertyAllowlist::FirstLine && !isValidFirstLineStyleProperty(propertyID))
                 return false;
 
             if (m_includedProperties.types.containsAll(normalPropertyTypes()))

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -303,6 +303,12 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
             if (propertyAllowlist == PropertyAllowlist::Marker && !isValidMarkerStyleProperty(propertyID))
                 return false;
             if (propertyAllowlist == PropertyAllowlist::Highlight && !isValidHighlightStyleProperty(propertyID))
+                return false;
+
+            if (propertyAllowlist == PropertyAllowlist::FirstLetter && !isValidFirstLetterStyleProperty(propertyID))
+                return false;
+
+            if (propertyAllowlist == PropertyAllowlist::FirstLine && !isValidFirstLineStyleProperty(propertyID))
                 return false;
 
             if (m_includedProperties.types.containsAll(normalPropertyTypes()))

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -101,6 +101,12 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector& se
 #endif
         if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Marker)
             return propertyAllowlistForPseudoElement(PseudoElementType::Marker);
+
+        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::FirstLetter)
+            return propertyAllowlistForPseudoElement(PseudoElementType::FirstLetter);
+
+        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::FirstLine)
+            return propertyAllowlistForPseudoElement(PseudoElementType::FirstLine);
 
         if (const auto* selectorList = selector.selectorList()) {
             for (auto& subSelector : *selectorList) {

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -98,6 +98,10 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector& se
                 return PropertyAllowlist::Highlight;
             case CSSSelector::PseudoElement::Marker:
                 return PropertyAllowlist::Marker;
+            case CSSSelector::PseudoElement::FirstLetter:
+                return PropertyAllowlist::FirstLetter;
+            case CSSSelector::PseudoElement::FirstLine:
+                return PropertyAllowlist::FirstLine;
 #if ENABLE(VIDEO)
             case CSSSelector::PseudoElement::UserAgentPart:
                 if (component->value() == UserAgentParts::cue())

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -81,7 +81,7 @@ private:
     unsigned m_matchBasedOnRuleHash : 3;
     unsigned m_canMatchPseudoElement : 1;
     unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
-    unsigned m_propertyAllowlist : 2;
+    unsigned m_propertyAllowlist : 3;
     unsigned m_isStartingStyle : 1;
     unsigned m_isEnabled : 1;
     // If we have more rules than 2^bitcount here we'll get confused about rule order.

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -117,6 +117,18 @@ const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement
         if (auto* element = renderer.element())
             return fromElement(*element);
         break;
+    case PseudoElementType::FirstLetter:
+    case PseudoElementType::FirstLine: {
+        // ::first-letter and ::first-line are typographic (non-tree-abiding) pseudo-elements
+        // realized as anonymous renderers with no element of their own. Walk up to the
+        // originating block (the one carrying the pseudo style) to recover the Styleable
+        // that owns any animations targeting the pseudo-element.
+        for (CheckedPtr ancestor = renderer.parent(); ancestor; ancestor = ancestor->parent()) {
+            if (RefPtr element = ancestor->element(); element && ancestor->style().hasPseudoStyle(*pseudoElementType))
+                return Styleable(*element, Style::PseudoElementIdentifier { *pseudoElementType });
+        }
+        break;
+    }
     default:
         return std::nullopt;
     }


### PR DESCRIPTION
#### 3fc010e5f16155877dee64739b8cc313ee02130c
<pre>
[css-pseudo] ::first-letter and ::first-line should reject some properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=245523">https://bugs.webkit.org/show_bug.cgi?id=245523</a>
<a href="https://rdar.apple.com/100561733">rdar://100561733</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Web Specification [1] &amp; [2]:

[1] <a href="https://drafts.csswg.org/css-pseudo/#first-line-styling">https://drafts.csswg.org/css-pseudo/#first-line-styling</a>
[2] <a href="https://drafts.csswg.org/css-pseudo/#first-letter-styling">https://drafts.csswg.org/css-pseudo/#first-letter-styling</a>

This patch updates our allowlist for properties, which can be applied to
first-letter and and first-line pseudo-elements similar to others.

While updating, we also make both pseudo elements (non-tree abiding) to
have animations (based on CSSWG Issue Resolution [3]).

[3] <a href="https://github.com/w3c/csswg-drafts/issues/12814#issuecomment-4040525212">https://github.com/w3c/csswg-drafts/issues/12814#issuecomment-4040525212</a>

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::isPropertyValidForPseudoElement):
(WebCore::KeyframeEffect::isCurrentlyAffectingProperty const):
(WebCore::KeyframeEffect::computeAcceleratedPropertiesState):
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::propertyAllowlistForPseudoElement):
(WebCore::Style::isValidFirstLetterStyleProperty):
(WebCore::Style::isValidFirstLineStyleProperty):
* Source/WebCore/style/PropertyAllowlist.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-first-letter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-first-line-expected.txt:

&gt; New &amp; Updated Tests:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-animate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-animate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-animate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-animate.html: Added.

&gt; Rebaseline:
* LayoutTests/inspector/layers/layers-anonymous.html: `transform` is now rejected on first-letter,
so updated it to use opacity + animation.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fc010e5f16155877dee64739b8cc313ee02130c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124894 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85f6b3b9-4e18-492f-b8ec-ef82597046e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130062 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91582 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17ccea2d-3e2c-4bc3-b78d-5219576347fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110579 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dd67373-2b73-484a-8e95-5d515bd93a93) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30145 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25000 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141428 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178803 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138447 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138339 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41470 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149724 "Exiting early after 10 failures. 615 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104451 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33587 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26599 "Exiting early after 10 failures. 70 tests run. 1 failures") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39371 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4697 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39621 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->