### PR TITLE
[EWS] Consult post-commit results to identify pre-existing JSC test failures

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -38,7 +38,7 @@ class ResultsDatabase(object):
     HOSTNAME = 'https://results.webkit.org'
     # TODO: Support more suites (Note, the API we're talking to already does)
     DEFAULT_SUITE = 'layout-tests'
-    SUITES = ('layout-tests', 'api-tests', 'safer-cpp-checks')
+    SUITES = ('layout-tests', 'api-tests', 'safer-cpp-checks', 'javascriptcore-tests')
     PERCENT_THRESHOLD = 10
     PERCENT_SUCCESS_RATE_FOR_PRE_EXISTING_FAILURE = 80
     CONFIGURATION_KEYS = [


### PR DESCRIPTION
#### 1eff0784923edf5a2b3dd412bc2fe8d4c7efd457
<pre>
[EWS] Consult post-commit results to identify pre-existing JSC test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=298682">https://bugs.webkit.org/show_bug.cgi?id=298682</a>
<a href="https://rdar.apple.com/150395210">rdar://150395210</a>

Reviewed by Aakash Jain.

Add support for querying javascriptcore-tests in EWS.
Any failures will be filtered by consulting resultsdb, like we do in RunWebKitTests.
If there are still failures after filtering, we rerun the tests on a clean build.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase):
* Tools/CISupport/ews-build/steps.py:
(RunJavaScriptCoreTests):
(RunJavaScriptCoreTests.__init__):
(RunJavaScriptCoreTests.run):
(RunJavaScriptCoreTests.evaluateCommand):
(RunJavaScriptCoreTests._check_for_preexisting_failures):
(RunJavaScriptCoreTests.filter_failures_using_results_db):

Canonical link: <a href="https://commits.webkit.org/300100@main">https://commits.webkit.org/300100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9dacf97b92f7699a092fce4c31fbe9640a6c668

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73277 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ad23c68-8d98-4623-a382-3131497e2fb6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92062 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61253 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba5c3e37-282d-40c5-865c-27729c65f61d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72740 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3682c5e8-0b3f-4554-bcc9-121d882f964d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71210 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130470 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100660 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/120616 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44817 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47981 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->