### PR TITLE
Re-implement toolbar, statusbar, and menubar visibility for site isolation

### DIFF
--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -73,16 +73,9 @@ class EmptyChromeClient : public ChromeClient {
     bool canRunModal() const final { return false; }
     void runModal() final { }
 
-    void setToolbarsVisible(bool) final { }
     bool toolbarsVisible() const final { return false; }
-
-    void setStatusbarVisible(bool) final { }
     bool statusbarVisible() const final { return false; }
-
-    void setScrollbarsVisible(bool) final { }
     bool scrollbarsVisible() const final { return false; }
-
-    void setMenubarVisible(bool) final { }
     bool menubarVisible() const final { return false; }
 
     void setResizable(bool) final { }

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -251,19 +251,9 @@ void Chrome::runModal()
     m_client->runModal();
 }
 
-void Chrome::setToolbarsVisible(bool b)
-{
-    m_client->setToolbarsVisible(b);
-}
-
 bool Chrome::toolbarsVisible() const
 {
     return m_client->toolbarsVisible();
-}
-
-void Chrome::setStatusbarVisible(bool b)
-{
-    m_client->setStatusbarVisible(b);
 }
 
 bool Chrome::statusbarVisible() const
@@ -271,19 +261,9 @@ bool Chrome::statusbarVisible() const
     return m_client->statusbarVisible();
 }
 
-void Chrome::setScrollbarsVisible(bool b)
-{
-    m_client->setScrollbarsVisible(b);
-}
-
 bool Chrome::scrollbarsVisible() const
 {
     return m_client->scrollbarsVisible();
-}
-
-void Chrome::setMenubarVisible(bool b)
-{
-    m_client->setMenubarVisible(b);
 }
 
 bool Chrome::menubarVisible() const

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -172,16 +172,9 @@ public:
     bool canRunModal() const;
     void runModal();
 
-    void setToolbarsVisible(bool);
     bool toolbarsVisible() const;
-
-    void setStatusbarVisible(bool);
     bool statusbarVisible() const;
-
-    void setScrollbarsVisible(bool);
     bool scrollbarsVisible() const;
-
-    void setMenubarVisible(bool);
     bool menubarVisible() const;
 
     void setResizable(bool);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -230,16 +230,9 @@ public:
     virtual bool canRunModal() const = 0;
     virtual void runModal() = 0;
 
-    virtual void setToolbarsVisible(bool) = 0;
     virtual bool toolbarsVisible() const = 0;
-
-    virtual void setStatusbarVisible(bool) = 0;
     virtual bool statusbarVisible() const = 0;
-
-    virtual void setScrollbarsVisible(bool) = 0;
     virtual bool scrollbarsVisible() const = 0;
-
-    virtual void setMenubarVisible(bool) = 0;
     virtual bool menubarVisible() const = 0;
 
     virtual void setResizable(bool) = 0;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5778,23 +5778,6 @@ bool Page::requiresScriptTrackingPrivacyProtections(const URL& scriptURL) const
 void Page::applyWindowFeatures(const WindowFeatures& features)
 {
     Ref frame = mainFrame();
-    chrome().setToolbarsVisible(features.toolBarVisible || features.locationBarVisible);
-
-    if (!frame->page())
-        return;
-    if (features.statusBarVisible)
-        chrome().setStatusbarVisible(*features.statusBarVisible);
-
-    if (!frame->page())
-        return;
-    if (features.scrollbarsVisible)
-        chrome().setScrollbarsVisible(*features.scrollbarsVisible);
-
-    if (!frame->page())
-        return;
-    if (features.menuBarVisible)
-        chrome().setMenubarVisible(*features.menuBarVisible);
-
     if (!frame->page())
         return;
     if (features.resizable)

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -332,6 +332,9 @@ struct WebPageCreationParameters {
     std::optional<WebCore::FrameIdentifier> mainFrameOpenerIdentifier { };
     WebCore::SandboxFlags initialSandboxFlags;
     std::optional<WebCore::WindowFeatures> windowFeatures { };
+    bool statusBarIsVisible;
+    bool menuBarIsVisible;
+    bool toolbarsAreVisible;
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     Vector<WebCore::LinkDecorationFilteringData> linkDecorationFilteringData { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -253,6 +253,9 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     std::optional<WebCore::FrameIdentifier> mainFrameOpenerIdentifier;
     WebCore::SandboxFlags initialSandboxFlags;
     std::optional<WebCore::WindowFeatures> windowFeatures;
+    bool statusBarIsVisible;
+    bool menuBarIsVisible;
+    bool toolbarsAreVisible;
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     Vector<WebCore::LinkDecorationFilteringData> linkDecorationFilteringData;

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -124,12 +124,14 @@ public:
     virtual void didNotHandleKeyEvent(WebKit::WebPageProxy*, const WebKit::NativeWebKeyboardEvent&) { }
     virtual void didNotHandleWheelEvent(WebKit::WebPageProxy*, const WebKit::NativeWebWheelEvent&) { }
 
+#if !PLATFORM(COCOA)
     virtual void toolbarsAreVisible(WebKit::WebPageProxy&, Function<void(bool)>&& completionHandler) { completionHandler(true); }
     virtual void setToolbarsAreVisible(WebKit::WebPageProxy&, bool) { }
     virtual void menuBarIsVisible(WebKit::WebPageProxy&, Function<void(bool)>&& completionHandler) { completionHandler(true); }
     virtual void setMenuBarIsVisible(WebKit::WebPageProxy&, bool) { }
     virtual void statusBarIsVisible(WebKit::WebPageProxy&, Function<void(bool)>&& completionHandler) { completionHandler(true); }
     virtual void setStatusBarIsVisible(WebKit::WebPageProxy&, bool) { }
+#endif
     virtual void setIsResizable(WebKit::WebPageProxy&, bool) { }
 
     virtual void setWindowFrame(WebKit::WebPageProxy&, const WebCore::FloatRect&) { }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1973,48 +1973,6 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             m_client.didNotHandleWheelEvent(toAPI(page), event.nativeEvent(), m_client.base.clientInfo);
         }
 
-        void toolbarsAreVisible(WebPageProxy& page, Function<void(bool)>&& completionHandler) final
-        {
-            if (!m_client.toolbarsAreVisible)
-                return completionHandler(true);
-            completionHandler(m_client.toolbarsAreVisible(toAPI(&page), m_client.base.clientInfo));
-        }
-
-        void setToolbarsAreVisible(WebPageProxy& page, bool visible) final
-        {
-            if (!m_client.setToolbarsAreVisible)
-                return;
-            m_client.setToolbarsAreVisible(toAPI(&page), visible, m_client.base.clientInfo);
-        }
-
-        void menuBarIsVisible(WebPageProxy& page, Function<void(bool)>&& completionHandler) final
-        {
-            if (!m_client.menuBarIsVisible)
-                return completionHandler(true);
-            completionHandler(m_client.menuBarIsVisible(toAPI(&page), m_client.base.clientInfo));
-        }
-
-        void setMenuBarIsVisible(WebPageProxy& page, bool visible) final
-        {
-            if (!m_client.setMenuBarIsVisible)
-                return;
-            m_client.setMenuBarIsVisible(toAPI(&page), visible, m_client.base.clientInfo);
-        }
-
-        void statusBarIsVisible(WebPageProxy& page, Function<void(bool)>&& completionHandler) final
-        {
-            if (!m_client.statusBarIsVisible)
-                return completionHandler(true);
-            completionHandler(m_client.statusBarIsVisible(toAPI(&page), m_client.base.clientInfo));
-        }
-
-        void setStatusBarIsVisible(WebPageProxy& page, bool visible) final
-        {
-            if (!m_client.setStatusBarIsVisible)
-                return;
-            m_client.setStatusBarIsVisible(toAPI(&page), visible, m_client.base.clientInfo);
-        }
-
         void setIsResizable(WebPageProxy& page, bool resizable) final
         {
             if (!m_client.setIsResizable)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -320,7 +320,6 @@ struct UIEdgeInsets;
 - (void)_webViewRunModal:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13.4));
 - (void)_webView:(WKWebView *)webView didNotHandleWheelEvent:(NSEvent *)event WK_API_AVAILABLE(macos(10.13.4));
 - (void)_webView:(WKWebView *)webView didClickAutoFillButtonWithUserInfo:(id <NSSecureCoding>)userInfo WK_API_AVAILABLE(macos(10.13.4));
-- (void)_webView:(WKWebView *)webView getToolbarsAreVisibleWithCompletionHandler:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(10.13.4));
 - (void)_webView:(WKWebView *)webView saveDataToFile:(NSData *)data suggestedFilename:(NSString *)suggestedFilename mimeType:(NSString *)mimeType originatingURL:(NSURL *)url WK_API_AVAILABLE(macos(10.13.4));
 - (CGFloat)_webViewHeaderHeight:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13.4));
 - (CGFloat)_webViewFooterHeight:(WKWebView *)webView WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4302,6 +4302,36 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
     });
 }
 
+- (void)_setStatusBarIsVisible:(BOOL)visible
+{
+    _page->setStatusBarIsVisible(visible);
+}
+
+- (BOOL)_statusBarIsVisible
+{
+    return _page->statusBarIsVisible();
+}
+
+- (void)_setMenuBarIsVisible:(BOOL)visible
+{
+    _page->setMenuBarIsVisible(visible);
+}
+
+- (BOOL)_menuBarIsVisible
+{
+    return _page->menuBarIsVisible();
+}
+
+- (void)_setToolbarsAreVisible:(BOOL)visible
+{
+    _page->setToolbarsAreVisible(visible);
+}
+
+- (BOOL)_toolbarsAreVisible
+{
+    return _page->toolbarsAreVisible();
+}
+
 - (void)_toggleInWindow
 {
     THROW_IF_SUSPENDED;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -438,6 +438,10 @@ for this property.
 - (void)_convertPoint:(CGPoint)point fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGPoint, NSError *error))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 - (void)_convertRect:(CGRect)rect fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGRect, NSError *error))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
+@property (nonatomic, setter=_setStatusBarIsVisible:) BOOL _statusBarIsVisible WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setMenuBarIsVisible:) BOOL _menuBarIsVisible WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setToolbarsAreVisible:) BOOL _toolbarsAreVisible WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 // If frame is nil, the main frame will be used if there is a main frame.
 // If frame is non-nil, not only will frame's coordinate space be used, but frame's subtree will be searched,
 // so a node from a parent node won't be returned, even if point is outside frame's rect.

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -144,7 +144,6 @@ private:
         void drawFooter(WebPageProxy&, WebFrameProxy&, WebCore::FloatRect&&) final;
 
         void didClickAutoFillButton(WebPageProxy&, API::Object*) final;
-        void toolbarsAreVisible(WebPageProxy&, Function<void(bool)>&&) final;
         void saveDataToFileInDownloadsFolder(WebPageProxy*, const WTF::String&, const WTF::String&, const URL&, API::Data&) final;
         Ref<API::InspectorConfiguration> configurationForLocalInspector(WebPageProxy&, WebInspectorUIProxy&) final;
         void didAttachLocalInspector(WebPageProxy&, WebInspectorUIProxy&) final;
@@ -259,7 +258,6 @@ private:
         bool webViewDrawHeaderInRectForPageWithTitleURL : 1;
         bool webViewDrawFooterInRectForPageWithTitleURL : 1;
         bool webViewGetWindowFrameWithCompletionHandler : 1;
-        bool webViewGetToolbarsAreVisibleWithCompletionHandler : 1;
         bool webViewSaveDataToFileSuggestedFilenameMimeTypeOriginatingURL : 1;
         bool webViewConfigurationForLocalInspector : 1;
         bool webViewDidAttachLocalInspector : 1;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -156,7 +156,6 @@ void UIDelegate::setDelegate(id<WKUIDelegate> delegate)
     m_delegateMethods.unfocusWebView = [delegate respondsToSelector:@selector(_unfocusWebView:)];
     m_delegateMethods.webViewRunModal = [delegate respondsToSelector:@selector(_webViewRunModal:)];
     m_delegateMethods.webViewDidScroll = [delegate respondsToSelector:@selector(_webViewDidScroll:)];
-    m_delegateMethods.webViewGetToolbarsAreVisibleWithCompletionHandler = [delegate respondsToSelector:@selector(_webView:getToolbarsAreVisibleWithCompletionHandler:)];
     m_delegateMethods.webViewDidNotHandleWheelEvent = [delegate respondsToSelector:@selector(_webView:didNotHandleWheelEvent:)];
     m_delegateMethods.webViewSetResizable = [delegate respondsToSelector:@selector(_webView:setResizable:)];
     m_delegateMethods.webViewGetWindowFrameWithCompletionHandler = [delegate respondsToSelector:@selector(_webView:getWindowFrameWithCompletionHandler:)];
@@ -1144,27 +1143,6 @@ void UIDelegate::UIClient::windowFrame(WebKit::WebPageProxy&, Function<void(WebC
             return;
         checker->didCallCompletionHandler();
         completionHandler(frame);
-    }).get()];
-}
-
-void UIDelegate::UIClient::toolbarsAreVisible(WebPageProxy&, Function<void(bool)>&& completionHandler)
-{
-    RefPtr uiDelegate = m_uiDelegate.get();
-    if (!uiDelegate)
-        return completionHandler(true);
-
-    if (!uiDelegate->m_delegateMethods.webViewGetToolbarsAreVisibleWithCompletionHandler)
-        return completionHandler(true);
-    
-    RetainPtr delegate = uiDelegatePrivate();
-    if (!delegate)
-        return completionHandler(true);
-    
-    [delegate _webView:uiDelegate->m_webView.get().get() getToolbarsAreVisibleWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getToolbarsAreVisibleWithCompletionHandler:))](BOOL visible) {
-        if (checker->completionHandlerHasBeenCalled())
-            return;
-        checker->didCallCompletionHandler();
-        completionHandler(visible);
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2793,6 +2793,13 @@ public:
     void resetPointerLockState(void);
 #endif
 
+    bool statusBarIsVisible() const { return m_statusBarIsVisible; }
+    void setStatusBarIsVisible(bool);
+    bool menuBarIsVisible() const { return m_menuBarIsVisible; }
+    void setMenuBarIsVisible(bool);
+    bool toolbarsAreVisible() const { return m_toolbarsAreVisible; }
+    void setToolbarsAreVisible(bool);
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -2917,12 +2924,6 @@ private:
     void setStatusText(const String&);
     void mouseDidMoveOverElement(WebHitTestResultData&&, OptionSet<WebEventModifier>);
 
-    void setToolbarsAreVisible(bool toolbarsAreVisible);
-    void getToolbarsAreVisible(CompletionHandler<void(bool)>&&);
-    void setMenuBarIsVisible(bool menuBarIsVisible);
-    void getMenuBarIsVisible(CompletionHandler<void(bool)>&&);
-    void setStatusBarIsVisible(bool statusBarIsVisible);
-    void getStatusBarIsVisible(CompletionHandler<void(bool)>&&);
     void getIsViewVisible(bool&);
     void setIsResizable(bool isResizable);
     void screenToRootView(const WebCore::IntPoint& screenPoint, CompletionHandler<void(const WebCore::IntPoint&)>&&);
@@ -3984,6 +3985,10 @@ private:
 
     const Ref<AboutSchemeHandler> m_aboutSchemeHandler;
     RefPtr<WebPageProxyTesting> m_pageForTesting;
+
+    bool m_statusBarIsVisible { true };
+    bool m_menuBarIsVisible { true };
+    bool m_toolbarsAreVisible { true };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -44,12 +44,6 @@ messages -> WebPageProxy {
     FocusFromServiceWorker() -> ()
     FocusedFrameChanged(std::optional<WebCore::FrameIdentifier> frameID)
     SetRenderTreeSize(uint64_t treeSize)
-    SetToolbarsAreVisible(bool toolbarsAreVisible)
-    GetToolbarsAreVisible() -> (bool toolbarsAreVisible) Synchronous
-    SetMenuBarIsVisible(bool menuBarIsVisible)
-    GetMenuBarIsVisible() -> (bool menuBarIsVisible) Synchronous
-    SetStatusBarIsVisible(bool statusBarIsVisible)
-    GetStatusBarIsVisible() -> (bool statusBarIsVisible) Synchronous
     SetIsResizable(bool isResizable)
     SetWindowFrame(WebCore::FloatRect windowFrame)
     GetWindowFrame() -> (WebCore::FloatRect windowFrame) Synchronous

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageUIClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageUIClient.h
@@ -55,16 +55,6 @@ public:
     virtual void willAddMessageToConsole(WebKit::WebPage*, JSC::MessageSource, JSC::MessageLevel, const WTF::String& message, unsigned lineNumber, unsigned columnNumber, const WTF::String& sourceID) { UNUSED_PARAM(message); UNUSED_PARAM(lineNumber); UNUSED_PARAM(columnNumber); UNUSED_PARAM(sourceID); }
 #endif
 
-    enum class UIElementVisibility {
-        Unknown,
-        Visible,
-        Hidden,
-    };
-
-    virtual UIElementVisibility statusBarIsVisible(WebKit::WebPage*) { return UIElementVisibility::Unknown; }
-    virtual UIElementVisibility menuBarIsVisible(WebKit::WebPage*) { return UIElementVisibility::Unknown; }
-    virtual UIElementVisibility toolbarsAreVisible(WebKit::WebPage*) { return UIElementVisibility::Unknown; }
-
     virtual void didClickAutoFillButton(WebKit::WebPage&, WebKit::InjectedBundleNodeHandle&, RefPtr<API::Object>&) { }
 };
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp
@@ -47,45 +47,6 @@ InjectedBundlePageUIClient::InjectedBundlePageUIClient(const WKBundlePageUIClien
     initialize(client);
 }
 
-static API::InjectedBundle::PageUIClient::UIElementVisibility toUIElementVisibility(WKBundlePageUIElementVisibility visibility)
-{
-    switch (visibility) {
-    case WKBundlePageUIElementVisibilityUnknown:
-        return API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown;
-    case WKBundlePageUIElementVisible:
-        return API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
-    case WKBundlePageUIElementHidden:
-        return API::InjectedBundle::PageUIClient::UIElementVisibility::Hidden;
-    }
-
-    ASSERT_NOT_REACHED();
-    return API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown;
-}
-
-API::InjectedBundle::PageUIClient::UIElementVisibility InjectedBundlePageUIClient::statusBarIsVisible(WebPage* page)
-{
-    if (!m_client.statusBarIsVisible)
-        return API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown;
-    
-    return toUIElementVisibility(m_client.statusBarIsVisible(toAPI(page), m_client.base.clientInfo));
-}
-
-API::InjectedBundle::PageUIClient::UIElementVisibility InjectedBundlePageUIClient::menuBarIsVisible(WebPage* page)
-{
-    if (!m_client.menuBarIsVisible)
-        return API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown;
-    
-    return toUIElementVisibility(m_client.menuBarIsVisible(toAPI(page), m_client.base.clientInfo));
-}
-
-API::InjectedBundle::PageUIClient::UIElementVisibility InjectedBundlePageUIClient::toolbarsAreVisible(WebPage* page)
-{
-    if (!m_client.toolbarsAreVisible)
-        return API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown;
-    
-    return toUIElementVisibility(m_client.toolbarsAreVisible(toAPI(page), m_client.base.clientInfo));
-}
-
 void InjectedBundlePageUIClient::didClickAutoFillButton(WebPage& page, InjectedBundleNodeHandle& nodeHandle, RefPtr<API::Object>& userData)
 {
     if (!m_client.didClickAutoFillButton)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.h
@@ -47,10 +47,6 @@ class InjectedBundlePageUIClient : public API::Client<WKBundlePageUIClientBase>,
 public:
     explicit InjectedBundlePageUIClient(const WKBundlePageUIClientBase*);
 
-    UIElementVisibility statusBarIsVisible(WebPage*) override;
-    UIElementVisibility menuBarIsVisible(WebPage*) override;
-    UIElementVisibility toolbarsAreVisible(WebPage*) override;
-
     void didClickAutoFillButton(WebPage&, InjectedBundleNodeHandle&, RefPtr<API::Object>& userData) override;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -449,31 +449,12 @@ void WebChromeClient::reportProcessCPUTime(Seconds cpuTime, ActivityStateForCPUS
     WebProcess::singleton().send(Messages::WebProcessPool::ReportWebContentCPUTime(cpuTime, static_cast<uint64_t>(activityState)), 0);
 }
 
-void WebChromeClient::setToolbarsVisible(bool toolbarsAreVisible)
-{
-    if (RefPtr page = m_page.get())
-        page->send(Messages::WebPageProxy::SetToolbarsAreVisible(toolbarsAreVisible));
-}
-
 bool WebChromeClient::toolbarsVisible() const
 {
     RefPtr page = m_page.get();
     if (!page)
         return false;
-
-    API::InjectedBundle::PageUIClient::UIElementVisibility toolbarsVisibility = page->injectedBundleUIClient().toolbarsAreVisible(page.get());
-    if (toolbarsVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
-        return toolbarsVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
-    
-    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetToolbarsAreVisible(), page->identifier());
-    auto [toolbarsAreVisible] = sendResult.takeReplyOr(true);
-    return toolbarsAreVisible;
-}
-
-void WebChromeClient::setStatusbarVisible(bool statusBarIsVisible)
-{
-    if (RefPtr page = m_page.get())
-        page->send(Messages::WebPageProxy::SetStatusBarIsVisible(statusBarIsVisible));
+    return page->toolbarsAreVisible();
 }
 
 bool WebChromeClient::statusbarVisible() const
@@ -481,19 +462,7 @@ bool WebChromeClient::statusbarVisible() const
     RefPtr page = m_page.get();
     if (!page)
         return false;
-
-    API::InjectedBundle::PageUIClient::UIElementVisibility statusbarVisibility = page->injectedBundleUIClient().statusBarIsVisible(page.get());
-    if (statusbarVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
-        return statusbarVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
-
-    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetStatusBarIsVisible(), page->identifier());
-    auto [statusBarIsVisible] = sendResult.takeReplyOr(true);
-    return statusBarIsVisible;
-}
-
-void WebChromeClient::setScrollbarsVisible(bool)
-{
-    notImplemented();
+    return page->statusBarIsVisible();
 }
 
 bool WebChromeClient::scrollbarsVisible() const
@@ -502,25 +471,12 @@ bool WebChromeClient::scrollbarsVisible() const
     return true;
 }
 
-void WebChromeClient::setMenubarVisible(bool menuBarVisible)
-{
-    if (RefPtr page = m_page.get())
-        page->send(Messages::WebPageProxy::SetMenuBarIsVisible(menuBarVisible));
-}
-
 bool WebChromeClient::menubarVisible() const
 {
     RefPtr page = m_page.get();
     if (!page)
         return false;
-
-    API::InjectedBundle::PageUIClient::UIElementVisibility menubarVisibility = page->injectedBundleUIClient().menuBarIsVisible(page.get());
-    if (menubarVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
-        return menubarVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
-    
-    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetMenuBarIsVisible(), page->identifier());
-    auto [menuBarIsVisible] = sendResult.takeReplyOr(true);
-    return menuBarIsVisible;
+    return page->menuBarIsVisible();
 }
 
 void WebChromeClient::setResizable(bool resizable)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -94,17 +94,10 @@ private:
     void runModal() final;
 
     void reportProcessCPUTime(Seconds, WebCore::ActivityStateForCPUSampling) final;
-    
-    void setToolbarsVisible(bool) final;
+
     bool toolbarsVisible() const final;
-    
-    void setStatusbarVisible(bool) final;
     bool statusbarVisible() const final;
-    
-    void setScrollbarsVisible(bool) final;
     bool scrollbarsVisible() const final;
-    
-    void setMenubarVisible(bool) final;
     bool menubarVisible() const final;
     
     void setResizable(bool) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -712,6 +712,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #if ENABLE(WRITING_TOOLS)
     , m_textAnimationController(makeUniqueRef<TextAnimationController>(*this))
 #endif
+    , m_statusBarIsVisible(parameters.statusBarIsVisible)
+    , m_menuBarIsVisible(parameters.menuBarIsVisible)
+    , m_toolbarsAreVisible(parameters.toolbarsAreVisible)
 {
     WEBPAGE_RELEASE_LOG(Loading, "constructor:");
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2058,6 +2058,13 @@ public:
     void setOverflowHeightForTopScrollEdgeEffect(double value) { m_overflowHeightForTopScrollEdgeEffect = value; }
 #endif
 
+    bool statusBarIsVisible() const { return m_statusBarIsVisible; }
+    void setStatusBarIsVisible(bool visible) { m_statusBarIsVisible = visible; }
+    bool menuBarIsVisible() const { return m_menuBarIsVisible; }
+    void setMenuBarIsVisible(bool visible) { m_menuBarIsVisible = visible; }
+    bool toolbarsAreVisible() const { return m_toolbarsAreVisible; }
+    void setToolbarsAreVisible(bool visible) { m_toolbarsAreVisible = visible; }
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -3152,6 +3159,10 @@ private:
     std::unique_ptr<FrameInfoData> m_mainFrameNavigationInitiator;
 
     mutable RefPtr<Logger> m_logger;
+
+    bool m_statusBarIsVisible { true };
+    bool m_menuBarIsVisible { true };
+    bool m_toolbarsAreVisible { true };
 };
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -623,6 +623,10 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     PerformHitTestForMouseEvent(WebKit::WebMouseEvent event) -> (struct WebKit::WebHitTestResultData hitTestResult, OptionSet<WebKit::WebEventModifier> modifiers)
 
+    SetStatusBarIsVisible(bool visible)
+    SetMenuBarIsVisible(bool visible)
+    SetToolbarsAreVisible(bool visible)
+
     SetUseColorAppearance(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)
 
 #if HAVE(APP_ACCENT_COLORS)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -72,16 +72,16 @@ private:
     bool canRunModal() const final;
     void runModal() final;
 
-    void setToolbarsVisible(bool) final;
+    void setToolbarsVisible(bool);
     bool toolbarsVisible() const final;
 
-    void setStatusbarVisible(bool) final;
+    void setStatusbarVisible(bool);
     bool statusbarVisible() const final;
 
-    void setScrollbarsVisible(bool) final;
+    void setScrollbarsVisible(bool);
     bool scrollbarsVisible() const final;
 
-    void setMenubarVisible(bool) final;
+    void setMenubarVisible(bool);
     bool menubarVisible() const final;
 
     void setResizable(bool) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -313,6 +313,15 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         if (!features.wantsNoOpener()) {
             m_webView.page->protectedStorageNamespaceProvider()->cloneSessionStorageNamespaceForPage(*m_webView.page, *newPage);
             newPage->mainFrame().setOpenerForWebKitLegacy(&frame);
+
+            auto& newPageClient = static_cast<WebChromeClient&>(newPage->chrome().client());
+            setToolbarsVisible(features.toolBarVisible || features.locationBarVisible);
+            if (features.statusBarVisible)
+                newPageClient.setStatusbarVisible(*features.statusBarVisible);
+            if (features.scrollbarsVisible)
+                newPageClient.setScrollbarsVisible(*features.scrollbarsVisible);
+            if (features.menuBarVisible)
+                newPageClient.setMenubarVisible(*features.menuBarVisible);
             newPage->applyWindowFeatures(features);
         }
 


### PR DESCRIPTION
#### f8c0856e009e18d51eead7aa7cf9110b278703c8
<pre>
Re-implement toolbar, statusbar, and menubar visibility for site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=298694">https://bugs.webkit.org/show_bug.cgi?id=298694</a>
<a href="https://rdar.apple.com/160333679">rdar://160333679</a>

Reviewed by Pascoe.

The way we&apos;ve done this so far has several undesirable aspects:

1. It uses the injected bundle
2. It sends synchronous IPC
3. It doesn&apos;t work with site isolation

This PR fixes all 3!  Instead of querying as needed, I push the state
from the UI process to all web content processes.  The initial state
comes from WindowFeatures, but it can be changed by setters on the
WKWebView.

* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::setToolbarsVisible): Deleted.
(WebCore::Chrome::setStatusbarVisible): Deleted.
(WebCore::Chrome::setScrollbarsVisible): Deleted.
(WebCore::Chrome::setMenubarVisible): Deleted.
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::applyWindowFeatures):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::toolbarsAreVisible): Deleted.
(API::UIClient::setToolbarsAreVisible): Deleted.
(API::UIClient::menuBarIsVisible): Deleted.
(API::UIClient::setMenuBarIsVisible): Deleted.
(API::UIClient::statusBarIsVisible): Deleted.
(API::UIClient::setStatusBarIsVisible): Deleted.
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setStatusBarIsVisible:]):
(-[WKWebView _statusBarIsVisible]):
(-[WKWebView _setMenuBarIsVisible:]):
(-[WKWebView _menuBarIsVisible]):
(-[WKWebView _setToolbarsAreVisible:]):
(-[WKWebView _toolbarsAreVisible]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::toolbarsAreVisible): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::windowFeature):
(WebKit::m_statusBarIsVisible):
(WebKit::m_menuBarIsVisible):
(WebKit::m_toolbarsAreVisible):
(WebKit::WebPageProxy::setToolbarsAreVisible):
(WebKit::WebPageProxy::setMenuBarIsVisible):
(WebKit::WebPageProxy::setStatusBarIsVisible):
(WebKit::WebPageProxy::creationParameters):
(WebKit::m_pageForTesting): Deleted.
(WebKit::WebPageProxy::getToolbarsAreVisible): Deleted.
(WebKit::WebPageProxy::getMenuBarIsVisible): Deleted.
(WebKit::WebPageProxy::getStatusBarIsVisible): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageUIClient.h:
(API::InjectedBundle::PageUIClient::statusBarIsVisible): Deleted.
(API::InjectedBundle::PageUIClient::menuBarIsVisible): Deleted.
(API::InjectedBundle::PageUIClient::toolbarsAreVisible): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp:
(WebKit::toUIElementVisibility): Deleted.
(WebKit::InjectedBundlePageUIClient::statusBarIsVisible): Deleted.
(WebKit::InjectedBundlePageUIClient::menuBarIsVisible): Deleted.
(WebKit::InjectedBundlePageUIClient::toolbarsAreVisible): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::toolbarsVisible const):
(WebKit::WebChromeClient::statusbarVisible const):
(WebKit::WebChromeClient::menubarVisible const):
(WebKit::WebChromeClient::setToolbarsVisible): Deleted.
(WebKit::WebChromeClient::setStatusbarVisible): Deleted.
(WebKit::WebChromeClient::setScrollbarsVisible): Deleted.
(WebKit::WebChromeClient::setMenubarVisible): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_toolbarsAreVisible):
(WebKit::m_textAnimationController): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, StatusBarVisibility)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
((WebKit, ToolbarVisible)):
(-[ToolbarDelegate _webView:getToolbarsAreVisibleWithCompletionHandler:]): Deleted.
(-[ToolbarDelegate webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/299861@main">https://commits.webkit.org/299861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae6d0347d60cd4330ae3da228a45ca8fa1bf21b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72531 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2af935ba-d1ae-40a4-add4-3f6c48b1b82f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91485 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60772 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e2ed58f-25eb-40a1-a15a-9d6f6547fcae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72036 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebd910c1-638e-46d7-9ecd-4b2e05cd2f06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26084 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70448 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129717 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100108 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99950 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44025 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19126 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52944 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46707 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50054 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->