### PR TITLE
Creating a _WKJSHandle multiple times with the same function should vend the same _WKJSHandle object

### DIFF
--- a/Source/WebCore/page/WebKitJSHandle.h
+++ b/Source/WebCore/page/WebKitJSHandle.h
@@ -29,31 +29,32 @@
 #include <WebCore/ProcessQualified.h>
 #include <wtf/Markable.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace JSC {
+class JSGlobalObject;
 class JSObject;
 }
 
 namespace WebCore {
 
-class Document;
 class Node;
 
 struct JSHandleIdentifierType;
 using WebProcessJSHandleIdentifier = ObjectIdentifier<JSHandleIdentifierType>;
 using JSHandleIdentifier = ProcessQualified<WebProcessJSHandleIdentifier>;
 
-class WebKitJSHandle : public RefCounted<WebKitJSHandle> {
+class WebKitJSHandle : public RefCountedAndCanMakeWeakPtr<WebKitJSHandle> {
 public:
-    static Ref<WebKitJSHandle> create(Document& document, JSC::JSObject* object) { return adoptRef(*new WebKitJSHandle(document, object)); }
-    WEBCORE_EXPORT static std::pair<RefPtr<Document>, JSC::JSObject*> objectForIdentifier(JSHandleIdentifier);
+    WEBCORE_EXPORT static Ref<WebKitJSHandle> getOrCreate(JSC::JSGlobalObject&, JSC::JSObject*);
+    WEBCORE_EXPORT static std::pair<JSC::JSGlobalObject*, JSC::JSObject*> objectForIdentifier(JSHandleIdentifier);
     WEBCORE_EXPORT static void jsHandleDestroyed(JSHandleIdentifier);
 
     JSHandleIdentifier identifier() const { return m_identifier; }
     Markable<FrameIdentifier> windowFrameIdentifier() const { return m_windowFrameIdentifier; }
 
 private:
-    WEBCORE_EXPORT WebKitJSHandle(Document&, JSC::JSObject*);
+    WebKitJSHandle(JSC::JSGlobalObject&, JSC::JSObject*);
 
     const JSHandleIdentifier m_identifier;
     const Markable<FrameIdentifier> m_windowFrameIdentifier;

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -69,9 +69,9 @@ UserMessageHandlersNamespace* WebKitNamespace::messageHandlers()
     return &m_messageHandlerNamespace.get();
 }
 
-Ref<WebKitJSHandle> WebKitNamespace::createJSHandle(Document& document, JSC::Strong<JSC::JSObject> object)
+Ref<WebKitJSHandle> WebKitNamespace::jsHandle(JSC::JSGlobalObject& globalObject, JSC::Strong<JSC::JSObject> object)
 {
-    return WebKitJSHandle::create(document, object.get());
+    return WebKitJSHandle::getOrCreate(globalObject, object.get());
 }
 
 ExceptionOr<Ref<WebKitSerializedNode>> WebKitNamespace::serializeNode(Node& node, SerializedNodeInit&& init)

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -32,6 +32,10 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSGlobalObject;
+}
+
 namespace WebCore {
 
 class Node;
@@ -50,7 +54,7 @@ public:
     virtual ~WebKitNamespace();
 
     UserMessageHandlersNamespace* messageHandlers();
-    Ref<WebKitJSHandle> createJSHandle(Document&, JSC::Strong<JSC::JSObject>);
+    Ref<WebKitJSHandle> jsHandle(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>);
 
     struct SerializedNodeInit {
         bool deep { false };

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -31,7 +31,7 @@
     Exposed=Window
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
-    [EnabledForWorld=allowJSHandleCreation, CallWith=CurrentDocument] WebKitJSHandle createJSHandle(object object);
+    [EnabledForWorld=allowJSHandleCreation, CallWith=CurrentGlobalObject] WebKitJSHandle jsHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
 };
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -114,7 +114,7 @@ RefPtr<API::Object> JavaScriptEvaluationResult::APIInserter::toAPI(Value&& root)
         m_dictionaries.append({ WTFMove(map), dictionary });
         return { WTFMove(dictionary) };
     }, [] (UniqueRef<JSHandleInfo>&& info) -> RefPtr<API::Object> {
-        return API::JSHandle::create(WTFMove(info.get()));
+        return API::JSHandle::getOrCreate(WTFMove(info.get()));
     }, [] (UniqueRef<WebCore::SerializedNode>&& node) -> RefPtr<API::Object> {
         return API::SerializedNode::create(WTFMove(node.get()));
     });
@@ -399,11 +399,11 @@ JSValueRef JavaScriptEvaluationResult::JSInserter::toJS(JSGlobalContextRef conte
         m_dictionaries.append({ WTFMove(map), Protected<JSObjectRef>(context, dictionary) });
         return dictionary;
     }, [&] (UniqueRef<JSHandleInfo>&& info) -> JSValueRef {
-        auto [originalDocument, object] = WebCore::WebKitJSHandle::objectForIdentifier(info.get().identifier);
+        auto [originalGlobalObject, object] = WebCore::WebKitJSHandle::objectForIdentifier(info.get().identifier);
         if (!object)
             return JSValueMakeUndefined(context);
         auto [lexicalGlobalObject, domGlobalObject, document] = globalObjectTuple(context);
-        if (document.get() != originalDocument.get())
+        if (lexicalGlobalObject != originalGlobalObject)
             return JSValueMakeUndefined(context);
         return ::toRef(object);
     }, [&] (UniqueRef<WebCore::SerializedNode>&& serializedNode) -> JSValueRef {

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -81,7 +81,7 @@ RetainPtr<id> JavaScriptEvaluationResult::ObjCInserter::toID(Value&& root)
         m_dictionaries.append({ WTFMove(map), dictionary });
         return dictionary;
     }, [] (UniqueRef<JSHandleInfo>&& info) -> RetainPtr<id> {
-        return wrapper(API::JSHandle::create(WTFMove(info.get())));
+        return wrapper(API::JSHandle::getOrCreate(WTFMove(info.get())));
     }, [] (UniqueRef<WebCore::SerializedNode>&& serializedNode) -> RetainPtr<id> {
         return wrapper(API::SerializedNode::create(WTFMove(serializedNode.get())).get());
     });

--- a/Source/WebKit/UIProcess/API/APIJSHandle.h
+++ b/Source/WebKit/UIProcess/API/APIJSHandle.h
@@ -32,7 +32,7 @@ namespace API {
 
 class JSHandle final : public ObjectImpl<Object::Type::JSHandle> {
 public:
-    static Ref<JSHandle> create(WebKit::JSHandleInfo&& info) { return adoptRef(*new JSHandle(WTFMove(info))); }
+    static Ref<JSHandle> getOrCreate(WebKit::JSHandleInfo&&);
     virtual ~JSHandle();
 
     const WebKit::JSHandleInfo& info() const { return m_info; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4298,7 +4298,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
     _page->hitTestAtPoint(frame ? frame->_frameInfo->frameInfoData().frameID : mainFrame->frameID(), point, [completionHandler = makeBlockPtr(completionHandler)] (auto&& result) mutable {
         if (!result)
             return completionHandler(nil, unknownError().get());
-        completionHandler(wrapper(API::JSHandle::create(WTFMove(*result))).get(), nil);
+        completionHandler(wrapper(API::JSHandle::getOrCreate(WTFMove(*result))).get(), nil);
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -50,7 +50,7 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
 @property (nonatomic) BOOL disableLegacyBuiltinOverrides;
 
-/*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
+/*! @abstract A boolean indicating whether window.webkit.jsHandle is available. */
 @property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10193,7 +10193,7 @@ void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoi
         RELEASE_ASSERT(lexicalGlobalObject->template inherits<WebCore::JSDOMGlobalObject>());
         auto* domGlobalObject = jsCast<WebCore::JSDOMGlobalObject*>(lexicalGlobalObject);
         JSLockHolder locker(lexicalGlobalObject);
-        return WebCore::WebKitJSHandle::create(document, WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
+        return WebCore::WebKitJSHandle::getOrCreate(*lexicalGlobalObject, WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
     }();
     completionHandler({ JSHandleInfo { nodeHandle->identifier(), nodeWebFrame->info(), nodeHandle->windowFrameIdentifier() } });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm
@@ -70,41 +70,90 @@ TEST(JSHandle, Basic)
     worldConfiguration.get().allowJSHandleCreation = YES;
     RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
 
-    RetainPtr<id> result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(onlyframe.contentWindow)" inFrame:nil inContentWorld:world.get()];
+    RetainPtr<id> result = [webView objectByEvaluatingJavaScript:@"window.webkit.jsHandle(onlyframe.contentWindow)" inFrame:nil inContentWorld:world.get()];
     EXPECT_WK_STREQ(getWindowFrameInfo(result).request.URL.absoluteString, "https://webkit.org/webkit");
-    RetainPtr<_WKJSHandle> iframeRef = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(onlyframe)" inFrame:nil inContentWorld:world.get()];
+    RetainPtr<_WKJSHandle> iframeRef = [webView objectByEvaluatingJavaScript:@"window.webkit.jsHandle(onlyframe)" inFrame:nil inContentWorld:world.get()];
 
-    result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(onlydiv)" inFrame:nil inContentWorld:world.get()];
+    result = [webView objectByEvaluatingJavaScript:@"window.webkit.jsHandle(onlydiv)" inFrame:nil inContentWorld:world.get()];
     EXPECT_NULL(getWindowFrameInfo(result));
     {
         __block bool done { false };
-        [webView evaluateJavaScript:@"window.webkit.createJSHandle(5)" inFrame:nil inContentWorld:world.get() completionHandler:^(id result, NSError *error) {
+        [webView evaluateJavaScript:@"window.webkit.jsHandle(5)" inFrame:nil inContentWorld:world.get() completionHandler:^(id result, NSError *error) {
             EXPECT_NULL(result);
             EXPECT_NOT_NULL(error);
             done = true;
         }];
         Util::run(&done);
     }
-    result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(document.createTextNode('hi'))" inFrame:nil inContentWorld:world.get()];
+    result = [webView objectByEvaluatingJavaScript:@"window.webkit.jsHandle(document.createTextNode('hi'))" inFrame:nil inContentWorld:world.get()];
     EXPECT_NULL(getWindowFrameInfo(result));
     result = [webView objectByEvaluatingJavaScript:@"window.WebKitJSHandle"];
     EXPECT_NULL(result);
 
-    result = [webView objectByCallingAsyncFunction:@"return {'arg':window.webkit.createJSHandle(onlydiv)}" withArguments:nil inFrame:nil inContentWorld:world.get()];
-    result = [webView objectByCallingAsyncFunction:@"return arg.outerHTML" withArguments:result.get()];
+    result = [webView objectByCallingAsyncFunction:@"return {'arg':window.webkit.jsHandle(onlydiv)}" withArguments:nil inFrame:nil inContentWorld:world.get()];
+    result = [webView objectByCallingAsyncFunction:@"return arg.outerHTML" withArguments:result.get() inFrame:nil inContentWorld:world.get()];
     EXPECT_WK_STREQ(result.get(), "<div id=\"onlydiv\"></div>");
 
     result = [webView objectByCallingAsyncFunction:@"return n === undefined" withArguments:@{ @"n" : iframeRef.get() } inFrame:[webView firstChildFrame] inContentWorld:WKContentWorld.pageWorld];
     EXPECT_EQ(result.get(), @YES);
 
-    result = [webView objectByCallingAsyncFunction:@"return n.id" withArguments:@{ @"n" : iframeRef.get() }];
+    result = [webView objectByCallingAsyncFunction:@"return n.id" withArguments:@{ @"n" : iframeRef.get() } inFrame:nil inContentWorld:world.get()];
     EXPECT_WK_STREQ(result.get(), "onlyframe");
 
-    result = [webView objectByEvaluatingJavaScript:@"function returnThirty() { return '30'; }; window.webkit.createJSHandle(returnThirty)" inFrame:nil inContentWorld:world.get()];
+    result = [webView objectByEvaluatingJavaScript:@"function returnThirty() { return '30'; }; window.webkit.jsHandle(returnThirty)" inFrame:nil inContentWorld:world.get()];
     EXPECT_WK_STREQ([webView objectByCallingAsyncFunction:@"return n()" withArguments:@{ @"n" : result.get() } inFrame:nil inContentWorld:world.get()], "30");
 
-    result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(window.parent)" inFrame:[webView firstChildFrame] inContentWorld:world.get()];
+    result = [webView objectByEvaluatingJavaScript:@"window.webkit.jsHandle(window.parent)" inFrame:[webView firstChildFrame] inContentWorld:world.get()];
     EXPECT_WK_STREQ(getWindowFrameInfo(result).request.URL.absoluteString, "https://example.com/example");
+}
+
+TEST(JSHandle, Equality)
+{
+    RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
+    worldConfiguration.get().allowJSHandleCreation = YES;
+    RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"let a = {'key':'value'}; let b = window.webkit.jsHandle(a); let c = window.webkit.jsHandle(a); b === c" inFrame:nil inContentWorld:world.get()] boolValue]);
+
+    _WKJSHandle *b = [webView objectByEvaluatingJavaScript:@"b" inFrame:nil inContentWorld:world.get()];
+    _WKJSHandle *c = [webView objectByEvaluatingJavaScript:@"c" inFrame:nil inContentWorld:world.get()];
+    _WKJSHandle *d = [webView objectByEvaluatingJavaScript:@"let d = {}; window.webkit.jsHandle(d)" inFrame:nil inContentWorld:world.get()];
+    EXPECT_TRUE([b isKindOfClass:_WKJSHandle.class]);
+    EXPECT_TRUE([c isKindOfClass:_WKJSHandle.class]);
+    EXPECT_TRUE([d isKindOfClass:_WKJSHandle.class]);
+    EXPECT_EQ(b, c);
+    EXPECT_NE(b, d);
+    EXPECT_TRUE([b isEqual:c]);
+    EXPECT_FALSE([b isEqual:d]);
+
+    NSMutableArray<_WKJSHandle *> *array = [NSMutableArray arrayWithCapacity:2];
+    [array addObject:b];
+    [array addObject:d];
+    [array addObject:c];
+    EXPECT_EQ(array.count, 3u);
+    [array removeObject:b];
+    EXPECT_EQ(array.count, 1u);
+
+    NSSet<_WKJSHandle *> *set = [NSSet setWithObjects:b, c, d, nil];
+    EXPECT_EQ(set.count, 2u);
+
+    NSDictionary<NSString *, _WKJSHandle *> *dictionary = @{
+        @"b" : b,
+        @"c" : c,
+        @"d" : d
+    };
+    EXPECT_EQ(dictionary[@"b"], b);
+    EXPECT_EQ(dictionary[@"c"], c);
+    EXPECT_EQ(dictionary[@"d"], d);
+    EXPECT_EQ(dictionary.count, 3u);
+
+    EXPECT_WK_STREQ([webView objectByCallingAsyncFunction:@"return b.key" withArguments:@{ @"b" : b } inFrame:nil inContentWorld:world.get()], "value");
+
+    worldConfiguration.get().name = @"otherworldly";
+    RetainPtr otherWorld = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
+    EXPECT_NE(world.get(), otherWorld.get());
+    EXPECT_TRUE([[webView objectByCallingAsyncFunction:@"return b === undefined" withArguments:@{ @"b" : b } inFrame:nil inContentWorld:otherWorld.get()] boolValue]);
 }
 
 }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1907,7 +1907,7 @@ void TestController::uiScriptDidComplete(const String& result, unsigned scriptCa
 constexpr auto testRunnerJS = R"testRunnerJS(
 if (window.testRunner) {
     let post = window.webkit.messageHandlers.webkitTestRunner.postMessage.bind(window.webkit.messageHandlers.webkitTestRunner);
-    let createHandle = (object) => object ? window.webkit.createJSHandle(object) : undefined;
+    let createHandle = (object) => object ? window.webkit.jsHandle(object) : undefined;
 
     testRunner.installTooltipDidChangeCallback = callback => post(['InstallTooltipCallback', createHandle(callback)]);
     testRunner.installDidBeginSwipeCallback = callback => post(['InstallBeginSwipeCallback', createHandle(callback)]);


### PR DESCRIPTION
#### 911765edd69ed979939716fe8a571c022641a429
<pre>
Creating a _WKJSHandle multiple times with the same function should vend the same _WKJSHandle object
<a href="https://bugs.webkit.org/show_bug.cgi?id=298700">https://bugs.webkit.org/show_bug.cgi?id=298700</a>
<a href="https://rdar.apple.com/160325717">rdar://160325717</a>

Reviewed by Brian Weinstein.

_WKJSHandle had a few issues.

First, if you called window.webkit.createJSHandle multiple times on the same object,
it would give you new and unique handles to the same object.  Now it gives you the same
handle if the handle still exists.

Second, if the UI process received the same _WKJSHandle multiple times, it would vend
different _WKJSHandle objects that weren&apos;t equal, making it hard to remove the _WKJSHandle
from any containers you may have stored it in.

Third, there was a check that the _WKJSHandle could only be used with the same Document,
but not with the same JSGlobalObject.  This had the result that, if it were used with
different WKContentWorlds, it would give different worlds access to objects in the wrong world.
This was fixed by changing the document check to a global object check.

Since it&apos;s no longer necessarily creating a new object, I renamed createJSHandle to just jsHandle.

* Source/WebCore/page/WebKitJSHandle.cpp:
(WebCore::globalObjectMap):
(WebCore::objectMap):
(WebCore::WebKitJSHandle::getOrCreate):
(WebCore::WebKitJSHandle::jsHandleDestroyed):
(WebCore::WebKitJSHandle::WebKitJSHandle):
(WebCore::documentMap): Deleted.
* Source/WebCore/page/WebKitJSHandle.h:
(WebCore::WebKitJSHandle::create): Deleted.
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::createJSHandle):
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::APIInserter::toAPI):
(WebKit::JavaScriptEvaluationResult::JSInserter::toJS):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::ObjCInserter::toID):
* Source/WebKit/UIProcess/API/APIJSHandle.cpp:
(API::handleMap):
(API::JSHandle::getOrCreate):
(API::JSHandle::JSHandle):
(API::JSHandle::~JSHandle):
* Source/WebKit/UIProcess/API/APIJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _hitTestAtPoint:inFrameCoordinateSpace:completionHandler:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hitTestAtPoint):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm:
(TestWebKitAPI::TEST(JSHandle, Basic)):
(TestWebKitAPI::TEST(JSHandle, Equality)):

Canonical link: <a href="https://commits.webkit.org/299859@main">https://commits.webkit.org/299859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be12176c4dc9f7492d03d40ee8914228a94b0bcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15d98631-8ec1-492f-a068-3734ef124acb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91487 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d90b6b1-ec74-4bfd-be89-008e635a5346) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72038 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/079cfa1a-58a1-4d5a-8321-c2ff4f02d4b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70449 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129718 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100106 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99948 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45396 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44026 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19124 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52945 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46708 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50055 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48395 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->