### PR TITLE
[iOS] VTDecompressionSession is not torn down when app is backgrounded

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -2100,6 +2100,18 @@ void MediaPlayerPrivateMediaSourceAVFObjC::applicationWillResignActive()
 {
     if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
         mediaSourcePrivate->applicationWillResignActive();
+
+    RefPtr videoRenderer = m_videoRenderer;
+    if (!videoRenderer || !videoRenderer->isUsingDecompressionSession())
+        return;
+
+    if (!paused()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Playing; not invalidating VideoMediaSampleRenderer Decompression Session");
+        return;
+    }
+
+    videoRenderer->invalidateDecompressionSession();
+    ALWAYS_LOG(LOGIDENTIFIER, "Paused; invalidating VideoMediaSampleRenderer Decompression Session");
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::applicationDidBecomeActive()

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -117,6 +117,8 @@ public:
 
     static WorkQueue& queueSingleton();
 
+    void invalidateDecompressionSession();
+
 private:
     VideoMediaSampleRenderer(WebSampleBufferVideoRendering *);
 


### PR DESCRIPTION
#### 7707a5ea4ea4deae99952e8681de55e6f2940f14
<pre>
[iOS] VTDecompressionSession is not torn down when app is backgrounded
<a href="https://rdar.apple.com/157599848">rdar://157599848</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298674">https://bugs.webkit.org/show_bug.cgi?id=298674</a>

Reviewed by Jean-Yves Avenard and Youenn Fablet.

When the MediaSourcePrefersDecompressionSession preference is enabled, a VTDecompressionSession is
created and used to decode video frames before enqueueing them for display. However this decompression
session is not torn down when the app moves to the background state, unlike the decompression session
used internally in AVSampleBufferDisplayLayer. This causes various system processes to use more memory
in this state, keeping server-side objects alive and in some cases keeping server processes themselves
from being closed.

For paused players, tear down the decompression session when moving to background; it will be silently
recreated the next time playback begins.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::applicationWillResignActive):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::invalidateDecompressionSession):

Canonical link: <a href="https://commits.webkit.org/299841@main">https://commits.webkit.org/299841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791612a879bab943a284b625014f02d9eff59159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72458 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72ced5a5-c12c-4506-a655-5ee15cfb3403) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48654 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91426 "12 flakes 57 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/390ed6ea-c61f-43ee-b7a8-150c106f7f9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71978 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6eda1639-9240-4545-ae3e-1271e9c0a586) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26026 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70370 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129639 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100045 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23369 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47166 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52871 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46634 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->