### PR TITLE
Address Safer CPP warnings in CrossOriginAccessControl.cpp, CrossOriginOpenerPolicy.cpp and CachedResourceHandle.h

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1953,6 +1953,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/archive/mhtml/MHTMLArchive.h
     loader/cache/CachePolicy.h
     loader/cache/CachedApplicationManifest.h
+    loader/cache/CachedCSSStyleSheet.h
     loader/cache/CachedFontLoadRequest.h
     loader/cache/CachedImage.h
     loader/cache/CachedImageClient.h

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -76,7 +76,6 @@ layout/formattingContexts/inline/text/TextUtil.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.h
 layout/layouttree/LayoutElementBox.h
 loader/cache/CachedImageClient.h
-loader/cache/CachedResourceHandle.h
 page/DOMWindow.cpp
 page/EventHandler.h
 page/Page.h

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -84,7 +84,6 @@ inspector/agents/InspectorCSSAgent.cpp
 layout/layouttree/LayoutIterator.h
 layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h
-loader/cache/CachedResourceHandle.h
 mathml/MathMLRowElement.cpp
 page/NavigatorLoginStatus.cpp
 page/mac/EventHandlerMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -563,8 +563,6 @@ inspector/agents/worker/WorkerRuntimeAgent.cpp
 layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
 loader/ApplicationManifestLoader.cpp
-loader/CrossOriginAccessControl.cpp
-loader/CrossOriginOpenerPolicy.cpp
 loader/CrossOriginPreflightChecker.cpp
 loader/DocumentThreadableLoader.cpp
 loader/DocumentWriter.cpp

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -22,6 +22,7 @@
 
 #include <WebCore/CSSURL.h>
 #include <WebCore/CSSValue.h>
+#include <WebCore/CachedImage.h>
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/ResourceLoaderOptions.h>
 #include <wtf/Function.h>

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <WebCore/CachedCSSStyleSheet.h>
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/CachedStyleSheetClient.h>
 #include <WebCore/MediaQuery.h>

--- a/Source/WebCore/dom/XMLDocument.h
+++ b/Source/WebCore/dom/XMLDocument.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/Document.h>
+#include <WebCore/DocumentInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -184,7 +184,7 @@ CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&& requ
     }
 
     CachedResourceRequest cachedRequest { WTFMove(request), WTFMove(options) };
-    updateRequestForAccessControl(cachedRequest.resourceRequest(), document.securityOrigin(), options.storedCredentialsPolicy);
+    updateRequestForAccessControl(cachedRequest.resourceRequest(), document.protectedSecurityOrigin().get(), options.storedCredentialsPolicy);
     return cachedRequest;
 }
 

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
@@ -174,7 +174,7 @@ static std::pair<Ref<SecurityOrigin>, CrossOriginOpenerPolicy> computeResponseOr
     // if the initiator and its top level document are same-origin, or default (unsafe-none) otherwise.
     // https://github.com/whatwg/html/issues/6913
     if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(response.url()) && requester)
-        return { requester->securityOrigin, requester->securityOrigin->isSameOriginAs(requester->topOrigin) ? requester->policyContainer.crossOriginOpenerPolicy : CrossOriginOpenerPolicy { } };
+        return { requester->securityOrigin, Ref { requester->securityOrigin }->isSameOriginAs(requester->topOrigin) ? requester->policyContainer.crossOriginOpenerPolicy : CrossOriginOpenerPolicy { } };
 
     // If the HTTP response contains a CSP header, it may set sandbox flags, which would cause the origin to become opaque.
     auto responseOrigin = responseCSP && !responseCSP->sandboxFlags().isEmpty() ? SecurityOrigin::createOpaque() : SecurityOrigin::create(response.url());
@@ -292,7 +292,7 @@ std::optional<CrossOriginOpenerPolicyEnforcementResult> doCrossOriginOpenerHandl
 CrossOriginOpenerPolicyEnforcementResult CrossOriginOpenerPolicyEnforcementResult::from(const URL& currentURL, Ref<SecurityOrigin>&& currentOrigin, const CrossOriginOpenerPolicy& crossOriginOpenerPolicy, std::optional<NavigationRequester> requester, const URL& openerURL)
 {
     CrossOriginOpenerPolicyEnforcementResult result { currentURL, WTFMove(currentOrigin), crossOriginOpenerPolicy };
-    result.isCurrentContextNavigationSource = requester && result.currentOrigin->isSameOriginAs(requester->securityOrigin);
+    result.isCurrentContextNavigationSource = requester && Ref { result.currentOrigin }->isSameOriginAs(requester->securityOrigin);
     if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(currentURL) && openerURL.isValid())
         result.url = openerURL;
     return result;

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <WebCore/CachedImage.h>
 #include <WebCore/CachedImageClient.h>
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/Element.h>

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -25,12 +25,11 @@
 
 #pragma once
 
+#include "CachedResource.h"
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-
-class CachedResource;
 
 class CachedResourceHandleBase {
 public:
@@ -65,7 +64,13 @@ public:
     CachedResourceHandle(const CachedResourceHandle<R>& o) : CachedResourceHandleBase(o) { }
     template<typename U> CachedResourceHandle(const CachedResourceHandle<U>& o) : CachedResourceHandleBase(o.get()) { }
 
-    R* get() const { return reinterpret_cast<R*>(CachedResourceHandleBase::get()); }
+    R* get() const
+    {
+        if constexpr (std::same_as<R, CachedResource>)
+            return CachedResourceHandleBase::get();
+        else
+            return downcast<R>(CachedResourceHandleBase::get());
+    }
     R* operator->() const { return get(); }
     R& operator*() const { ASSERT(get()); return *get(); }
 

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/CachedResourceHandle.h>
+#include <WebCore/CachedSVGDocument.h>
 #include <WebCore/CachedSVGDocumentClient.h>
 #include <WebCore/LoaderMalloc.h>
 #include <WebCore/StyleURL.h>

--- a/Source/WebCore/rendering/style/StyleCachedImage.h
+++ b/Source/WebCore/rendering/style/StyleCachedImage.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <WebCore/CachedImage.h>
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/StyleImage.h>
 #include <wtf/TZoneMalloc.h>


### PR DESCRIPTION
#### c3e60cd35cd0bf5f511ea2f608f44aafb304640c
<pre>
Address Safer CPP warnings in CrossOriginAccessControl.cpp, CrossOriginOpenerPolicy.cpp and CachedResourceHandle.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=298702">https://bugs.webkit.org/show_bug.cgi?id=298702</a>

Reviewed by Darin Adler.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/StyleRuleImport.h:
* Source/WebCore/dom/XMLDocument.h:
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createPotentialAccessControlRequest):
* Source/WebCore/loader/CrossOriginOpenerPolicy.cpp:
(WebCore::computeResponseOriginAndCOOP):
(WebCore::CrossOriginOpenerPolicyEnforcementResult::from):
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/cache/CachedResourceHandle.h:
(WebCore::CachedResourceHandle::get const):
* Source/WebCore/loader/cache/CachedSVGDocumentReference.h:
* Source/WebCore/rendering/style/StyleCachedImage.h:

Canonical link: <a href="https://commits.webkit.org/299877@main">https://commits.webkit.org/299877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a940682bfe48d6341b34558896a5138e90b00687

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72607 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84355e40-d276-487f-89af-28c89b5006aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91544 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ffdad21-fabc-4e38-a123-b306436e3e34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72095 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf193101-ff7c-45b1-8df9-1aff5ea94cbc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70525 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129793 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100163 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100005 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25386 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44101 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53020 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50130 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->