### PR TITLE
[JSC] Profile call_indirect / call_ref monomorphic target and do direct call / inlining in OMG

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1398,6 +1398,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     tools/LLVMProfiling.h
     tools/SourceProfiler.h
 
+    wasm/WasmBaselineData.h
     wasm/WasmBranchHints.h
     wasm/WasmCallSlot.h
     wasm/WasmCallee.h
@@ -1427,6 +1428,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmOpcodeOrigin.h
     wasm/WasmParser.h
     wasm/WasmPlan.h
+    wasm/WasmProfileCollection.h
     wasm/WasmSIMDOpcodes.h
     wasm/WasmSections.h
     wasm/WasmSIMDOpcodes.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1956,6 +1956,7 @@
 		E319A3EF28DA84EB00DF18C7 /* IntlDurationFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = E319A3E928DA84EB00DF18C7 /* IntlDurationFormat.h */; };
 		E319A3F128DA84EB00DF18C7 /* IntlDurationFormatPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E319A3EB28DA84EB00DF18C7 /* IntlDurationFormatPrototype.h */; };
 		E31C31322511AFD700E7A3A0 /* IntlCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E31C31302511AFD600E7A3A0 /* IntlCache.h */; };
+		E31D8F482E71227200DE481A /* WasmMergedProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = E31D8F462E71227200DE481A /* WasmMergedProfile.h */; };
 		E3201C1D1F8E82360076A032 /* JSScriptFetchParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = E38D060B1F8E814100649CF2 /* JSScriptFetchParameters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3201C1E1F8E824C0076A032 /* ScriptFetchParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = E38D060C1F8E814100649CF2 /* ScriptFetchParameters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E320B66C2912298100E87CDB /* MemoryMode.h in Headers */ = {isa = PBXBuildFile; fileRef = E320B66A2912298000E87CDB /* MemoryMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2039,10 +2040,12 @@
 		E378DC8D2727629400427B0B /* IntlNumberFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1D792F61B43864B004516F5 /* IntlNumberFormat.cpp */; };
 		E379006628F8F4E100206FD8 /* DFGValidateUnlinked.h in Headers */ = {isa = PBXBuildFile; fileRef = E379006428F8F4E100206FD8 /* DFGValidateUnlinked.h */; };
 		E3794E761B77EB97005543AE /* ModuleAnalyzer.h in Headers */ = {isa = PBXBuildFile; fileRef = E3794E741B77EB97005543AE /* ModuleAnalyzer.h */; };
+		E37986372E6FA60E008B5EA6 /* WasmProfileCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = E37986352E6FA60E008B5EA6 /* WasmProfileCollection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E379B59029834EC5007C4C0E /* SIMDShuffle.h in Headers */ = {isa = PBXBuildFile; fileRef = E379B58F29834EC5007C4C0E /* SIMDShuffle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E37F44C72A13088000E56D8D /* KeyAtomStringCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E37F44C52A13088000E56D8D /* KeyAtomStringCacheInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E37F44C82A13088000E56D8D /* KeyAtomStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E37F44C62A13088000E56D8D /* KeyAtomStringCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E383500A2390D93B0036316D /* WasmGlobal.h in Headers */ = {isa = PBXBuildFile; fileRef = E38350092390D9370036316D /* WasmGlobal.h */; };
+		E38416422E6FC06000591840 /* WasmBaselineData.h in Headers */ = {isa = PBXBuildFile; fileRef = E38416412E6FC06000591840 /* WasmBaselineData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3850B15226ED641009ABF9C /* DFGMinifiedIDInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3850B14226ED63E009ABF9C /* DFGMinifiedIDInlines.h */; };
 		E38652E3237CA0C900E1D5EE /* BlockDirectoryBits.h in Headers */ = {isa = PBXBuildFile; fileRef = E38652E2237CA0C800E1D5EE /* BlockDirectoryBits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E386FD7B26E867B800E4C28B /* TemporalPlainTimeConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7526E867B700E4C28B /* TemporalPlainTimeConstructor.h */; };
@@ -5700,6 +5703,8 @@
 		E319A3EB28DA84EB00DF18C7 /* IntlDurationFormatPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlDurationFormatPrototype.h; sourceTree = "<group>"; };
 		E31C31302511AFD600E7A3A0 /* IntlCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlCache.h; sourceTree = "<group>"; };
 		E31C31312511AFD600E7A3A0 /* IntlCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntlCache.cpp; sourceTree = "<group>"; };
+		E31D8F462E71227200DE481A /* WasmMergedProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmMergedProfile.h; sourceTree = "<group>"; };
+		E31D8F472E71227200DE481A /* WasmMergedProfile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmMergedProfile.cpp; sourceTree = "<group>"; };
 		E320B66A2912298000E87CDB /* MemoryMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryMode.h; sourceTree = "<group>"; };
 		E320B66B2912298000E87CDB /* MemoryMode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryMode.cpp; sourceTree = "<group>"; };
 		E322E5A01DA64435006E7709 /* DFGSnippetParams.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGSnippetParams.cpp; path = dfg/DFGSnippetParams.cpp; sourceTree = "<group>"; };
@@ -5815,6 +5820,8 @@
 		E379006428F8F4E100206FD8 /* DFGValidateUnlinked.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGValidateUnlinked.h; path = dfg/DFGValidateUnlinked.h; sourceTree = "<group>"; };
 		E3794E731B77EB97005543AE /* ModuleAnalyzer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModuleAnalyzer.cpp; sourceTree = "<group>"; };
 		E3794E741B77EB97005543AE /* ModuleAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModuleAnalyzer.h; sourceTree = "<group>"; };
+		E37986352E6FA60E008B5EA6 /* WasmProfileCollection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmProfileCollection.h; sourceTree = "<group>"; };
+		E37986362E6FA60E008B5EA6 /* WasmProfileCollection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmProfileCollection.cpp; sourceTree = "<group>"; };
 		E379B58F29834EC5007C4C0E /* SIMDShuffle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIMDShuffle.h; sourceTree = "<group>"; };
 		E37CFB2D22F27C57009A7B38 /* WasmCompilationMode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCompilationMode.cpp; sourceTree = "<group>"; };
 		E37F44C52A13088000E56D8D /* KeyAtomStringCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyAtomStringCacheInlines.h; sourceTree = "<group>"; };
@@ -5823,6 +5830,7 @@
 		E380D66B1F19249D00A59095 /* BuiltinNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuiltinNames.cpp; sourceTree = "<group>"; };
 		E38350082390D9370036316D /* WasmGlobal.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmGlobal.cpp; sourceTree = "<group>"; };
 		E38350092390D9370036316D /* WasmGlobal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmGlobal.h; sourceTree = "<group>"; };
+		E38416412E6FC06000591840 /* WasmBaselineData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmBaselineData.h; sourceTree = "<group>"; };
 		E3850B14226ED63E009ABF9C /* DFGMinifiedIDInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGMinifiedIDInlines.h; path = dfg/DFGMinifiedIDInlines.h; sourceTree = "<group>"; };
 		E38652E2237CA0C800E1D5EE /* BlockDirectoryBits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockDirectoryBits.h; sourceTree = "<group>"; };
 		E386FD7426E867B700E4C28B /* TemporalPlainTimeConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainTimeConstructor.cpp; sourceTree = "<group>"; };
@@ -7908,6 +7916,7 @@
 			children = (
 				AD2FCB8A1DB5840000B3E736 /* js */,
 				FED5FA3629A085BD00798A7F /* wasm.json */,
+				E38416412E6FC06000591840 /* WasmBaselineData.h */,
 				E30D06B629C6C3E80014CCE7 /* WasmBBQDisassembler.cpp */,
 				E30D06B729C6C3E80014CCE7 /* WasmBBQDisassembler.h */,
 				FED5FA3329A0859C00798A7F /* WasmBBQJIT.cpp */,
@@ -7971,6 +7980,8 @@
 				535557131D9D9EA5006D583B /* WasmMemory.h */,
 				79B759711DFA4C600052174C /* WasmMemoryInformation.cpp */,
 				79B759721DFA4C600052174C /* WasmMemoryInformation.h */,
+				E31D8F472E71227200DE481A /* WasmMergedProfile.cpp */,
+				E31D8F462E71227200DE481A /* WasmMergedProfile.h */,
 				790081361E95A8EC0052D7CD /* WasmModule.cpp */,
 				790081371E95A8EC0052D7CD /* WasmModule.h */,
 				53E777E11E92E265007CBEC4 /* WasmModuleInformation.cpp */,
@@ -7996,6 +8007,8 @@
 				53F40E8C1D5901F20099A1B6 /* WasmParser.h */,
 				531374BE1D5CE95000AF7A0B /* WasmPlan.cpp */,
 				531374BC1D5CE67600AF7A0B /* WasmPlan.h */,
+				E37986362E6FA60E008B5EA6 /* WasmProfileCollection.cpp */,
+				E37986352E6FA60E008B5EA6 /* WasmProfileCollection.h */,
 				E3A0531721342B660022EC14 /* WasmSectionParser.cpp */,
 				E3A0531821342B670022EC14 /* WasmSectionParser.h */,
 				53F40E841D58F9770099A1B6 /* WasmSections.h */,
@@ -12093,6 +12106,7 @@
 				FE6F56DE1E64EAD600D17801 /* VMTraps.h in Headers */,
 				FEF5B42C2628CBC80016E776 /* VMTrapsInlines.h in Headers */,
 				FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */,
+				E38416422E6FC06000591840 /* WasmBaselineData.h in Headers */,
 				E30D06B829C6C3EE0014CCE7 /* WasmBBQDisassembler.h in Headers */,
 				FED5FA3429A0859C00798A7F /* WasmBBQJIT.h in Headers */,
 				53CA730A1EA533D80076049D /* WasmBBQPlan.h in Headers */,
@@ -12128,6 +12142,7 @@
 				53E9E0AC1EAE83DF00FEE251 /* WasmMachineThreads.h in Headers */,
 				535557141D9D9EA5006D583B /* WasmMemory.h in Headers */,
 				79B759751DFA4C600052174C /* WasmMemoryInformation.h in Headers */,
+				E31D8F482E71227200DE481A /* WasmMergedProfile.h in Headers */,
 				790081391E95A8EC0052D7CD /* WasmModule.h in Headers */,
 				53E777E41E92E265007CBEC4 /* WasmModuleInformation.h in Headers */,
 				AD5B416F1EBAFB77008EFA43 /* WasmName.h in Headers */,
@@ -12144,6 +12159,7 @@
 				527E6CEC2772B9CB005E0782 /* WasmOSREntryPlan.h in Headers */,
 				53F40E8D1D5901F20099A1B6 /* WasmParser.h in Headers */,
 				531374BD1D5CE67600AF7A0B /* WasmPlan.h in Headers */,
+				E37986372E6FA60E008B5EA6 /* WasmProfileCollection.h in Headers */,
 				E3A0531C21342B680022EC14 /* WasmSectionParser.h in Headers */,
 				53F40E851D58F9770099A1B6 /* WasmSections.h in Headers */,
 				641DF80E2890C7D500F9895F /* WasmSIMDOpcodes.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1152,6 +1152,7 @@ wasm/WasmIPIntSlowPaths.cpp @no-unify
 wasm/WasmMachineThreads.cpp
 wasm/WasmMemory.cpp
 wasm/WasmMemoryInformation.cpp
+wasm/WasmMergedProfile.cpp
 wasm/WasmModule.cpp
 wasm/WasmModuleInformation.cpp
 wasm/WasmNameSectionParser.cpp
@@ -1160,6 +1161,7 @@ wasm/WasmOSREntryPlan.cpp
 wasm/WasmOpcodeOrigin.cpp
 wasm/WasmOperations.cpp
 wasm/WasmPlan.cpp
+wasm/WasmProfileCollection.cpp
 wasm/WasmSectionParser.cpp
 wasm/WasmTypeDefinition.cpp
 wasm/WasmOpcodeCounter.cpp

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -238,7 +238,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::getGlobal(uint32_t index, Value& result
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
 
-    int32_t offset = JSWebAssemblyInstance::offsetOfGlobalPtr(m_info.importFunctionCount(), m_info.tableCount(), index);
+    int32_t offset = JSWebAssemblyInstance::offsetOfGlobal(m_info, index);
     Value globalValue = Value::pinned(type.kind, Location::fromGlobal(offset));
 
     switch (global.bindingMode) {
@@ -308,7 +308,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::setGlobal(uint32_t index, Value value)
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
 
-    int32_t offset = JSWebAssemblyInstance::offsetOfGlobalPtr(m_info.importFunctionCount(), m_info.tableCount(), index);
+    int32_t offset = JSWebAssemblyInstance::offsetOfGlobal(m_info, index);
     Location valueLocation = locationOf(value);
 
     switch (global.bindingMode) {

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -50,9 +50,10 @@ namespace WasmBBQPlanInternal {
 static constexpr bool verbose = false;
 }
 
-BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation>&& moduleInformation, FunctionCodeIndex functionIndex, Ref<IPIntCallee>&& profiledCallee, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
+BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation>&& moduleInformation, FunctionCodeIndex functionIndex, Ref<IPIntCallee>&& profiledCallee, Ref<Module>&& module, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
     : Plan(vm, WTFMove(moduleInformation), WTFMove(completionTask))
     , m_profiledCallee(WTFMove(profiledCallee))
+    , m_module(WTFMove(module))
     , m_calleeGroup(WTFMove(calleeGroup))
     , m_functionIndex(functionIndex)
 {
@@ -175,7 +176,7 @@ std::unique_ptr<InternalFunction> BBQPlan::compileFunction(FunctionCodeIndex fun
 
     beginCompilerSignpost(callee);
     RELEASE_ASSERT(mode() == m_calleeGroup->mode());
-    parseAndCompileResult = parseAndCompileBBQ(context, m_profiledCallee.get(), callee, function, signature, unlinkedWasmToWasmCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, functionIndex);
+    parseAndCompileResult = parseAndCompileBBQ(context, m_profiledCallee.get(), callee, function, signature, unlinkedWasmToWasmCalls, m_module.get(), m_calleeGroup.get(), m_moduleInformation.get(), m_mode, functionIndex);
     endCompilerSignpost(callee);
 
     if (!parseAndCompileResult) [[unlikely]] {

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -53,9 +53,9 @@ class BBQPlan final : public Plan {
 public:
     using Base = Plan;
 
-    static Ref<BBQPlan> create(VM& vm, Ref<ModuleInformation>&& info, FunctionCodeIndex functionIndex, Ref<IPIntCallee>&& profiledCallee, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
+    static Ref<BBQPlan> create(VM& vm, Ref<ModuleInformation>&& info, FunctionCodeIndex functionIndex, Ref<IPIntCallee>&& profiledCallee, Ref<Module>&& module, Ref<CalleeGroup>&& calleeGroup, CompletionTask&& completionTask)
     {
-        return adoptRef(*new BBQPlan(vm, WTFMove(info), functionIndex, WTFMove(profiledCallee), WTFMove(calleeGroup), WTFMove(completionTask)));
+        return adoptRef(*new BBQPlan(vm, WTFMove(info), functionIndex, WTFMove(profiledCallee), WTFMove(module), WTFMove(calleeGroup), WTFMove(completionTask)));
     }
 
     bool hasWork() const final { return !m_completed; }
@@ -66,7 +66,7 @@ public:
 
 
 private:
-    BBQPlan(VM&, Ref<ModuleInformation>&&, FunctionCodeIndex functionIndex, Ref<IPIntCallee>&&, Ref<CalleeGroup>&&, CompletionTask&&);
+    BBQPlan(VM&, Ref<ModuleInformation>&&, FunctionCodeIndex functionIndex, Ref<IPIntCallee>&&, Ref<Module>&&, Ref<CalleeGroup>&&, CompletionTask&&);
 
     bool dumpDisassembly(CompilationContext&, LinkBuffer&, const TypeDefinition&, FunctionSpaceIndex functionIndexSpace);
 
@@ -81,6 +81,7 @@ private:
     void fail(String&& errorMessage, CompilationError);
 
     const Ref<IPIntCallee> m_profiledCallee;
+    const Ref<Module> m_module;
     const Ref<CalleeGroup> m_calleeGroup;
     FunctionCodeIndex m_functionIndex;
     bool m_completed { false };

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -37,6 +37,7 @@
 #include "NativeCalleeRegistry.h"
 #include "PCToCodeOriginMap.h"
 #include "VMManager.h"
+#include "WasmBaselineData.h"
 #include "WasmCallSlot.h"
 #include "WasmCallingConvention.h"
 #include "WasmModuleInformation.h"
@@ -237,7 +238,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
     , m_numLocals(generator.m_numLocals)
     , m_numArgumentsOnStack(generator.m_numArgumentsOnStack)
     , m_maxFrameSizeInV128(generator.m_maxFrameSizeInV128)
-    , m_callSlots(generator.m_numCallSlots)
+    , m_numCallSlots(generator.m_numCallSlots)
     , m_tierUpCounter(WTFMove(generator.m_tierUpCounter))
 {
     if (size_t count = generator.m_exceptionHandlers.size()) {
@@ -284,6 +285,11 @@ const RegisterAtOffsetList* IPIntCallee::calleeSaveRegistersImpl()
 {
     ASSERT(RegisterAtOffsetList::ipintCalleeSaveRegisters().registerCount() == numberOfIPIntCalleeSaveRegisters);
     return &RegisterAtOffsetList::ipintCalleeSaveRegisters();
+}
+
+bool IPIntCallee::needsProfiling() const
+{
+    return m_numCallSlots;
 }
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -57,6 +57,7 @@ class PCToOriginMap;
 
 namespace Wasm {
 
+class BaselineData;
 class CallSlot;
 class CalleeGroup;
 
@@ -441,10 +442,9 @@ public:
     unsigned localSizeToAlloc() const { return m_localSizeToAlloc; }
     unsigned rethrowSlots() const { return m_numRethrowSlotsToAlloc; }
 
-    FixedVector<CallSlot>& callSlots() { return m_callSlots; }
-    const FixedVector<CallSlot>& callSlots() const { return m_callSlots; }
+    unsigned numCallSlots() const { return m_numCallSlots; }
 
-    bool needsProfiling() const { return !m_callSlots.isEmpty(); }
+    bool needsProfiling() const;
 
     IPIntTierUpCounter& tierUpCounter() { return m_tierUpCounter; }
 
@@ -473,8 +473,7 @@ private:
     unsigned m_numLocals;
     unsigned m_numArgumentsOnStack;
     unsigned m_maxFrameSizeInV128;
-
-    FixedVector<CallSlot> m_callSlots;
+    unsigned m_numCallSlots;
 
     IPIntTierUpCounter m_tierUpCounter;
 };

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -35,6 +35,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/WasmJS.h>
 #include <JavaScriptCore/WasmMemory.h>
 #include <JavaScriptCore/WasmOps.h>
+#include <JavaScriptCore/WasmProfileCollection.h>
 #include <wtf/Expected.h>
 #include <wtf/Lock.h>
 #include <wtf/SharedTask.h>
@@ -48,7 +49,9 @@ class WebAssemblyCompileOptions;
 
 namespace Wasm {
 
+class IPIntCallee;
 class IPIntPlan;
+class MergedProfile;
 struct ModuleInformation;
 enum class BindingFailure;
 
@@ -82,6 +85,12 @@ public:
 
     CodePtr<WasmEntryPtrTag> importFunctionStub(FunctionSpaceIndex importFunctionNum) { return m_wasmToJSExitStubs[importFunctionNum].code(); }
 
+    IPIntCallees& ipintCallees() const { return m_ipintCallees.get(); }
+
+    Ref<Wasm::ProfileCollection> createProfiles();
+
+    std::unique_ptr<MergedProfile> createMergedProfile(IPIntCallee&);
+
 private:
     Ref<CalleeGroup> getOrCreateCalleeGroup(VM&, MemoryMode);
 
@@ -90,6 +99,7 @@ private:
     RefPtr<CalleeGroup> m_calleeGroups[numberOfMemoryModes];
     const Ref<IPIntCallees> m_ipintCallees;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToJSExitStubs;
+    ThreadSafeWeakHashSet<ProfileCollection> m_profiles;
     Lock m_lock;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -134,7 +134,7 @@ void OMGPlan::work()
     beginCompilerSignpost(callee.get());
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
     CompilationContext context;
-    auto parseAndCompileResult = parseAndCompileOMG(context, profiledCallee.get(), callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGMode, m_functionIndex, UINT32_MAX);
+    auto parseAndCompileResult = parseAndCompileOMG(context, profiledCallee.get(), callee.get(), function, signature, unlinkedCalls, m_module.get(), m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGMode, m_functionIndex, UINT32_MAX);
     endCompilerSignpost(callee.get());
 
     if (!parseAndCompileResult) [[unlikely]] {

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -109,7 +109,7 @@ void OSREntryPlan::work()
     beginCompilerSignpost(callee.get());
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
     CompilationContext context;
-    auto parseAndCompileResult = parseAndCompileOMG(context, profiledCallee.get(), callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGForOSREntryMode, m_functionIndex, m_loopIndex);
+    auto parseAndCompileResult = parseAndCompileOMG(context, profiledCallee.get(), callee.get(), function, signature, unlinkedCalls, m_module.get(), m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGForOSREntryMode, m_functionIndex, m_loopIndex);
     endCompilerSignpost(callee.get());
 
     if (!parseAndCompileResult) [[unlikely]] {

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1250,6 +1250,20 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe:
 
 #endif
 
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMaterializeBaselineData, void, (CallFrame* callFrame, JSWebAssemblyInstance* instance))
+{
+    BBQCallee& callee = *static_cast<BBQCallee*>(callFrame->callee().asNativeCallee());
+    ASSERT(callee.compilationMode() == CompilationMode::BBQMode);
+
+    Wasm::CalleeGroup& calleeGroup = *instance->calleeGroup();
+    ASSERT(instance->memory()->mode() == calleeGroup.mode());
+
+    FunctionSpaceIndex functionIndexInSpace = callee.index();
+    FunctionCodeIndex functionIndex = calleeGroup.toCodeIndex(functionIndexInSpace);
+    instance->ensureBaselineData(functionIndex);
+}
+#endif
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmUnwind, void*, (JSWebAssemblyInstance* instance))
 {

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -71,6 +71,9 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (CallFra
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe::Context&));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe::Context&));
 #endif
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMaterializeBaselineData, void, (CallFrame*, JSWebAssemblyInstance*));
+#endif
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmUnwind, void*, (JSWebAssemblyInstance*));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationConvertToI64, int64_t, (JSWebAssemblyInstance*, EncodedJSValue));

--- a/Source/JavaScriptCore/wasm/WasmProfileCollection.cpp
+++ b/Source/JavaScriptCore/wasm/WasmProfileCollection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,35 +23,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "WasmProfileCollection.h"
 
-#if ENABLE(WEBASSEMBLY_OMGJIT)
+#include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
-#include "B3Common.h"
-#include "B3Procedure.h"
-#include "CCallHelpers.h"
-#include "JITCompilation.h"
-#include "JITOpaqueByproducts.h"
-#include "PCToCodeOriginMap.h"
-#include "WasmBBQDisassembler.h"
-#include "WasmCompilationContext.h"
-#include "WasmCompilationMode.h"
-#include "WasmJS.h"
-#include "WasmMemory.h"
-#include "WasmModuleInformation.h"
-#include "WasmTierUpCount.h"
-#include <wtf/Box.h>
-#include <wtf/Expected.h>
-
-extern "C" void SYSV_ABI dumpProcedure(void*);
+#if ENABLE(WEBASSEMBLY)
 
 namespace JSC::Wasm {
 
-class IPIntCallee;
-class Module;
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProfileCollection);
 
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(CompilationContext&, IPIntCallee&, OptimizingJITCallee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, Module&, CalleeGroup&, const ModuleInformation&, MemoryMode, CompilationMode, FunctionCodeIndex functionIndex, uint32_t loopIndexForOSREntry);
+Ref<ProfileCollection> ProfileCollection::create(Module&)
+{
+    return adoptRef(*new ProfileCollection);
+}
+
+RefPtr<BaselineData> ProfileCollection::tryGetBaselineData(FunctionCodeIndex index)
+{
+    Locker locker { m_lock };
+    return m_collection.get(index.rawIndex());
+}
+
+void ProfileCollection::registerBaselineData(FunctionCodeIndex index, Ref<BaselineData>&& data)
+{
+    Locker locker { m_lock };
+    m_collection.add(index.rawIndex(), WTFMove(data));
+}
 
 } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY_OMGJIT)
+#endif

--- a/Source/JavaScriptCore/wasm/WasmProfileCollection.h
+++ b/Source/JavaScriptCore/wasm/WasmProfileCollection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,33 +25,29 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY_OMGJIT)
+#if ENABLE(WEBASSEMBLY)
 
-#include "B3Common.h"
-#include "B3Procedure.h"
-#include "CCallHelpers.h"
-#include "JITCompilation.h"
-#include "JITOpaqueByproducts.h"
-#include "PCToCodeOriginMap.h"
-#include "WasmBBQDisassembler.h"
-#include "WasmCompilationContext.h"
-#include "WasmCompilationMode.h"
-#include "WasmJS.h"
-#include "WasmMemory.h"
-#include "WasmModuleInformation.h"
-#include "WasmTierUpCount.h"
-#include <wtf/Box.h>
+#include <JavaScriptCore/WasmBaselineData.h>
 #include <wtf/Expected.h>
-
-extern "C" void SYSV_ABI dumpProcedure(void*);
+#include <wtf/text/WTFString.h>
 
 namespace JSC::Wasm {
 
-class IPIntCallee;
 class Module;
 
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(CompilationContext&, IPIntCallee&, OptimizingJITCallee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, Module&, CalleeGroup&, const ModuleInformation&, MemoryMode, CompilationMode, FunctionCodeIndex functionIndex, uint32_t loopIndexForOSREntry);
+class ProfileCollection final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ProfileCollection> {
+    WTF_MAKE_TZONE_ALLOCATED(ProfileCollection);
+public:
+    static Ref<ProfileCollection> create(Module&);
+
+    RefPtr<BaselineData> tryGetBaselineData(FunctionCodeIndex);
+    void registerBaselineData(FunctionCodeIndex, Ref<BaselineData>&&);
+
+private:
+    UncheckedKeyHashMap<uint32_t, Ref<BaselineData>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_collection;
+    mutable Lock m_lock;
+};
 
 } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY_OMGJIT)
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmThunks.h
+++ b/Source/JavaScriptCore/wasm/WasmThunks.h
@@ -40,6 +40,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> throwStackOverflowFromWasmThunkGenerator(c
 MacroAssemblerCodeRef<JITThunkPtrTag> catchInWasmThunkGenerator(const AbstractLocker&);
 MacroAssemblerCodeRef<JITThunkPtrTag> crashDueToBBQStackOverflowGenerator(const AbstractLocker&);
 MacroAssemblerCodeRef<JITThunkPtrTag> crashDueToOMGStackOverflowGenerator(const AbstractLocker&);
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+MacroAssemblerCodeRef<JITThunkPtrTag> materializeBaselineDataGenerator(const AbstractLocker&);
+#endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGeneratorImpl(const AbstractLocker&, bool isSIMDContext);
 MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGeneratorSIMD(const AbstractLocker&);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -39,6 +39,7 @@
 #include "JSWebAssemblyModule.h"
 #include "JSWebAssemblyStruct.h"
 #include "Register.h"
+#include "WasmBaselineData.h"
 #include "WasmConstExprGenerator.h"
 #include "WasmModuleInformation.h"
 #include "WasmTag.h"
@@ -69,23 +70,24 @@ JSWebAssemblyInstance::JSWebAssemblyInstance(VM& vm, Structure* structure, JSWeb
     , m_moduleRecord(moduleRecord, WriteBarrierEarlyInit)
     , m_tables(module->module().moduleInformation().tableCount())
     , m_module(module->module())
+    , m_moduleInformation(module->moduleInformation())
+    , m_profiles(m_module->createProfiles())
     , m_sourceProvider(sourceProvider)
-    , m_globalsToMark(m_module.get().moduleInformation().globalCount())
-    , m_globalsToBinding(m_module.get().moduleInformation().globalCount())
-    , m_numImportFunctions(m_module->moduleInformation().importFunctionCount())
-    , m_passiveElements(m_module->moduleInformation().elementCount())
-    , m_passiveDataSegments(m_module->moduleInformation().dataSegmentsCount())
-    , m_tags(m_module->moduleInformation().exceptionIndexSpaceSize())
+    , m_globalsToMark(m_moduleInformation->globalCount())
+    , m_globalsToBinding(m_moduleInformation->globalCount())
+    , m_numImportFunctions(m_moduleInformation->importFunctionCount())
+    , m_passiveElements(m_moduleInformation->elementCount())
+    , m_passiveDataSegments(m_moduleInformation->dataSegmentsCount())
+    , m_tags(m_moduleInformation->exceptionIndexSpaceSize())
 {
     static_assert(static_cast<ptrdiff_t>(JSWebAssemblyInstance::offsetOfCachedMemory() + sizeof(void*)) == JSWebAssemblyInstance::offsetOfCachedBoundsCheckingSize());
     for (unsigned i = 0; i < m_numImportFunctions; ++i)
         new (importFunctionInfo(i)) WasmOrJSImportableFunctionCallLinkInfo();
 
-    auto& moduleInformation = m_module->moduleInformation();
-    m_globals = std::bit_cast<Global::Value*>(std::bit_cast<char*>(this) + offsetOfGlobalPtr(m_numImportFunctions, moduleInformation.tableCount(), 0));
-    memset(std::bit_cast<char*>(m_globals), 0, moduleInformation.globalCount() * sizeof(Global::Value));
-    for (unsigned i = 0; i < moduleInformation.globals.size(); ++i) {
-        const GlobalInformation& global = moduleInformation.globals[i];
+    m_globals = globals().data();
+    memset(reinterpret_cast<uint8_t*>(globals().data()), 0, globals().size_bytes());
+    for (unsigned i = 0; i < m_moduleInformation->globals.size(); ++i) {
+        const GlobalInformation& global = m_moduleInformation->globals[i];
         if (global.bindingMode == GlobalInformation::BindingMode::Portable) {
             // This is kept alive by JSWebAssemblyInstance -> JSWebAssemblyGlobal -> binding.
             m_globalsToBinding.set(i);
@@ -94,27 +96,28 @@ JSWebAssemblyInstance::JSWebAssemblyInstance(VM& vm, Structure* structure, JSWeb
             m_globalsToMark.set(i);
         }
     }
-    memset(std::bit_cast<char*>(this) + offsetOfTablePtr(m_numImportFunctions, 0), 0, moduleInformation.tableCount() * sizeof(Table*));
-    for (unsigned elementIndex = 0; elementIndex < moduleInformation.elementCount(); ++elementIndex) {
-        const auto& element = moduleInformation.elements[elementIndex];
+
+    memset(reinterpret_cast<uint8_t*>(tables().data()), 0, tables().size_bytes());
+    for (unsigned elementIndex = 0; elementIndex < m_moduleInformation->elementCount(); ++elementIndex) {
+        const auto& element = m_moduleInformation->elements[elementIndex];
         if (element.isPassive())
             m_passiveElements.quickSet(elementIndex);
     }
 
-    for (unsigned dataSegmentIndex = 0; dataSegmentIndex < moduleInformation.dataSegmentsCount(); ++dataSegmentIndex) {
-        const auto& dataSegment = moduleInformation.data[dataSegmentIndex];
+    for (unsigned dataSegmentIndex = 0; dataSegmentIndex < m_moduleInformation->dataSegmentsCount(); ++dataSegmentIndex) {
+        const auto& dataSegment = m_moduleInformation->data[dataSegmentIndex];
         if (dataSegment->isPassive())
             m_passiveDataSegments.quickSet(dataSegmentIndex);
     }
 
-    if (moduleInformation.hasGCObjectTypes()) {
-        memset(reinterpret_cast<char*>(&gcObjectStructureID(0)), 0, moduleInformation.typeCount() * sizeof(std::decay_t<decltype(gcObjectStructureID(0))>));
-
+    memset(reinterpret_cast<uint8_t*>(baselineDatas().data()), 0, baselineDatas().size_bytes());
+    if (m_moduleInformation->hasGCObjectTypes()) {
+        memset(reinterpret_cast<uint8_t*>(gcObjectStructureIDs().data()), 0, gcObjectStructureIDs().size_bytes());
         CompleteSubspace* subspace = JSWebAssemblyArray::subspaceFor<JSWebAssemblyArray, SubspaceAccess::OnMainThread>(vm);
         CompleteSubspace* structSubspace = JSWebAssemblyStruct::subspaceFor<JSWebAssemblyStruct, SubspaceAccess::OnMainThread>(vm);
         RELEASE_ASSERT(subspace == structSubspace);
         subspace->prepareAllAllocators();
-        memcpySpan(unsafeMakeSpan(&allocatorForGCObject(0), MarkedSpace::numSizeClasses), subspace->allocatorsForSizeSteps());
+        memcpySpan(allocators(), subspace->allocatorsForSizeSteps());
     }
 }
 
@@ -127,17 +130,14 @@ void JSWebAssemblyInstance::finishCreation(VM& vm)
     // FIXME: Maybe we should cache these structures. It's unclear how profitable this would be though since there's typically only one instance per module per VM.
     // Since we don't have a global GC it's somewhat unlikely we'd end up de-duplicating much. It's also a bit unclear how much of a perf win it would be at least
     // until folks start doing dynamic code loading.
-    auto& moduleInformation = m_module->moduleInformation();
     JSGlobalObject* globalObject = this->globalObject();
-    for (unsigned i = 0; i < moduleInformation.typeCount(); ++i) {
-        Ref rtt = moduleInformation.rtts[i];
+    for (unsigned i = 0; i < m_moduleInformation->typeCount(); ++i) {
+        Ref rtt = m_moduleInformation->rtts[i];
         if (rtt->kind() == RTTKind::Array)
-            gcObjectStructureID(i).setWithoutWriteBarrier(JSWebAssemblyArray::createStructure(vm, globalObject, moduleInformation.typeSignatures[i]->expand(), WTFMove(rtt)));
+            gcObjectStructureID(i).set(vm, this, JSWebAssemblyArray::createStructure(vm, globalObject, m_moduleInformation->typeSignatures[i]->expand(), WTFMove(rtt)));
         else if (rtt->kind() == RTTKind::Struct)
-            gcObjectStructureID(i).setWithoutWriteBarrier(JSWebAssemblyStruct::createStructure(vm, globalObject, moduleInformation.typeSignatures[i]->expand(), WTFMove(rtt)));
+            gcObjectStructureID(i).set(vm, this, JSWebAssemblyStruct::createStructure(vm, globalObject, m_moduleInformation->typeSignatures[i]->expand(), WTFMove(rtt)));
     }
-    if (moduleInformation.typeCount())
-        vm.writeBarrier(this);
 
     m_vm->traps().registerMirror(m_stackMirror);
 }
@@ -146,12 +146,15 @@ JSWebAssemblyInstance::~JSWebAssemblyInstance()
 {
     m_vm->traps().unregisterMirror(m_stackMirror);
     clearJSCallICs(*m_vm);
-    for (unsigned i = 0; i < m_numImportFunctions; ++i)
-        importFunctionInfo(i)->~WasmOrJSImportableFunctionCallLinkInfo();
-    for (unsigned i = 0; i < m_module->moduleInformation().tableCount(); ++i) {
-        if (Table* table = this->table(i))
-            table->deref();
-    }
+
+    for (auto& slot : importFunctionInfos())
+        std::destroy_at(&slot);
+
+    for (auto& slot : tables())
+        std::destroy_at(&slot);
+
+    for (auto& slot : baselineDatas())
+        std::destroy_at(&slot);
 }
 
 void JSWebAssemblyInstance::destroy(JSCell* cell)
@@ -185,7 +188,7 @@ void JSWebAssemblyInstance::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     const auto& moduleInformation = thisObject->moduleInformation();
     if (moduleInformation.hasGCObjectTypes()) {
         for (unsigned i = 0; i < moduleInformation.typeCount(); ++i)
-            visitor.append(thisObject->gcObjectStructureID(thisObject->numImportFunctions(), moduleInformation.tableCount(), moduleInformation.globalCount(), i));
+            visitor.append(thisObject->gcObjectStructureID(i));
     }
 
     Locker locker { cell->cellLock() };
@@ -268,15 +271,9 @@ Identifier JSWebAssemblyInstance::createPrivateModuleKey()
 
 size_t JSWebAssemblyInstance::allocationSize(const Wasm::ModuleInformation& info)
 {
-    Checked<size_t> size = offsetOfTail();
-    size += sizeof(WasmOrJSImportableFunctionCallLinkInfo) * info.importFunctionCount();
-    size += sizeof(Wasm::Table*) * info.tableCount();
-    size = roundUpToMultipleOf<alignof(Wasm::Global::Value)>(size) + sizeof(Wasm::Global::Value) * info.globalCount();
-    if (info.hasGCObjectTypes()) {
-        size = roundUpToMultipleOf<alignof(WriteBarrierStructureID)>(size) + sizeof(WriteBarrierStructureID) * info.typeCount();
-        size = roundUpToMultipleOf<alignof(Allocator)>(size) + sizeof(Allocator) * MarkedSpace::numSizeClasses;
-    }
-    return size;
+    if (info.hasGCObjectTypes())
+        return offsetOfAllocatorForGCObject(info, MarkedSpace::numSizeClasses);
+    return offsetOfBaselineData(info, info.internalFunctionCount());
 }
 
 
@@ -412,17 +409,14 @@ void JSWebAssemblyInstance::setFunctionWrapper(unsigned i, JSValue value)
 
 Table* JSWebAssemblyInstance::table(unsigned i)
 {
-    RELEASE_ASSERT(i < m_module->moduleInformation().tableCount());
-    return *std::bit_cast<Table**>(std::bit_cast<char*>(this) + offsetOfTablePtr(m_numImportFunctions, i));
+    return tables()[i].get();
 }
 
 void JSWebAssemblyInstance::tableCopy(uint32_t dstOffset, uint32_t srcOffset, uint32_t length, uint32_t dstTableIndex, uint32_t srcTableIndex)
 {
-    RELEASE_ASSERT(srcTableIndex < m_module->moduleInformation().tableCount());
-    RELEASE_ASSERT(dstTableIndex < m_module->moduleInformation().tableCount());
-
-    Table* dstTable = table(dstTableIndex);
-    Table* srcTable = table(srcTableIndex);
+    auto span = tables();
+    Table* dstTable = span[dstTableIndex].get();
+    Table* srcTable = span[srcTableIndex].get();
     RELEASE_ASSERT(dstTable->type() == srcTable->type());
 
     auto forEachTableElement = [&](auto fn) {
@@ -479,10 +473,10 @@ void JSWebAssemblyInstance::dataDrop(uint32_t dataSegmentIndex)
 
 const Element* JSWebAssemblyInstance::elementAt(unsigned index) const
 {
-    RELEASE_ASSERT(index < m_module->moduleInformation().elementCount());
+    RELEASE_ASSERT(index < m_moduleInformation->elementCount());
 
     if (m_passiveElements.quickGet(index))
-        return &m_module->moduleInformation().elements[index];
+        return &m_moduleInformation->elements[index];
     return nullptr;
 }
 
@@ -669,8 +663,8 @@ void JSWebAssemblyInstance::copyElementSegment(JSWebAssemblyArray* array, const 
 
 bool JSWebAssemblyInstance::evaluateConstantExpression(uint64_t index, Type expectedType, uint64_t& result)
 {
-    const auto& constantExpression = m_module->moduleInformation().constantExpressions[index];
-    auto evalResult = evaluateExtendedConstExpr(constantExpression, this, m_module->moduleInformation(), expectedType);
+    const auto& constantExpression = m_moduleInformation->constantExpressions[index];
+    auto evalResult = evaluateExtendedConstExpr(constantExpression, this, m_moduleInformation.get(), expectedType);
     if (!evalResult.has_value()) [[unlikely]]
         return false;
 
@@ -680,8 +674,8 @@ bool JSWebAssemblyInstance::evaluateConstantExpression(uint64_t index, Type expe
 
 void JSWebAssemblyInstance::tableInit(uint32_t dstOffset, uint32_t srcOffset, uint32_t length, uint32_t elementIndex, uint32_t tableIndex)
 {
-    RELEASE_ASSERT(elementIndex < m_module->moduleInformation().elementCount());
-    RELEASE_ASSERT(tableIndex < m_module->moduleInformation().tableCount());
+    RELEASE_ASSERT(elementIndex < m_moduleInformation->elementCount());
+    RELEASE_ASSERT(tableIndex < m_moduleInformation->tableCount());
 
     const Element* elementSegment = elementAt(elementIndex);
     RELEASE_ASSERT(elementSegment);
@@ -691,9 +685,8 @@ void JSWebAssemblyInstance::tableInit(uint32_t dstOffset, uint32_t srcOffset, ui
 
 void JSWebAssemblyInstance::setTable(unsigned i, Ref<Table>&& table)
 {
-    RELEASE_ASSERT(i < m_module->moduleInformation().tableCount());
     ASSERT(!this->table(i));
-    *std::bit_cast<Table**>(std::bit_cast<char*>(this) + offsetOfTablePtr(m_numImportFunctions, i)) = &table.leakRef();
+    tables()[i] = WTFMove(table);
 }
 
 void JSWebAssemblyInstance::linkGlobal(unsigned i, Ref<Global>&& global)
@@ -705,6 +698,17 @@ void JSWebAssemblyInstance::linkGlobal(unsigned i, Ref<Global>&& global)
 void JSWebAssemblyInstance::setTag(unsigned index, Ref<const Tag>&& tag)
 {
     m_tags[index] = WTFMove(tag);
+}
+
+Wasm::BaselineData& JSWebAssemblyInstance::ensureBaselineData(Wasm::FunctionCodeIndex index)
+{
+    auto& slot = baselineData(index);
+    if (!slot) [[unlikely]] {
+        auto result = Wasm::BaselineData::create(m_module->ipintCallees().at(index.rawIndex()));
+        m_profiles->registerBaselineData(index, Ref { result });
+        slot = WTFMove(result);
+    }
+    return *slot;
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 1045bbc1a8e3b42ef926b776cb315219c1ba0d0d
<pre>
[JSC] Profile call_indirect / call_ref monomorphic target and do direct call / inlining in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=298677">https://bugs.webkit.org/show_bug.cgi?id=298677</a>
<a href="https://rdar.apple.com/160312708">rdar://160312708</a>

Reviewed by Yijia Huang.

This patch extends our profiling mechanism for wasm calls.

1. We start collecting per-instance level profiles instead of per-module
   level. This is easier for us to collect more information without
   locking. Previously, we were only collecting call counts, which is
   fine for data race. But we would like to collect more complicated
   profile information (like polymorphic call targets), and we do not
   want to take a lock.
   This per-instance data is chained by thread safe weak set from
   module. And compiler will gather information through this backward
   reference from module to this data collection.
2. (1)&apos;s data pointer is stored in JSWebAssemblyInstance (to achieve
   that, we were working on shrink some of sizes in
   JSWebAssemblyInstance, like 299480@main etc.). And BBQ will load it
   into GPRInfo::jitDataRegister. So the code can quickly access to this
   information.
3. Call profiling is extended to collect boxed callee. Right now, we
   only collect (1) init, (2) monomorphic, or (3) megamorphic status.
   In OMG, we use this information, and attempt to directly call this
   target when it is monomorphic and it is call_indirect / call_ref.
   This allows us to remove many weird code around call_indirect etc.
   And OMG even inlines calls when the monomorphic call target is small.
   Right now, we only collect non-cross-instance calls.
4. The current limitation is this is only handling monomorphic calls. We
   also found that polymorphic call collection is useful and effective
   for some of real world code. So we will extend it later.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIncrementCallSlotCount):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoopOSREntrypoint):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIndirectCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
(JSC::Wasm::parseAndCompileBBQ):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::getGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setGlobal):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::getGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCStructUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::BBQPlan):
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmBaselineData.h: Copied from Source/JavaScriptCore/wasm/WasmCallSlot.h.
* Source/JavaScriptCore/wasm/WasmCallSlot.h:
(JSC::Wasm::CallSlot::observeCrossInstanceCall):
(JSC::Wasm::CallSlot::observeCallIndirect):
(JSC::Wasm::CallSlot::boxedCallee const):
(JSC::Wasm::CallSlot::offsetOfBoxedCallee):
(JSC::Wasm::CallSlot::addressOfCount): Deleted.
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
(JSC::Wasm::IPIntCallee::needsProfiling const):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::jitCompileSIMDFunctionSynchronously):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmMergedProfile.cpp: Copied from Source/JavaScriptCore/wasm/WasmCallSlot.h.
(JSC::Wasm::MergedProfile::MergedProfile):
(JSC::Wasm::MergedProfile::CallSite::merge):
* Source/JavaScriptCore/wasm/WasmMergedProfile.h: Copied from Source/JavaScriptCore/wasm/WasmCallSlot.h.
(JSC::Wasm::MergedProfile::CallSite::count const):
(JSC::Wasm::MergedProfile::CallSite::callee const):
(JSC::Wasm::MergedProfile::CallSite::isMegamorphic const):
(JSC::Wasm::MergedProfile::isCalled const):
(JSC::Wasm::MergedProfile::callee const):
(JSC::Wasm::MergedProfile::isMegamorphic const):
(JSC::Wasm::MergedProfile::mutableSpan):
(JSC::Wasm::MergedProfile::span const):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::createProfiles):
(JSC::Wasm::Module::createMergedProfile):
* Source/JavaScriptCore/wasm/WasmModule.h:
(JSC::Wasm::Module::ipintCallees const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
(JSC::Wasm::OMGIRGenerator::getGlobal):
(JSC::Wasm::OMGIRGenerator::setGlobal):
(JSC::Wasm::OMGIRGenerator::allocatorForWasmGCHeapCellSize):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCStructUninitialized):
(JSC::Wasm::OMGIRGenerator::addInlinedReturn):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::emitInlineDirectCall):
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::OMGIRGenerator::emitDirectCall):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::addCallRef):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::getGlobal):
(JSC::Wasm::OMGIRGenerator::setGlobal):
(JSC::Wasm::OMGIRGenerator::allocatorForWasmGCHeapCellSize):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCStructUninitialized):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::emitInlineDirectCall):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmProfileCollection.cpp: Copied from Source/JavaScriptCore/wasm/WasmCallSlot.h.
(JSC::Wasm::ProfileCollection::create):
(JSC::Wasm::ProfileCollection::tryGetBaselineData):
(JSC::Wasm::ProfileCollection::registerBaselineData):
* Source/JavaScriptCore/wasm/WasmProfileCollection.h: Copied from Source/JavaScriptCore/wasm/WasmCallSlot.h.
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::materializeBaselineDataGenerator):
* Source/JavaScriptCore/wasm/WasmThunks.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::finishCreation):
(JSC::JSWebAssemblyInstance::~JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::allocationSize):
(JSC::JSWebAssemblyInstance::table):
(JSC::JSWebAssemblyInstance::tableCopy):
(JSC::JSWebAssemblyInstance::elementAt const):
(JSC::JSWebAssemblyInstance::evaluateConstantExpression):
(JSC::JSWebAssemblyInstance::tableInit):
(JSC::JSWebAssemblyInstance::setTable):
(JSC::JSWebAssemblyInstance::ensureBaselineData):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/299870@main">https://commits.webkit.org/299870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c794ec692c9fc698dcae6ef4defd88910288359

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120530 "4 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/40224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126911 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/72605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/40921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/48801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/72605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123482 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/40921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/40921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/70523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/112656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/40921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/26331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/119046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/47451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/48801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/129791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/47818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/104225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19131 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/47313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53018 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147745 "Failed to checkout and rebase branch from PR 50561") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/46781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/147745 "Failed to checkout and rebase branch from PR 50561") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/50128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->