### PR TITLE
Avoid unnecessary ref churn in identifierForStyleProperty in EditingStyle.cpp

### DIFF
--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -177,10 +177,10 @@ static RefPtr<CSSValue> extractPropertyValue(Style::Extractor& computedStyle, CS
 // This synthesizes CSSValueBold and CSSValueItalic when appropriate, and never returns CSSValueOblique.
 template<typename T> CSSValueID identifierForStyleProperty(T& style, CSSPropertyID propertyID)
 {
-    auto value = extractPropertyValue(style, propertyID);
+    RefPtr<CSSValue> value = extractPropertyValue(style, propertyID);
     if (RefPtr fontStyleValue = dynamicDowncast<CSSFontStyleWithAngleValue>(value.get())) {
         ASSERT(propertyID == CSSPropertyFontStyle);
-        auto resolvedAngle = Style::fontStyleAngleFromCSSFontStyleWithAngleValueDeprecated(Ref { *fontStyleValue });
+        auto resolvedAngle = Style::fontStyleAngleFromCSSFontStyleWithAngleValueDeprecated(*fontStyleValue);
         if (!resolvedAngle)
             return CSSValueNormal;
         return *resolvedAngle >= italicThreshold() ? CSSValueItalic : CSSValueNormal;


### PR DESCRIPTION
#### 660e8c21bf9078fcac94ada906ce87e3262d73bf
<pre>
Avoid unnecessary ref churn in identifierForStyleProperty in EditingStyle.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298705">https://bugs.webkit.org/show_bug.cgi?id=298705</a>

Reviewed by Vitor Roriz and Chris Dumez.

The static analyzer was getting confused by `RefPtr fontStyleValue`. Because it comes from `auto`,
it couldn&apos;t deduce that we&apos;re using `RefPtr` as the actual template so it gives up determining the type.
This PR fixes eliminates this ambiguity by explicitly declaring the type of `value` and removes the
superfluous construction of Ref in calling fontStyleAngleFromCSSFontStyleWithAngleValueDeprecated.

* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::identifierForStyleProperty):

Canonical link: <a href="https://commits.webkit.org/299860@main">https://commits.webkit.org/299860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/498bc669687484dba2616016322b7b64bbd139de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72493 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e59fb2b8-1a90-4301-a6b3-1d50dc7fe890) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48689 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91449 "17 flakes 72 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60740 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb2885ef-e3b7-44f1-ad6e-15e7fd87e5c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57d365b1-18a7-478c-81f7-a852e3a5c189) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26050 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70406 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100070 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99912 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43985 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19125 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52906 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46669 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->