### PR TITLE
[LibWebRTC] Fix build for Linux after 299803@main

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -586,7 +586,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/modules/audio_coding/neteq/tools/neteq_rtpplay.cc
     Source/webrtc/modules/audio_coding/neteq/tools/neteq_stats_getter.cc
     Source/webrtc/modules/audio_coding/neteq/tools/neteq_stats_plotter.cc
-    Source/webrtc/modules/audio_coding/neteq/tools/packet.cc
     Source/webrtc/modules/audio_coding/neteq/tools/packet_source.cc
     Source/webrtc/modules/audio_coding/neteq/tools/resample_input_audio_file.cc
     Source/webrtc/modules/audio_coding/neteq/tools/rtp_analyze.cc
@@ -767,7 +766,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/modules/congestion_controller/goog_cc/goog_cc_network_control.cc
     Source/webrtc/modules/congestion_controller/goog_cc/inter_arrival_delta.cc
     Source/webrtc/modules/congestion_controller/goog_cc/link_capacity_estimator.cc
-    Source/webrtc/modules/congestion_controller/goog_cc/loss_based_bandwidth_estimation.cc
     Source/webrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2.cc
     Source/webrtc/modules/congestion_controller/goog_cc/probe_bitrate_estimator.cc
     Source/webrtc/modules/congestion_controller/goog_cc/probe_controller.cc
@@ -1084,7 +1082,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/p2p/base/port.cc
     Source/webrtc/p2p/base/port_allocator.cc
     Source/webrtc/p2p/base/port_interface.cc
-    Source/webrtc/p2p/base/pseudo_tcp.cc
     Source/webrtc/p2p/base/regathering_controller.cc
     Source/webrtc/p2p/base/stun_dictionary.cc
     Source/webrtc/p2p/base/stun_port.cc
@@ -1201,7 +1198,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/rtc_base/experiments/quality_scaler_settings.cc
     Source/webrtc/rtc_base/experiments/quality_scaling_experiment.cc
     Source/webrtc/rtc_base/experiments/rate_control_settings.cc
-    Source/webrtc/rtc_base/experiments/stable_target_rate_experiment.cc
     Source/webrtc/rtc_base/experiments/struct_parameters_parser.cc
     Source/webrtc/rtc_base/fake_clock.cc
     Source/webrtc/rtc_base/fake_ssl_identity.cc
@@ -1294,8 +1290,6 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/stats/rtc_stats_report.cc
     Source/webrtc/stats/rtcstats_objects.cc
     Source/webrtc/system_wrappers/source/clock.cc
-    Source/webrtc/system_wrappers/source/cpu_features.cc
-    Source/webrtc/system_wrappers/source/cpu_features_linux.cc
     Source/webrtc/system_wrappers/source/field_trial.cc
     Source/webrtc/system_wrappers/source/metrics.cc
     Source/webrtc/video/adaptation/balanced_constraint.cc
@@ -1322,6 +1316,7 @@ list(APPEND webrtc_SOURCES
     Source/webrtc/video/corruption_detection/halton_frame_sampler.cc
     Source/webrtc/video/corruption_detection/halton_sequence.cc
     Source/webrtc/video/corruption_detection/utils.cc
+    Source/webrtc/video/corruption_detection/video_frame_sampler.cc
     Source/webrtc/video/decode_synchronizer.cc
     Source/webrtc/video/encoder_bitrate_adjuster.cc
     Source/webrtc/video/encoder_overshoot_detector.cc
@@ -2239,7 +2234,6 @@ else ()
 
             Source/webrtc/modules/video_coding/codecs/h264/h264_encoder_impl.cc
 
-            Source/webrtc/system_wrappers/source/cpu_features_linux.cc
         )
         set(WEBKIT_LIBWEBRTC_OPENH264_ENCODER 1)
     endif ()

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_device/audio_device_impl.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_device/audio_device_impl.cc
@@ -28,7 +28,6 @@
 
 #if defined(WEBRTC_WIN)
 #include "modules/audio_device/win/audio_device_core_win.h"
-#endif
 #elif defined(WEBRTC_ANDROID)
 #include <stdlib.h>
 #include "webkit_sdk/android/native_api/audio_device_module/audio_device_android.h"

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/echo_detector/mean_variance_estimator.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/echo_detector/mean_variance_estimator.cc
@@ -26,8 +26,8 @@ void MeanVarianceEstimator::Update(float value) {
   mean_ = (1.f - kAlpha) * mean_ + kAlpha * value;
   variance_ =
       (1.f - kAlpha) * variance_ + kAlpha * (value - mean_) * (value - mean_);
-  RTC_DCHECK(isfinite(mean_));
-  RTC_DCHECK(isfinite(variance_));
+  RTC_DCHECK(std::isfinite(mean_));
+  RTC_DCHECK(std::isfinite(variance_));
 }
 
 float MeanVarianceEstimator::std_deviation() const {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/echo_detector/normalized_covariance_estimator.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/echo_detector/normalized_covariance_estimator.cc
@@ -31,8 +31,8 @@ void NormalizedCovarianceEstimator::Update(float x,
   covariance_ =
       (1.f - kAlpha) * covariance_ + kAlpha * (x - x_mean) * (y - y_mean);
   normalized_cross_correlation_ = covariance_ / (x_sigma * y_sigma + .0001f);
-  RTC_DCHECK(isfinite(covariance_));
-  RTC_DCHECK(isfinite(normalized_cross_correlation_));
+  RTC_DCHECK(std::isfinite(covariance_));
+  RTC_DCHECK(std::isfinite(normalized_cross_correlation_));
 }
 
 void NormalizedCovarianceEstimator::Clear() {

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp
@@ -33,10 +33,10 @@ static webrtc::SdpVideoFormat createH264Format(webrtc::H264Profile profile, webr
 {
     const auto profileString = webrtc::H264ProfileLevelIdToString(webrtc::H264ProfileLevelId(profile, level));
 
-    return webrtc::SdpVideoFormat(cricket::kH264CodecName,
-        { { cricket::kH264FmtpProfileLevelId, *profileString },
-            { cricket::kH264FmtpLevelAsymmetryAllowed, "1" },
-            { cricket::kH264FmtpPacketizationMode, packetizationMode } });
+    return webrtc::SdpVideoFormat(webrtc::kH264CodecName,
+        { { webrtc::kH264FmtpProfileLevelId, *profileString },
+            { webrtc::kH264FmtpLevelAsymmetryAllowed, "1" },
+            { webrtc::kH264FmtpPacketizationMode, packetizationMode } });
 }
 
 std::vector<webrtc::SdpVideoFormat> supportedH264Formats()

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -27,6 +27,7 @@
 #include "GStreamerVideoCommon.h"
 #include "GStreamerVideoFrameLibWebRTC.h"
 #include "LibWebRTCWebKitMacros.h"
+#include "webrtc/api/make_ref_counted.h"
 #include "webrtc/api/video_codecs/vp9_profile.h"
 #include "webrtc/common_video/h264/h264_common.h"
 #include "webrtc/modules/video_coding/codecs/h264/include/h264.h"
@@ -63,9 +64,9 @@ class GStreamerEncodedImageBuffer : public webrtc::EncodedImageBufferInterface {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(x);
 
 public:
-    static rtc::scoped_refptr<GStreamerEncodedImageBuffer> create(GRefPtr<GstSample>&& sample)
+    static webrtc::scoped_refptr<GStreamerEncodedImageBuffer> create(GRefPtr<GstSample>&& sample)
     {
-        return rtc::make_ref_counted<GStreamerEncodedImageBuffer>(WTFMove(sample));
+        return webrtc::make_ref_counted<GStreamerEncodedImageBuffer>(WTFMove(sample));
     }
 
     const uint8_t* data() const final { return m_mappedBuffer->data(); }

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -84,17 +84,17 @@ webrtc::VideoFrame convertGStreamerSampleToLibWebRTCVideoFrame(GRefPtr<GstSample
         .build();
 }
 
-rtc::scoped_refptr<webrtc::VideoFrameBuffer> GStreamerVideoFrameLibWebRTC::create(GRefPtr<GstSample>&& sample)
+webrtc::scoped_refptr<webrtc::VideoFrameBuffer> GStreamerVideoFrameLibWebRTC::create(GRefPtr<GstSample>&& sample)
 {
     GstVideoInfo info;
 
     if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get())))
         ASSERT_NOT_REACHED();
 
-    return rtc::scoped_refptr<webrtc::VideoFrameBuffer>(new GStreamerVideoFrameLibWebRTC(WTFMove(sample), info));
+    return webrtc::scoped_refptr<webrtc::VideoFrameBuffer>(new GStreamerVideoFrameLibWebRTC(WTFMove(sample), info));
 }
 
-rtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC::ToI420()
+webrtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC::ToI420()
 {
     ensureDebugCategoryIsRegistered();
     GstMappedFrame inFrame(m_sample, GST_MAP_READ);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h
@@ -35,7 +35,7 @@ WARN_UNUSED_RETURN GRefPtr<GstSample> convertLibWebRTCVideoFrameToGStreamerSampl
 
 webrtc::VideoFrame convertGStreamerSampleToLibWebRTCVideoFrame(GRefPtr<GstSample>&&, uint32_t rtpTimestamp);
 
-class GStreamerVideoFrameLibWebRTC : public rtc::RefCountedObject<webrtc::VideoFrameBuffer> {
+class GStreamerVideoFrameLibWebRTC : public webrtc::RefCountedObject<webrtc::VideoFrameBuffer> {
 public:
     GStreamerVideoFrameLibWebRTC(GRefPtr<GstSample>&& sample, GstVideoInfo info)
         : m_sample(WTFMove(sample))
@@ -43,10 +43,10 @@ public:
     {
     }
 
-    static rtc::scoped_refptr<webrtc::VideoFrameBuffer> create(GRefPtr<GstSample>&&);
+    static webrtc::scoped_refptr<webrtc::VideoFrameBuffer> create(GRefPtr<GstSample>&&);
 
     GstSample* getSample() const { return m_sample.get(); }
-    rtc::scoped_refptr<webrtc::I420BufferInterface> ToI420() final;
+    webrtc::scoped_refptr<webrtc::I420BufferInterface> ToI420() final;
 
     int width() const final { return GST_VIDEO_INFO_WIDTH(&m_info); }
     int height() const final { return GST_VIDEO_INFO_HEIGHT(&m_info); }

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
@@ -72,7 +72,7 @@ void RealtimeOutgoingVideoSourceLibWebRTC::videoFrameAvailable(VideoFrame& video
     sendFrame(WTFMove(frameBuffer));
 }
 
-rtc::scoped_refptr<webrtc::VideoFrameBuffer> RealtimeOutgoingVideoSourceLibWebRTC::createBlackFrame(size_t  width, size_t  height)
+webrtc::scoped_refptr<webrtc::VideoFrameBuffer> RealtimeOutgoingVideoSourceLibWebRTC::createBlackFrame(size_t  width, size_t  height)
 {
     GstVideoInfo info;
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.h
@@ -39,7 +39,7 @@ public:
 private:
     explicit RealtimeOutgoingVideoSourceLibWebRTC(Ref<MediaStreamTrackPrivate>&&);
 
-    rtc::scoped_refptr<webrtc::VideoFrameBuffer> createBlackFrame(size_t, size_t) final;
+    webrtc::scoped_refptr<webrtc::VideoFrameBuffer> createBlackFrame(size_t, size_t) final;
 
     // RealtimeMediaSource::VideoFrameObserver API
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final;


### PR DESCRIPTION
#### 315dee9c54c2afa61343cab1b2c9390509ff494b
<pre>
[LibWebRTC] Fix build for Linux after 299803@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=298537">https://bugs.webkit.org/show_bug.cgi?id=298537</a>

Reviewed by Philippe Normand.

Namespaces &apos;rtc&apos; and &apos;cricket&apos; were deprecated in LibWebRTC commit
0bdeb7818c.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_device/audio_device_impl.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/echo_detector/mean_variance_estimator.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_processing/echo_detector/normalized_covariance_estimator.cc:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp:
(WebCore::createH264Format):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp:
(WebCore::GStreamerEncodedImageBuffer::create):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp:
(WebCore::GStreamerVideoFrameLibWebRTC::create):
(WebCore::GStreamerVideoFrameLibWebRTC::ToI420):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp:
(WebCore::RealtimeOutgoingVideoSourceLibWebRTC::createBlackFrame):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.h:

Canonical link: <a href="https://commits.webkit.org/299832@main">https://commits.webkit.org/299832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb199eb202b574f1b50b87a76624e23bae0f6397

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91429 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60721 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129643 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100048 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23364 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/43954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19118 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52875 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->