### PR TITLE
[JSC] WASM IPInt SIMD: implement replace lane, load lane, store lane, and load zero-pad instructions

### DIFF
--- a/JSTests/wasm/stress/simd-instructions-construct.js
+++ b/JSTests/wasm/stress/simd-instructions-construct.js
@@ -174,6 +174,67 @@ const constructTests = [
         [0xF0, 0xE1, 0xD2, 0xC3, 0xB4, 0xA5, 0x96, 0x87, 0x78, 0x69, 0x5A, 0x4B, 0x3C, 0x2D, 0x1E, 0x0F], // data vector
         [0x00, 0x00, 0x01, 0x01, 0x02, 0x02, 0x03, 0x03, 0x04, 0x04, 0x05, 0x05, 0x06, 0x06, 0x07, 0x07], // index vector (duplicates)
         [0xF0, 0xF0, 0xE1, 0xE1, 0xD2, 0xD2, 0xC3, 0xC3, 0xB4, 0xB4, 0xA5, 0xA5, 0x96, 0x96, 0x87, 0x87]  // expected (duplicated values)
+    ],
+
+    // i8x16.replace_lane - replace a single 8-bit lane in a vector
+    [
+        "i8x16.replace_lane",
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F], // input vector
+        0xFF, // replacement value
+        7,    // lane index
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0xFF, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F]  // expected (lane 7 replaced)
+    ],
+    [
+        "i8x16.replace_lane",
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F], // input vector
+        0x80, // replacement value
+        15,   // lane index
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x80]  // expected (lane 15 replaced)
+    ],
+
+    // i16x8.replace_lane - replace a single 16-bit lane in a vector
+    [
+        "i16x8.replace_lane",
+        [0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007], // input vector
+        0xFFFF, // replacement value
+        3,      // lane index
+        [0x0000, 0x0001, 0x0002, 0xFFFF, 0x0004, 0x0005, 0x0006, 0x0007]  // expected (lane 3 replaced)
+    ],
+
+    // i32x4.replace_lane - replace a single 32-bit lane in a vector
+    [
+        "i32x4.replace_lane",
+        [0x00000000, 0x11111111, 0x22222222, 0x33333333], // input vector
+        0xFFFFFFFF, // replacement value
+        1,          // lane index
+        [0x00000000, 0xFFFFFFFF, 0x22222222, 0x33333333]  // expected (lane 1 replaced)
+    ],
+
+    // i64x2.replace_lane - replace a single 64-bit lane in a vector
+    [
+        "i64x2.replace_lane",
+        [0x0000000000000000n, 0x1111111111111111n], // input vector
+        0xFFFFFFFFFFFFFFFFn, // replacement value
+        0,                   // lane index
+        [0xFFFFFFFFFFFFFFFFn, 0x1111111111111111n]  // expected (lane 0 replaced)
+    ],
+
+    // f32x4.replace_lane - replace a single 32-bit float lane in a vector
+    [
+        "f32x4.replace_lane",
+        [0.0, 1.0, 2.0, 3.0], // input vector
+        2.5, // replacement value
+        2,   // lane index
+        [0.0, 1.0, 2.5, 3.0]  // expected (lane 2 replaced)
+    ],
+
+    // f64x2.replace_lane - replace a single 64-bit float lane in a vector
+    [
+        "f64x2.replace_lane",
+        [0.0, 1.0], // input vector
+        2.718281828459045, // replacement value (e)
+        1,                 // lane index
+        [0.0, 2.718281828459045]  // expected (lane 1 replaced)
     ]
 ];
 

--- a/JSTests/wasm/stress/simd-instructions-lib.js
+++ b/JSTests/wasm/stress/simd-instructions-lib.js
@@ -98,7 +98,7 @@ function scalarToWasmText(val, instruction) {
 export async function runSIMDTests(testData, verbose = false, testType = "SIMD") {
 
     const numInputs = instruction =>
-        ['.bitselect', '.shuffle'].some(pattern => instruction.includes(pattern)) ? 3 :
+        ['.bitselect', '.shuffle', '.replace_lane'].some(pattern => instruction.includes(pattern)) ? 3 :
         ['.abs', '.neg', '.sqrt', '.not', '.any_true', '.popcnt', '.all_true', '.bitmask', '.splat'].some(pattern => instruction.includes(pattern)) ? 1 : 2;
 
     const returnsI32 = instruction => ['.any_true', '.all_true', '.bitmask'].some(pattern => instruction.includes(pattern));
@@ -142,6 +142,11 @@ export async function runSIMDTests(testData, verbose = false, testType = "SIMD")
                 // For shuffle, arg2 contains the 16 immediate indices that come right after instruction name
                 const indices = arg2.join(' ');
                 wat += `            (${instruction} ${indices} ${input0Str} ${input1Str})`;
+            } else if (instruction.includes('.replace_lane')) {
+                // For replace_lane, arg2 is the lane index (immediate), arg1 is the replacement value
+                const laneIndex = arg2;
+                const replacementStr = scalarToWasmText(arg1, instruction);
+                wat += `            (${instruction} ${laneIndex} ${input0Str} ${replacementStr})`;
             } else {
                 // For other 3-arg instructions like bitselect
                 const input2Str = Array.isArray(arg2) ? arrayToV128Const(arg2, instruction) : arg2;

--- a/JSTests/wasm/stress/simd-instructions-load-store.js
+++ b/JSTests/wasm/stress/simd-instructions-load-store.js
@@ -78,6 +78,60 @@ let wat = `
         (v128.store (local.get $dst)
             (v128.load64_splat (local.get $src)))
     )
+
+    (func (export "test_v128_load8_lane") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load8_lane offset=16 5 (local.get $src)
+                (v128.const i8x16 0x11 0x22 0x33 0x44 0x55 0x66 0x77 0x88 0x99 0xAA 0xBB 0xCC 0xDD 0xEE 0xFF 0x10)))
+    )
+
+    (func (export "test_v128_load16_lane") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load16_lane offset=1024 3 (local.get $src)
+                (v128.const i16x8 0x1000 0x1111 0x2222 0x3333 0x4444 0x5555 0x6666 0x7777)))
+    )
+
+    (func (export "test_v128_load32_lane") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load32_lane offset=32768 2 (local.get $src)
+                (v128.const i32x4 0x10000000 0x11111111 0x22222222 0x33333333)))
+    )
+
+    (func (export "test_v128_load64_lane") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load64_lane offset=8 1 (local.get $src)
+                (v128.const i64x2 0x1000000000000000 0x1111111111111111)))
+    )
+
+    (func (export "test_v128_store8_lane") (param $addr i32)
+        (v128.store8_lane offset=16 5 (local.get $addr)
+            (v128.const i8x16 0x11 0x22 0x33 0x44 0x55 0xAB 0x77 0x88 0x99 0xAA 0xBB 0xCC 0xDD 0xEE 0xFF 0x10))
+    )
+
+    (func (export "test_v128_store16_lane") (param $addr i32)
+        (v128.store16_lane offset=1024 3 (local.get $addr)
+            (v128.const i16x8 0x1000 0x1111 0x2222 0xABCD 0x4444 0x5555 0x6666 0x7777))
+    )
+
+    (func (export "test_v128_store32_lane") (param $addr i32)
+        (v128.store32_lane offset=32768 2 (local.get $addr)
+            (v128.const i32x4 0x10000000 0x11111111 0xABCDEF12 0x33333333))
+    )
+
+    (func (export "test_v128_store64_lane") (param $addr i32)
+        (v128.store64_lane offset=8 1 (local.get $addr)
+            (v128.const i64x2 0x1000000000000000 0xABCDEF1234567890))
+    )
+
+    (func (export "test_v128_load32_zero") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load32_zero offset=2048 (local.get $src)))
+    )
+
+    (func (export "test_v128_load64_zero") (param $src i32) (param $dst i32)
+        (v128.store (local.get $dst)
+            (v128.load64_zero offset=4096 (local.get $src)))
+    )
 )
 `
 
@@ -340,6 +394,212 @@ async function test_load_splat() {
         print("Load splat tests passed!")
 }
 
+async function test_load_lane() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const memory = instance.exports.memory
+    const buffer = memory.buffer
+    const u8 = new Uint8Array(buffer)
+    const u16 = new Uint16Array(buffer)
+    const u32 = new Uint32Array(buffer)
+    const u64 = new BigUint64Array(buffer)
+
+    const {
+        test_v128_load8_lane,
+        test_v128_load16_lane,
+        test_v128_load32_lane,
+        test_v128_load64_lane
+    } = instance.exports
+
+    function clearMemory() {
+        u8.fill(0)
+    }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // Test v128.load8_lane - load 8-bit value and replace specific lane (offset=16)
+        clearMemory()
+        u8[42 + 16] = 0xAB 
+        test_v128_load8_lane(42, 896)
+
+        // Verify the result: lane 5 should be 0xAB, others should be from the constant vector
+        const expectedBytes = [0x11, 0x22, 0x33, 0x44, 0x55, 0xAB, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x10]
+        for (let j = 0; j < 16; j++) {
+            assert.eq(u8[896 + j], expectedBytes[j])
+        }
+
+        // Test v128.load16_lane - load 16-bit value and replace specific lane (offset=1024)
+        clearMemory()
+        u16[(42 + 1024) / 2] = 0xABCD
+        test_v128_load16_lane(42, 960)
+
+        // Verify the result: lane 3 should be 0xABCD, others should be from the constant vector
+        const expectedWords = [0x1000, 0x1111, 0x2222, 0xABCD, 0x4444, 0x5555, 0x6666, 0x7777]
+        for (let j = 0; j < 8; j++) {
+            assert.eq(u16[960 / 2 + j], expectedWords[j])
+        }
+
+        // Test v128.load32_lane - load 32-bit value and replace specific lane (offset=32768)
+        clearMemory()
+        u32[(44 + 32768) / 4] = 0xABCDEF12
+        test_v128_load32_lane(44, 1024)
+
+        // Verify the result: lane 2 should be 0xABCDEF12, others should be from the constant vector
+        const expectedDwords = [0x10000000, 0x11111111, 0xABCDEF12, 0x33333333]
+        for (let j = 0; j < 4; j++) {
+            assert.eq(u32[1024 / 4 + j], expectedDwords[j])
+        }
+
+        // Test v128.load64_lane - load 64-bit value and replace specific lane (offset=8)
+        clearMemory()
+        u64[(48 + 8) / 8] = 0xABCDEF1234567890n
+        test_v128_load64_lane(48, 1088)
+
+        // Verify the result: lane 1 should be 0xABCDEF1234567890n, lane 0 should be from the constant vector
+        assert.eq(u64[1088 / 8], 0x1000000000000000n)
+        assert.eq(u64[1088 / 8 + 1], 0xABCDEF1234567890n)
+    }
+    if (verbose)
+        print("Load lane tests passed!")
+}
+
+async function test_store_lane() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const memory = instance.exports.memory
+    const buffer = memory.buffer
+    const u8 = new Uint8Array(buffer)
+    const u16 = new Uint16Array(buffer)
+    const u32 = new Uint32Array(buffer)
+    const u64 = new BigUint64Array(buffer)
+
+    const {
+        test_v128_store8_lane,
+        test_v128_store16_lane,
+        test_v128_store32_lane,
+        test_v128_store64_lane
+    } = instance.exports
+
+    function clearMemory() {
+        u8.fill(0)
+    }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // Test v128.store8_lane - store lane 5 (0xAB) to memory with offset 16
+        clearMemory()
+        test_v128_store8_lane(42)  // Store to address 42 + offset 16 = 58
+        
+        // Verify only the target byte was written
+        assert.eq(u8[58], 0xAB)
+        // Verify surrounding bytes are still zero
+        assert.eq(u8[57], 0)
+        assert.eq(u8[59], 0)
+
+        // Test v128.store16_lane - store lane 3 (0xABCD) to memory with offset 1024
+        clearMemory()
+        test_v128_store16_lane(44)  // Store to address 44 + offset 1024 = 1068
+        
+        // Verify the 16-bit value was written correctly
+        assert.eq(u16[534], 0xABCD)  // 1068 / 2 = 534
+        // Verify surrounding words are still zero
+        assert.eq(u16[533], 0)
+        assert.eq(u16[535], 0)
+
+        // Test v128.store32_lane - store lane 2 (0xABCDEF12) to memory with offset 32768
+        clearMemory()
+        test_v128_store32_lane(48)  // Store to address 48 + offset 32768 = 32816 (4-byte aligned)
+        
+        // Verify the 32-bit value was written correctly
+        assert.eq(u32[8204], 0xABCDEF12)  // 32816 / 4 = 8204
+        // Verify surrounding dwords are still zero
+        assert.eq(u32[8203], 0)
+        assert.eq(u32[8205], 0)
+
+        // Test v128.store64_lane - store lane 1 (0xABCDEF1234567890) to memory with offset 8
+        clearMemory()
+        test_v128_store64_lane(48)  // Store to address 48 + offset 8 = 56
+        
+        // Verify the 64-bit value was written correctly
+        assert.eq(u64[7], 0xABCDEF1234567890n)  // 56 / 8 = 7
+        // Verify surrounding qwords are still zero
+        assert.eq(u64[6], 0n)
+        assert.eq(u64[8], 0n)
+
+        // Test edge cases - store at different memory locations
+        clearMemory()
+        test_v128_store8_lane(0)    // Store to address 0 + offset 16 = 16
+        test_v128_store16_lane(0)   // Store to address 0 + offset 1024 = 1024
+        test_v128_store32_lane(0)   // Store to address 0 + offset 32768 = 32768
+        test_v128_store64_lane(0)   // Store to address 0 + offset 8 = 8
+
+        // Verify all values were stored correctly
+        assert.eq(u8[16], 0xAB)
+        assert.eq(u16[512], 0xABCD)     // 1024 / 2 = 512
+        assert.eq(u32[8192], 0xABCDEF12) // 32768 / 4 = 8192
+        assert.eq(u64[1], 0xABCDEF1234567890n) // 8 / 8 = 1
+    }
+    if (verbose)
+        print("Store lane tests passed!")
+}
+
+async function test_load_zero() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const memory = instance.exports.memory
+    const buffer = memory.buffer
+    const u8 = new Uint8Array(buffer)
+    const u32 = new Uint32Array(buffer)
+    const u64 = new BigUint64Array(buffer)
+
+    const {
+        test_v128_load32_zero,
+        test_v128_load64_zero
+    } = instance.exports
+
+    const scribble_byte = 0xDE
+
+    // To verify that the high bits of the dst are zeroed, scribble the memory
+    function scribbleMemory() {
+        u8.fill(scribble_byte)
+    }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // Test v128.load32_zero - load 32-bit value into lane 0, zero-pad remaining lanes (offset=2048)
+        scribbleMemory()
+        u32[(1024 + 2048) / 4] = 0xABCDEF12;
+        test_v128_load32_zero(1024, 1152);
+
+        // Verify the result: lane 0 should be 0xABCDEF12, remaining lanes should be zero
+        assert.eq(u32[(1152 / 4) + 0], 0xABCDEF12)
+        assert.eq(u32[(1152 / 4) + 1], 0)
+        assert.eq(u32[(1152 / 4) + 2], 0)
+        assert.eq(u32[(1152 / 4) + 3], 0)
+
+        // Test v128.load64_zero - load 64-bit value into lane 0, zero-pad remaining lanes (offset=4096)
+        scribbleMemory()
+        u64[(48 + 4096) / 8] = 0xABCDEF1234567890n
+        test_v128_load64_zero(48, 1216)
+
+        // Verify the result: lane 0 should be 0xABCDEF1234567890n, lane 1 should be zero
+        assert.eq(u64[1216 / 8], 0xABCDEF1234567890n)
+        assert.eq(u64[(1216 / 8) + 1], 0n)
+
+        scribbleMemory()
+        u32[(0 + 2048) / 4] = 0x12345678
+        u64[(0 + 4096) / 8] = 0x123456789ABCDEF0n
+        
+        test_v128_load32_zero(0, 1280)
+        test_v128_load64_zero(0, 1344)
+
+        // Verify results
+        assert.eq(u32[(1280 / 4) + 0], 0x12345678)
+        assert.eq(u32[(1280 / 4) + 1], 0)
+        assert.eq(u32[(1280 / 4) + 2], 0)
+        assert.eq(u32[(1280 / 4) + 3], 0)
+        
+        assert.eq(u64[(1344 / 8) + 0], 0x123456789ABCDEF0n)
+        assert.eq(u64[(1344 / 8) + 1], 0n)
+    }
+    if (verbose)
+        print("Load zero tests passed!")
+}
+
 async function test_bounds_checking() {
     const instance = await instantiate(wat, {}, { simd: true })
     const memory = instance.exports.memory
@@ -354,7 +614,17 @@ async function test_bounds_checking() {
         test_v128_load8_splat,
         test_v128_load16_splat,
         test_v128_load32_splat,
-        test_v128_load64_splat
+        test_v128_load64_splat,
+        test_v128_load8_lane,
+        test_v128_load16_lane,
+        test_v128_load32_lane,
+        test_v128_load64_lane,
+        test_v128_store8_lane,
+        test_v128_store16_lane,
+        test_v128_store32_lane,
+        test_v128_store64_lane,
+        test_v128_load32_zero,
+        test_v128_load64_zero
     } = instance.exports
 
     for (let i = 0; i < wasmTestLoopCount; ++i) {
@@ -414,6 +684,79 @@ async function test_bounds_checking() {
             if (e.message.includes("should have thrown")) throw e
         }
 
+        // Test load lane bounds checking (accounting for offsets)
+        try {
+            test_v128_load8_lane(memorySize - 16, 0)  // offset=16, so tries to read at memorySize
+            throw new Error("v128.load8_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load16_lane(memorySize - 1025, 0)  // offset=1024, so tries to read 2 bytes at memorySize-1
+            throw new Error("v128.load16_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load32_lane(memorySize - 32771, 0)  // offset=32768, so tries to read 4 bytes at memorySize-3
+            throw new Error("v128.load32_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load64_lane(memorySize - 15, 0)  // offset=8, so tries to read 8 bytes at memorySize-7
+            throw new Error("v128.load64_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        // Test store lane bounds checking (accounting for offsets)
+        try {
+            test_v128_store8_lane(memorySize - 16)  // offset=16, so tries to write at memorySize
+            throw new Error("v128.store8_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_store16_lane(memorySize - 1025)  // offset=1024, so tries to write 2 bytes at memorySize-1
+            throw new Error("v128.store16_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_store32_lane(memorySize - 32771)  // offset=32768, so tries to write 4 bytes at memorySize-3
+            throw new Error("v128.store32_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_store64_lane(memorySize - 15)  // offset=8, so tries to write 8 bytes at memorySize-7
+            throw new Error("v128.store64_lane should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        // Test load and zero-pad bounds checking
+        try {
+            test_v128_load32_zero(memorySize - 2051, 0)  // offset=2048, so tries to read 4 bytes at memorySize-3
+            throw new Error("v128.load32_zero should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
+        try {
+            test_v128_load64_zero(memorySize - 4103, 0)  // offset=4096, so tries to read 8 bytes at memorySize-7
+            throw new Error("v128.load64_zero should have thrown on out-of-bounds access")
+        } catch (e) {
+            if (e.message.includes("should have thrown")) throw e
+        }
+
         // Test valid boundary cases (should succeed)
         test_v128_load16x4_s(memorySize - 8, 0)   // Exactly at boundary: reads 8 bytes
         test_v128_load16x4_u(memorySize - 8, 16)  // Exactly at boundary: reads 8 bytes
@@ -423,6 +766,24 @@ async function test_bounds_checking() {
         test_v128_load16_splat(memorySize - 2, 80) // Exactly at boundary: reads 2 bytes
         test_v128_load32_splat(memorySize - 4, 96) // Exactly at boundary: reads 4 bytes
         test_v128_load64_splat(memorySize - 8, 112) // Exactly at boundary: reads 8 bytes
+        
+        // Test valid boundary cases for load lane instructions (should succeed)
+        // Note: These functions have offsets, so we need to account for them
+        test_v128_load8_lane(memorySize - 17, 128)  // offset=16, so reads at memorySize-1
+        test_v128_load16_lane(memorySize - 1026, 144) // offset=1024, so reads at memorySize-2
+        test_v128_load32_lane(memorySize - 32772, 160) // offset=32768, so reads at memorySize-4
+        test_v128_load64_lane(memorySize - 16, 176) // offset=8, so reads at memorySize-8
+
+        // Test valid boundary cases for load and zero-pad instructions (should succeed)
+        test_v128_load32_zero(memorySize - 2052, 192) // offset=2048, so reads at memorySize-4
+        test_v128_load64_zero(memorySize - 4104, 208) // offset=4096, so reads at memorySize-8
+
+        // Test valid boundary cases for store lane instructions (should succeed)
+        // Note: These functions have offsets, so we need to account for them
+        test_v128_store8_lane(memorySize - 17)   // offset=16, so writes at memorySize-1
+        test_v128_store16_lane(memorySize - 1026) // offset=1024, so writes at memorySize-2
+        test_v128_store32_lane(memorySize - 32772) // offset=32768, so writes at memorySize-4
+        test_v128_store64_lane(memorySize - 16)  // offset=8, so writes at memorySize-8
     }
     if (verbose)
         print("Bounds checking tests passed!")
@@ -430,5 +791,8 @@ async function test_bounds_checking() {
 
 await assert.asyncTest(test_store())
 await assert.asyncTest(test_load_extend())
+await assert.asyncTest(test_load_lane())
+await assert.asyncTest(test_store_lane())
 await assert.asyncTest(test_load_splat())
+await assert.asyncTest(test_load_zero())
 await assert.asyncTest(test_bounds_checking())

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -716,15 +716,29 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperat
     return addSIMDLoad(pointer, offset, result);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&) IPINT_UNIMPLEMENTED
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) IPINT_UNIMPLEMENTED
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&)
+{
+    changeStackSize(-1);
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t)
+{
+    changeStackSize(-2);
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
 {
     return addSIMDLoad(pointer, offset, result);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) IPINT_UNIMPLEMENTED
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+{
+    return addSIMDLoad(pointer, offset, result);
+}
 
 IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 {
@@ -737,7 +751,11 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addExtractLane(SIMDInfo, uint8_
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) IPINT_UNIMPLEMENTED
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
+{
+    changeStackSize(-1);
+    return { };
+}
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {


### PR DESCRIPTION
#### a0ae7f1229e81835f333992abdaa4ff90f1109d8
<pre>
[JSC] WASM IPInt SIMD: implement replace lane, load lane, store lane, and load zero-pad instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=298666">https://bugs.webkit.org/show_bug.cgi?id=298666</a>
<a href="https://rdar.apple.com/160296848">rdar://160296848</a>

Reviewed by Yusuke Suzuki.

Implement WASM SIMD instructions for replace lane, load lane, store lane,
and load zero-pad in IPInt. These are all implemented architecture independent
in offlineasm.

Add isolated instruction tests for each.

Canonical link: <a href="https://commits.webkit.org/299816@main">https://commits.webkit.org/299816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e65b39b43cd7ddb4818afe0aac9715efeac7da52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72350 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91346 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60637 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71897 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25933 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70262 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112403 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129531 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118793 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99804 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43830 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19109 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52765 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147492 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46528 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37896 "Found 1 new JSC binary failure: testapi, Found 18656 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->