### PR TITLE
WebDriver Bidi: implement context created event and destroyed

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -29,6 +29,7 @@
 #include "AutomationBackendDispatchers.h"
 #include "AutomationFrontendDispatchers.h"
 #include "Connection.h"
+#include "FrameTreeNodeData.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include "SimulatedInputDispatcher.h"
@@ -173,6 +174,12 @@ public:
     void navigationFailedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>);
     void navigationAbortedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>);
     void fragmentNavigatedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>);
+    void emitContextCreatedEvent(const WebPageProxy&);
+    void didCreateFrame(const WebFrameProxy&);
+    void willDestroyFrame(const WebFrameProxy&);
+    void contextCreatedForFrame(const WebFrameProxy&);
+    void contextDestroyedForPage(const WebPageProxy&);
+    void contextDestroyedForFrame(const WebFrameProxy&);
 #endif
     void willClosePage(const WebPageProxy&);
     void handleRunOpenPanel(const WebPageProxy&, const WebFrameProxy&, const API::OpenPanelParameters&, WebOpenPanelResultListenerProxy&);
@@ -321,6 +328,11 @@ private:
     void restoreWindowForPage(WebPageProxy&, WTF::CompletionHandler<void()>&&);
     void maximizeWindowForPage(WebPageProxy&, WTF::CompletionHandler<void()>&&);
     void hideWindowForPage(WebPageProxy&, WTF::CompletionHandler<void()>&&);
+
+#if ENABLE(WEBDRIVER_BIDI)
+    void recursivelyEmitContextCreatedEvent(const FrameTreeNodeData&, std::optional<String>&& parentContext);
+    WebPageProxy* getOpenerPage(const WebPageProxy&);
+#endif
 
     // IPC::MessageReceiver (Implemented by generated code in WebAutomationSessionMessageReceiver.cpp).
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -282,6 +282,36 @@
                 { "name": "message", "type": "string" },
                 { "name": "defaultValue", "type": "string", "optional": true }
             ]
-        }
+        },
+        {
+            "name": "contextCreated",
+            "description": "Event fired when a browsing context is created.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#event-browsingContext-contextCreated",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/context_created",
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext" },
+                { "name": "url", "type": "string", "description": "The URL of the browsing context when it was created." },
+                { "name": "originalOpener", "$ref": "BidiBrowsingContext.BrowsingContext", "nullable": true },
+                { "name": "parent", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "nullable": true },
+                { "name": "children", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "nullable": true },
+                { "name": "clientWindow", "$ref": "BidiBrowser.ClientWindow" },
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext" }
+            ]
+       },
+       {
+            "name": "contextDestroyed",
+            "description": "Event fired when a browsing context is destroyed.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#event-browsingContext-contextDestroyed",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/context_destroyed",
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext" },
+                { "name": "url", "type": "string", "description": "The URL of the browsing context when it was destroyed." },
+                { "name": "originalOpener", "$ref": "BidiBrowsingContext.BrowsingContext", "nullable": true },
+                { "name": "parent", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "nullable": true },
+                { "name": "children", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "nullable": true },
+                { "name": "clientWindow", "$ref": "BidiBrowser.ClientWindow" },
+                { "name": "userContext", "$ref": "BidiBrowser.UserContext" }
+            ]
+       }
     ]
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -196,6 +196,7 @@ public:
     void setNavigationCallback(CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)>&&);
 
     void disconnect();
+    bool isConnected() const;
     void didCreateSubframe(WebCore::FrameIdentifier, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
     ProcessID processID() const;
     void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, CompletionHandler<void(WebCore::PageIdentifier)>&&);


### PR DESCRIPTION
#### c6598da6cf2a095929b14ae38e135f9a08ef9fcd
<pre>
WebDriver Bidi: implement context created event and destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=297401">https://bugs.webkit.org/show_bug.cgi?id=297401</a>
<a href="https://rdar.apple.com/158325731">rdar://158325731</a>

Reviewed by BJ Burg.

Added contextCreated and contextDestroyed events to track browsing context life cycles.
Events are emitted at key points in page and frame creation/destruction to provide proper
information like parent relationship and opener details. Hooking into didCreatePage()
and didCreateSubFrame() for creation events. We recursively emit events for existing frame
hierarchies with getAllFrameTrees(). Destruction events are triggered from disconnect() for
frames and willClosePage() for pages. A key note is cleanup logic about removing context
handles from the m_handleWebPageMap was moved to the new destruction methods.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::closeBrowsingContext):
(WebKit::WebAutomationSession::didCreatePage):
(WebKit::WebAutomationSession::emitContextCreatedEvent):
(WebKit::getClientWindowAndUserContext):
(WebKit::WebAutomationSession::getOpenerPage):
(WebKit::WebAutomationSession::didCreateFrame):
(WebKit::WebAutomationSession::willDestroyFrame):
(WebKit::WebAutomationSession::contextCreatedForFrame):
(WebKit::WebAutomationSession::recursivelyEmitContextCreatedEvent):
(WebKit::WebAutomationSession::contextDestroyedForPage):
(WebKit::WebAutomationSession::contextDestroyedForFrame):
(WebKit::WebAutomationSession::willClosePage):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::disconnect):
(WebKit::WebFrameProxy::isConnected const):
(WebKit::WebFrameProxy::didCreateSubframe):
* Source/WebKit/UIProcess/WebFrameProxy.h:

Canonical link: <a href="https://commits.webkit.org/302865@main">https://commits.webkit.org/302865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d967b9d5a4b1693317acdb0a23126c7cb1c2cd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80869 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d129fa07-105a-4552-9677-a4d303dbb1ad) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/1583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98591 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/66481 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/264b530f-60e1-46a8-8070-e143595e162f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/1281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/79243 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5db0c576-6e03-4f59-9241-4581548900fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/1201 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/80104 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/139303 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/1497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/1438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/107117 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/1539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/112287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106961 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/1220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30807 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54169 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/1568 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64931 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/1386 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/1422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/1490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->