### PR TITLE
[JSC] WASM IPInt SIMD: implement demote, promote, ceil, floor, trunc, nearest, trunc w/ saturation, convert low

### DIFF
--- a/JSTests/wasm/stress/simd-instructions-float.js
+++ b/JSTests/wasm/stress/simd-instructions-float.js
@@ -301,6 +301,208 @@ const floatTests = [
         [Number.NaN, 1.0],
         [1.0, Number.NaN],
         [Number.NaN, 1.0]
+    ],
+
+    // f32x4 rounding operations
+    [
+        "f32x4.ceil",
+        [1.1, -2.7, 3.9, -0.5],
+        [2.0, -2.0, 4.0, -0.0]
+    ],
+    [
+        "f32x4.ceil",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, 0.0],
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, 0.0]
+    ],
+
+    [
+        "f32x4.floor",
+        [1.1, -2.7, 3.9, -0.5],
+        [1.0, -3.0, 3.0, -1.0]
+    ],
+    [
+        "f32x4.floor",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, -0.0],
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, -0.0]
+    ],
+
+    [
+        "f32x4.trunc",
+        [1.9, -2.1, 3.7, -0.8],
+        [1.0, -2.0, 3.0, -0.0]
+    ],
+    [
+        "f32x4.trunc",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, 0.0],
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, 0.0]
+    ],
+
+    [
+        "f32x4.nearest",
+        [1.5, 2.5, -1.5, -2.5],
+        [2.0, 2.0, -2.0, -2.0]
+    ],
+    [
+        "f32x4.nearest",
+        [0.5, 1.4, Number.POSITIVE_INFINITY, Number.NaN],
+        [0.0, 1.0, Number.POSITIVE_INFINITY, Number.NaN]
+    ],
+
+    // f64x2 rounding operations
+    [
+        "f64x2.ceil",
+        [1.1, -2.7],
+        [2.0, -2.0]
+    ],
+    [
+        "f64x2.ceil",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]
+    ],
+
+    [
+        "f64x2.floor",
+        [1.1, -2.7],
+        [1.0, -3.0]
+    ],
+    [
+        "f64x2.floor",
+        [Number.NaN, -0.0],
+        [Number.NaN, -0.0]
+    ],
+
+    [
+        "f64x2.trunc",
+        [1.9, -2.1],
+        [1.0, -2.0]
+    ],
+    [
+        "f64x2.trunc",
+        [Number.POSITIVE_INFINITY, Number.NaN],
+        [Number.POSITIVE_INFINITY, Number.NaN]
+    ],
+
+    [
+        "f64x2.nearest",
+        [1.5, -2.5],
+        [2.0, -2.0]
+    ],
+    [
+        "f64x2.nearest",
+        [0.5, Number.NEGATIVE_INFINITY],
+        [0.0, Number.NEGATIVE_INFINITY]
+    ],
+
+    // f32x4/f64x2 conversion operations
+    [
+        "f32x4.demote_f64x2_zero",
+        [1.5, 2.5],
+        [1.5, 2.5, 0.0, 0.0]
+    ],
+    [
+        "f32x4.demote_f64x2_zero",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 0.0, 0.0]
+    ],
+
+    [
+        "f64x2.promote_low_f32x4",
+        [1.5, 2.5, 3.5, 4.5],
+        [1.5, 2.5]
+    ],
+    [
+        "f64x2.promote_low_f32x4",
+        [Number.POSITIVE_INFINITY, Number.NaN, 0.0, -0.0],
+        [Number.POSITIVE_INFINITY, Number.NaN]
+    ],
+
+    // Integer/float conversion operations
+    [
+        "i32x4.trunc_sat_f32x4_s",
+        [1.5, -2.7, 2147483647.0, -2147483648.0],
+        [0x00000001, 0xFFFFFFFE, 0x7FFFFFFF, 0x80000000] // 1, -2, 2147483647, -2147483648
+    ],
+    [
+        "i32x4.trunc_sat_f32x4_s",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, 3000000000.0],
+        [0x7FFFFFFF, 0x80000000, 0x00000000, 0x7FFFFFFF] // 2147483647, -2147483648, 0, 2147483647
+    ],
+
+    [
+        "i32x4.trunc_sat_f32x4_u",
+        [1.5, 2.7, 4294967295.0, -1.0],
+        [0x00000001, 0x00000002, 0xFFFFFFFF, 0x00000000] // 1, 2, 4294967295, 0
+    ],
+    [
+        "i32x4.trunc_sat_f32x4_u",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN, 5000000000.0],
+        [0xFFFFFFFF, 0x00000000, 0x00000000, 0xFFFFFFFF] // 4294967295, 0, 0, 4294967295
+    ],
+
+    [
+        "f32x4.convert_i32x4_s",
+        [1, -2, 2147483647, -2147483648],
+        [1.0, -2.0, 2147483648.0, -2147483648.0]
+    ],
+    [
+        "f32x4.convert_i32x4_s",
+        [0, -1, 1000000, -1000000],
+        [0.0, -1.0, 1000000.0, -1000000.0]
+    ],
+
+    [
+        "f32x4.convert_i32x4_u",
+        [1, 2, 4294967295, 0],
+        [1.0, 2.0, 4294967296.0, 0.0]
+    ],
+    [
+        "f32x4.convert_i32x4_u",
+        [1000000, 2000000, 3000000000, 4000000000],
+        [1000000.0, 2000000.0, 3000000000.0, 4000000000.0]
+    ],
+
+    [
+        "i32x4.trunc_sat_f64x2_s_zero",
+        [1.5, -2.7],
+        [0x00000001, 0xFFFFFFFE, 0x00000000, 0x00000000] // 1, -2, 0, 0
+    ],
+    [
+        "i32x4.trunc_sat_f64x2_s_zero",
+        [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+        [0x7FFFFFFF, 0x80000000, 0x00000000, 0x00000000] // 2147483647, -2147483648, 0, 0
+    ],
+
+    [
+        "i32x4.trunc_sat_f64x2_u_zero",
+        [1.5, 2.7],
+        [1, 2, 0, 0]
+    ],
+    [
+        "i32x4.trunc_sat_f64x2_u_zero",
+        [Number.NaN, -1.0],
+        [0, 0, 0, 0]
+    ],
+
+    [
+        "f64x2.convert_low_i32x4_s",
+        [1, -2, 3, 4],
+        [1.0, -2.0]
+    ],
+    [
+        "f64x2.convert_low_i32x4_s",
+        [2147483647, -2147483648, 0, -1],
+        [2147483647.0, -2147483648.0]
+    ],
+
+    [
+        "f64x2.convert_low_i32x4_u",
+        [1, 2, 3, 4],
+        [1.0, 2.0]
+    ],
+    [
+        "f64x2.convert_low_i32x4_u",
+        [4294967295, 0, 1000000, 2000000],
+        [4294967295.0, 0.0]
     ]
 ];
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -5472,8 +5472,35 @@ ipintOp(_simd_v128_load64_zero_mem, macro()
 end)
 
 # 0xFD 0x5E - 0xFD 0x5F: f32x4/f64x2 conversion
-unimplementedInstruction(_simd_f32x4_demote_f64x2_zero)
-unimplementedInstruction(_simd_f64x2_promote_low_f32x4)
+
+ipintOp(_simd_f32x4_demote_f64x2_zero, macro()
+    # f32x4.demote_f64x2_zero - demote 2 f64 values to f32, zero upper 2 lanes
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Convert the two f64 values in lanes 0,1 to f32 and store in lanes 0,1
+        emit "fcvtn v16.2s, v16.2d"
+        # Zero the upper 64 bits (lanes 2,3)
+        emit "mov v16.d[1], xzr"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f64x2_promote_low_f32x4, macro()
+    # f64x2.promote_low_f32x4 - promote lower 2 f32 values to f64
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "fcvtl v16.2d, v16.2s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
 
 # 0xFD 0x60 - 0x66: i8x16 operations
 
@@ -5566,10 +5593,58 @@ unimplementedInstruction(_simd_i8x16_narrow_i16x8_s)
 unimplementedInstruction(_simd_i8x16_narrow_i16x8_u)
 
 # 0xFD 0x67 - 0xFD 0x6A: f32x4 operations
-unimplementedInstruction(_simd_f32x4_ceil)
-unimplementedInstruction(_simd_f32x4_floor)
-unimplementedInstruction(_simd_f32x4_trunc)
-unimplementedInstruction(_simd_f32x4_nearest)
+
+ipintOp(_simd_f32x4_ceil, macro()
+    # f32x4.ceil - ceiling of 4 32-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintp v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f32x4_floor, macro()
+    # f32x4.floor - floor of 4 32-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintm v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f32x4_trunc, macro()
+    # f32x4.trunc - truncate 4 32-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintz v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f32x4_nearest, macro()
+    # f32x4.nearest - round to nearest integer (ties to even) for 4 32-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintn v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
 
 # 0xFD 0x6B - 0xFD 0x73: i8x16 binary operations
 ipintOp(_simd_i8x16_shl, macro()
@@ -5718,8 +5793,32 @@ ipintOp(_simd_i8x16_sub_sat_u, macro()
 end)
 
 # 0xFD 0x74 - 0xFD 0x75: f64x2 operations
-unimplementedInstruction(_simd_f64x2_ceil)
-unimplementedInstruction(_simd_f64x2_floor)
+
+ipintOp(_simd_f64x2_ceil, macro()
+    # f64x2.ceil - ceiling of 2 64-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintp v16.2d, v16.2d"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f64x2_floor, macro()
+    # f64x2.floor - floor of 2 64-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintm v16.2d, v16.2d"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
 
 # 0xFD 0x76 - 0xFD 0x79: i8x16 binary operations
 ipintOp(_simd_i8x16_min_s, macro()
@@ -5779,7 +5878,19 @@ ipintOp(_simd_i8x16_max_u, macro()
 end)
 
 # 0xFD 0x7A: f64x2 trunc
-unimplementedInstruction(_simd_f64x2_trunc)
+
+ipintOp(_simd_f64x2_trunc, macro()
+    # f64x2.trunc - truncate 2 64-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintz v16.2d, v16.2d"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
 
 # 0xFD 0x7B: i8x16 avgr_u
 unimplementedInstruction(_simd_i8x16_avgr_u)
@@ -6020,7 +6131,18 @@ end)
 
 # 0xFD 0x94 0x01: f64x2.nearest
 
-unimplementedInstruction(_simd_f64x2_nearest)
+ipintOp(_simd_f64x2_nearest, macro()
+    # f64x2.nearest - round to nearest integer (ties to even) for 2 64-bit floats
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "frintn v16.2d, v16.2d"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
 
 # 0xFD 0x95 0x01 - 0xFD 0x9F 0x01: i16x8 operations
 
@@ -6974,14 +7096,123 @@ end)
 
 # 0xFD 0xF8 0x01 - 0xFD 0xFF 0x01: trunc/convert
 
-unimplementedInstruction(_simd_i32x4_trunc_sat_f32x4_s)
-unimplementedInstruction(_simd_i32x4_trunc_sat_f32x4_u)
-unimplementedInstruction(_simd_f32x4_convert_i32x4_s)
-unimplementedInstruction(_simd_f32x4_convert_i32x4_u)
-unimplementedInstruction(_simd_i32x4_trunc_sat_f64x2_s_zero)
-unimplementedInstruction(_simd_i32x4_trunc_sat_f64x2_u_zero)
-unimplementedInstruction(_simd_f64x2_convert_low_i32x4_s)
-unimplementedInstruction(_simd_f64x2_convert_low_i32x4_u)
+ipintOp(_simd_i32x4_trunc_sat_f32x4_s, macro()
+    # i32x4.trunc_sat_f32x4_s - truncate 4 f32 values to signed i32 with saturation
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "fcvtzs v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_i32x4_trunc_sat_f32x4_u, macro()
+    # i32x4.trunc_sat_f32x4_u - truncate 4 f32 values to unsigned i32 with saturation
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "fcvtzu v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f32x4_convert_i32x4_s, macro()
+    # f32x4.convert_i32x4_s - convert 4 signed i32 values to f32
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "scvtf v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f32x4_convert_i32x4_u, macro()
+    # f32x4.convert_i32x4_u - convert 4 unsigned i32 values to f32
+    popVec(v0)
+    if ARM64 or ARM64E
+        emit "ucvtf v16.4s, v16.4s"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_i32x4_trunc_sat_f64x2_s_zero, macro()
+    # i32x4.trunc_sat_f64x2_s_zero - truncate 2 f64 values to signed i32, zero upper 2 lanes
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Convert f64 to signed i64 first
+        emit "fcvtzs v16.2d, v16.2d"
+        # Signed saturating extract narrow from i64 to i32
+        emit "sqxtn v16.2s, v16.2d"
+        # Zero the upper 64 bits (lanes 2,3)
+        emit "mov v16.d[1], xzr"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_i32x4_trunc_sat_f64x2_u_zero, macro()
+    # i32x4.trunc_sat_f64x2_u_zero - truncate 2 f64 values to unsigned i32, zero upper 2 lanes
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Convert f64 to unsigned i64 first
+        emit "fcvtzu v16.2d, v16.2d"
+        # Unsigned saturating extract narrow from i64 to i32
+        emit "uqxtn v16.2s, v16.2d"
+        # Zero the upper 64 bits (lanes 2,3)
+        emit "mov v16.d[1], xzr"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f64x2_convert_low_i32x4_s, macro()
+    # f64x2.convert_low_i32x4_s - convert lower 2 signed i32 values to f64
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Sign-extend lower 2 i32 values to i64, then convert to f64
+        emit "sxtl v16.2d, v16.2s"
+        emit "scvtf v16.2d, v16.2d"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
+
+ipintOp(_simd_f64x2_convert_low_i32x4_u, macro()
+    # f64x2.convert_low_i32x4_u - convert lower 2 unsigned i32 values to f64
+    popVec(v0)
+    if ARM64 or ARM64E
+        # Zero-extend lower 2 i32 values to i64, then convert to f64
+        emit "uxtl v16.2d, v16.2s"
+        emit "ucvtf v16.2d, v16.2d"
+    else
+        break # Not implemented
+    end
+    pushVec(v0)
+    advancePC(2)
+    nextIPIntInstruction()
+end)
 
     #########################
     ## Atomic instructions ##


### PR DESCRIPTION
#### c44ae7fd33717f3895d78009ccd70af69ff88b86
<pre>
[JSC] WASM IPInt SIMD: implement demote, promote, ceil, floor, trunc, nearest, trunc w/ saturation, convert low
<a href="https://bugs.webkit.org/show_bug.cgi?id=298681">https://bugs.webkit.org/show_bug.cgi?id=298681</a>
<a href="https://rdar.apple.com/160315006">rdar://160315006</a>

Reviewed by Yusuke Suzuki.

Implement demote, promote, ceil, floor, trunc, nearest,
trunc w/ saturation, convert low instructions in ARM64 WASM
InPlaceInterpreter.

Add isolated instruction test for each.

Canonical link: <a href="https://commits.webkit.org/299855@main">https://commits.webkit.org/299855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f331f83db1735405001b3bc8170d21b61581460b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca6f8f6d-2bd4-41f6-8a01-3ff9683c775c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48587 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91374 "20 flakes 74 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60667 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72da639a-21ff-42b8-a5a0-861621455f0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71927 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99e6f5cb-5fd5-445a-b4c9-f36186201b0d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70303 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112442 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129570 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118832 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99990 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99832 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25375 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23312 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43880 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52804 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147531 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46567 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37903 "Found 1 new JSC binary failure: testapi, Found 18678 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_lastindexof.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48254 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->