### PR TITLE
[Navigation API] Fix 16% PLT regression by removing Sync IPC

### DIFF
--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -180,17 +180,6 @@ Vector<Ref<HistoryItem>> BackForwardController::allItems()
     return m_client->allItems(m_page->mainFrame().frameID());
 }
 
-Vector<Ref<HistoryItem>> BackForwardController::itemsForFrame(FrameIdentifier frameID)
-{
-    Vector<Ref<HistoryItem>> historyItems;
-    for (Ref item : allItems()) {
-        if (item->frameID() == frameID)
-            historyItems.append(WTFMove(item));
-    }
-
-    return historyItems;
-}
-
 Vector<Ref<HistoryItem>> BackForwardController::reachableItemsForFrame(FrameIdentifier frameID)
 {
     // Returns only the frame items that correspond to the currently reachable session history.

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -75,7 +75,6 @@ public:
     WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem(std::optional<FrameIdentifier> = std::nullopt);
 
     Vector<Ref<HistoryItem>> allItems();
-    Vector<Ref<HistoryItem>> itemsForFrame(FrameIdentifier);
     Vector<Ref<HistoryItem>> reachableItemsForFrame(FrameIdentifier);
 
 private:


### PR DESCRIPTION
#### c0ca2b2a9f47c653d83beaf6f54213ee73b6f0b0
<pre>
[Navigation API] Fix 16% PLT regression by removing Sync IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=298498">https://bugs.webkit.org/show_bug.cgi?id=298498</a>
<a href="https://rdar.apple.com/160000632">rdar://160000632</a>

Reviewed by Charlie Wolfe.

When a new Document is created, its Navigation object&apos;s list of history entries
must be initialized. In the initial implementation of the Navigation API in
273532@main, this was done by making a sync IPC to the UI Process to get each
item in the b/f list. (The calls to itemAtIndex()). 298922@main changed this so
the whole list is retrieved in just one sync IPC call (The call to itemsForFrame()).
Then, the list would be filtered to keep only the items that this frame could reach
via the Navigation API.

So enabling the Navigation API means that every time a new Document is created,
a new sync IPC is sent. This is terrible for performance. It&apos;s a ~16% PLT regression.

To fix this, this patch removes this extra sync IPC. Instead of getting this list
via IPC, we get the list from the previous Document.

There are three situations to handle:

1. If the previous Document is of the same origin, then it will have list we need.
   It will not have the new entry that triggered this navigation, but we can add this.
   Since the previous list only contains items reachable via the Navigation API, we
   do not need to filter out any items.

2. If the previous Document is not of the same origin, it means we don&apos;t need the
   entries of it&apos;s list. The only entry in the new Document&apos;s list should be the
   entry that triggered this navigation. So we can initialize the new list with just
   this entry.

These two situations are handled.

3. If we are creating this Document as a result of a back/forward navigation that is
   cross-origin, then the previous Document&apos;s entries are not needed. But we must
   restore the entries that this Document used to have. For example, imagine we do
   the following navigations in the same frame:

   google.com
   google.com#1
   google.com#2
   webkit.org
   go back

   Then navigation.entries() should contain three entries:
   (google.com, google.com#1, google.com#2).

   Currently, it will (wrongly) contain only the last. This wrong behavior predates
   this patch. Since this patch simply aims to remove the sync IPC, it does not fix
   this behavior. A bug has been filed: <a href="https://bugs.webkit.org/show_bug.cgi?id=298683.">https://bugs.webkit.org/show_bug.cgi?id=298683.</a>

* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::itemsForFrame): Deleted.
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::getEntryIndexOfHistoryItem):
(WebCore::Navigation::initializeForNewWindow):

- Get the previous Document&apos;s list regardless of if the previous Document was in the
  main frame or a subframe.
- No need for the filtering since we aren&apos;t getting the entire unfiltered b/f list from
  the UI Process but rather the previous Document&apos;s already filtered list.
- Add the entry that triggered this navigation.

(WebCore::Navigation::updateForReactivation):

This patch initially causes the https-in-page-cache.html test to fail. That&apos;s because
in this situation, the second location change is a RedirectWithLockedBackForwardList
with the history handling set to Push. The UI Process does a replace but the
Navigation API spec expects a Push operation--a second item to be added to b/f list
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface">https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface</a>:location-object-navigate).

Now that we are getting the list from the previous window instead of the UI Process,
we end up two items with the same itemID in updateForReactivation. So instead of
comparing with the itemID, we must compare with itemSequenceNumber.

Canonical link: <a href="https://commits.webkit.org/299858@main">https://commits.webkit.org/299858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcc157a1ecd9319cde1158b6f56fde3b9e6d5f30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72469 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45f46e41-40bb-4c80-b0b4-e3d97a45e448) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91436 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60729 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d294d512-ffd0-4c81-ae02-c71bd994ed30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71988 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0346dde3-3904-48e3-8947-9940e2a540ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26035 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70381 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129650 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100056 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99898 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43961 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19123 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47177 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52882 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46645 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->