### PR TITLE
[Smart Lists] Add a context menu item to toggle Smart Lists

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7344,6 +7344,20 @@ SmartInsertDeleteEnabled:
     WebCore:
       default: true
 
+SmartListsEnabled:
+  type: bool
+  status: embedder
+  category: dom
+  humanReadableName: "Smart Lists"
+  humanReadableDescription: "Enable Smart Lists"
+  defaultValue:
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 SourceBufferChangeTypeEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1990,6 +1990,17 @@ void Editor::toggleAutomaticSpellingCorrection()
         client()->toggleAutomaticSpellingCorrection();
 }
 
+bool Editor::isSmartListsEnabled()
+{
+    return client() && client()->isSmartListsEnabled();
+}
+
+void Editor::toggleSmartLists()
+{
+    if (client())
+        client()->toggleSmartLists();
+}
+
 #endif
 
 bool Editor::shouldEndEditing(const SimpleRange& range)

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -573,6 +573,8 @@ public:
     WEBCORE_EXPORT bool isAutomaticSpellingCorrectionEnabled();
     WEBCORE_EXPORT void toggleAutomaticSpellingCorrection();
     WEBCORE_EXPORT bool canEnableAutomaticSpellingCorrection() const;
+    WEBCORE_EXPORT bool isSmartListsEnabled();
+    WEBCORE_EXPORT void toggleSmartLists();
 #endif
 
     RefPtr<DocumentFragment> webContentFromPasteboard(Pasteboard&, const SimpleRange& context, bool allowPlainText, bool& chosePlainText);

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1393,6 +1393,9 @@
 /* Smart Quotes context menu item */
 "Smart Quotes" = "Smart Quotes";
 
+/* Smart Lists context menu item */
+"Smart Lists" = "Smart Lists";
+
 /* Speech context sub-menu item */
 "Speech" = "Speech";
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -370,6 +370,8 @@ private:
     void toggleAutomaticTextReplacement() final { }
     bool isAutomaticSpellingCorrectionEnabled() final { return false; }
     void toggleAutomaticSpellingCorrection() final { }
+    bool isSmartListsEnabled() final { return false; }
+    void toggleSmartLists() { }
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -614,6 +614,9 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
     case ContextMenuItemTagSmartLinks:
         frame->protectedEditor()->toggleAutomaticLinkDetection();
         break;
+    case ContextMenuItemTagSmartLists:
+        frame->protectedEditor()->toggleSmartLists();
+        break;
     case ContextMenuItemTagTextReplacement:
         frame->protectedEditor()->toggleAutomaticTextReplacement();
         break;
@@ -865,12 +868,17 @@ void ContextMenuController::createAndAppendSubstitutionsSubMenu(ContextMenuItem&
     ContextMenuItem smartQuotes(ContextMenuItemType::CheckableAction, ContextMenuItemTagSmartQuotes, contextMenuItemTagSmartQuotes());
     ContextMenuItem smartDashes(ContextMenuItemType::CheckableAction, ContextMenuItemTagSmartDashes, contextMenuItemTagSmartDashes());
     ContextMenuItem smartLinks(ContextMenuItemType::CheckableAction, ContextMenuItemTagSmartLinks, contextMenuItemTagSmartLinks());
+    ContextMenuItem smartLists(ContextMenuItemType::CheckableAction, ContextMenuItemTagSmartLists, contextMenuItemTagSmartLists());
     ContextMenuItem textReplacement(ContextMenuItemType::CheckableAction, ContextMenuItemTagTextReplacement, contextMenuItemTagTextReplacement());
 
     appendItem(showSubstitutions, &substitutionsMenu);
     appendItem(*separatorItem(), &substitutionsMenu);
     appendItem(smartCopyPaste, &substitutionsMenu);
     appendItem(smartQuotes, &substitutionsMenu);
+
+    if (m_page->settings().smartListsEnabled() && m_page->isEditable())
+        appendItem(smartLists, &substitutionsMenu);
+
     appendItem(smartDashes, &substitutionsMenu);
     appendItem(smartLinks, &substitutionsMenu);
     appendItem(textReplacement, &substitutionsMenu);
@@ -1671,6 +1679,9 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
             break;
         case ContextMenuItemTagSmartDashes:
             shouldCheck = frame->editor().isAutomaticDashSubstitutionEnabled();
+            break;
+        case ContextMenuItemTagSmartLists:
+            shouldCheck = frame->editor().isSmartListsEnabled();
             break;
         case ContextMenuItemTagSmartLinks:
             shouldCheck = frame->editor().isAutomaticLinkDetectionEnabled();

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -183,6 +183,8 @@ public:
     virtual void toggleAutomaticTextReplacement() = 0;
     virtual bool isAutomaticSpellingCorrectionEnabled() = 0;
     virtual void toggleAutomaticSpellingCorrection() = 0;
+    virtual bool isSmartListsEnabled() = 0;
+    virtual void toggleSmartLists() = 0;
 #endif
     
 #if PLATFORM(GTK)

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -246,6 +246,7 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagSmartQuotes:
     case ContextMenuAction::ContextMenuItemTagSmartDashes:
     case ContextMenuAction::ContextMenuItemTagSmartLinks:
+    case ContextMenuAction::ContextMenuItemTagSmartLists:
     case ContextMenuAction::ContextMenuItemTagTextReplacement:
     case ContextMenuAction::ContextMenuItemTagTransformationsMenu:
     case ContextMenuAction::ContextMenuItemTagMakeUpperCase:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -169,7 +169,12 @@ enum ContextMenuAction {
     ContextMenuItemTagProofread,
     ContextMenuItemTagRewrite,
     ContextMenuItemTagSummarize,
+#if PLATFORM(COCOA)
+    ContextMenuItemTagSmartLists,
+    ContextMenuItemLastNonCustomTag = ContextMenuItemTagSmartLists,
+#else
     ContextMenuItemLastNonCustomTag = ContextMenuItemTagSummarize,
+#endif
     ContextMenuItemBaseCustomTag = 5000,
     ContextMenuItemLastCustomTag = 5999,
     ContextMenuItemBaseApplicationTag = 10000

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -140,6 +140,7 @@ namespace WebCore {
     WEBCORE_EXPORT String contextMenuItemTagSmartQuotes();
     WEBCORE_EXPORT String contextMenuItemTagSmartDashes();
     WEBCORE_EXPORT String contextMenuItemTagSmartLinks();
+    WEBCORE_EXPORT String contextMenuItemTagSmartLists();
     WEBCORE_EXPORT String contextMenuItemTagTextReplacement();
     WEBCORE_EXPORT String contextMenuItemTagTransformationsMenu();
     WEBCORE_EXPORT String contextMenuItemTagMakeUpperCase();

--- a/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
+++ b/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
@@ -141,6 +141,11 @@ String contextMenuItemTagSmartLinks()
     return WEB_UI_STRING("Smart Links", "Smart Links context menu item");
 }
 
+String contextMenuItemTagSmartLists()
+{
+    return WEB_UI_STRING("Smart Lists", "Smart Lists context menu item");
+}
+
 String contextMenuItemTagTextReplacement()
 {
     return WEB_UI_STRING("Text Replacement", "Text Replacement context menu item");

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -222,6 +222,7 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     case WebCore::ContextMenuItemTagSmartCopyPaste:
     case WebCore::ContextMenuItemTagSmartDashes:
     case WebCore::ContextMenuItemTagSmartLinks:
+    case WebCore::ContextMenuItemTagSmartLists:
     case WebCore::ContextMenuItemTagSmartQuotes:
     case WebCore::ContextMenuItemTagSpeechMenu:
     case WebCore::ContextMenuItemTagSpellingGuess:

--- a/Source/WebKit/Shared/TextCheckerState.h
+++ b/Source/WebKit/Shared/TextCheckerState.h
@@ -36,6 +36,7 @@ enum class TextCheckerState : uint8_t {
     AutomaticQuoteSubstitutionEnabled = 1 << 4,
     AutomaticDashSubstitutionEnabled = 1 << 5,
     AutomaticLinkDetectionEnabled = 1 << 6,
+    SmartListsEnabled = 1 << 7,
 #endif
 };
 

--- a/Source/WebKit/Shared/TextFlags.serialization.in
+++ b/Source/WebKit/Shared/TextFlags.serialization.in
@@ -125,7 +125,8 @@ enum class WebCore::FontSmoothingMode : uint8_t {
     AutomaticSpellingCorrectionEnabled,
     AutomaticQuoteSubstitutionEnabled,
     AutomaticDashSubstitutionEnabled,
-    AutomaticLinkDetectionEnabled
+    AutomaticLinkDetectionEnabled,
+    SmartListsEnabled
 #endif
 };
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -513,6 +513,21 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
     _impl->toggleAutomaticTextReplacement();
 }
 
+- (BOOL)isSmartListsEnabled
+{
+    return _impl->isSmartListsEnabled();
+}
+
+- (void)setSmartListsEnabled:(BOOL)flag
+{
+    _impl->setSmartListsEnabled(flag);
+}
+
+- (void)toggleSmartLists:(id)sender
+{
+    _impl->toggleSmartLists();
+}
+
 - (void)uppercaseWord:(id)sender
 {
     _impl->uppercaseWord();

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -868,6 +868,17 @@ void WebProcessPool::registerNotificationObservers()
         textCheckerStateChanged();
     }];
 
+    // FIXME: This isn't that ideal since it listens to every user default change and not just the smart lists default.
+    m_smartListsNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSUserDefaultsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+        TextChecker::didChangeSmartListsEnabled();
+
+        auto newValue = TextChecker::state().contains(TextCheckerState::SmartListsEnabled);
+        if (std::exchange(m_smartListsEnabled, newValue) == newValue)
+            return;
+
+        textCheckerStateChanged();
+    }];
+
     m_accessibilityDisplayOptionsNotificationObserver = [[NSWorkspace.sharedWorkspace notificationCenter] addObserverForName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         screenPropertiesChanged();
     }];
@@ -1026,6 +1037,7 @@ void WebProcessPool::unregisterNotificationObservers()
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticSpellingCorrectionNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticQuoteSubstitutionNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticDashSubstitutionNotificationObserver.get()];
+    [[NSNotificationCenter defaultCenter] removeObserver:m_smartListsNotificationObserver.get()];
     [[NSWorkspace.sharedWorkspace notificationCenter] removeObserver:m_accessibilityDisplayOptionsNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_scrollerStyleNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_deactivationObserver.get()];

--- a/Source/WebKit/UIProcess/TextChecker.h
+++ b/Source/WebKit/UIProcess/TextChecker.h
@@ -53,11 +53,13 @@ public:
     static void setAutomaticDashSubstitutionEnabled(bool);
     static void setAutomaticLinkDetectionEnabled(bool);
     static void setAutomaticTextReplacementEnabled(bool);
+    static void setSmartListsEnabled(bool);
 
     static void didChangeAutomaticTextReplacementEnabled();
     static void didChangeAutomaticSpellingCorrectionEnabled();
     static void didChangeAutomaticQuoteSubstitutionEnabled();
     static void didChangeAutomaticDashSubstitutionEnabled();
+    static void didChangeSmartListsEnabled();
 
     static bool isSmartInsertDeleteEnabled();
     static void setSmartInsertDeleteEnabled(bool);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10535,6 +10535,11 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item, c
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
         return;
 
+    case ContextMenuItemTagSmartLists:
+        TextChecker::setSmartListsEnabled(!TextChecker::state().contains(TextCheckerState::SmartListsEnabled));
+        protectedLegacyMainFrameProcess()->updateTextCheckerState();
+        return;
+
     case ContextMenuItemTagTextReplacement:
         TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled));
             protectedLegacyMainFrameProcess()->updateTextCheckerState();
@@ -13542,6 +13547,12 @@ void WebPageProxy::toggleAutomaticDashSubstitution()
 {
     if (TextChecker::isTestingMode())
         TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled));
+}
+
+void WebPageProxy::toggleSmartLists()
+{
+    if (TextChecker::isTestingMode())
+        TextChecker::setSmartListsEnabled(!TextChecker::state().contains(TextCheckerState::SmartListsEnabled));
 }
 
 void WebPageProxy::toggleAutomaticTextReplacement()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3143,6 +3143,7 @@ private:
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)
     void toggleSmartInsertDelete();
+    void toggleSmartLists();
     void toggleAutomaticQuoteSubstitution();
     void toggleAutomaticLinkDetection();
     void toggleAutomaticDashSubstitution();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -363,6 +363,7 @@ messages -> WebPageProxy {
 #endif
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)
     toggleSmartInsertDelete()
+    toggleSmartLists()
     toggleAutomaticQuoteSubstitution()
     toggleAutomaticLinkDetection()
     toggleAutomaticDashSubstitution()

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -251,6 +251,7 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
     , m_historyClient(makeUnique<API::LegacyContextHistoryClient>())
     , m_visitedLinkStore(VisitedLinkStore::create())
 #if PLATFORM(MAC)
+    , m_smartListsEnabled(TextChecker::state().contains(TextCheckerState::SmartListsEnabled))
     , m_perActivityStateCPUUsageSampler(makeUniqueRefWithoutRefCountedCheck<PerActivityStateCPUUsageSampler>(*this))
 #endif
     , m_alwaysRunsAtBackgroundPriority(m_configuration->alwaysRunsAtBackgroundPriority())

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -842,10 +842,12 @@ private:
     RetainPtr<NSObject> m_automaticSpellingCorrectionNotificationObserver;
     RetainPtr<NSObject> m_automaticQuoteSubstitutionNotificationObserver;
     RetainPtr<NSObject> m_automaticDashSubstitutionNotificationObserver;
+    RetainPtr<NSObject> m_smartListsNotificationObserver;
     RetainPtr<NSObject> m_accessibilityDisplayOptionsNotificationObserver;
     RetainPtr<NSObject> m_scrollerStyleNotificationObserver;
     RetainPtr<NSObject> m_deactivationObserver;
     RetainPtr<NSObject> m_didChangeScreenParametersNotificationObserver;
+    bool m_smartListsEnabled { false };
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     RetainPtr<NSObject> m_didBeginSuppressingHighDynamicRange;
     RetainPtr<NSObject> m_didEndSuppressingHighDynamicRange;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -460,6 +460,9 @@ public:
     bool isAutomaticTextReplacementEnabled();
     void setAutomaticTextReplacementEnabled(bool);
     void toggleAutomaticTextReplacement();
+    bool isSmartListsEnabled();
+    void setSmartListsEnabled(bool);
+    void toggleSmartLists();
     void uppercaseWord();
     void lowercaseWord();
     void capitalizeWord();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3340,6 +3340,35 @@ void WebViewImpl::toggleAutomaticTextReplacement()
     m_page->protectedLegacyMainFrameProcess()->updateTextCheckerState();
 }
 
+bool WebViewImpl::isSmartListsEnabled()
+{
+    if (!m_page->protectedPreferences()->smartListsEnabled() || !isEditable())
+        return false;
+
+    return TextChecker::state().contains(TextCheckerState::SmartListsEnabled);
+}
+
+void WebViewImpl::setSmartListsEnabled(bool flag)
+{
+    if (!m_page->protectedPreferences()->smartListsEnabled() || !isEditable())
+        return;
+
+    if (flag == TextChecker::state().contains(TextCheckerState::SmartListsEnabled))
+        return;
+
+    TextChecker::setSmartListsEnabled(flag);
+    m_page->protectedLegacyMainFrameProcess()->updateTextCheckerState();
+}
+
+void WebViewImpl::toggleSmartLists()
+{
+    if (!m_page->protectedPreferences()->smartListsEnabled() || !isEditable())
+        return;
+
+    TextChecker::setSmartListsEnabled(!TextChecker::state().contains(TextCheckerState::SmartListsEnabled));
+    m_page->protectedLegacyMainFrameProcess()->updateTextCheckerState();
+}
+
 void WebViewImpl::uppercaseWord()
 {
     m_page->uppercaseWord();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -142,6 +142,8 @@ private:
     bool isAutomaticLinkDetectionEnabled() final;
     void toggleAutomaticLinkDetection() final;
     bool isAutomaticDashSubstitutionEnabled() final;
+    bool isSmartListsEnabled() final;
+    void toggleSmartLists() final;
     void toggleAutomaticDashSubstitution() final;
     bool isAutomaticTextReplacementEnabled() final;
     void toggleAutomaticTextReplacement() final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -194,6 +194,20 @@ void WebEditorClient::toggleAutomaticTextReplacement()
         page->send(Messages::WebPageProxy::toggleAutomaticTextReplacement());
 }
 
+bool WebEditorClient::isSmartListsEnabled()
+{
+    if (RefPtr page = m_page.get(); page && page->isControlledByAutomation())
+        return false;
+
+    return WebProcess::singleton().textCheckerState().contains(TextCheckerState::SmartListsEnabled);
+}
+
+void WebEditorClient::toggleSmartLists()
+{
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::toggleSmartLists());
+}
+
 bool WebEditorClient::isAutomaticSpellingCorrectionEnabled()
 {
     if (RefPtr page = m_page.get(); page && page->isControlledByAutomation())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1308,6 +1308,9 @@ public:
     bool isSmartInsertDeleteEnabled();
     void setSmartInsertDeleteEnabled(bool);
 
+    bool isSmartListsEnabled();
+    void setSmartListsEnabled(bool);
+
     bool isWebTransportEnabled() const;
 
     bool isSelectTrailingWhitespaceEnabled() const;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -106,6 +106,8 @@ private:
     void toggleAutomaticTextReplacement() final;
     bool isAutomaticSpellingCorrectionEnabled() final;
     void toggleAutomaticSpellingCorrection() final;
+    bool isSmartListsEnabled() final;
+    void toggleSmartLists() final;
 #endif
 
     TextCheckerClient* textChecker() final { return this; }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -579,6 +579,15 @@ void WebEditorClient::toggleAutomaticSpellingCorrection()
     [m_webView toggleAutomaticSpellingCorrection:nil];
 }
 
+bool WebEditorClient::isSmartListsEnabled()
+{
+    return false;
+}
+
+void WebEditorClient::toggleSmartLists()
+{
+}
+
 #endif // USE(AUTOMATIC_TEXT_REPLACEMENT)
 
 bool WebEditorClient::shouldInsertNode(Node& node, const std::optional<SimpleRange>& replacingRange, EditorInsertAction givenAction)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8186,6 +8186,15 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
     [self setAutomaticSpellingCorrectionEnabled:![self isAutomaticSpellingCorrectionEnabled]];
 }
 
+- (BOOL)isSmartListsEnabled
+{
+    return NO;
+}
+
+- (void)setSmartListsEnabled:(BOOL)flag
+{
+}
+
 #endif // !PLATFORM(IOS_FAMILY)
 
 @end

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		04DB2396235E43EC00328F17 /* BumpPointerAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */; };
 		0714677A2DFE8DEA00F77867 /* WebPageTransferableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */; };
 		07275CBC2D01398C002315A5 /* _WebKit_SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */; };
+		073310B52E6E4EFC0048CF1E /* SmartLists.mm in Sources */ = {isa = PBXBuildFile; fileRef = 073310AD2E6E4E800048CF1E /* SmartLists.mm */; };
 		074E87E52CF920A20059E469 /* Bundle+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E42CF920A20059E469 /* Bundle+Extras.swift */; };
 		075663822DF68BAB00E9A4E3 /* TestPDFDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B0CA82DF656BD00B3E569 /* TestPDFDocument.swift */; };
 		075A9CF526177218006DFA3A /* MediaSessionCoordinatorTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 075A9CF426177217006DFA3A /* MediaSessionCoordinatorTest.mm */; };
@@ -2394,6 +2395,7 @@
 		071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageTransferableTests.swift; sourceTree = "<group>"; };
 		0721D4582838295400A95853 /* start-offset.ts */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.typescript; path = "start-offset.ts"; sourceTree = "<group>"; };
 		07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = _WebKit_SwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		073310AD2E6E4E800048CF1E /* SmartLists.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SmartLists.mm; sourceTree = "<group>"; };
 		07338E042B7433A400F949EB /* WritingSuggestions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WritingSuggestions.mm; sourceTree = "<group>"; };
 		0738012E275EADAB000FA77C /* GetDisplayMediaWindowAndScreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GetDisplayMediaWindowAndScreen.mm; sourceTree = "<group>"; };
 		0746645722FF62D000E3451A /* AccessibilityTestSupportProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityTestSupportProtocol.h; sourceTree = "<group>"; };
@@ -4936,6 +4938,7 @@
 				F4C3F29A2C447EB50029A47D /* SimulateClickOverText.mm */,
 				5C29FE9128EE5F3D00D4FB00 /* SiteIsolation.mm */,
 				5C24A002294A75DD00463E2B /* SkipDecidePolicyForResponsePlugIn.mm */,
+				073310AD2E6E4E800048CF1E /* SmartLists.mm */,
 				2DFF7B6C1DA487AF00814614 /* SnapshotStore.mm */,
 				5774AA6721FBBF7800AF2A1B /* SOAuthorizationTests.mm */,
 				CD5F16612DBC652000CE85D9 /* SpatialAudioExperience.mm */,
@@ -7902,6 +7905,7 @@
 				7CCE7F141A411AE600447C4C /* ShouldKeepCurrentBackForwardListItemInList.cpp in Sources */,
 				7CCE7ECD1A411A7E00447C4C /* SimplifyMarkup.mm in Sources */,
 				C149D550242E98DF003EBB12 /* SleepDisabler.mm in Sources */,
+				073310B52E6E4EFC0048CF1E /* SmartLists.mm in Sources */,
 				0F4FFA9E1ED3AA8500F7111F /* SnapshotViaRenderInContext.mm in Sources */,
 				510A91F824D3622100BFD89C /* SonyDualShock3.mm in Sources */,
 				51EB126424CA6B66000CB030 /* SonyDualShock4.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKMenuItemIdentifiersPrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFeature.h>
+
+// FIXME: Come up with a better testing infrastructure that doesn't rely on forward declarations.
+@interface WKWebView (SmartLists)
+- (BOOL)isSmartListsEnabled;
+- (void)setSmartListsEnabled:(BOOL)flag;
+- (void)toggleSmartLists:(id)sender;
+@end
+
+static NSString* const WebSmartListsEnabled = @"WebSmartListsEnabled";
+
+// MARK: Utilities
+
+static void setSmartListsPreference(WKWebViewConfiguration *configuration, BOOL value)
+{
+    auto preferences = [configuration preferences];
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"SmartListsEnabled"]) {
+            [preferences _setEnabled:value forFeature:feature];
+            break;
+        }
+    }
+}
+
+static NSNumber *userDefaultsValue()
+{
+    return [[NSUserDefaults standardUserDefaults] objectForKey:WebSmartListsEnabled];
+}
+
+static void resetUserDefaults()
+{
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:WebSmartListsEnabled];
+}
+
+static void setUserDefaultsValue(BOOL value)
+{
+    [[NSUserDefaults standardUserDefaults] setBool:value forKey:WebSmartListsEnabled];
+}
+
+static RetainPtr<NSMenu> invokeContextMenu(TestWKWebView *webView)
+{
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block RetainPtr<NSMenu> proposedMenu;
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        proposedMenu = menu;
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    [webView setUIDelegate:delegate.get()];
+
+    [webView waitForNextPresentationUpdate];
+    [webView rightClickAtPoint:NSMakePoint(10, [webView frame].size.height - 10)];
+    TestWebKitAPI::Util::run(&gotProposedMenu);
+
+    return proposedMenu;
+}
+
+// MARK: Tests
+
+TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<div>hi</div>"];
+    [webView waitForNextPresentationUpdate];
+
+    // Case 1: _editable => false, user default => nil, preference => false
+
+    [webView _setEditable:NO];
+    setSmartListsPreference(configuration.get(), NO);
+    resetUserDefaults();
+
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_NULL(userDefaultsValue());
+
+    [webView setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_NULL(userDefaultsValue());
+
+    // Case 2: _editable => true, user default => nil, preference => false
+
+    [webView _setEditable:YES];
+    setSmartListsPreference(configuration.get(), NO);
+    resetUserDefaults();
+
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_NULL(userDefaultsValue());
+
+    [webView setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_NULL(userDefaultsValue());
+
+    // Case 3: _editable => false, user default => true, preference => false
+
+    [webView _setEditable:NO];
+    setSmartListsPreference(configuration.get(), NO);
+    setUserDefaultsValue(YES);
+
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    [webView setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    // Case 4: _editable => true, user default => true, preference => false
+
+    [webView _setEditable:YES];
+    setSmartListsPreference(configuration.get(), NO);
+    setUserDefaultsValue(YES);
+
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    [webView setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    // Case 5: _editable => false, user default => nil, preference => true
+
+    [webView _setEditable:NO];
+    setSmartListsPreference(configuration.get(), YES);
+    resetUserDefaults();
+
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_NULL(userDefaultsValue());
+
+    [webView setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_NULL(userDefaultsValue());
+
+    // Case 6: _editable => true, user default => nil, preference => true
+
+    [webView _setEditable:YES];
+    setSmartListsPreference(configuration.get(), YES);
+    resetUserDefaults();
+
+    EXPECT_TRUE([webView isSmartListsEnabled]);
+    EXPECT_NULL(userDefaultsValue());
+
+    [webView setSmartListsEnabled:NO];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([userDefaultsValue() boolValue]);
+
+    [webView toggleSmartLists:nil];
+    EXPECT_TRUE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    // Case 7: _editable => false, user default => true, preference => true
+
+    [webView _setEditable:NO];
+    setSmartListsPreference(configuration.get(), YES);
+    setUserDefaultsValue(YES);
+
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    [webView setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    // Case 8: _editable => true, user default => true, preference => true
+
+    [webView _setEditable:YES];
+    setSmartListsPreference(configuration.get(), YES);
+    setUserDefaultsValue(YES);
+
+    EXPECT_TRUE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    [webView setSmartListsEnabled:NO];
+    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([userDefaultsValue() boolValue]);
+}
+
+TEST(SmartLists, ContextMenuItemStateIsConsistentWithAvailability)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+
+    [webView synchronouslyLoadHTMLString:@"<body contenteditable>hi</body>"];
+    [webView waitForNextPresentationUpdate];
+
+    // Case 1: Feature disabled
+    {
+        [webView _setEditable:NO];
+        setSmartListsPreference(configuration.get(), YES);
+
+        NSString *script = @"document.body.focus()";
+        [webView stringByEvaluatingJavaScript:script];
+
+        RetainPtr menu = invokeContextMenu(webView.get());
+        RetainPtr substitutionMenu = [menu itemWithTitle:@"Substitutions"];
+        EXPECT_NOT_NULL(substitutionMenu.get());
+
+        RetainPtr smartListsItem = [[substitutionMenu submenu] itemWithTitle:@"Smart Lists"];
+        EXPECT_NULL(smartListsItem);
+    }
+
+    // Case 2: Feature enabled, preference enabled
+    {
+        [webView _setEditable:YES];
+        setSmartListsPreference(configuration.get(), YES);
+
+        NSString *script = @"document.body.focus()";
+        [webView stringByEvaluatingJavaScript:script];
+
+        RetainPtr menu = invokeContextMenu(webView.get());
+        RetainPtr substitutionMenu = [menu itemWithTitle:@"Substitutions"];
+        EXPECT_NOT_NULL(substitutionMenu.get());
+
+        RetainPtr smartListsItem = [[substitutionMenu submenu] itemWithTitle:@"Smart Lists"];
+        EXPECT_TRUE([smartListsItem isEnabled]);
+    }
+
+    // Case 3: Feature enabled, preference disabled
+    {
+        [webView _setEditable:YES];
+        setSmartListsPreference(configuration.get(), NO);
+
+        NSString *script = @"document.body.focus()";
+        [webView stringByEvaluatingJavaScript:script];
+
+        RetainPtr menu = invokeContextMenu(webView.get());
+        RetainPtr substitutionMenu = [menu itemWithTitle:@"Substitutions"];
+        EXPECT_NOT_NULL(substitutionMenu.get());
+
+        RetainPtr smartListsItem = [[substitutionMenu submenu] itemWithTitle:@"Smart Lists"];
+        EXPECT_FALSE([smartListsItem isEnabled]);
+    }
+}
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 5a304afdeefe0c85a121ed7d01aed1de4804bd8b
<pre>
[Smart Lists] Add a context menu item to toggle Smart Lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=298701">https://bugs.webkit.org/show_bug.cgi?id=298701</a>
<a href="https://rdar.apple.com/160346343">rdar://160346343</a>

Reviewed by Aditya Keerthi.

Add support for querying, modifying, and toggling the enablement of Smart Lists on macOS.

Consequently, a new runtime feature flag is added and the `_editable` property is used to ensure the availability of the feature under these conditions:

- By default, the runtime feature flag is disabled
- The feature is not available if either (a) the runtime feature flag is disabled, or (b) the `_editable` property is `false`.

When the feature is available, it is true by default.

There are three main entry points to enabling Smart Lists:

1. A new context menu item is added to the Substitutions sub-menu, &quot;Smart Lists&quot;
2. A new UserDefaults key/value pair is used as the source of truth, which can also be controlled independently
3. Implementation methods are added to WKWebView which can be invoked by actions in the embdedding client&apos;s menu bar.

The implementation of this feature uses the existing precedent of the various other &quot;TextChecker&quot; properties.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::isSmartListsEnabled):
(WebCore::Editor::toggleSmartLists):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::createAndAppendSubstitutionsSubMenu):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/page/EditorClient.h:
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm:
(WebCore::contextMenuItemTagSmartLists):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameWithTypeForAction):
* Source/WebKit/Shared/TextCheckerState.h:
* Source/WebKit/Shared/TextFlags.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView isSmartListsEnabled]):
(-[WKWebView setSmartListsEnabled:]):
(-[WKWebView toggleSmartLists:]):
* Source/WebKit/UIProcess/TextChecker.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::toggleSmartLists):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::shouldSmartListsBeEnabled):
(WebKit::mutableState):
(WebKit::TextChecker::setTestingMode):
(WebKit::TextChecker::isSmartListsEnabled):
(WebKit::TextChecker::setSmartListsEnabled):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::menuItemIdentifier):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::isSmartListsEnabled):
(WebKit::WebViewImpl::setSmartListsEnabled):
(WebKit::WebViewImpl::toggleSmartLists):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::toggleSmartLists):
(WebKit::WebEditorClient::isSmartListsEnabled):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(WebEditorClient::isSmartListsEnabled):
(WebEditorClient::toggleSmartLists):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView isSmartListsEnabled]):
(-[WebView setSmartListsEnabled:]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm: Added.
(-[NSMenu itemWithIdentifier:]):
(setSmartListsPreference):
(userDefaultsValue):
(resetUserDefaults):
(setUserDefaultsValue):
(TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)):
(TEST(SmartLists, ContextMenuItemStateIsConsistentWithAvailability)):

Canonical link: <a href="https://commits.webkit.org/299884@main">https://commits.webkit.org/299884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10c62585d1a8921e7eaf26b204e859abb5220fdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72656 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2ce5c4a-303c-4c29-9e2b-9491c3819344) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48852 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91580 "Failed to checkout and rebase branch from PR 50587") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8730d9ba-3ed4-4043-82e7-3b9c54088c6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36ca4932-df2d-424b-8083-5c2fd5a15ba8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70576 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112707 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129842 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119097 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100198 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100039 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25391 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45481 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23508 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44150 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53069 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/148177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46832 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/148177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50179 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->