### PR TITLE
[WebDriver][BiDi] Implement the browsingContext.captureScreenshot command

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -40,6 +40,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include <JavaScriptCore/MathCommon.h>
+#include <WebCore/FloatRect.h>
 #include <limits>
 #include <wtf/Borrow.h>
 #include <wtf/Ref.h>
@@ -103,6 +104,53 @@ void BidiBrowsingContextAgent::close(const BrowsingContext& browsingContext, std
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, FrameNotFound);
 
     session->closeBrowsingContext(pageHandle, WTF::move(callback));
+}
+
+void BidiBrowsingContextAgent::captureScreenshot(const BrowsingContext& browsingContext, std::optional<Inspector::Protocol::BidiBrowsingContext::ScreenshotOrigin>&& optionalOrigin, RefPtr<JSON::Object>&& format, RefPtr<JSON::Object>&& clip, CommandCallback<String>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
+
+    ScreenshotParameters params;
+
+    if (optionalOrigin) {
+        auto origin = *optionalOrigin;
+        switch (origin) {
+        case Inspector::Protocol::BidiBrowsingContext::ScreenshotOrigin::Viewport:
+            params.origin = ScreenshotOrigin::Viewport;
+            break;
+        case Inspector::Protocol::BidiBrowsingContext::ScreenshotOrigin::Document:
+            params.origin = ScreenshotOrigin::Document;
+            break;
+        }
+    } else
+        params.origin = ScreenshotOrigin::Viewport;
+
+    if (format) {
+        String typeValue = format->getString("type"_s);
+        if (!typeValue.isEmpty()) {
+            auto parsedFormat = parseImageFormatType(typeValue);
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!parsedFormat, InvalidParameter);
+            params.format = *parsedFormat;
+        }
+        if (auto qualityValue = format->getDouble("quality"_s))
+            params.quality = qualityValue.value();
+    }
+
+    auto originRect = getOriginRectangle(params.origin, *webPageProxy);
+
+    if (clip) {
+        auto clipRect = parseClipRectangle(clip, originRect);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!clipRect, InvalidParameter);
+        params.clipRect = rectangleIntersection(originRect, *clipRect);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(params.clipRect->isEmpty(), InternalError);
+    } else
+        params.clipRect = originRect;
+
+    performScreenshotCapture(*webPageProxy, params, WTF::move(callback));
 }
 
 static constexpr Inspector::Protocol::Automation::BrowsingContextPresentation defaultBrowsingContextPresentation = Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
@@ -417,6 +465,137 @@ void BidiBrowsingContextAgent::setViewport(const BrowsingContext& optionalContex
         // https://bugs.webkit.org/show_bug.cgi?id=288104
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(true, NotImplemented);
     }
+}
+
+WebCore::FloatRect BidiBrowsingContextAgent::getOriginRectangle(ScreenshotOrigin origin, const WebPageProxy& webPageProxy)
+{
+    auto viewSize = webPageProxy.viewSize();
+
+    if (origin == ScreenshotOrigin::Viewport)
+        return WebCore::FloatRect(0, 0, viewSize.width(), viewSize.height());
+
+    // FIXME: Get actual document scroll dimensions when available
+    return WebCore::FloatRect(0, 0, viewSize.width(), viewSize.height());
+}
+
+WebCore::FloatRect BidiBrowsingContextAgent::normalizeRect(const WebCore::FloatRect& rect)
+{
+    float x = rect.x(), y = rect.y();
+    float width = rect.width(), height = rect.height();
+
+    if (width < 0) {
+        x += width;
+        width = -width;
+    }
+    if (height < 0) {
+        y += height;
+        height = -height;
+    }
+    return { x, y, width, height };
+}
+
+WebCore::FloatRect BidiBrowsingContextAgent::rectangleIntersection(const WebCore::FloatRect& rect1, const WebCore::FloatRect& rect2)
+{
+    auto norm1 = normalizeRect(rect1);
+    auto norm2 = normalizeRect(rect2);
+
+    float x0 = std::max(norm1.x(), norm2.x());
+    float x1 = std::min(norm1.maxX(), norm2.maxX());
+    float y0 = std::max(norm1.y(), norm2.y());
+    float y1 = std::min(norm1.maxY(), norm2.maxY());
+
+    float width = (x1 < x0) ? 0 : (x1 - x0);
+    float height = (y1 < y0) ? 0 : (y1 - y0);
+    return WebCore::FloatRect(x0, y0, width, height);
+}
+
+std::optional<WebCore::FloatRect> BidiBrowsingContextAgent::parseClipRectangle(const RefPtr<JSON::Object>& clip, const WebCore::FloatRect& originRect)
+{
+    if (!clip)
+        return std::nullopt;
+
+    String clipType = clip->getString("type"_s);
+
+    if (clipType == "element"_s)
+        return parseElementClipRectangle(clip, originRect);
+
+    return parseBoxClipRectangle(clip, originRect);
+}
+
+std::optional<WebCore::FloatRect> BidiBrowsingContextAgent::parseBoxClipRectangle(const RefPtr<JSON::Object>& clip, const WebCore::FloatRect& originRect)
+{
+    auto x = clip->getDouble("x"_s).value_or(0);
+    auto y = clip->getDouble("y"_s).value_or(0);
+    auto width = clip->getDouble("width"_s).value_or(0);
+    auto height = clip->getDouble("height"_s).value_or(0);
+    return WebCore::FloatRect(originRect.x() + x, originRect.y() + y, width, height);
+}
+
+std::optional<WebCore::FloatRect> BidiBrowsingContextAgent::parseElementClipRectangle(const RefPtr<JSON::Object>& clip, const WebCore::FloatRect& originRect)
+{
+    // FIXME: rdar://160959983 - implement element reference resolution
+    auto elementObj = clip->getObject("element"_s);
+    if (!elementObj)
+        return std::nullopt;
+    return std::nullopt;
+}
+
+void BidiBrowsingContextAgent::performScreenshotCapture(WebPageProxy& page, const ScreenshotParameters& params, Inspector::CommandCallback<String>&& callback)
+{
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    String frameHandle = ""_s;
+    String nodeHandle = ""_s;
+    bool scrollIntoViewIfNeeded = false;
+    bool clipToViewport = (params.origin == ScreenshotOrigin::Viewport);
+
+    session->takeScreenshot(session->handleForWebPageProxy(page), frameHandle, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, [this, params, callback = WTF::move(callback)](CommandResult<String>&& result) mutable {
+        if (!result) {
+            callback(makeUnexpected(result.error()));
+            return;
+        }
+
+        String finalImage = result.value();
+        if (params.format != ImageFormatType::Png)
+            finalImage = convertImageFormat(result.value(), imageFormatTypeToString(params.format), params.quality);
+
+        callback(WTF::move(finalImage));
+    });
+}
+
+std::optional<BidiBrowsingContextAgent::ImageFormatType> BidiBrowsingContextAgent::parseImageFormatType(const String& format)
+{
+    if (format == "png"_s || format == "image/png"_s)
+        return ImageFormatType::Png;
+    if (format == "jpeg"_s || format == "image/jpeg"_s)
+        return ImageFormatType::Jpeg;
+    if (format == "webp"_s || format == "image/webp"_s)
+        return ImageFormatType::Webp;
+    return std::nullopt;
+}
+
+String BidiBrowsingContextAgent::imageFormatTypeToString(ImageFormatType format)
+{
+    switch (format) {
+    case ImageFormatType::Png:
+        return "image/png"_s;
+    case ImageFormatType::Jpeg:
+        return "image/jpeg"_s;
+    case ImageFormatType::Webp:
+        return "image/webp"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return "image/png"_s;
+}
+
+String BidiBrowsingContextAgent::convertImageFormat(const String& base64PNG, const String& targetFormat, std::optional<double> quality) const
+{
+    UNUSED_PARAM(targetFormat);
+    UNUSED_PARAM(quality);
+
+    // FIXME: Implement image format conversion
+    return base64PNG;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
@@ -31,6 +31,7 @@
 
 #include "WebDriverBidiBackendDispatchers.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <WebCore/FloatRect.h>
 #include <WebCore/FrameIdentifier.h>
 #include <cstdint>
 #include <optional>
@@ -52,6 +53,7 @@ public:
 
     // Inspector::BidiBrowsingContextDispatcherHandler methods.
     void activate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, Inspector::CommandCallback<void>&&) override;
+    void captureScreenshot(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<Inspector::Protocol::BidiBrowsingContext::ScreenshotOrigin>&&, RefPtr<JSON::Object>&& format, RefPtr<JSON::Object>&& clip, Inspector::CommandCallback<String>&&) override;
     void close(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalPromptUnload, Inspector::CommandCallback<void>&&) override;
     void create(Inspector::Protocol::BidiBrowsingContext::CreateType, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalReferenceContext, std::optional<bool>&& optionalBackground, const String& optionalUserContext, Inspector::CommandCallback<String>&&) override;
     void getTree(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&) override;
@@ -63,6 +65,27 @@ public:
 
 private:
     enum class IncludeParentID: bool { No, Yes };
+
+    enum class ScreenshotOrigin { Viewport, Document };
+    enum class ImageFormatType { Png, Jpeg, Webp };
+
+    struct ScreenshotParameters {
+        ScreenshotOrigin origin { ScreenshotOrigin::Viewport };
+        ImageFormatType format { ImageFormatType::Png };
+        std::optional<double> quality;
+        std::optional<WebCore::FloatRect> clipRect;
+    };
+
+    static WebCore::FloatRect getOriginRectangle(ScreenshotOrigin, const WebPageProxy&);
+    static WebCore::FloatRect normalizeRect(const WebCore::FloatRect&);
+    static std::optional<ImageFormatType> parseImageFormatType(const String&);
+    static String imageFormatTypeToString(ImageFormatType);
+    WebCore::FloatRect rectangleIntersection(const WebCore::FloatRect&, const WebCore::FloatRect&);
+    std::optional<WebCore::FloatRect> parseClipRectangle(const RefPtr<JSON::Object>& clip, const WebCore::FloatRect& originRect);
+    std::optional<WebCore::FloatRect> parseBoxClipRectangle(const RefPtr<JSON::Object>& clip, const WebCore::FloatRect& originRect);
+    std::optional<WebCore::FloatRect> parseElementClipRectangle(const RefPtr<JSON::Object>& clip, const WebCore::FloatRect& originRect);
+    void performScreenshotCapture(WebPageProxy&, const ScreenshotParameters&, Inspector::CommandCallback<String>&&);
+    String convertImageFormat(const String& base64PNG, const String& targetFormat, std::optional<double> quality) const;
 
     void getNextTree(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>, std::optional<uint64_t> maxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&);
     Ref<Inspector::Protocol::BidiBrowsingContext::Info> getNavigableInfo(const WebKit::FrameTreeNodeData&, std::optional<uint64_t> maxDepth, IncludeParentID);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -3071,6 +3071,11 @@ std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(cons
 {
     return std::nullopt;
 }
+
+std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(const ViewSnapshot& snapshot, const WebCore::IntRect&)
+{
+    return platformGetBase64EncodedPNGData(snapshot);
+}
 #endif // !PLATFORM(COCOA) && !USE(CAIRO) && !USE(SKIA)
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -386,6 +386,7 @@ private:
     // Get base64-encoded PNG data from a bitmap.
     static std::optional<String> platformGetBase64EncodedPNGData(WebCore::ShareableBitmap::Handle&&);
     static std::optional<String> platformGetBase64EncodedPNGData(const ViewSnapshot&);
+    static std::optional<String> platformGetBase64EncodedPNGData(const ViewSnapshot&, const WebCore::IntRect& cropRect);
 
     // Save base64-encoded file contents to a local file path and return the path.
     // This reuses the basename of the remote file path so that the filename exposed to DOM API remains the same.

--- a/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
+++ b/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
@@ -71,6 +71,11 @@ std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(cons
     notImplemented();
     return std::nullopt;
 }
+
+std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(const ViewSnapshot& snapshot, const WebCore::IntRect&)
+{
+    return platformGetBase64EncodedPNGData(snapshot);
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -67,6 +67,63 @@
             "enum": [ "alert", "beforeunload", "confirm", "prompt" ]
         },
         {
+            "id": "ScreenshotOrigin",
+            "description": "Represents the origin coordinate system for screenshots.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-browsingcontextscreenshotorigin",
+            "type": "string",
+            "enum": ["viewport", "document"]
+        },
+        {
+            "id": "ImageFormatType",
+            "description": "Represents the supported image format types for screenshots.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-browsingcontextimageformattype",
+            "type": "string",
+            "enum": ["png", "jpeg", "webp"]
+        },
+        {
+            "id": "ImageFormat",
+            "description": "Represents the image format for screenshots.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-browsingcontextimageformat",
+            "type": "object",
+            "properties": [
+                { "name": "type", "$ref": "BidiBrowsingContext.ImageFormatType", "description": "The image format type." },
+                { "name": "quality", "type": "number", "optional": true, "description": "The image quality from 0.0 to 1.0 (only applicable for lossy formats)." }
+            ]
+        },
+        {
+            "id": "ClipRectangle",
+            "description": "Represents a clipping rectangle for screenshots.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-browsingcontextcliprectangle",
+            "type": "object",
+            "oneOf": [
+                { "$ref": "BidiBrowsingContext.BoxClipRectangle" },
+                { "$ref": "BidiBrowsingContext.ElementClipRectangle" }
+            ]
+        },
+        {
+            "id": "BoxClipRectangle",
+            "description": "Represents a box-based clipping rectangle.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-browsingcontextboxcliprectangle",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["box"] },
+                { "name": "x", "type": "number", "description": "The x coordinate of the rectangle." },
+                { "name": "y", "type": "number", "description": "The y coordinate of the rectangle." },
+                { "name": "width", "type": "number", "description": "The width of the rectangle." },
+                { "name": "height", "type": "number", "description": "The height of the rectangle." }
+            ]
+        },
+        {
+            "id": "ElementClipRectangle",
+            "description": "Represents an element-based clipping rectangle.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#cddl-type-browsingcontextelementcliprectangle",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["element"] },
+                { "name": "element", "$ref": "BidiScript.SharedReference", "description": "The element to clip to." }
+            ]
+        },
+        {
             "id": "Viewport",
             "description": "Represents viewport dimensions.",
             "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-setViewport",
@@ -97,6 +154,22 @@
             "parameters": [
                 { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to close.  It is an error to pass a non-top level traversable." },
                 { "name": "promptUnload", "type": "boolean", "optional": true, "description": "Whether to permit prompting the user from beforeunload event." }
+            ]
+        },
+        {
+            "name": "captureScreenshot",
+            "description": "Captures an image of the given navigable, and returns it as a Base64-encoded string.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-captureScreenshot",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/capture_screenshot",
+            "async": true,
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to capture." },
+                { "name": "origin", "$ref": "BidiBrowsingContext.ScreenshotOrigin", "optional": true, "description": "The origin of the screenshot (default is 'viewport')." },
+                { "name": "format", "$ref": "BidiBrowsingContext.ImageFormat", "optional": true, "description": "The image format specification." },
+                { "name": "clip", "$ref": "BidiBrowsingContext.ClipRectangle", "optional": true, "description": "The clipping rectangle." }
+            ],
+            "returns": [
+                { "name": "data", "type": "string", "description": "The Base64-encoded screenshot data." }
             ]
         },
         {

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -153,6 +153,16 @@
             ]
         },
         {
+            "id": "SharedReference",
+            "description": "Represents a shared reference to a remote value that can be serialized.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-script-SharedReference",
+            "type": "object",
+            "properties": [
+                { "name": "handle", "$ref": "BidiScript.Handle", "optional": true, "description": "Represents a handle to a remote object." },
+                { "name": "internalId", "$ref": "BidiScript.InternalId", "optional": true, "description": "Represents an internal identifier for a remote value." }
+            ]
+        },
+        {
             "id": "StackFrame",
             "description": "Represents a single call frame within a <code>BidiScript.StackTrace</code>.",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-script-StackFrame",

--- a/Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp
+++ b/Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp
@@ -76,6 +76,11 @@ std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(cons
     return std::nullopt;
 #endif
 }
+
+std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(const ViewSnapshot& snapshot, const WebCore::IntRect&)
+{
+    return platformGetBase64EncodedPNGData(snapshot);
+}
 #endif
 
 } // namespace WebKit


### PR DESCRIPTION
#### 4d977154878c3e61dc49955fb5f7527acbedb2e1
<pre>
[WebDriver][BiDi] Implement the browsingContext.captureScreenshot command
<a href="https://bugs.webkit.org/show_bug.cgi?id=288325">https://bugs.webkit.org/show_bug.cgi?id=288325</a>
<a href="https://rdar.apple.com/145987196">rdar://145987196</a>

Reviewed by NOBODY (OOPS!).

Adds captureScreenshot support to capture screenshots of browsing contexts with rectangle
clipping and format options. Uses existing WebAutomationSession screenshot
infrastructure. Needs additional work surrounding supporting all origins, formatting
options, and element reference resolutions.

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::captureScreenshot):
(WebKit::BidiBrowsingContextAgent::getOriginRectangle):
(WebKit::BidiBrowsingContextAgent::normalizeRect):
(WebKit::BidiBrowsingContextAgent::rectangleIntersection):
(WebKit::BidiBrowsingContextAgent::parseClipRectangle):
(WebKit::BidiBrowsingContextAgent::parseBoxClipRectangle):
(WebKit::BidiBrowsingContextAgent::parseElementClipRectangle):
(WebKit::BidiBrowsingContextAgent::performScreenshotCapture):
(WebKit::BidiBrowsingContextAgent::parseImageFormatType):
(WebKit::BidiBrowsingContextAgent::imageFormatTypeToString):
(WebKit::BidiBrowsingContextAgent::convertImageFormat const):
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::platformGetBase64EncodedPNGData):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp:
(WebKit::WebAutomationSession::platformGetBase64EncodedPNGData):
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
* Source/WebKit/UIProcess/Automation/protocol/BidiScript.json:
* Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp:
(WebKit::WebAutomationSession::platformGetBase64EncodedPNGData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d977154878c3e61dc49955fb5f7527acbedb2e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114193 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cccdb22-3514-4e54-ac60-286956f2baaa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123834 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91572 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b16fb05-64c3-4634-b852-0f7a6a40175c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104469 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c5b3d39-7929-4dd9-bb36-fd115e3d9a2d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25146 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23743 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16433 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134838 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171164 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132100 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132144 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91041 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19920 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32452 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98849 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31949 "Built successfully") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32100 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->