### PR TITLE
[WebM|iOS] VTDecompressionSession is not torn down when app is backgrounded

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -131,6 +131,8 @@ public:
     virtual void flush() = 0;
     virtual void flushTrack(TrackIdentifier) = 0;
 
+    virtual void applicationWillResignActive() { }
+
     virtual void notifyWhenErrorOccurs(Function<void(PlatformMediaError)>&&) = 0;
 
     using SoundStageSize = MediaPlayerSoundStageSize;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -76,6 +76,8 @@ public:
     void flush() final;
     void flushTrack(TrackIdentifier) final;
 
+    void applicationWillResignActive() final;
+
     void notifyWhenErrorOccurs(Function<void(PlatformMediaError)>&&) final;
 
     // SynchronizerInterface

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -323,6 +323,21 @@ void AudioVideoRendererAVFObjC::flushTrack(TrackIdentifier trackId)
     }
 }
 
+void AudioVideoRendererAVFObjC::applicationWillResignActive()
+{
+    RefPtr videoRenderer = m_videoRenderer;
+    if (!videoRenderer || !videoRenderer->isUsingDecompressionSession())
+        return;
+
+    if (!paused()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Playing; not invalidating VideoMediaSampleRenderer Decompression Session");
+        return;
+    }
+
+    videoRenderer->invalidateDecompressionSession();
+    ALWAYS_LOG(LOGIDENTIFIER, "Paused; invalidating VideoMediaSampleRenderer Decompression Session");
+}
+
 void AudioVideoRendererAVFObjC::notifyWhenErrorOccurs(Function<void(PlatformMediaError)>&& callback)
 {
     m_errorCallback = WTFMove(callback);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1412,6 +1412,7 @@ void MediaPlayerPrivateWebM::sceneIdentifierDidChange()
 void MediaPlayerPrivateWebM::applicationWillResignActive()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+    m_renderer->applicationWillResignActive();
     m_applicationIsActive = false;
 }
 


### PR DESCRIPTION
#### 15ee68a1c1562c0b96c2a947300a6100c709b68a
<pre>
[WebM|iOS] VTDecompressionSession is not torn down when app is backgrounded
<a href="https://bugs.webkit.org/show_bug.cgi?id=298704">https://bugs.webkit.org/show_bug.cgi?id=298704</a>
<a href="https://rdar.apple.com/160353574">rdar://160353574</a>

Reviewed by Youenn Fablet.

We implement the same feature as done for MSE in 299841@main for WebM playback.

* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::TracksRendererManager::applicationWillResignActive):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::applicationWillResignActive):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::applicationWillResignActive):

Canonical link: <a href="https://commits.webkit.org/299850@main">https://commits.webkit.org/299850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb7fcf1dcb908eb540ef575735fe800d3696cff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72484 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da49509f-d377-4c5e-8024-cb6dac4e43c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48680 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91446 "13 flakes 58 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60735 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd53eb88-535b-4c02-9263-051e737fd7fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71998 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1607e16b-0463-409b-af89-9699b70c0743) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70397 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129665 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99907 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25368 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43976 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52897 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->