### PR TITLE
[JSC] Implement `Set.prototype.difference` in C++

### DIFF
--- a/JSTests/stress/set-prototype-difference-empty-sets.js
+++ b/JSTests/stress/set-prototype-difference-empty-sets.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function assertArrayContent(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < actual.length; i++) {
+        if (!expected.includes(actual[i]))
+            throw new Error(`unexpected element: ${actual[i]}`);
+    }
+    for (let i = 0; i < expected.length; i++) {
+        if (!actual.includes(expected[i]))
+            throw new Error(`missing element: ${expected[i]}`);
+    }
+}
+
+let emptySet1 = new Set();
+let emptySet2 = new Set();
+let result = emptySet1.difference(emptySet2);
+shouldBe(result.size, 0);
+
+let set1 = new Set([1, 2, 3]);
+let empty = new Set();
+result = empty.difference(set1);
+shouldBe(result.size, 0);
+
+result = set1.difference(empty);
+assertArrayContent(Array.from(result), [1, 2, 3]);
+
+let disjoint1 = new Set([1, 2, 3]);
+let disjoint2 = new Set([4, 5, 6]);
+result = disjoint1.difference(disjoint2);
+assertArrayContent(Array.from(result), [1, 2, 3]);
+
+result = disjoint2.difference(disjoint1);
+assertArrayContent(Array.from(result), [4, 5, 6]);
+
+let overlapping1 = new Set([1, 2, 3]);
+let overlapping2 = new Set([3, 4, 5]);
+result = overlapping1.difference(overlapping2);
+assertArrayContent(Array.from(result), [1, 2]);
+
+result = overlapping2.difference(overlapping1);
+assertArrayContent(Array.from(result), [4, 5]);
+
+let identical1 = new Set([1, 2, 3]);
+let identical2 = new Set([1, 2, 3]);
+result = identical1.difference(identical2);
+shouldBe(result.size, 0);
+
+result = identical2.difference(identical1);
+shouldBe(result.size, 0);

--- a/JSTests/stress/set-prototype-difference-large-sets.js
+++ b/JSTests/stress/set-prototype-difference-large-sets.js
@@ -1,0 +1,121 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function createLargeSet(size, start = 0) {
+    let set = new Set();
+    for (let i = start; i < start + size; i++) {
+        set.add(i);
+    }
+    return set;
+}
+
+let largeSet1 = createLargeSet(10000, 0);
+let largeSet2 = createLargeSet(10000, 10000);
+
+let result = largeSet1.difference(largeSet2);
+shouldBe(result.size, 10000);
+for (let i = 0; i < 10000; i++) {
+    shouldBe(result.has(i), true);
+}
+for (let i = 10000; i < 20000; i++) {
+    shouldBe(result.has(i), false);
+}
+
+result = largeSet2.difference(largeSet1);
+shouldBe(result.size, 10000);
+for (let i = 0; i < 10000; i++) {
+    shouldBe(result.has(i), false);
+}
+for (let i = 10000; i < 20000; i++) {
+    shouldBe(result.has(i), true);
+}
+
+let overlappingSet1 = createLargeSet(5000, 0);
+let overlappingSet2 = createLargeSet(5000, 2500);
+
+result = overlappingSet1.difference(overlappingSet2);
+shouldBe(result.size, 2500);
+for (let i = 0; i < 2500; i++) {
+    shouldBe(result.has(i), true);
+}
+for (let i = 2500; i < 7500; i++) {
+    shouldBe(result.has(i), false);
+}
+
+result = overlappingSet2.difference(overlappingSet1);
+shouldBe(result.size, 2500);
+for (let i = 0; i < 2500; i++) {
+    shouldBe(result.has(i), false);
+}
+for (let i = 5000; i < 7500; i++) {
+    shouldBe(result.has(i), true);
+}
+
+let largeSet = createLargeSet(1000, 0);
+let smallSet = createLargeSet(100, 1000);
+
+result = largeSet.difference(smallSet);
+shouldBe(result.size, 1000);
+for (let i = 0; i < 1000; i++) {
+    shouldBe(result.has(i), true);
+}
+
+result = smallSet.difference(largeSet);
+shouldBe(result.size, 100);
+for (let i = 1000; i < 1100; i++) {
+    shouldBe(result.has(i), true);
+}
+
+let perfTestSet = createLargeSet(2000, 0);
+let perfSetLike = {
+    size: 1000,
+    has: function(key) {
+        return key >= 2000 && key < 3000;
+    },
+    keys: function() {
+        let index = 2000;
+        return {
+            next: function() {
+                if (index < 3000) {
+                    return { value: index++, done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = perfTestSet.difference(perfSetLike);
+shouldBe(result.size, 2000);
+for (let i = 0; i < 2000; i++) {
+    shouldBe(result.has(i), true);
+}
+
+let overlappingPerfSetLike = {
+    size: 500,
+    has: function(key) {
+        return key >= 1500 && key < 2000;
+    },
+    keys: function() {
+        let index = 1500;
+        return {
+            next: function() {
+                if (index < 2000) {
+                    return { value: index++, done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = perfTestSet.difference(overlappingPerfSetLike);
+shouldBe(result.size, 1500);
+for (let i = 0; i < 1500; i++) {
+    shouldBe(result.has(i), true);
+}
+for (let i = 1500; i < 2000; i++) {
+    shouldBe(result.has(i), false);
+}

--- a/JSTests/stress/set-prototype-difference-optimized.js
+++ b/JSTests/stress/set-prototype-difference-optimized.js
@@ -1,0 +1,209 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function assertArrayContent(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < actual.length; i++) {
+        if (!expected.includes(actual[i]))
+            throw new Error(`unexpected element: ${actual[i]}`);
+    }
+    for (let i = 0; i < expected.length; i++) {
+        if (!actual.includes(expected[i]))
+            throw new Error(`missing element: ${expected[i]}`);
+    }
+}
+
+// Test 1: Fast path with native Sets
+let set1 = new Set([1, 2, 3, 4, 5]);
+let set2 = new Set([3, 4, 5, 6, 7]);
+let result = set1.difference(set2);
+assertArrayContent(Array.from(result), [1, 2]);
+
+let set3 = new Set([1, 2, 3]);
+let set4 = new Set([4, 5, 6]);
+result = set3.difference(set4);
+assertArrayContent(Array.from(result), [1, 2, 3]);
+
+// Test 2: Empty sets
+let emptySet1 = new Set();
+let emptySet2 = new Set();
+result = emptySet1.difference(emptySet2);
+shouldBe(result.size, 0);
+
+result = set1.difference(emptySet1);
+assertArrayContent(Array.from(result), [1, 2, 3, 4, 5]);
+
+result = emptySet1.difference(set1);
+shouldBe(result.size, 0);
+
+// Test 3: Large sets
+function createLargeSet(size, start = 0) {
+    let set = new Set();
+    for (let i = start; i < start + size; i++) {
+        set.add(i);
+    }
+    return set;
+}
+
+let largeSet1 = createLargeSet(10000, 0);
+let largeSet2 = createLargeSet(5000, 5000);
+result = largeSet1.difference(largeSet2);
+shouldBe(result.size, 5000);
+for (let i = 0; i < 5000; i++) {
+    shouldBe(result.has(i), true);
+}
+for (let i = 5000; i < 10000; i++) {
+    shouldBe(result.has(i), false);
+}
+
+// Test 4: Set-like objects with small size (thisSet.size <= otherSize)
+let smallSet = new Set([1, 2, 3]);
+let largeSetLike = {
+    size: 10,
+    has: function(key) {
+        return key === 2 || key === 4;
+    },
+    keys: function() {
+        let values = [2, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = smallSet.difference(largeSetLike);
+assertArrayContent(Array.from(result), [1, 3]);
+
+// Test 5: Set-like objects with large size (thisSet.size > otherSize)
+let bigSet = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+let smallSetLike = {
+    size: 3,
+    has: function(key) {
+        return [2, 4, 6].includes(key);
+    },
+    keys: function() {
+        let values = [2, 4, 6];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = bigSet.difference(smallSetLike);
+assertArrayContent(Array.from(result), [1, 3, 5, 7, 8, 9, 10]);
+
+// Test 6: Special values
+let specialSet1 = new Set([0, -0, NaN, undefined, null, "", false, true, 42]);
+let specialSet2 = new Set([0, NaN, null, true, 100]);
+result = specialSet1.difference(specialSet2);
+assertArrayContent(Array.from(result), [undefined, "", false, 42]);
+
+// Test 7: Objects and symbols
+let obj1 = { a: 1 };
+let obj2 = { b: 2 };
+let obj3 = { c: 3 };
+let sym1 = Symbol('test1');
+let sym2 = Symbol('test2');
+
+let objectSet1 = new Set([obj1, obj2, obj3, sym1, sym2]);
+let objectSet2 = new Set([obj2, sym1]);
+result = objectSet1.difference(objectSet2);
+assertArrayContent(Array.from(result), [obj1, obj3, sym2]);
+
+// Test 8: Iterator modification during iteration
+let modSet = new Set([1, 2, 3, 4, 5]);
+let modSetLike = {
+    size: 3,
+    has: function(key) {
+        return [2, 4, 6].includes(key);
+    },
+    keys: function() {
+        let values = [2, 4, 6];
+        let index = 0;
+        return {
+            next: function() {
+                if (index === 1) {
+                    // Modify the original set during iteration
+                    modSet.add(10);
+                    modSet.delete(1);
+                }
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = modSet.difference(modSetLike);
+// The result should contain elements not in modSetLike (2, 4, 6)
+// Note: 1 was deleted during iteration, 10 was added during iteration
+// The result captures the state at the time of difference computation
+shouldBe(result.has(1), true); // was in original set, not in modSetLike
+shouldBe(result.has(3), true);
+shouldBe(result.has(5), true);
+shouldBe(result.has(10), false); // added after iteration started
+
+// Test 9: Performance test with different sizes
+let perfSet1 = createLargeSet(1000, 0);
+let perfSet2 = createLargeSet(100, 500);
+result = perfSet1.difference(perfSet2);
+shouldBe(result.size, 900);
+
+// Test 10: All elements removed
+let allSet1 = new Set([1, 2, 3]);
+let allSet2 = new Set([1, 2, 3, 4, 5]);
+result = allSet1.difference(allSet2);
+shouldBe(result.size, 0);
+
+// Test 11: Property access order validation
+let accessOrder = [];
+let trackedSetLike = {
+    get size() {
+        accessOrder.push('size');
+        return 3;
+    },
+    get has() {
+        accessOrder.push('has');
+        return function(key) {
+            return [2, 4].includes(key);
+        };
+    },
+    get keys() {
+        accessOrder.push('keys');
+        return function() {
+            let values = [2, 4, 6];
+            let index = 0;
+            return {
+                next: function() {
+                    if (index < values.length) {
+                        return { value: values[index++], done: false };
+                    }
+                    return { done: true };
+                }
+            };
+        };
+    }
+};
+
+let propSet = new Set([1, 2, 3, 4, 5]);
+result = propSet.difference(trackedSetLike);
+shouldBe(accessOrder.length, 3);
+shouldBe(accessOrder[0], 'size');
+shouldBe(accessOrder[1], 'has');
+shouldBe(accessOrder[2], 'keys');

--- a/JSTests/stress/set-prototype-difference-property-access-order.js
+++ b/JSTests/stress/set-prototype-difference-property-access-order.js
@@ -1,0 +1,148 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let accessOrder = [];
+    let set = new Set([1, 2, 3, 4, 5]);
+    
+    let obj = {
+        get size() {
+            accessOrder.push('size');
+            return 3;
+        },
+        get has() {
+            accessOrder.push('has');
+            return function(key) {
+                return [2, 4].includes(key);
+            };
+        },
+        get keys() {
+            accessOrder.push('keys');
+            return function() {
+                let values = [2, 4, 6];
+                let index = 0;
+                return {
+                    next: function() {
+                        if (index < values.length) {
+                            return { value: values[index++], done: false };
+                        }
+                        return { done: true };
+                    }
+                };
+            };
+        }
+    };
+    
+    let result = set.difference(obj);
+    shouldBe(result.has(1), true);
+    shouldBe(result.has(2), false);
+    shouldBe(result.has(3), true);
+    shouldBe(result.has(4), false);
+    shouldBe(result.has(5), true);
+    
+    shouldBe(accessOrder.length, 3);
+    shouldBe(accessOrder[0], 'size');
+    shouldBe(accessOrder[1], 'has');
+    shouldBe(accessOrder[2], 'keys');
+}
+
+main();
+
+function testSmallSetOptimization() {
+    let accessOrder = [];
+    let smallSet = new Set([1, 2, 3]);
+    
+    let obj = {
+        get size() {
+            accessOrder.push('size');
+            return 5;
+        },
+        get has() {
+            accessOrder.push('has');
+            return function(key) {
+                return [2, 4, 6, 7, 8].includes(key);
+            };
+        },
+        get keys() {
+            accessOrder.push('keys');
+            return function() {
+                let values = [2, 4, 6, 7, 8];
+                let index = 0;
+                return {
+                    next: function() {
+                        if (index < values.length) {
+                            return { value: values[index++], done: false };
+                        }
+                        return { done: true };
+                    }
+                };
+            };
+        }
+    };
+    
+    let result = smallSet.difference(obj);
+    shouldBe(result.has(1), true);
+    shouldBe(result.has(2), false);
+    shouldBe(result.has(3), true);
+    
+    shouldBe(accessOrder.length, 3);
+    shouldBe(accessOrder[0], 'size');
+    shouldBe(accessOrder[1], 'has');
+    shouldBe(accessOrder[2], 'keys');
+}
+
+testSmallSetOptimization();
+
+function testLargeSetOptimization() {
+    let accessOrder = [];
+    let largeSet = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    
+    let obj = {
+        get size() {
+            accessOrder.push('size');
+            return 3;
+        },
+        get has() {
+            accessOrder.push('has');
+            return function(key) {
+                return [2, 4, 6].includes(key);
+            };
+        },
+        get keys() {
+            accessOrder.push('keys');
+            return function() {
+                let values = [2, 4, 6];
+                let index = 0;
+                return {
+                    next: function() {
+                        if (index < values.length) {
+                            return { value: values[index++], done: false };
+                        }
+                        return { done: true };
+                    }
+                };
+            };
+        }
+    };
+    
+    let result = largeSet.difference(obj);
+    shouldBe(result.has(1), true);
+    shouldBe(result.has(2), false);
+    shouldBe(result.has(3), true);
+    shouldBe(result.has(4), false);
+    shouldBe(result.has(5), true);
+    shouldBe(result.has(6), false);
+    shouldBe(result.has(7), true);
+    shouldBe(result.has(8), true);
+    shouldBe(result.has(9), true);
+    shouldBe(result.has(10), true);
+    
+    shouldBe(accessOrder.length, 3);
+    shouldBe(accessOrder[0], 'size');
+    shouldBe(accessOrder[1], 'has');
+    shouldBe(accessOrder[2], 'keys');
+}
+
+testLargeSetOptimization();

--- a/JSTests/stress/set-prototype-difference-special-values.js
+++ b/JSTests/stress/set-prototype-difference-special-values.js
@@ -1,0 +1,171 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function assertArrayContent(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < actual.length; i++) {
+        if (!expected.includes(actual[i]))
+            throw new Error(`unexpected element: ${actual[i]}`);
+    }
+    for (let i = 0; i < expected.length; i++) {
+        if (!actual.includes(expected[i]))
+            throw new Error(`missing element: ${expected[i]}`);
+    }
+}
+
+let set = new Set([0, -0, NaN, undefined, null, "", false, true, 42, "extra"]);
+
+let disjointSetLike = {
+    size: 8,
+    has: function(key) {
+        if (key === 100) return true;
+        if (key === "different") return true;
+        if (key === false) return false;
+        return [99, 98, 97, 96, 95, 94, 93].includes(key);
+    },
+    keys: function() {
+        let values = [99, 98, 97, 96, 95, 94, 93, 100];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+let result = set.difference(disjointSetLike);
+assertArrayContent(Array.from(result), [0, NaN, undefined, null, "", false, true, 42, "extra"]);
+
+let overlappingSetLike = {
+    size: 8,
+    has: function(key) {
+        if (key === 0 || key === -0) return true;
+        if (Number.isNaN(key)) return true;
+        if (key === undefined) return true;
+        if (key === null) return true;
+        if (key === "") return true;
+        if (key === false) return true;
+        if (key === true) return true;
+        if (key === 42) return true;
+        return false;
+    },
+    keys: function() {
+        let values = [0, NaN, undefined, null, "", false, true, 42];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = set.difference(overlappingSetLike);
+assertArrayContent(Array.from(result), ["extra"]);
+
+let sym1 = Symbol('test1');
+let sym2 = Symbol('test2');
+let sym3 = Symbol('test3');
+let symbolSet = new Set([sym1, sym2, sym3]);
+
+let disjointSymbolSetLike = {
+    size: 2,
+    has: function(key) {
+        return key === Symbol('test4') || key === Symbol('test5');
+    },
+    keys: function() {
+        let values = [Symbol('test4'), Symbol('test5')];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = symbolSet.difference(disjointSymbolSetLike);
+assertArrayContent(Array.from(result), [sym1, sym2, sym3]);
+
+let overlappingSymbolSetLike = {
+    size: 2,
+    has: function(key) {
+        return key === sym1 || key === sym2;
+    },
+    keys: function() {
+        let values = [sym1, sym2];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = symbolSet.difference(overlappingSymbolSetLike);
+assertArrayContent(Array.from(result), [sym3]);
+
+let obj1 = { a: 1 };
+let obj2 = { b: 2 };
+let obj3 = { c: 3 };
+let objectSet = new Set([obj1, obj2, obj3]);
+
+let disjointObjectSetLike = {
+    size: 2,
+    has: function(key) {
+        return key === { a: 1 } || key === { b: 2 };
+    },
+    keys: function() {
+        let values = [{ a: 1 }, { b: 2 }];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = objectSet.difference(disjointObjectSetLike);
+assertArrayContent(Array.from(result), [obj1, obj2, obj3]);
+
+let overlappingObjectSetLike = {
+    size: 2,
+    has: function(key) {
+        return key === obj1 || key === obj2;
+    },
+    keys: function() {
+        let values = [obj1, obj2];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = objectSet.difference(overlappingObjectSetLike);
+assertArrayContent(Array.from(result), [obj3]);

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -67,53 +67,6 @@ function getSetSizeAsInt(other)
     return sizeInt;
 }
 
-function difference(other)
-{
-    "use strict";
-
-    if (!@isSet(this))
-        @throwTypeError("Set operation called on non-Set object");
-
-    // Get Set Record
-    var size = @getSetSizeAsInt(other);
-
-    var has = other.has;
-    if (!@isCallable(has))
-        @throwTypeError("Set.prototype.difference expects other.has to be callable");
-
-    var keys = other.keys;
-    if (!@isCallable(keys))
-        @throwTypeError("Set.prototype.difference expects other.keys to be callable");
-
-    var result = @setClone(this);
-    if (this.@size <= size) {
-        var storage = @setStorage(result);
-        var entry = 0;
-
-        while (true) {
-            storage = @setIterationNext(storage, entry);
-            if (storage == @orderedHashTableSentinel)
-                break;
-            entry = @setIterationEntry(storage) + 1;
-            var key = @setIterationEntryKey(storage);
-
-            if (has.@call(other, key))
-                result.@delete(key);
-        }
-    } else {
-        var iterator = keys.@call(other);
-        var wrapper = {
-            @@iterator: function () { return iterator; }
-        };
-
-        for (var key of wrapper) {
-            if (result.@has(key))
-                result.@delete(key);
-        }
-    }
-
-    return result;
-}
 
 function symmetricDifference(other)
 {


### PR DESCRIPTION
#### 326fe132d52717c19ec93ecdefaa1105065498c8
<pre>
[JSC] Implement `Set.prototype.difference` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=298696">https://bugs.webkit.org/show_bug.cgi?id=298696</a>

Reviewed by Yusuke Suzuki.

This patch changes to implement `Set.prototype.difference` in C++.

                        TipOfTree                  Patched

set-difference       21.0741+-0.5328     ^     14.7943+-0.6722        ^ definitely 1.4245x faster

* JSTests/stress/set-prototype-difference-empty-sets.js: Added.
(shouldBe):
* JSTests/stress/set-prototype-difference-large-sets.js: Added.
(shouldBe):
(set let):
(let.perfSetLike.has):
(let.perfSetLike.return.next):
(let.perfSetLike.keys):
(let.overlappingPerfSetLike.has):
(let.overlappingPerfSetLike.return.next):
(let.overlappingPerfSetLike.keys):
* JSTests/stress/set-prototype-difference-optimized.js: Added.
(shouldBe):
(set let):
(let.largeSetLike.has):
(let.largeSetLike.return.next):
(let.largeSetLike.keys):
(let.smallSetLike.has):
(let.smallSetLike.return.next):
(let.smallSetLike.keys):
(let.modSetLike.has):
(let.modSetLike.return.next):
(let.modSetLike.keys):
(let.trackedSetLike.get size):
(let.trackedSetLike.get has):
(let.trackedSetLike.get keys.return.next):
(let.trackedSetLike.get keys):
* JSTests/stress/set-prototype-difference-property-access-order.js: Added.
(shouldBe):
(main.let.obj.get size):
(main.let.obj.get has):
(main.let.obj.get keys.return.next):
(main.let.obj.get keys):
(main.let.set new):
(testSmallSetOptimization.let.obj.get size):
(testSmallSetOptimization.let.obj.get has):
(testSmallSetOptimization.let.obj.get keys.return.next):
(testSmallSetOptimization.let.obj.get keys):
(testSmallSetOptimization):
(testLargeSetOptimization.let.obj.get size):
(testLargeSetOptimization.let.obj.get has):
(testLargeSetOptimization.let.obj.get keys.return.next):
(testLargeSetOptimization.let.obj.get keys):
(testLargeSetOptimization):
* JSTests/stress/set-prototype-difference-special-values.js: Added.
(shouldBe):
(let.disjointSetLike.has):
(let.disjointSetLike.return.next):
(let.disjointSetLike.keys):
(let.set new):
(let.overlappingSetLike.has):
(let.overlappingSetLike.return.next):
(let.overlappingSetLike.keys):
(let.result.set difference):
(let.disjointSymbolSetLike.has):
(let.disjointSymbolSetLike.return.next):
(let.disjointSymbolSetLike.keys):
(result.set difference):
(let.overlappingSymbolSetLike.has):
(let.overlappingSymbolSetLike.return.next):
(let.overlappingSymbolSetLike.keys):
(let.disjointObjectSetLike.has):
(let.disjointObjectSetLike.return.next):
(let.disjointObjectSetLike.keys):
(let.overlappingObjectSetLike.has):
(let.overlappingObjectSetLike.return.next):
(let.overlappingObjectSetLike.keys):
* Source/JavaScriptCore/builtins/SetPrototype.js:
(difference.else.wrapper.iterator): Deleted.
(difference): Deleted.
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):
(JSC::fastSetDifference):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/299885@main">https://commits.webkit.org/299885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7e4cc2944d6b971c17019b0790603cec6c592a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72443 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91414 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60709 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26008 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70355 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112494 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129623 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118884 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99873 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45323 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43935 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52856 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147583 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46619 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37914 "Found 1 new JSC binary failure: testapi, Found 18682 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse2.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->