### PR TITLE
REGRESSION (iOS 26): editing/selection/ios/selection-handles-in-readonly-input.html is a constant timeout

### DIFF
--- a/LayoutTests/editing/selection/ios/select-text-using-tap-and-half-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-using-tap-and-half-expected.txt
@@ -1,0 +1,7 @@
+
+Selected range: (0, 2)
+Verifies that text inside an input element can be selected using a tap-and-half gesture.
+
+To manually test, tap once to focus the input. Then tap and tap and hold in quick succession to select the word "aa".
+
+This test is best run under WebKitTestRunner.

--- a/LayoutTests/editing/selection/ios/select-text-using-tap-and-half.html
+++ b/LayoutTests/editing/selection/ios/select-text-using-tap-and-half.html
@@ -39,34 +39,29 @@ function appendOutput(s) {
 }
 
 async function runTest() {
-    // First, focus the readonly input.
+    // First, focus the input.
     await UIHelper.activateAt(100, 50);
     await UIHelper.waitForDoubleTapDelay();
 
-    // Then, select 'aa' with a tap-and-drag gesture.
+    // Then, select 'aa' with a tap-and-half gesture.
     await UIHelper.activateAt(100, 50);
-    await touchAndDragFromPointToPoint(100, 50, 125, 50);
-    await liftUpAtPoint(125, 50);
+    await longPressAtPoint(100, 50);
 
     let grabberEndRect = null;
     while (!grabberEndRect || !grabberEndRect.width || !grabberEndRect.height)
         grabberEndRect = await UIHelper.getSelectionEndGrabberViewRect();
 
-    const [midX, midY] = [grabberEndRect.left + (grabberEndRect.width / 2), grabberEndRect.top + (grabberEndRect.height / 2)];
-    appendOutput(`Initial selected range: (${input.selectionStart}, ${input.selectionEnd})`);
-    await touchAndDragFromPointToPoint(midX, midY, midX + 25, midY + 150);
-    await liftUpAtPoint(midX + 25, midY + 150);
-    appendOutput(`Final selected range: (${input.selectionStart}, ${input.selectionEnd})`);
+    appendOutput(`Selected range: (${input.selectionStart}, ${input.selectionEnd})`);
+
     testRunner.notifyDone();
 }
 </script>
 </head>
 
 <body onload="runTest()">
-<input id="input" readonly value="aa">
+<input id="input" value="aa">
 <pre id="output"></pre>
-<p>Verifies that dragging a selection handle outside of a readonly input does not cause the selection to jump outside of the input.</p>
-<p>To manually test, double-tap to select the word "aa", drag the selection end handle out of the bounds of the input, and then drag the selection handle back in.</p>
-<p>"aa" should remain selected.</p>
+<p>Verifies that text inside an input element can be selected using a tap-and-half gesture.</p>
+<p>To manually test, tap once to focus the input. Then tap and tap and hold in quick succession to select the word "aa".</p>
 <p>This test is best run under WebKitTestRunner.</p></body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8127,7 +8127,6 @@ imported/w3c/web-platform-tests/digital-credentials/user-activation.https.html [
 imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/interesttarget.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/uievents/mouse/mousemove_after_mouseover_target_removed.html [ Failure ]
 platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport.html [ Failure ]
-editing/selection/ios/selection-handles-in-readonly-input.html [ Timeout ]
 fast/css/accent-color/button.html [ ImageOnlyFailure ]
 fast/css/accent-color/date.html [ ImageOnlyFailure ]
 fast/css/accent-color/select.html [ ImageOnlyFailure ]
@@ -8137,6 +8136,9 @@ imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-
 
 # <rdar://156470462> RTL inputs with type=password have larger logical width than RTL inputs with type number, url, tel, & text
 fast/forms/input-password-logical-widths.html [ Failure ]
+
+# <rdar://160314418> Tap-and-half selection gesture is broken in WebKit
+editing/selection/ios/select-text-using-tap-and-half.html [ Skip ]
 
 webkit.org/b/296338 http/tests/site-isolation/fullscreen.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 8703d99e315d38450c93461cc90cd94240c08528
<pre>
REGRESSION (iOS 26): editing/selection/ios/selection-handles-in-readonly-input.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=298679">https://bugs.webkit.org/show_bug.cgi?id=298679</a>
<a href="https://rdar.apple.com/156727121">rdar://156727121</a>

Reviewed by Abrar Rahman Protyasha.

Changes in Gestures.framework in iOS 26 broke the tap-and-half gesture to
perform selections in WebKit. <a href="https://rdar.apple.com/160314418">rdar://160314418</a> tracks a fix at the system level.

The fact that the tap-and-half gesture no longer selects text causes
editing/selection/ios/selection-handles-in-readonly-input.html to timeout.
To restore test coverage, rewrite the test to select text by tapping and
dragging.

Then, a new test is added to provide coverage specifically for the tap-and-half
gesture. Once <a href="https://rdar.apple.com/160314418">rdar://160314418</a> is fixed, the skip expectation can be removed.

* LayoutTests/editing/selection/ios/select-text-using-tap-and-half-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-text-using-tap-and-half.html: Added.
* LayoutTests/editing/selection/ios/selection-handles-in-readonly-input.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/299828@main">https://commits.webkit.org/299828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f98b61d688be43dc682084103afabcb8fa20c41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72401 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d0af082-f33b-46e8-87e6-20434caebf9c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91384 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60676 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62297bba-ffdc-4856-b883-be2df6f23832) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3b9511c-d426-49af-a6f2-590d6187df3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25972 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70315 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129582 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100000 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99842 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43893 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19117 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47111 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46579 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49925 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->