### PR TITLE
Introduce anyOf() / allOf() / noneOf() in WTF which leverage NOESCAPE

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -87,8 +87,8 @@
 		3A5BCFA3298768E300E0ABB2 /* RefVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5BCFA2298768E300E0ABB2 /* RefVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		44235FF72D76449300F4A6CB /* XPCExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 44235FF62D76448F00F4A6CB /* XPCExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4427C5AA21F6D6C300A612A4 /* ASCIICType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */; };
-		4448265228D18CA600D916F9 /* NotificationCenterCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916F9 /* NotificationCenterCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4448265228D18CA600D916E8 /* VectorCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916E8 /* VectorCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4448265228D18CA600D916F9 /* NotificationCenterCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916F9 /* NotificationCenterCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4606FEE62B1E901800D704F1 /* WeakRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		461229722ACF6B3100BB1CCC /* FastCharacterComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -99,6 +99,7 @@
 		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		466E7A7A2D66E57E0096FDA4 /* AlignedStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 466E7A792D66E57E0096FDA4 /* AlignedStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */; };
+		467DD3052E72C23F007869CC /* Algorithm.h in Headers */ = {isa = PBXBuildFile; fileRef = 467DD3042E72C23F007869CC /* Algorithm.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		468742F12D7F8A0100F4BE74 /* FileHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = 468742EF2D7F8A0100F4BE74 /* FileHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		468742F22D7F8A0100F4BE74 /* FileHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 468742F02D7F8A0100F4BE74 /* FileHandle.cpp */; };
 		468EAFD42D5B1E37005069CF /* SocketPOSIX.h in Headers */ = {isa = PBXBuildFile; fileRef = 468EAFD32D5B1E37005069CF /* SocketPOSIX.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1282,8 +1283,8 @@
 		44235FF62D76448F00F4A6CB /* XPCExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPCExtras.h; sourceTree = "<group>"; };
 		4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASCIICType.cpp; sourceTree = "<group>"; };
 		4434F91B27948A65007E3E8A /* TollFreeBridging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TollFreeBridging.h; sourceTree = "<group>"; };
-		4448265128D18CA600D916F9 /* NotificationCenterCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationCenterCF.h; sourceTree = "<group>"; };
 		4448265128D18CA600D916E8 /* VectorCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VectorCF.h; sourceTree = "<group>"; };
+		4448265128D18CA600D916F9 /* NotificationCenterCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationCenterCF.h; sourceTree = "<group>"; };
 		4468567225094FE8008CCA05 /* ThreadSanitizerSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSanitizerSupport.h; sourceTree = "<group>"; };
 		44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCastsCocoa.h; sourceTree = "<group>"; };
 		4606FEE62B1E901800D704F1 /* WeakRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakRef.h; sourceTree = "<group>"; };
@@ -1297,6 +1298,7 @@
 		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
 		466E7A792D66E57E0096FDA4 /* AlignedStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AlignedStorage.h; sourceTree = "<group>"; };
 		467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnicodeExtras.cpp; sourceTree = "<group>"; };
+		467DD3042E72C23F007869CC /* Algorithm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Algorithm.h; sourceTree = "<group>"; };
 		468742EF2D7F8A0100F4BE74 /* FileHandle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileHandle.h; sourceTree = "<group>"; };
 		468742F02D7F8A0100F4BE74 /* FileHandle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileHandle.cpp; sourceTree = "<group>"; };
 		468EAFD32D5B1E37005069CF /* SocketPOSIX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SocketPOSIX.h; sourceTree = "<group>"; };
@@ -2261,6 +2263,7 @@
 				5363861E2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h */,
 				E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */,
 				CDCC9BC422382FCE00FFB51C /* AggregateLogger.h */,
+				467DD3042E72C23F007869CC /* Algorithm.h */,
 				466E7A792D66E57E0096FDA4 /* AlignedStorage.h */,
 				CE1132832370634900A8C83B /* AnsiColors.h */,
 				E37E96522702AD0700E1C36A /* ApproximateTime.cpp */,
@@ -3371,6 +3374,7 @@
 				E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */,
 				E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */,
 				DD3DC8FA27A4BF8E007E5B61 /* AggregateLogger.h in Headers */,
+				467DD3052E72C23F007869CC /* Algorithm.h in Headers */,
 				466E7A7A2D66E57E0096FDA4 /* AlignedStorage.h in Headers */,
 				DD3DC99627A4BF8E007E5B61 /* AnsiColors.h in Headers */,
 				DD3DC92527A4BF8E007E5B61 /* ApproximateTime.h in Headers */,

--- a/Source/WTF/wtf/Algorithm.h
+++ b/Source/WTF/wtf/Algorithm.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <ranges>
+
+namespace WTF {
+
+// We provide our own alternative in WTF so that we can mark the predicate as NOESCAPE,
+// to avoid safer cpp static analysis false positives.
+template<std::ranges::input_range R, class Proj = std::identity,
+    std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<R>, Proj>> Pred>
+constexpr bool anyOf(R&& r, NOESCAPE const Pred& pred, Proj proj = { })
+{
+    return std::ranges::any_of(std::forward<R>(r), pred, proj);
+}
+
+// We provide our own alternative in WTF so that we can mark the predicate as NOESCAPE,
+// to avoid safer cpp static analysis false positives.
+template<std::ranges::input_range R, class Proj = std::identity,
+    std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<R>, Proj>> Pred>
+constexpr bool allOf(R&& r, NOESCAPE const Pred& pred, Proj proj = { })
+{
+    return std::ranges::all_of(std::forward<R>(r), pred, proj);
+}
+
+// We provide our own alternative in WTF so that we can mark the predicate as NOESCAPE,
+// to avoid safer cpp static analysis false positives.
+template<std::ranges::input_range R, class Proj = std::identity,
+    std::indirect_unary_predicate<std::projected<std::ranges::iterator_t<R>, Proj>> Pred>
+constexpr bool noneOf(R&& r, NOESCAPE const Pred& pred, Proj proj = { })
+{
+    return std::ranges::none_of(std::forward<R>(r), pred, proj);
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -9,6 +9,7 @@ set(WTF_PUBLIC_HEADERS
     ASCIICType.h
     AccessibleAddress.h
     AggregateLogger.h
+    Algorithm.h
     AlignedStorage.h
     AnsiColors.h
     ApproximateTime.h

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include <ranges>
+#include <wtf/Algorithm.h>
 #include <wtf/IndexedRange.h>
 #include <wtf/text/StringView.h>
 
@@ -162,7 +162,7 @@ template<ASCIISubset subset, typename CharacterType> constexpr std::make_unsigne
 template<ASCIISubset subset> constexpr ComparableASCIISubsetLiteral<subset>::ComparableASCIISubsetLiteral(ASCIILiteral inputLiteral)
     : literal { inputLiteral }
 {
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::ranges::all_of(literal.span(), isInSubset<subset>));
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(WTF::allOf(literal.span(), [](char c) { return isInSubset<subset>(c); }));
 }
 
 template<typename ArrayType> constexpr SortedArrayMap<ArrayType>::SortedArrayMap(const ArrayType& array)

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <algorithm>
+#include <wtf/Algorithm.h>
 #include <wtf/HashTable.h>
 #include <wtf/WeakPtr.h>
 
@@ -334,7 +334,7 @@ public:
     bool hasNullReferences() const
     {
         unsigned count = 0;
-        auto result = std::ranges::any_of(m_map, [&](auto& iterator) {
+        auto result = WTF::anyOf(m_map, [&](auto& iterator) {
             ++count;
             return !iterator.key.get();
         });

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <algorithm>
+#include <wtf/Algorithm.h>
 #include <wtf/HashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -176,7 +176,7 @@ public:
     bool hasNullReferences() const
     {
         unsigned count = 0;
-        auto result = std::ranges::any_of(m_set, [&](auto& value) {
+        auto result = WTF::anyOf(m_set, [&](auto& value) {
             ++count;
             return !value.get();
         });

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <algorithm>
+#include <wtf/Algorithm.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -278,7 +278,7 @@ public:
     bool hasNullReferences() const
     {
         unsigned count = 0;
-        auto result = std::ranges::any_of(m_set, [&](auto& iterator) {
+        auto result = WTF::anyOf(m_set, [&](auto& iterator) {
             ++count;
             return !iterator.get();
         });

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.mm
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.mm
@@ -160,7 +160,7 @@ WebMediaSessionLogger& WebMediaSessionManager::logger()
 
 bool WebMediaSessionManager::alwaysOnLoggingAllowed() const
 {
-    return std::ranges::all_of(m_clientState, [](auto& state) {
+    return WTF::allOf(m_clientState, [](auto& state) {
         return state->client.alwaysOnLoggingAllowed();
     });
 }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
@@ -71,7 +71,7 @@ bool MediaKeyStatusMap::has(const BufferSource& keyId)
         return false;
 
     auto& statuses = m_session->statuses();
-    return std::ranges::any_of(statuses, [&keyId] (auto& it) { return keyIdsMatch(it.first, keyId); });
+    return WTF::anyOf(statuses, [&keyId] (auto& it) { return keyIdsMatch(it.first, keyId); });
 }
 
 JSC::JSValue MediaKeyStatusMap::get(JSC::JSGlobalObject& state, const BufferSource& keyId)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -175,7 +175,7 @@ void MediaKeys::attemptToResumePlaybackOnClients()
 
 bool MediaKeys::hasOpenSessions() const
 {
-    return std::ranges::any_of(m_sessions,
+    return WTF::anyOf(m_sessions,
         [](auto& session) {
             return !session->isClosed();
         });

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -404,7 +404,7 @@ bool IDBKeyData::isValidValue(const ValueVariant& variant)
     }, [&](const Date& date) {
         return !std::isnan(date.value);
     }, [&](const Vector<IDBKeyData>& keys) {
-        return std::ranges::all_of(keys, IDBKeyData::isValidValue, &IDBKeyData::value);
+        return WTF::allOf(keys, [](auto& value) { return IDBKeyData::isValidValue(value); }, &IDBKeyData::value);
     }, [&](const auto&) {
         return true;
     });

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -620,7 +620,7 @@ void IDBServer::closeDatabasesForOrigins(const Vector<SecurityOriginData>& targe
     HashSet<UniqueIDBDatabase*> openDatabases;
     for (auto& database : m_uniqueIDBDatabaseMap.values()) {
         const auto& databaseOrigin = database->identifier().origin();
-        bool filtered = std::ranges::any_of(targetOrigins, [&databaseOrigin, &filter](auto& targetOrigin) {
+        bool filtered = WTF::anyOf(targetOrigins, [&databaseOrigin, &filter](auto& targetOrigin) {
             return filter(targetOrigin, databaseOrigin);
         });
         if (filtered)

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1405,7 +1405,7 @@ RefPtr<UniqueIDBDatabaseTransaction> UniqueIDBDatabase::takeNextRunnableTransact
     if (m_pendingTransactions.isEmpty())
         return nullptr;
 
-    bool hasReadWriteTransactionInProgress = std::ranges::any_of(m_inProgressTransactions, [&](auto& entry) {
+    bool hasReadWriteTransactionInProgress = WTF::anyOf(m_inProgressTransactions, [&](auto& entry) {
         return !entry.value->isReadOnly();
     });
     Deque<RefPtr<UniqueIDBDatabaseTransaction>> deferredTransactions;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -129,7 +129,7 @@ bool UniqueIDBDatabaseTransaction::shouldAbortDueToUnhandledRequestError(uint64_
     }
 
     auto pendingRequestResults = m_requestResults.subspan(handledRequestResultsCount);
-    return std::ranges::any_of(pendingRequestResults, [&](auto& error) {
+    return WTF::anyOf(pendingRequestResults, [&](auto& error) {
         return !error.isNull();
     });
 }

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -343,7 +343,7 @@ static inline bool exposeSpeakersWithoutMicrophoneAccess(const Document& documen
 
 static inline bool haveMicrophoneDevice(const Vector<CaptureDeviceWithCapabilities>& devices, const String& deviceId)
 {
-    return std::ranges::any_of(devices, [&deviceId](auto& deviceWithCapabilities) {
+    return WTF::anyOf(devices, [&deviceId](auto& deviceWithCapabilities) {
         auto& device = deviceWithCapabilities.device;
         return device.persistentId() == deviceId && device.type() == CaptureDevice::DeviceType::Microphone;
     });

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -91,7 +91,7 @@ public:
     bool active() const { return m_isActive; }
     bool muted() const { return m_private->muted(); }
 
-    template<typename Function> bool hasMatchingTrack(Function&& function) const { return std::ranges::any_of(m_trackMap.values(), std::forward<Function>(function)); }
+    template<typename Function> bool hasMatchingTrack(NOESCAPE const Function& function) const { return WTF::anyOf(m_trackMap.values(), function); }
 
     MediaStreamPrivate& privateStream() { return m_private.get(); }
     Ref<MediaStreamPrivate> protectedPrivateStream();

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -324,12 +324,12 @@ struct MediaStreamAndTrackItem {
 static void setAssociatedRemoteStreams(RTCRtpReceiver& receiver, const PeerConnectionBackend::TransceiverState& state, Vector<MediaStreamAndTrackItem>& addList, Vector<MediaStreamAndTrackItem>& removeList)
 {
     for (auto& currentStream : receiver.associatedStreams()) {
-        if (currentStream && !std::ranges::any_of(state.receiverStreams, [&currentStream](auto& stream) { return stream->id() == currentStream->id(); }))
+        if (currentStream && !WTF::anyOf(state.receiverStreams, [&currentStream](auto& stream) { return stream->id() == currentStream->id(); }))
             removeList.append({ Ref { *currentStream }, Ref { receiver.track() } });
     }
 
     for (auto& stream : state.receiverStreams) {
-        if (!std::ranges::any_of(receiver.associatedStreams(), [&stream](auto& currentStream) { return stream->id() == currentStream->id(); }))
+        if (!WTF::anyOf(receiver.associatedStreams(), [&stream](auto& currentStream) { return stream->id() == currentStream->id(); }))
             addList.append({ stream, Ref { receiver.track() } });
     }
 
@@ -462,7 +462,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
         Vector<MediaStreamAndTrackItem> removeList;
         if (transceiverStates) {
             for (auto& transceiver : peerConnection.currentTransceivers()) {
-                if (!std::ranges::any_of(*transceiverStates, [&transceiver](auto& state) { return state.mid == transceiver->mid(); })) {
+                if (!WTF::anyOf(*transceiverStates, [&transceiver](auto& state) { return state.mid == transceiver->mid(); })) {
                     for (auto& stream : transceiver->receiver().associatedStreams()) {
                         if (stream)
                             removeList.append({ Ref { *stream }, Ref { transceiver->receiver().track() } });

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -199,7 +199,7 @@ static bool isAudioTransceiver(const RTCPeerConnection::AddTransceiverTrackOrKin
 static std::optional<Exception> validateSendEncodings(Vector<RTCRtpEncodingParameters>& encodings, bool isAudio)
 {
     size_t encodingIndex = 0;
-    bool hasAnyScaleResolutionDownBy = !isAudio && std::ranges::any_of(encodings, [](auto& encoding) { return !!encoding.scaleResolutionDownBy; });
+    bool hasAnyScaleResolutionDownBy = !isAudio && WTF::anyOf(encodings, [](auto& encoding) { return !!encoding.scaleResolutionDownBy; });
     for (auto& encoding: encodings) {
         // FIXME: Validate rid and codec
         if (isAudio) {
@@ -847,7 +847,7 @@ RTCPeerConnectionState RTCPeerConnection::computeConnectionState()
     iceTransports.removeAllMatching([&](auto& iceTransport) {
         if (m_sctpTransport && &m_sctpTransport->transport().iceTransport() == iceTransport.ptr())
             return false;
-        return std::ranges::all_of(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
+        return WTF::allOf(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
             return !isIceTransportUsedByTransceiver(iceTransport.get(), *transceiver);
         });
     });
@@ -856,24 +856,24 @@ RTCPeerConnectionState RTCPeerConnection::computeConnectionState()
     dtlsTransports.removeAllMatching([&](auto& dtlsTransport) {
         if (m_sctpTransport && &m_sctpTransport->transport() == dtlsTransport.ptr())
             return false;
-        return std::ranges::all_of(m_transceiverSet.list(), [&dtlsTransport](auto& transceiver) {
+        return WTF::allOf(m_transceiverSet.list(), [&dtlsTransport](auto& transceiver) {
             return transceiver->sender().transport() != dtlsTransport.ptr();
         });
     });
 
-    if (std::ranges::any_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Failed; }) || std::ranges::any_of(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::Failed; }))
+    if (WTF::anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Failed; }) || WTF::anyOf(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::Failed; }))
         return RTCPeerConnectionState::Failed;
 
-    if (std::ranges::any_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Disconnected; }))
+    if (WTF::anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Disconnected; }))
         return RTCPeerConnectionState::Disconnected;
 
-    if (std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; }) && std::ranges::all_of(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::New || transport->state() == RTCDtlsTransportState::Closed; }))
+    if (WTF::allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; }) && WTF::allOf(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::New || transport->state() == RTCDtlsTransportState::Closed; }))
         return RTCPeerConnectionState::New;
 
-    if (std::ranges::any_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Checking; }) || std::ranges::any_of(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::New || transport->state() == RTCDtlsTransportState::Connecting; }))
+    if (WTF::anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Checking; }) || WTF::anyOf(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::New || transport->state() == RTCDtlsTransportState::Connecting; }))
         return RTCPeerConnectionState::Connecting;
 
-    ASSERT(std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }) && std::ranges::all_of(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::Connected || transport->state() == RTCDtlsTransportState::Closed; }));
+    ASSERT(WTF::allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }) && WTF::allOf(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::Connected || transport->state() == RTCDtlsTransportState::Closed; }));
     return RTCPeerConnectionState::Connected;
 }
 
@@ -901,22 +901,22 @@ RTCIceConnectionState RTCPeerConnection::computeIceConnectionStateFromIceTranspo
     iceTransports.removeAllMatching([&](auto& iceTransport) {
         if (m_sctpTransport && &m_sctpTransport->transport().iceTransport() == iceTransport.ptr())
             return false;
-        return std::ranges::all_of(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
+        return WTF::allOf(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
             return !isIceTransportUsedByTransceiver(iceTransport.get(), *transceiver);
         });
     });
 
-    if (std::ranges::any_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Failed; }))
+    if (WTF::anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Failed; }))
         return RTCIceConnectionState::Failed;
-    if (std::ranges::any_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Disconnected; }))
+    if (WTF::anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Disconnected; }))
         return RTCIceConnectionState::Disconnected;
-    if (std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; }))
+    if (WTF::allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; }))
         return RTCIceConnectionState::New;
-    if (std::ranges::any_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Checking; }))
+    if (WTF::anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Checking; }))
         return RTCIceConnectionState::Checking;
-    if (std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }))
+    if (WTF::allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }))
         return RTCIceConnectionState::Completed;
-    ASSERT(std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }));
+    ASSERT(WTF::allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }));
     return RTCIceConnectionState::Connected;
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
@@ -163,7 +163,7 @@ ExceptionOr<void> RTCRtpSFrameTransformer::setEncryptionKey(const Vector<uint8_t
 bool RTCRtpSFrameTransformer::hasKey(uint64_t keyId) const
 {
     Locker locker { m_keyLock };
-    return std::ranges::any_of(m_keys, [keyId](auto& key) { return keyId == key.keyId; });
+    return WTF::anyOf(m_keys, [keyId](auto& key) { return keyId == key.keyId; });
 }
 
 ExceptionOr<void> RTCRtpSFrameTransformer::updateEncryptionKey(const Vector<uint8_t>& rawKey, std::optional<uint64_t> keyId, ShouldUpdateKeys shouldUpdateKeys)

--- a/Source/WebCore/Modules/mediastream/UserMediaController.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.cpp
@@ -95,7 +95,7 @@ void UserMediaController::checkDocumentForVoiceActivity(const Document* document
             return;
     }
 
-    bool shouldListenToVoiceActivity = std::ranges::any_of(m_voiceActivityDocuments, [](auto& document) {
+    bool shouldListenToVoiceActivity = WTF::anyOf(m_voiceActivityDocuments, [](auto& document) {
         return document.mediaState().containsAny(MediaProducer::IsCapturingAudioMask);
     });
     if (m_shouldListenToVoiceActivity == shouldListenToVoiceActivity)

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -152,7 +152,7 @@ static inline bool isMediaStreamCorrectlyStarted(const MediaStream& stream)
     if (stream.getTracks().isEmpty())
         return false;
 
-    return std::ranges::all_of(stream.getTracks(), [](auto& track) {
+    return WTF::allOf(stream.getTracks(), [](auto& track) {
         return !track->source().captureDidFail();
     });
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1756,7 +1756,7 @@ ExceptionOr<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::createTran
         scaleValues.reserveInitialCapacity(sendEncodings.size());
         if (sendEncodings.size() == 1 && sendEncodings[0].scaleResolutionDownBy)
             scaleValues.append(sendEncodings[0].scaleResolutionDownBy.value());
-        else if (std::ranges::all_of(sendEncodings, [](auto& encoding) { return encoding.scaleResolutionDownBy.value_or(1) == 1; })) {
+        else if (WTF::allOf(sendEncodings, [](auto& encoding) { return encoding.scaleResolutionDownBy.value_or(1) == 1; })) {
             for (unsigned i = sendEncodings.size() - 1; i >= 1; i--)
                 scaleValues.append(i * 2);
             scaleValues.append(1);
@@ -1781,7 +1781,7 @@ ExceptionOr<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::createTran
         }
         if (allRids.isEmpty() && sendEncodings.size() > 1)
             return Exception { ExceptionCode::TypeError, "Missing rid"_s };
-        if (allRids.size() > 1 && std::ranges::any_of(allRids, [](auto& rid) { return rid.isNull() || rid.isEmpty(); }))
+        if (allRids.size() > 1 && WTF::anyOf(allRids, [](auto& rid) { return rid.isNull() || rid.isEmpty(); }))
             return Exception { ExceptionCode::TypeError, "Empty rid"_s };
         if (allRids.size() == 1 && allRids[0] == emptyString())
             return Exception { ExceptionCode::TypeError, "Empty rid"_s };

--- a/Source/WebCore/Modules/webcodecs/OpusEncoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/OpusEncoderConfig.h
@@ -37,7 +37,7 @@ struct OpusEncoderConfig {
     bool isValid()
     {
         float frameDurationMs = frameDuration / 1000.0;
-        if (!std::ranges::any_of(std::initializer_list<float> { 2.5, 5, 10, 20, 40, 60, 120 }, [frameDurationMs](auto value) {
+        if (!WTF::anyOf(std::initializer_list<float> { 2.5, 5, 10, 20, 40, 60, 120 }, [frameDurationMs](auto value) {
             return WTF::areEssentiallyEqual(value, frameDurationMs);
         })) {
             return false;

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -135,7 +135,7 @@ void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inp
     //  3.1 Let inputSource be the XRInputSource in session's list of active XR input sources associated with the XR input source.
     //  3.2 Add inputSource to removed.
     m_inputSources.removeAllMatching([&inputSources, &removed, &removedWithInputEvents, &inputEvents](auto& source) {
-        if (!std::ranges::any_of(inputSources, [&source](auto& item) { return item.handle == source->handle(); })) {
+        if (!WTF::anyOf(inputSources, [&source](auto& item) { return item.handle == source->handle(); })) {
             Vector<Ref<XRInputSourceEvent>> sourceInputEvents;
             source->disconnect();
             source->pollEvents(sourceInputEvents);

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -94,7 +94,6 @@ style/StyleCustomProperty.cpp
 style/Styleable.cpp
 style/values/StyleValueTypes.h
 style/values/backgrounds/StyleFillLayers.h
-style/values/images/StyleGradient.cpp
 testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp
 workers/WorkerMessagingProxy.cpp

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -454,7 +454,7 @@ AccessibilityObject* AccessibilityRenderObject::nextSibling() const
             if (nextObject.get() == this) {
                 // WebKit accessibility objects use DOM nodes as the "primary key" (i.e. in m_nodeIdMapping).
                 // This can cause a bit of trouble for continuations, which result in multiple renderers being associated
-                // with the same node. That can cause us to get into this branch — if nextSibling or us is a continuation,
+                // with the same node. That can cause us to get into this branch — if nextSibling or us is a continuation,
                 // we will be different renderers with the same node, and thus `nextObject` will be us.
                 //
                 // Fallback to walking the DOM in this case to avoid looping infinitely.
@@ -2567,7 +2567,7 @@ bool AccessibilityRenderObject::inheritsPresentationalRole() const
         // If native tag of the parent element matches an acceptable name, then return
         // based on its presentational status.
         auto& name = node->tagQName();
-        if (std::ranges::any_of(parentTags, [&name](auto* possibleName) { return possibleName->get() == name; }))
+        if (WTF::anyOf(parentTags, [&name](auto* possibleName) { return possibleName->get() == name; }))
             return parent->role() == AccessibilityRole::Presentational;
     }
 

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -78,7 +78,7 @@ template<TupleLike CSSType> struct StyleImageIsUncacheable<CSSType> {
 };
 
 template<RangeLike CSSType> struct StyleImageIsUncacheable<CSSType> {
-    bool operator()(const auto& value) { return std::ranges::any_of(value, [](auto& element) { return styleImageIsUncacheable(element); }); }
+    bool operator()(const auto& value) { return WTF::anyOf(value, [](auto& element) { return styleImageIsUncacheable(element); }); }
 };
 
 template<VariantLike CSSType> struct StyleImageIsUncacheable<CSSType> {

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1329,7 +1329,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             if (list.size() == 1)
                 return true;
 
-            return std::ranges::all_of(list.span().subspan(1),
+            return WTF::allOf(list.span().subspan(1),
                 [&](const AtomString& classSelector) {
                     return checkingContext.classList.contains(classSelector);
                 }

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -559,7 +559,7 @@ std::optional<Child> simplify(Sum& root, const SimplificationOptions& options)
     // 8. If root is a Sum node:
 
     // 8.1. For each of root’s children that are Sum nodes, replace them with their children.
-    if (std::ranges::any_of(root.children, [](auto& child) { return WTF::holdsAlternative<IndirectNode<Sum>>(child); })) {
+    if (WTF::anyOf(root.children, [](auto& child) { return WTF::holdsAlternative<IndirectNode<Sum>>(child); })) {
         Vector<Child> newChildren;
         for (auto& child : root.children) {
             if (auto* childSum = get_if<IndirectNode<Sum>>(&child))
@@ -773,7 +773,7 @@ std::optional<Child> simplify(Product& root, const SimplificationOptions& option
                     return makeChildWithValueBasedOn(numeric.value * numericProduct->value, numeric);
                 },
                 [&](IndirectNode<Sum>& sum) -> std::optional<Child> {
-                    if (!std::ranges::all_of(sum->children, isNumeric))
+                    if (!WTF::allOf(sum->children, [](auto& v) { return isNumeric(v); }))
                         return { };
 
                     for (auto& child : sum->children) {
@@ -931,7 +931,7 @@ std::optional<Child> simplify(Negate& root, const SimplificationOptions&)
         [](IndirectNode<Sum>& a) -> std::optional<Child> {
             // Not stated in spec, but needed for tests.
 
-            if (!std::ranges::all_of(a->children, isNumeric))
+            if (!WTF::allOf(a->children, [](auto& v) { return isNumeric(v); }))
                 return { };
 
             for (auto& child : a->children) {
@@ -946,7 +946,7 @@ std::optional<Child> simplify(Negate& root, const SimplificationOptions&)
         [](IndirectNode<Product>& a) -> std::optional<Child> {
             // Not stated in spec, but needed for tests.
 
-            if (!std::ranges::all_of(a->children, isNumeric))
+            if (!WTF::allOf(a->children, [](auto& v) { return isNumeric(v); }))
                 return { };
 
             for (auto& child : a->children) {

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -212,7 +212,7 @@ static ExceptionOr<Ref<CSSNumericValue>> invert(Ref<CSSNumericValue>&& value)
 template<typename T>
 static RefPtr<CSSNumericValue> operationOnValuesOfSameUnit(T&& operation, const Vector<Ref<CSSNumericValue>>& values)
 {
-    bool allValuesHaveSameUnit = values.size() && std::ranges::all_of(values, [&](auto& value) {
+    bool allValuesHaveSameUnit = values.size() && WTF::allOf(values, [&](auto& value) {
         auto* unitValue = dynamicDowncast<CSSUnitValue>(value.get());
         return unitValue ? unitValue->unitEnum() == downcast<CSSUnitValue>(values[0].get()).unitEnum() : false;
     });
@@ -266,7 +266,7 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::multiplyInternal(Vector<Ref<C
     // https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-mul
     auto values = prependItemsOfTypeOrThis<CSSMathProduct>(WTFMove(numericValues));
 
-    bool allUnitValues = std::ranges::all_of(values, [](auto& value) {
+    bool allUnitValues = WTF::allOf(values, [](auto& value) {
         return is<CSSUnitValue>(value.get());
     });
     if (allUnitValues) {
@@ -348,7 +348,7 @@ bool CSSNumericValue::equals(FixedVector<CSSNumberish>&& values)
     // https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-equals
     auto numericValues = WTF::map(WTFMove(values), rectifyNumberish);
     // FIXME: Drop SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE once <rdar://150855062> is fixed.
-    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE return std::ranges::all_of(numericValues, [&](auto& value) {
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE return WTF::allOf(numericValues, [&](auto& value) {
         return this->equals(value.get());
     });
 }

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -140,7 +140,7 @@ ExceptionOr<Ref<CSSTransformComponent>> CSSTransformValue::setItem(size_t index,
 bool CSSTransformValue::is2D() const
 {
     // https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-is2d
-    return std::ranges::all_of(m_components, [](auto& component) {
+    return WTF::allOf(m_components, [](auto& component) {
         return component->is2D();
     });
 }

--- a/Source/WebCore/css/values/color/CSSColorLayers.cpp
+++ b/Source/WebCore/css/values/color/CSSColorLayers.cpp
@@ -52,14 +52,14 @@ WebCore::Color createColor(const ColorLayers& value, PlatformColorResolutionStat
 
 bool containsCurrentColor(const ColorLayers& value)
 {
-    return std::ranges::any_of(value.colors, [](const auto& color) {
+    return WTF::anyOf(value.colors, [](const auto& color) {
         return containsCurrentColor(color);
     });
 }
 
 bool containsColorSchemeDependentColor(const ColorLayers& value)
 {
-    return std::ranges::any_of(value.colors, [](const auto& color) {
+    return WTF::anyOf(value.colors, [](const auto& color) {
         return containsColorSchemeDependentColor(color);
     });
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -600,7 +600,7 @@ void Document::configureSharedLogger()
     if (!logger)
         return;
 
-    bool alwaysOnLoggingAllowed = !allDocumentsMap().isEmpty() && std::ranges::all_of(allDocumentsMap().values(), [](auto& document) {
+    bool alwaysOnLoggingAllowed = !allDocumentsMap().isEmpty() && WTF::allOf(allDocumentsMap().values(), [](auto& document) {
         return document->isAlwaysOnLoggingAllowed();
     });
     logger->setEnabled(sharedLoggerOwner(), alwaysOnLoggingAllowed);

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -192,7 +192,7 @@ bool MouseEvent::canTriggerActivationBehavior(const Event& event)
 MouseButton MouseEvent::button() const
 {
     static constexpr std::array mouseButtonCases { MouseButton::None, MouseButton::PointerHasNotChanged, MouseButton::Left, MouseButton::Middle, MouseButton::Right };
-    const auto isKnownButton = std::ranges::any_of(mouseButtonCases, [buttonValue = this->m_button](MouseButton button) {
+    const auto isKnownButton = WTF::anyOf(mouseButtonCases, [buttonValue = this->m_button](MouseButton button) {
         return buttonValue == enumToUnderlyingType(button);
     });
     return isKnownButton ? static_cast<MouseButton>(m_button) : MouseButton::Other;

--- a/Source/WebCore/dom/MouseEventTypes.h
+++ b/Source/WebCore/dom/MouseEventTypes.h
@@ -26,8 +26,8 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
+#include <wtf/Algorithm.h>
 #include <wtf/EnumTraits.h>
 
 namespace WebCore {
@@ -47,7 +47,7 @@ enum class MouseButton : int8_t { None = -2, PointerHasNotChanged, Left, Middle,
 inline MouseButton buttonFromShort(int16_t buttonValue)
 {
     static constexpr std::array knownMouseButtonCases { MouseButton::None, MouseButton::PointerHasNotChanged, MouseButton::Left, MouseButton::Middle, MouseButton::Right };
-    bool isKnownButton = std::ranges::any_of(knownMouseButtonCases, [buttonValue](MouseButton button) {
+    bool isKnownButton = WTF::anyOf(knownMouseButtonCases, [buttonValue](MouseButton button) {
         return buttonValue == enumToUnderlyingType(button);
     });
     return isKnownButton ? static_cast<MouseButton>(buttonValue) : MouseButton::Other;

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -243,7 +243,7 @@ Vector<Ref<PointerEvent>> PointerEvent::getCoalescedEvents() const
 
         ASSERT(timestampsAreMonotonicallyIncreasing, "Coalesced event timestamps are not monotonically increasing.");
 
-        auto canBubbleOrIsCancelable = std::ranges::any_of(m_coalescedEvents, [](const auto& event) {
+        auto canBubbleOrIsCancelable = WTF::anyOf(m_coalescedEvents, [](const auto& event) {
             return event->bubbles() || event->cancelable();
         });
 
@@ -271,7 +271,7 @@ Vector<Ref<PointerEvent>> PointerEvent::getPredictedEvents() const
         if (!m_predictedEvents.isEmpty())
             ASSERT(m_predictedEvents.first()->timeStamp() >= this->timeStamp(), "Predicted events must have a timestamp greater than or equal to the dispatched event.");
 
-        auto canBubbleOrIsCancelable = std::ranges::any_of(m_predictedEvents, [](const auto& event) {
+        auto canBubbleOrIsCancelable = WTF::anyOf(m_predictedEvents, [](const auto& event) {
             return event->bubbles() || event->cancelable();
         });
 

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -694,7 +694,7 @@ bool TreeScope::isElementWithPendingSVGResources(SVGElement& element) const
 {
     // This algorithm takes time proportional to the number of pending resources and need not.
     // If performance becomes an issue we can keep a counted set of elements and answer the question efficiently.
-    return std::ranges::any_of(svgResourcesMap().pendingResources.values(), std::bind(&WeakSVGElementSet::contains<SVGElement>, std::placeholders::_1, std::ref(element)));
+    return WTF::anyOf(svgResourcesMap().pendingResources.values(), std::bind(&WeakSVGElementSet::contains<SVGElement>, std::placeholders::_1, std::ref(element)));
 }
 
 bool TreeScope::isPendingSVGResource(SVGElement& element, const AtomString& id) const

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -896,7 +896,7 @@ static bool isElementExcludedByRule(const MarkupExclusionRule& rule, const Eleme
 
 bool MarkupAccumulator::shouldExcludeElement(const Element& element)
 {
-    return std::ranges::any_of(m_exclusionRules, std::bind(isElementExcludedByRule, std::placeholders::_1, std::ref(element)));
+    return WTF::anyOf(m_exclusionRules, std::bind(isElementExcludedByRule, std::placeholders::_1, std::ref(element)));
 }
 
 SerializationSyntax MarkupAccumulator::serializationSyntax(Document& document)

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -869,7 +869,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
         } else
             tokensInCurrentNode = createUnit(content.text, *content.node).tokens;
 
-        bool isNodeIncluded = std::ranges::any_of(tokensInCurrentNode, [](auto& token) {
+        bool isNodeIncluded = WTF::anyOf(tokensInCurrentNode, [](auto& token) {
             return !token.isExcluded;
         });
         for (auto& token : tokensInCurrentNode) {

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -146,7 +146,7 @@ static std::pair<std::array<int, 4>, std::array<int, 4>> boundingNeighbors(int i
     const auto compareColorsAndSetBounds = [&areColorsRelated](const auto& bytes, auto& tightestBoundingColors, auto& tightestBoundingDiff, auto colorIndex, auto neighborIndex1, auto neighborIndex2) {
         if (areColorsRelated(neighborIndex1, colorIndex, neighborIndex2)) {
             if (setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex1, colorIndex, neighborIndex2)) {
-                if (std::ranges::all_of(tightestBoundingDiff, [](auto& item) { return !item; })) {
+                if (WTF::allOf(tightestBoundingDiff, [](auto& item) { return !item; })) {
                     tightestBoundingColors = {
                         { bytes[colorIndex], bytes[colorIndex + 1], bytes[colorIndex + 2], bytes[colorIndex + 3] },
                         { bytes[colorIndex], bytes[colorIndex + 1], bytes[colorIndex + 2], bytes[colorIndex + 3] }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8201,7 +8201,7 @@ HTMLMediaElement::SleepType HTMLMediaElement::shouldDisableSleep() const
 #if ENABLE(MEDIA_STREAM)
     // Remote media stream video tracks may have their corresponding audio tracks being played outside of the media element. Let's ensure to not IDLE the screen in that case.
     // FIXME: We should check that audio is being/to be played. Ideally, we would come up with a media stream agnostic heuristisc.
-    shouldBeAbleToSleep = shouldBeAbleToSleep && !(m_mediaStreamSrcObject && m_mediaStreamSrcObject->hasMatchingTrack(isRemoteMediaStreamVideoTrack));
+    shouldBeAbleToSleep = shouldBeAbleToSleep && !(m_mediaStreamSrcObject && m_mediaStreamSrcObject->hasMatchingTrack([](auto& v) { return isRemoteMediaStreamVideoTrack(v); }));
 #endif
 
     if (shouldBeAbleToSleep)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3177,7 +3177,7 @@ void FrameLoader::checkLoadComplete(LoadWillContinueInAnotherProcess loadWillCon
 
     // Provisional frames that are not in the frame tree need to be included to report provisional load failures.
     if (m_frame->settings().siteIsolationEnabled()) {
-        bool containsThisFrame = std::ranges::any_of(frames, [thisFrame = Ref { m_frame.get() }] (auto& frame) {
+        bool containsThisFrame = WTF::anyOf(frames, [thisFrame = Ref { m_frame.get() }] (auto& frame) {
             return frame.ptr() == thisFrame.ptr();
         });
         if (!containsThisFrame)

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -842,7 +842,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(const String& markupSt
 
         ResolveURLs resolveURLs = ResolveURLs::No;
         // Base element is excluded, so all URLs should be replaced with absolute URL.
-        bool baseElementExcluded = std::ranges::any_of(options.markupExclusionRules, [&](auto& rule) {
+        bool baseElementExcluded = WTF::anyOf(options.markupExclusionRules, [&](auto& rule) {
             return rule.elementLocalName == "base"_s;
         });
         if (!document->baseElementURL().isEmpty() && baseElementExcluded)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4855,7 +4855,7 @@ OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes() const
 
 bool Page::shouldDisableCorsForRequestTo(const URL& url) const
 {
-    return std::ranges::any_of(m_corsDisablingPatterns, [&](auto& pattern) {
+    return WTF::anyOf(m_corsDisablingPatterns, [&](auto& pattern) {
         return pattern.matches(url);
     });
 }

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -184,7 +184,7 @@ void PointerCaptureController::reset()
 
 void PointerCaptureController::updateHaveAnyCapturingElement()
 {
-    m_haveAnyCapturingElement = std::ranges::any_of(m_activePointerIdsToCapturingData.values(), [&](auto& capturingData) {
+    m_haveAnyCapturingElement = WTF::anyOf(m_activePointerIdsToCapturingData.values(), [&](auto& capturingData) {
         return capturingData->hasAnyElement();
     });
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -822,7 +822,7 @@ bool ContentSecurityPolicy::requireTrustedTypesForSinkGroup(const String& sinkGr
 // https://w3c.github.io/trusted-types/dist/spec/#should-block-sink-type-mismatch
 bool ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup(const String& stringContext, const String& sink, const String& sinkGroup, StringView source) const
 {
-    return std::ranges::all_of(m_policies, [&](auto& policy) {
+    return WTF::allOf(m_policies, [&](auto& policy) {
         bool isAllowed = true;
         if (policy->requiresTrustedTypesForScript() && sinkGroup == "script"_s) {
             if (!policy->isReportOnly())

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -1052,7 +1052,7 @@ void WritingToolsController::updateStateForSelectedSuggestionIfNeeded()
 
 static bool appliedCommandIsWritingToolsCommand(const Vector<Ref<WritingToolsCompositionCommand>>& commands, EditCommandComposition* composition)
 {
-    return std::ranges::any_of(commands, [composition](const auto& command) {
+    return WTF::anyOf(commands, [composition](const auto& command) {
         return &command->ensureComposition() == composition;
     });
 }
@@ -1306,7 +1306,7 @@ void WritingToolsController::replaceContentsOfRangeInSession(CompositionState& s
         return;
     }
 
-    auto hasAttributes = std::ranges::any_of(replacementText.attributes, [](auto& rangeAndAttributeValues) {
+    auto hasAttributes = WTF::anyOf(replacementText.attributes, [](auto& rangeAndAttributeValues) {
         return !rangeAndAttributeValues.second.isEmpty();
     });
     auto matchStyle = hasAttributes ? WritingToolsCompositionCommand::MatchStyle::No : WritingToolsCompositionCommand::MatchStyle::Yes;

--- a/Source/WebCore/platform/RectCorners.h
+++ b/Source/WebCore/platform/RectCorners.h
@@ -28,6 +28,7 @@
 #include <WebCore/BoxSides.h>
 #include <array>
 #include <type_traits>
+#include <wtf/Algorithm.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -81,17 +82,17 @@ public:
 
     template<typename F> bool anyOf(F&& functor) const
     {
-        return std::ranges::any_of(m_corners, std::forward<F>(functor));
+        return WTF::anyOf(m_corners, std::forward<F>(functor));
     }
 
     template<typename F> bool allOf(F&& functor) const
     {
-        return std::ranges::all_of(m_corners, std::forward<F>(functor));
+        return WTF::allOf(m_corners, std::forward<F>(functor));
     }
 
     template<typename F> bool noneOf(F&& functor) const
     {
-        return std::ranges::none_of(m_corners, std::forward<F>(functor));
+        return WTF::noneOf(m_corners, std::forward<F>(functor));
     }
 
     bool isZero() const

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -29,6 +29,7 @@
 #include <WebCore/WritingMode.h>
 #include <array>
 #include <concepts>
+#include <wtf/Algorithm.h>
 #include <wtf/OptionSet.h>
 #include <wtf/text/TextStream.h>
 
@@ -143,17 +144,17 @@ public:
 
     template<typename F> bool anyOf(F&& functor) const
     {
-        return std::ranges::any_of(m_sides, std::forward<F>(functor));
+        return WTF::anyOf(m_sides, std::forward<F>(functor));
     }
 
     template<typename F> bool allOf(F&& functor) const
     {
-        return std::ranges::all_of(m_sides, std::forward<F>(functor));
+        return WTF::allOf(m_sides, std::forward<F>(functor));
     }
 
     template<typename F> bool noneOf(F&& functor) const
     {
-        return std::ranges::none_of(m_sides, std::forward<F>(functor));
+        return WTF::noneOf(m_sides, std::forward<F>(functor));
     }
 
     bool isZero() const

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -144,7 +144,7 @@ bool MediaSessionManagerInterface::activeAudioSessionRequired() const
     if (anyOfSessions([] (auto& session) { return session.activeAudioSessionRequired(); }))
         return true;
 
-    return std::ranges::any_of(m_audioCaptureSources, [](auto& source) {
+    return WTF::anyOf(m_audioCaptureSources, [](auto& source) {
         return source.isCapturingAudio();
     });
 #else

--- a/Source/WebCore/platform/graphics/ContentTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/ContentTypeUtilities.cpp
@@ -27,7 +27,7 @@
 #include "ContentTypeUtilities.h"
 
 #include "FourCC.h"
-#include <algorithm>
+#include <wtf/Algorithm.h>
 
 namespace WebCore {
 
@@ -39,8 +39,8 @@ bool contentTypeMeetsContainerAndCodecTypeRequirements(const ContentType& type, 
     if (!allowedMediaCodecTypes)
         return true;
 
-    return std::ranges::all_of(type.codecs(), [&](auto& codec) {
-        return std::ranges::any_of(*allowedMediaCodecTypes, [&](auto& allowedCodec) {
+    return WTF::allOf(type.codecs(), [&](auto& codec) {
+        return WTF::anyOf(*allowedMediaCodecTypes, [&](auto& allowedCodec) {
             return codec.startsWith(allowedCodec);
         });
     });

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -147,7 +147,7 @@ bool MediaSourcePrivate::hasAudio() const
 {
     ASSERT(m_dispatcher->isCurrent() || Thread::mayBeGCThread());
 
-    return std::ranges::any_of(m_activeSourceBuffers, [](auto* sourceBuffer) {
+    return WTF::anyOf(m_activeSourceBuffers, [](auto* sourceBuffer) {
         return sourceBuffer->hasAudio();
     });
 }
@@ -156,7 +156,7 @@ bool MediaSourcePrivate::hasVideo() const
 {
     assertIsCurrent(m_dispatcher);
 
-    return std::ranges::any_of(m_activeSourceBuffers, [](auto* sourceBuffer) {
+    return WTF::anyOf(m_activeSourceBuffers, [](auto* sourceBuffer) {
         return sourceBuffer->hasVideo();
     });
 }

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -42,7 +42,7 @@
 #include "NotImplemented.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/DataView.h>
-#include <algorithm>
+#include <wtf/Algorithm.h>
 #include <wtf/JSONValues.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/NeverDestroyed.h>
@@ -329,7 +329,7 @@ Vector<AtomString> CDMPrivateFairPlayStreaming::supportedInitDataTypes() const
 
 bool CDMPrivateFairPlayStreaming::supportsConfiguration(const CDMKeySystemConfiguration& configuration) const
 {
-    if (!std::ranges::any_of(configuration.initDataTypes, [](auto& initDataType) { return validInitDataTypes().contains(initDataType); })) {
+    if (!WTF::anyOf(configuration.initDataTypes, [](auto& initDataType) { return validInitDataTypes().contains(initDataType); })) {
         INFO_LOG(LOGIDENTIFIER, " false, no initDataType supported");
         return false;
     }
@@ -354,13 +354,13 @@ bool CDMPrivateFairPlayStreaming::supportsConfiguration(const CDMKeySystemConfig
     }
 
     if (!configuration.audioCapabilities.isEmpty()
-        && !std::ranges::any_of(configuration.audioCapabilities, CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability)) {
+        && !WTF::anyOf(configuration.audioCapabilities, [](auto& v) { return CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability(v); })) {
         INFO_LOG(LOGIDENTIFIER, "false, no audio configuration supported");
         return false;
     }
 
     if (!configuration.videoCapabilities.isEmpty()
-        && !std::ranges::any_of(configuration.videoCapabilities, CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability)) {
+        && !WTF::anyOf(configuration.videoCapabilities, [](auto& v) { return CDMInstanceFairPlayStreamingAVFObjC::supportsMediaCapability(v); })) {
             INFO_LOG(LOGIDENTIFIER, "false, no video configuration supported");
         return false;
     }
@@ -382,7 +382,7 @@ bool CDMPrivateFairPlayStreaming::supportsConfigurationWithRestrictions(const CD
     if (restrictions.persistentStateDenied && configuration.persistentState == CDMRequirement::Required)
         return false;
 
-    if (std::ranges::all_of(configuration.sessionTypes, [restrictions](auto& sessionType) {
+    if (WTF::allOf(configuration.sessionTypes, [restrictions](auto& sessionType) {
         return restrictions.deniedSessionTypes.contains(sessionType);
     }))
         return false;
@@ -456,7 +456,7 @@ bool CDMPrivateFairPlayStreaming::supportsInitData(const AtomString& initDataTyp
         return false;
 
     if (initDataType == sinfName()) {
-        return std::ranges::any_of(extractSchemeAndKeyIdFromSinf(initData), [](auto& result) {
+        return WTF::anyOf(extractSchemeAndKeyIdFromSinf(initData), [](auto& result) {
             return validFairPlayStreamingSchemes().contains(result.first);
         });
     }
@@ -467,7 +467,7 @@ bool CDMPrivateFairPlayStreaming::supportsInitData(const AtomString& initDataTyp
         if (!psshBoxes)
             return false;
 
-        return std::ranges::any_of(psshBoxes.value(), [](auto& psshBox) {
+        return WTF::anyOf(psshBoxes.value(), [](auto& psshBox) {
             return is<ISOFairPlayStreamingPsshBox>(*psshBox);
         });
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -626,7 +626,7 @@ CDMInstanceSessionFairPlayStreamingAVFObjC* CDMInstanceFairPlayStreamingAVFObjC:
             continue;
 
         auto sessionKeys = sessionInterface->keyIDs();
-        if (std::ranges::any_of(sessionKeys, [&](auto& sessionKey) {
+        if (WTF::anyOf(sessionKeys, [&](auto& sessionKey) {
             return keyIDs.containsIf([&](auto& keyID) {
                 return keyID.get() == sessionKey.get();
             });

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -175,7 +175,7 @@ void MediaSourcePrivateAVFObjC::keyAdded()
 
 bool MediaSourcePrivateAVFObjC::hasSelectedVideo() const
 {
-    return std::ranges::any_of(m_activeSourceBuffers, [](auto* sourceBuffer) {
+    return WTF::anyOf(m_activeSourceBuffers, [](auto* sourceBuffer) {
         return downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->hasSelectedVideo();
     });
 }
@@ -279,7 +279,7 @@ void MediaSourcePrivateAVFObjC::attemptToDecryptWithInstance(CDMInstance& instan
 
 bool MediaSourcePrivateAVFObjC::waitingForKey() const
 {
-    return std::ranges::any_of(m_sourceBuffers, [](auto& sourceBuffer) {
+    return WTF::anyOf(m_sourceBuffers, [](auto& sourceBuffer) {
         return sourceBuffer->waitingForKey();
     });
 }
@@ -317,7 +317,7 @@ void MediaSourcePrivateAVFObjC::failedToCreateRenderer(RendererType type)
 
 bool MediaSourcePrivateAVFObjC::needsVideoLayer() const
 {
-    return std::ranges::any_of(m_sourceBuffers, [](auto& sourceBuffer) {
+    return WTF::anyOf(m_sourceBuffers, [](auto& sourceBuffer) {
         return downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->needsVideoLayer();
     });
 }

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -147,17 +147,17 @@ bool FilterOperations::inverseTransformColor(Color& color) const
 
 bool FilterOperations::hasFilterThatAffectsOpacity() const
 {
-    return std::ranges::any_of(m_operations, [](auto& op) { return op->affectsOpacity(); });
+    return WTF::anyOf(m_operations, [](auto& op) { return op->affectsOpacity(); });
 }
 
 bool FilterOperations::hasFilterThatMovesPixels() const
 {
-    return std::ranges::any_of(m_operations, [](auto& op) { return op->movesPixels(); });
+    return WTF::anyOf(m_operations, [](auto& op) { return op->movesPixels(); });
 }
 
 bool FilterOperations::hasFilterThatShouldBeRestrictedBySecurityOrigin() const
 {
-    return std::ranges::any_of(m_operations, [](auto& op) { return op->shouldBeRestrictedBySecurityOrigin(); });
+    return WTF::anyOf(m_operations, [](auto& op) { return op->shouldBeRestrictedBySecurityOrigin(); });
 }
 
 bool FilterOperations::canInterpolate(const FilterOperations& to, CompositeOperation compositeOperation) const

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -99,7 +99,7 @@ private:
 
 template<FilterOperation::Type type> bool FilterOperations::hasFilterOfType() const
 {
-    return std::ranges::any_of(m_operations, [](auto& op) { return op->type() == type; });
+    return WTF::anyOf(m_operations, [](auto& op) { return op->type() == type; });
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FilterOperations&);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -712,7 +712,7 @@ bool CoordinatedPlatformLayer::needsBackingStore() const
         return false;
 
     // Check if there's a filter that sets the opacity to zero.
-    bool hasOpacityZeroFilter = std::ranges::any_of(m_filters, [](auto& operation) {
+    bool hasOpacityZeroFilter = WTF::anyOf(m_filters, [](auto& operation) {
         return operation->type() == FilterOperation::Type::Opacity && !downcast<BasicComponentTransferFilterOperation>(operation.get()).amount();
     });
 

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.h
@@ -25,7 +25,7 @@
 
 #include <WebCore/LayoutSize.h>
 #include <WebCore/TransformOperation.h>
-#include <algorithm>
+#include <wtf/Algorithm.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
@@ -82,7 +82,7 @@ private:
 template<TransformOperation::Type operationType>
 bool TransformOperations::hasTransformOfType() const
 {
-    return std::ranges::any_of(m_operations, [](auto& op) { return op->type() == operationType; });
+    return WTF::anyOf(m_operations, [](auto& op) { return op->type() == operationType; });
 }
 
 TransformOperations blend(const TransformOperations& from, const TransformOperations& to, const BlendingContext&, const LayoutSize&);

--- a/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
@@ -90,12 +90,12 @@ void MediaEngineConfigurationFactory::installFactory(MediaEngineFactory&& factor
 
 bool MediaEngineConfigurationFactory::hasDecodingConfigurationFactory()
 {
-    return mockEnabled() || std::ranges::any_of(factories(), [](auto& factory) { return (bool)factory.createDecodingConfiguration; });
+    return mockEnabled() || WTF::anyOf(factories(), [](auto& factory) { return (bool)factory.createDecodingConfiguration; });
 }
 
 bool MediaEngineConfigurationFactory::hasEncodingConfigurationFactory()
 {
-    return mockEnabled() || std::ranges::any_of(factories(), [](auto& factory) { return (bool)factory.createEncodingConfiguration; });
+    return mockEnabled() || WTF::anyOf(factories(), [](auto& factory) { return (bool)factory.createEncodingConfiguration; });
 }
 
 void MediaEngineConfigurationFactory::createDecodingConfiguration(MediaDecodingConfiguration&& config, DecodingConfigurationCallback&& callback)

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -127,7 +127,7 @@ void MediaStreamPrivate::forEachTrack(NOESCAPE const Function<void(MediaStreamTr
 
 bool MediaStreamPrivate::computeActiveState()
 {
-    return std::ranges::any_of(m_trackSet, [](auto& track) { return !track.value->ended(); });
+    return WTF::anyOf(m_trackSet, [](auto& track) { return !track.value->ended(); });
 }
 
 void MediaStreamPrivate::updateActiveState()

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -580,7 +580,7 @@ String SizeFrameRateAndZoom::toJSONString() const
 
 bool RealtimeVideoCaptureSource::canBePowerEfficient()
 {
-    return std::ranges::any_of(presets(), [](auto& preset) { return preset.isEfficient(); }) && std::ranges::any_of(presets(), [](auto& preset) { return !preset.isEfficient(); });
+    return WTF::anyOf(presets(), [](auto& preset) { return preset.isEfficient(); }) && WTF::anyOf(presets(), [](auto& preset) { return !preset.isEfficient(); });
 }
 
 

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -454,7 +454,7 @@ void AVVideoCaptureSource::configurationChanged()
 
 static bool isZoomSupported(const Vector<VideoPreset>& presets)
 {
-    return std::ranges::any_of(presets, [](auto& preset) {
+    return WTF::anyOf(presets, [](auto& preset) {
         return preset.isZoomSupported();
     });
 }

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -191,7 +191,7 @@ void BaseAudioSharedUnit::devicesChanged()
     if (persistentID.isEmpty())
         return;
 
-    if (std::ranges::any_of(devices, [&persistentID](auto& device) { return persistentID == device.persistentId(); })) {
+    if (WTF::anyOf(devices, [&persistentID](auto& device) { return persistentID == device.persistentId(); })) {
         validateOutputDevice(m_outputDeviceID);
         return;
     }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -248,7 +248,7 @@ std::optional<CoreAudioCaptureDevice> CoreAudioCaptureDeviceManager::coreAudioDe
 
 static inline bool hasDevice(const Vector<CoreAudioCaptureDevice>& devices, uint32_t deviceID, CaptureDevice::DeviceType deviceType)
 {
-    return std::ranges::any_of(devices, [&deviceID, deviceType](auto& device) {
+    return WTF::anyOf(devices, [&deviceID, deviceType](auto& device) {
         return device.deviceID() == deviceID && device.type() == deviceType;
     });
 }

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -311,7 +311,7 @@ auto MockRealtimeVideoSource::getPhotoSettings() -> Ref<PhotoSettingsNativePromi
 
 static bool isZoomSupported(const Vector<VideoPreset>& presets)
 {
-    return std::ranges::any_of(presets, [](auto& preset) {
+    return WTF::anyOf(presets, [](auto& preset) {
         return preset.isZoomSupported();
     });
 }

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -590,7 +590,7 @@ std::optional<OrganizationStorageAccessPromptQuirk> NetworkStorageSession::stora
         auto entry = quirkDomains.find(topDomain);
         if (entry == quirkDomains.end())
             continue;
-        if (!std::ranges::any_of(entry->value, [&subDomain](auto&& entry) { return entry == subDomain; }))
+        if (!WTF::anyOf(entry->value, [&subDomain](auto&& entry) { return entry == subDomain; }))
             break;
         return quirk;
     }

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -702,7 +702,7 @@ void NetworkStorageSession::deleteCookies(const ClientOrigin& origin, Completion
     auto domain = origin.clientOrigin.host();
 
     deleteCookiesMatching([&domain, &cachePartitions](auto *cookie) {
-        bool partitionMatched = std::ranges::any_of(cachePartitions, [&cookie](auto& cachePartition) {
+        bool partitionMatched = WTF::anyOf(cachePartitions, [&cookie](auto& cachePartition) {
             return equalIgnoringNullity(cachePartition, String(cookie._storagePartition));
         });
         return partitionMatched && domain == String(cookie.domain);

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -125,7 +125,7 @@ unsigned MatchedDeclarationsCache::computeHash(const MatchResult& matchResult, c
         return 0;
 
     if (matchResult.userAgentDeclarations.isEmpty() && matchResult.userDeclarations.isEmpty()) {
-        bool allNonCacheable = std::ranges::all_of(matchResult.authorDeclarations, [](auto& matchedProperties) {
+        bool allNonCacheable = WTF::allOf(matchResult.authorDeclarations, [](auto& matchedProperties) {
             return matchedProperties.isCacheable != IsCacheable::Yes;
         });
         // No point of caching if we are not applying any properties.

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -769,7 +769,7 @@ public:
 
         // FIXME: Something like LLVM ADT's zip_shortest (https://llvm.org/doxygen/structllvm_1_1detail_1_1zip__shortest.html) would allow this to be done without indexing:
         //
-        // return std::ranges::all_of(
+        // return WTF::allOf(
         //     zip_shortest(makeReversedRange(fromShadowList), makeReversedRange(toShadowList)),
         //     [](const auto& pair) {
         //         return shadowStyle(std::get<0>(pair)) == shadowStyle(std::get<1>(pair));

--- a/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
+++ b/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
@@ -126,7 +126,7 @@ void FillLayers<Layer>::computeClipMax() const
 template<typename Layer>
 bool FillLayers<Layer>::imagesAreLoaded(const RenderElement* renderer) const
 {
-    return std::ranges::all_of(*this, [&renderer](auto& layer) {
+    return WTF::allOf(*this, [&renderer](auto& layer) {
         RefPtr image = layer.image().tryStyleImage();
         return !image || image->isLoaded(renderer);
     });
@@ -135,7 +135,7 @@ bool FillLayers<Layer>::imagesAreLoaded(const RenderElement* renderer) const
 template<typename Layer>
 bool FillLayers<Layer>::hasImageInAnyLayer() const
 {
-    return std::ranges::any_of(*this, [](auto& layer) {
+    return WTF::anyOf(*this, [](auto& layer) {
         return layer.hasImage();
     });
 }
@@ -143,7 +143,7 @@ bool FillLayers<Layer>::hasImageInAnyLayer() const
 template<typename Layer>
 bool FillLayers<Layer>::hasImageWithAttachment(FillAttachment attachment) const
 {
-    return std::ranges::any_of(*this, [&attachment](auto& layer) {
+    return WTF::anyOf(*this, [&attachment](auto& layer) {
         return layer.hasImage() && layer.attachment() == attachment;
     });
 }
@@ -151,7 +151,7 @@ bool FillLayers<Layer>::hasImageWithAttachment(FillAttachment attachment) const
 template<typename Layer>
 bool FillLayers<Layer>::hasHDRContent() const
 {
-    return std::ranges::any_of(*this, [](auto& layer) {
+    return WTF::anyOf(*this, [](auto& layer) {
         RefPtr image = layer.image().tryStyleImage();
         if (auto* cachedImage = image ? image->cachedImage() : nullptr) {
             if (cachedImage->hasHDRContent())
@@ -164,7 +164,7 @@ bool FillLayers<Layer>::hasHDRContent() const
 template<typename Layer>
 bool FillLayers<Layer>::hasEntirelyFixedBackground() const
 {
-    return std::ranges::all_of(*this, [](auto& layer) {
+    return WTF::allOf(*this, [](auto& layer) {
         return layer.hasImage() && layer.attachment() == FillAttachment::FixedBackground;
     });
 }
@@ -172,7 +172,7 @@ bool FillLayers<Layer>::hasEntirelyFixedBackground() const
 template<typename Layer>
 bool FillLayers<Layer>::hasAnyBackgroundClipText() const
 {
-    return std::ranges::any_of(*this, [](auto& layer) {
+    return WTF::anyOf(*this, [](auto& layer) {
         return layer.clip() == FillBox::Text;
     });
 }

--- a/Source/WebCore/style/values/color/StyleColorLayers.cpp
+++ b/Source/WebCore/style/values/color/StyleColorLayers.cpp
@@ -47,7 +47,7 @@ Color toStyleColor(const CSS::ColorLayers& unresolved, ColorResolutionState& sta
         return toStyleColor(color, state);
     }) };
 
-    if (std::ranges::any_of(colors, [](auto& color) { return color.isResolvedColor(); })) {
+    if (WTF::anyOf(colors, [](auto& color) { return color.isResolvedColor(); })) {
         // If the any of the layer's colors are not resolved, we cannot fully resolve the
         // color yet. Instead we return a Style::ColorLayers to be resolved at use time.
         return Color {
@@ -87,7 +87,7 @@ WebCore::Color resolveColor(const ColorLayers& colorLayers, const WebCore::Color
 
 bool containsCurrentColor(const ColorLayers& colorLayers)
 {
-    return std::ranges::any_of(colorLayers.colors, [&](auto& color) {
+    return WTF::anyOf(colorLayers.colors, [&](auto& color) {
         return WebCore::Style::containsCurrentColor(color);
     });
 }

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -1193,7 +1193,7 @@ static bool stopColorIsCacheable(const Markable<Color>& stopColor)
 
 template<typename Gradient> static bool stopsAreCacheable(const Gradient& gradient)
 {
-    return std::ranges::all_of(gradient.parameters.stops, [](auto& stop) {
+    return WTF::allOf(gradient.parameters.stops, [](auto& stop) {
         return stopColorIsCacheable(stop.color);
     });
 }
@@ -1209,7 +1209,7 @@ template<typename T> static bool isOpaque(const T& gradient, const RenderStyle& 
 {
     bool hasColorFilter = style.hasAppleColorFilter();
 
-    return std::ranges::all_of(gradient.parameters.stops, [&](auto& stop) {
+    return WTF::allOf(gradient.parameters.stops, [&](auto& stop) {
         return resolveColorStopColor(stop.color, style, hasColorFilter).isOpaque();
     });
 }

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -31,7 +31,7 @@
 #include "InitDataRegistry.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/ArrayBuffer.h>
-#include <algorithm>
+#include <wtf/Algorithm.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
@@ -149,10 +149,10 @@ bool MockCDM::supportsConfiguration(const MediaKeySystemConfiguration& configura
         return true;
     };
 
-    if (!configuration.audioCapabilities.isEmpty() && !std::ranges::any_of(configuration.audioCapabilities, capabilityHasSupportedEncryptionScheme))
+    if (!configuration.audioCapabilities.isEmpty() && !WTF::anyOf(configuration.audioCapabilities, capabilityHasSupportedEncryptionScheme))
         return false;
 
-    if (!configuration.videoCapabilities.isEmpty() && !std::ranges::any_of(configuration.videoCapabilities, capabilityHasSupportedEncryptionScheme))
+    if (!configuration.videoCapabilities.isEmpty() && !WTF::anyOf(configuration.videoCapabilities, capabilityHasSupportedEncryptionScheme))
         return false;
 
     return true;

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -824,7 +824,7 @@ void ServiceWorkerContainer::cookieChangeSubscriptions(ServiceWorkerRegistration
 
 void ServiceWorkerContainer::whenRegisterJobsAreFinished(CompletionHandler<void()>&& completionHandler)
 {
-    bool isRegistering = std::ranges::any_of(m_jobMap.values(), [](auto& ongoing) {
+    bool isRegistering = WTF::anyOf(m_jobMap.values(), [](auto& ongoing) {
         return ongoing.job->isRegistering();
     });
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -211,7 +211,7 @@ void BackgroundFetch::handleStoreResult(BackgroundFetchStore::StoreResult result
 
 void BackgroundFetch::recordIsCompleted()
 {
-    if (std::ranges::any_of(m_records, [](auto& record) { return !record->isCompleted(); }))
+    if (WTF::anyOf(m_records, [](auto& record) { return !record->isCompleted(); }))
         return;
     updateBackgroundFetchStatus(BackgroundFetchResult::Success, BackgroundFetchFailureReason::EmptyString);
 }

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -101,7 +101,7 @@ void GPUProcess::setScreenProperties(const WebCore::ScreenProperties& screenProp
         return;
     }
 
-    bool allScreensAreHDR = std::ranges::all_of(screenProperties.screenDataMap.values(), [](auto& screenData) {
+    bool allScreensAreHDR = WTF::allOf(screenProperties.screenDataMap.values(), [](auto& screenData) {
         return screenData.screenSupportsHighDynamicRange;
     });
     setShouldOverrideScreenSupportsHighDynamicRange(true, allScreensAreHDR);

--- a/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp
@@ -43,7 +43,7 @@ void NetworkOriginAccessPatterns::allowAccessTo(const WebCore::UserContentURLPat
 bool NetworkOriginAccessPatterns::anyPatternMatches(const URL& url) const
 {
     ASSERT(RunLoop::isMain());
-    return std::ranges::any_of(m_patterns, [&](auto& pattern) {
+    return WTF::anyOf(m_patterns, [&](auto& pattern) {
         return pattern.matches(url);
     });
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1171,7 +1171,7 @@ void NetworkProcess::hasLocalStorage(PAL::SessionID sessionID, const Registrable
 
     auto types = OptionSet<WebsiteDataType> { WebsiteDataType::LocalStorage };
     session->storageManager().fetchData(types, NetworkStorageManager::ShouldComputeSize::No, [domain, completionHandler = WTFMove(completionHandler)](auto entries) mutable {
-        completionHandler(std::ranges::any_of(entries, [&domain](auto& entry) {
+        completionHandler(WTF::anyOf(entries, [&domain](auto& entry) {
             return domain.matches(entry.origin);
         }));
     });
@@ -3091,7 +3091,7 @@ void NetworkProcess::clearBundleIdentifier(CompletionHandler<void()>&& completio
 
 bool NetworkProcess::shouldDisableCORSForRequestTo(PageIdentifier pageIdentifier, const URL& url) const
 {
-    return std::ranges::any_of(m_extensionCORSDisablingPatterns.get(pageIdentifier), [&](auto& pattern) {
+    return WTF::anyOf(m_extensionCORSDisablingPatterns.get(pageIdentifier), [&](auto& pattern) {
         return pattern.matches(url);
     });
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
@@ -69,7 +69,7 @@ RefPtr<NetworkResourceLoader> NetworkResourceLoadMap::take(WebCore::ResourceLoad
         return nullptr;
 
     if (loader->originalRequest().hasUpload())
-        setHasUpload(std::ranges::any_of(m_loaders.values(), [](auto& loader) { return loader->originalRequest().hasUpload(); }));
+        setHasUpload(WTF::anyOf(m_loaders.values(), [](auto& loader) { return loader->originalRequest().hasUpload(); }));
 
     return loader;
 }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -512,7 +512,7 @@ void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientO
 
     MESSAGE_CHECK(!contextOrigin.isNull());
 
-    bool isNewOrigin = std::ranges::all_of(m_clientOrigins.values(), [&contextOrigin](auto& origin) {
+    bool isNewOrigin = WTF::allOf(m_clientOrigins.values(), [&contextOrigin](auto& origin) {
         return contextOrigin != origin.clientOrigin;
     });
     RefPtr server = this->server();
@@ -558,7 +558,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
     if (!m_isThrottleable)
         updateThrottleState();
 
-    bool isDeletedOrigin = std::ranges::all_of(m_clientOrigins.values(), [&clientOrigin](auto& origin) {
+    bool isDeletedOrigin = WTF::allOf(m_clientOrigins.values(), [&clientOrigin](auto& origin) {
         return clientOrigin.clientOrigin != origin.clientOrigin;
     });
 
@@ -575,7 +575,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
 
 bool WebSWServerConnection::hasMatchingClient(const RegistrableDomain& domain) const
 {
-    return std::ranges::any_of(m_clientOrigins.values(), [&domain](auto& origin) {
+    return WTF::anyOf(m_clientOrigins.values(), [&domain](auto& origin) {
         return domain.matches(origin.clientOrigin);
     });
 }
@@ -586,7 +586,7 @@ bool WebSWServerConnection::computeThrottleState(const RegistrableDomain& domain
     if (!server)
         return true;
 
-    return std::ranges::all_of(server->connections().values(), [&domain](auto& serverConnection) {
+    return WTF::allOf(server->connections().values(), [&domain](auto& serverConnection) {
         Ref connection = downcast<WebSWServerConnection>(serverConnection.get());
         return connection->isThrottleable() || !connection->hasMatchingClient(domain);
     });

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -215,7 +215,7 @@ bool IDBStorageManager::isActive() const
 
 bool IDBStorageManager::hasDataInMemory() const
 {
-    return std::ranges::any_of(m_databases.values(), [&](auto& database) {
+    return WTF::anyOf(m_databases.values(), [&](auto& database) {
         return database->hasDataInMemory();
     });
 }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -131,7 +131,7 @@ static bool isEmptyOriginDirectory(const String& directory)
         , ".DS_Store"_s
 #endif
     };
-    return std::ranges::all_of(children, [&](auto& child) {
+    return WTF::allOf(children, [&](auto& child) {
         return invalidFileNames.contains(child);
     });
 }

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -300,7 +300,7 @@ bool OriginStorageManager::StorageBucket::isEmpty()
     ASSERT(!RunLoop::isMain());
 
     auto files = FileSystem::listDirectory(m_rootPath);
-    auto hasValidFile = std::ranges::any_of(files, [&](auto file) {
+    auto hasValidFile = WTF::anyOf(files, [&](auto file) {
         bool isInvalidFile = (file == originFileName);
 #if PLATFORM(COCOA)
         isInvalidFile |= (file == ".DS_Store"_s);

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
@@ -42,14 +42,14 @@ SessionStorageManager::SessionStorageManager(StorageAreaRegistry& registry)
 
 bool SessionStorageManager::isActive() const
 {
-    return std::ranges::any_of(m_storageAreas.values(), [&](auto& storageArea) {
+    return WTF::anyOf(m_storageAreas.values(), [&](auto& storageArea) {
         return storageArea->hasListeners();
     });
 }
 
 bool SessionStorageManager::hasDataInMemory() const
 {
-    return std::ranges::any_of(m_storageAreas.values(), [&](auto& storageArea) {
+    return WTF::anyOf(m_storageAreas.values(), [&](auto& storageArea) {
         return !storageArea->isEmpty();
     });
 }

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -135,11 +135,11 @@ static bool isSerializable(API::Object* object)
     case API::Object::Type::SerializedNode:
         return true;
     case API::Object::Type::Array:
-        return std::ranges::all_of(downcast<API::Array>(object)->elements(), [] (const RefPtr<API::Object>& element) {
+        return WTF::allOf(downcast<API::Array>(object)->elements(), [] (const RefPtr<API::Object>& element) {
             return isSerializable(element.get());
         });
     case API::Object::Type::Dictionary:
-        return std::ranges::all_of(downcast<API::Dictionary>(object)->map(), [] (const KeyValuePair<String, RefPtr<API::Object>>& pair) {
+        return WTF::allOf(downcast<API::Dictionary>(object)->map(), [] (const KeyValuePair<String, RefPtr<API::Object>>& pair) {
             return isSerializable(pair.value.get());
         });
     default:

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -135,7 +135,7 @@ static void updateApplicationBackgroundState()
 {
     static bool s_isApplicationInBackground = false;
     auto isAnyStateTrackerInForeground = []() -> bool {
-        return std::ranges::any_of(allApplicationStateTrackers(), [](auto& tracker) {
+        return WTF::anyOf(allApplicationStateTrackers(), [](auto& tracker) {
             return !tracker.isInBackground();
         });
     };

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -470,7 +470,7 @@ void GPUProcessProxy::setShouldListenToVoiceActivity(const WebPageProxy& proxy, 
             return;
     }
 
-    bool shouldListenToVoiceActivity = std::ranges::any_of(m_pagesListeningToVoiceActivity, [](auto& page) {
+    bool shouldListenToVoiceActivity = WTF::anyOf(m_pagesListeningToVoiceActivity, [](auto& page) {
         return page.shouldListenToVoiceActivity();
     });
     if (m_shouldListenToVoiceActivity == shouldListenToVoiceActivity)

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -847,9 +847,9 @@ bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera
     if (!protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), origin.topOrigin.toURL()))
         return true;
 
-    return !std::ranges::any_of(m_deniedRequests, [](auto& request) { return request.isVideoDenied; })
-        && !std::ranges::any_of(m_pregrantedRequests, [](auto& request) { return request->requiresVideoCapture(); })
-        && !std::ranges::any_of(m_grantedRequests, [](auto& request) { return request->requiresVideoCapture(); });
+    return !WTF::anyOf(m_deniedRequests, [](auto& request) { return request.isVideoDenied; })
+        && !WTF::anyOf(m_pregrantedRequests, [](auto& request) { return request->requiresVideoCapture(); })
+        && !WTF::anyOf(m_grantedRequests, [](auto& request) { return request->requiresVideoCapture(); });
 }
 
 bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrophone(const ClientOrigin& origin) const
@@ -861,9 +861,9 @@ bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrop
     if (!protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), origin.topOrigin.toURL()))
         return true;
 
-    return !std::ranges::any_of(m_deniedRequests, [](auto& request) { return request.isAudioDenied; })
-        && !std::ranges::any_of(m_pregrantedRequests, [](auto& request) { return request->requiresAudioCapture(); })
-        && !std::ranges::any_of(m_grantedRequests, [](auto& request) { return request->requiresAudioCapture(); });
+    return !WTF::anyOf(m_deniedRequests, [](auto& request) { return request.isAudioDenied; })
+        && !WTF::anyOf(m_pregrantedRequests, [](auto& request) { return request->requiresAudioCapture(); })
+        && !WTF::anyOf(m_grantedRequests, [](auto& request) { return request->requiresAudioCapture(); });
 }
 
 bool UserMediaPermissionRequestManagerProxy::shouldChangePromptToGrantForCamera(const ClientOrigin& origin) const

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2032,7 +2032,7 @@ void WebProcessPool::updateProcessAssertions()
 bool WebProcessPool::isServiceWorkerPageID(WebPageProxyIdentifier pageID) const
 {
     // FIXME: This is inefficient.
-    return std::ranges::any_of(remoteWorkerProcesses(), [pageID](auto& process) {
+    return WTF::anyOf(remoteWorkerProcesses(), [pageID](auto& process) {
         return process.hasServiceWorkerPageProxy(pageID);
     });
     return false;
@@ -2479,7 +2479,7 @@ void WebProcessPool::setUseSeparateServiceWorkerProcess(bool useSeparateServiceW
 
 bool WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion()
 {
-    return std::ranges::any_of(WebProcessPool::allProcessPools(), [](auto& processPool) {
+    return WTF::anyOf(WebProcessPool::allProcessPools(), [](auto& processPool) {
         return processPool->shouldTakeUIBackgroundAssertion();
     });
 }
@@ -2536,14 +2536,14 @@ void WebProcessPool::isJITDisabledInAllRemoteWorkerProcesses(CompletionHandler<v
 
 bool WebProcessPool::hasServiceWorkerForegroundActivityForTesting() const
 {
-    return std::ranges::any_of(remoteWorkerProcesses(), [](auto& process) {
+    return WTF::anyOf(remoteWorkerProcesses(), [](auto& process) {
         return process.hasServiceWorkerForegroundActivityForTesting();
     });
 }
 
 bool WebProcessPool::hasServiceWorkerBackgroundActivityForTesting() const
 {
-    return std::ranges::any_of(remoteWorkerProcesses(), [](auto& process) {
+    return WTF::anyOf(remoteWorkerProcesses(), [](auto& process) {
         return process.hasServiceWorkerBackgroundActivityForTesting();
     });
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -797,7 +797,7 @@ bool WebProcessProxy::shouldDropNearSuspendedAssertionAfterDelay() const
         // The setting come from pages but this process has no page, we thus use the default setting value.
         return defaultShouldDropNearSuspendedAssertionAfterDelay();
     }
-    return std::ranges::any_of(m_pageMap.values(), [](auto& page) { return page->preferences().shouldDropNearSuspendedAssertionAfterDelay(); });
+    return WTF::anyOf(m_pageMap.values(), [](auto& page) { return page->preferences().shouldDropNearSuspendedAssertionAfterDelay(); });
 }
 
 void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataStore beginsUsingDataStore)
@@ -1937,14 +1937,14 @@ String WebProcessProxy::environmentIdentifier() const
 
 void WebProcessProxy::updateAudibleMediaAssertions()
 {
-    bool hasAudibleMainPage = std::ranges::any_of(pages(), [](auto& page) {
+    bool hasAudibleMainPage = WTF::anyOf(pages(), [](auto& page) {
 #if ENABLE(EXTENSION_CAPABILITIES)
         if (page->preferences().mediaCapabilityGrantsEnabled())
             return false;
 #endif
         return page->isPlayingAudio();
     });
-    bool hasAudibleRemotePage = std::ranges::any_of(remotePages(), [](auto& remotePage) {
+    bool hasAudibleRemotePage = WTF::anyOf(remotePages(), [](auto& remotePage) {
 #if ENABLE(EXTENSION_CAPABILITIES)
         if (RefPtr page = remotePage ? remotePage->protectedPage() : nullptr) {
             if (page->preferences().mediaCapabilityGrantsEnabled())
@@ -1972,10 +1972,10 @@ void WebProcessProxy::updateAudibleMediaAssertions()
 
 void WebProcessProxy::updateMediaStreamingActivity()
 {
-    bool hasMediaStreamingMainPage = std::ranges::any_of(pages(), [](auto& page) {
+    bool hasMediaStreamingMainPage = WTF::anyOf(pages(), [](auto& page) {
         return page->hasMediaStreaming();
     });
-    bool hasMediaStreamingRemotePage = std::ranges::any_of(remotePages(), [](auto& remotePage) {
+    bool hasMediaStreamingRemotePage = WTF::anyOf(remotePages(), [](auto& remotePage) {
         return remotePage ? remotePage->mediaState().contains(MediaProducerMediaState::HasStreamingActivity) : false;
     });
     bool hasMediaStreamingWebPage = hasMediaStreamingMainPage || hasMediaStreamingRemotePage;
@@ -2613,7 +2613,7 @@ void WebProcessProxy::updateRemoteWorkerProcessAssertion(RemoteWorkerType worker
     WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "updateRemoteWorkerProcessAssertion: workerType=%" PUBLIC_LOG_STRING, workerType == RemoteWorkerType::SharedWorker ? "shared" : "service");
 
     // FIXME: Drop SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE once <rdar://150855062> is fixed.
-    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE bool shouldTakeForegroundActivity = std::ranges::any_of(workerInformation->clientProcesses, [&](auto& process) {
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE bool shouldTakeForegroundActivity = WTF::anyOf(workerInformation->clientProcesses, [&](auto& process) {
         return &process != this && !!process.m_foregroundToken;
     });
     if (shouldTakeForegroundActivity) {
@@ -2623,7 +2623,7 @@ void WebProcessProxy::updateRemoteWorkerProcessAssertion(RemoteWorkerType worker
     }
 
     // FIXME: Drop SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE once <rdar://150855062> is fixed.
-    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE bool shouldTakeBackgroundActivity = std::ranges::any_of(workerInformation->clientProcesses, [&](auto& process) {
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE bool shouldTakeBackgroundActivity = WTF::anyOf(workerInformation->clientProcesses, [&](auto& process) {
         return &process != this && !!process.m_backgroundToken;
     });
     if (shouldTakeBackgroundActivity) {
@@ -2988,7 +2988,7 @@ void WebProcessProxy::updateRuntimeStatistics()
 
 bool WebProcessProxy::isAlwaysOnLoggingAllowed() const
 {
-    return std::ranges::all_of(pages(), [](auto& page) {
+    return WTF::allOf(pages(), [](auto& page) {
         return page->isAlwaysOnLoggingAllowed();
     });
 }

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -266,8 +266,8 @@ std::optional<bool> WebsiteDataStore::useNetworkLoader()
 bool WebsiteDataStore::isOptInCookiePartitioningEnabled() const
 {
 #if defined(CFN_COOKIE_ACCEPTS_POLICY_PARTITION) && CFN_COOKIE_ACCEPTS_POLICY_PARTITION
-    return std::ranges::any_of(m_processes, [](auto& process) {
-        return std::ranges::any_of(process.pages(), [](auto& page) {
+    return WTF::anyOf(m_processes, [](auto& process) {
+        return WTF::anyOf(process.pages(), [](auto& page) {
             return page->preferences().optInPartitionedCookiesEnabled();
         });
     });

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1093,7 +1093,7 @@ void WebsiteDataStore::resetServiceWorkerTimeoutForTesting()
 
 bool WebsiteDataStore::hasServiceWorkerBackgroundActivityForTesting() const
 {
-    return std::ranges::any_of(WebProcessPool::allProcessPools(), [](auto& pool) { return pool->hasServiceWorkerBackgroundActivityForTesting(); });
+    return WTF::anyOf(WebProcessPool::allProcessPools(), [](auto& pool) { return pool->hasServiceWorkerBackgroundActivityForTesting(); });
 }
 
 void WebsiteDataStore::runningOrTerminatingServiceWorkerCountForTesting(CompletionHandler<void(unsigned)>&& completionHandler)
@@ -2001,8 +2001,8 @@ void WebsiteDataStore::setPrivateTokenIPCForTesting(bool enabled)
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES) && !PLATFORM(COCOA)
 bool WebsiteDataStore::isOptInCookiePartitioningEnabled() const
 {
-    return std::ranges::any_of(m_processes, [](auto& process) {
-        return std::ranges::any_of(process.pages(), [](auto& page) {
+    return WTF::anyOf(m_processes, [](auto& process) {
+        return WTF::anyOf(process.pages(), [](auto& page) {
             return page->preferences().optInPartitionedCookiesEnabled();
         });
     });
@@ -2708,7 +2708,7 @@ void WebsiteDataStore::resumeDownload(const DownloadProxy& downloadProxy, const 
 bool WebsiteDataStore::hasActivePages()
 {
     // FIXME: Drop SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE once <rdar://150855062> is fixed.
-    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE return std::ranges::any_of(WebProcessPool::allProcessPools(), [&](auto& pool) {
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE return WTF::anyOf(WebProcessPool::allProcessPools(), [&](auto& pool) {
         return pool->hasPagesUsingWebsiteDataStore(*this);
     });
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -180,7 +180,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         }
 #endif
         for (auto& network : networks) {
-            if (std::ranges::any_of(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name))))
+            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name))))
                 filteredNetworks.append(network);
         }
     }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm
@@ -88,7 +88,7 @@ bool annotationCheckerInternal(PDFAnnotation *annotation, std::initializer_list<
         return annotationCheckerInternal(annotation.get(), std::forward<decltype(type)>(type), WTFMove(converter));
     };
     ASSERT(std::ranges::count_if(types, checker) <= 1);
-    return std::ranges::any_of(WTFMove(types), WTFMove(checker));
+    return WTF::anyOf(WTFMove(types), WTFMove(checker));
 }
 
 bool annotationIsOfType(PDFAnnotation *annotation, AnnotationType type)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2463,7 +2463,7 @@ auto UnifiedPDFPlugin::toContextMenuItemTag(int tagValue) -> ContextMenuItemTag
         ContextMenuItemTag::ZoomOut,
         ContextMenuItemTag::ActualSize,
     };
-    const auto isKnownContextMenuItemTag = std::ranges::any_of(regularContextMenuItemTags, [tagValue](ContextMenuItemTag tag) {
+    const auto isKnownContextMenuItemTag = WTF::anyOf(regularContextMenuItemTags, [tagValue](ContextMenuItemTag tag) {
         return tagValue == enumToUnderlyingType(tag);
     });
     return isKnownContextMenuItemTag ? static_cast<ContextMenuItemTag>(tagValue) : ContextMenuItemTag::Unknown;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9095,7 +9095,7 @@ void WebPage::completeTextManipulation(const Vector<WebCore::TextManipulationIte
         return controller->completeManipulation(items);
     };
 
-    bool containsItemsForMultipleFrames = std::ranges::any_of(items, [&](auto& item) {
+    bool containsItemsForMultipleFrames = WTF::anyOf(items, [&](auto& item) {
         return currentFrameID != item.frameID;
     });
     if (!containsItemsForMultipleFrames)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2255,10 +2255,10 @@ void WebProcess::grantUserMediaDeviceSandboxExtensions(MediaDeviceSandboxExtensi
 static inline void checkDocumentsCaptureStateConsistency(const Vector<String>& extensionIDs)
 {
 #if ASSERT_ENABLED
-    bool isCapturingAudio = std::ranges::any_of(Document::allDocumentsMap().values(), [](auto& document) {
+    bool isCapturingAudio = WTF::anyOf(Document::allDocumentsMap().values(), [](auto& document) {
         return static_cast<bool>(document->mediaState() & MediaProducer::MicrophoneCaptureMask);
     });
-    bool isCapturingVideo = std::ranges::any_of(Document::allDocumentsMap().values(), [](auto& document) {
+    bool isCapturingVideo = WTF::anyOf(Document::allDocumentsMap().values(), [](auto& document) {
         return static_cast<bool>(document->mediaState() & MediaProducer::VideoCaptureMask);
     });
 
@@ -2309,7 +2309,7 @@ void WebProcess::clearCurrentModifierStateForTesting()
 
 bool WebProcess::areAllPagesThrottleable() const
 {
-    return std::ranges::all_of(m_pageMap.values(), [](auto& page) {
+    return WTF::allOf(m_pageMap.values(), [](auto& page) {
         return page->isThrottleable();
     });
 }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1478,7 +1478,7 @@ void WebProcess::updatePageScreenProperties()
         return;
     }
 
-    bool allPagesAreOnHDRScreens = std::ranges::all_of(m_pageMap.values(), [](auto& page) {
+    bool allPagesAreOnHDRScreens = WTF::allOf(m_pageMap.values(), [](auto& page) {
         return page && screenSupportsHighDynamicRange(page->localMainFrameView());
     });
     setShouldOverrideScreenSupportsHighDynamicRange(true, allPagesAreOnHDRScreens);

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3568,6 +3568,10 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_atoi:
         error(line_number, 'safercpp/atoi', 4, "Use parseInteger<int>() instead of atoi().")
 
+    uses_ranges_algorithm = search(r'std::ranges::*_of\(', line)
+    if uses_ranges_algorithm:
+        error(line_number, 'safercpp/ranges', 4, "Use WTF::allOf() / WTF::anyOf() / WTF::noneOf() instead of std::ranges::all_of() / std::ranges::any_of() / std::ranges::none_of().")
+
     uses_memset = search(r'memset\(', line)
     if uses_memset:
         error(line_number, 'safercpp/memset', 4, "Use memsetSpan() / zeroSpan() instead of memset().")
@@ -5014,6 +5018,7 @@ class CppChecker(object):
         'safercpp/memmove',
         'safercpp/memset',
         'safercpp/memset_s',
+        'safercpp/ranges',
         'safercpp/weak_ref_exception',
         'safercpp/strcmp',
         'safercpp/strncmp',

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -32,6 +32,7 @@
 #include "RefLogger.h"
 #include "Test.h"
 #include <string>
+#include <wtf/Algorithm.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/UniqueRef.h>
@@ -1315,22 +1316,22 @@ TEST(WTF_HashMap, KeysValuesRangesAllAnyNoneOf)
     map.add(2, 2);
     map.add(3, 3);
 
-    EXPECT_TRUE(std::ranges::all_of(map.keys(), [] (int el) {
+    EXPECT_TRUE(WTF::allOf(map.keys(), [] (int el) {
         return el < 4;
     }));
-    EXPECT_TRUE(std::ranges::none_of(map.keys(), [] (int el) {
+    EXPECT_TRUE(WTF::noneOf(map.keys(), [] (int el) {
         return el > 4;
     }));
-    EXPECT_TRUE(std::ranges::any_of(map.keys(), [] (int el) {
+    EXPECT_TRUE(WTF::anyOf(map.keys(), [] (int el) {
         return el < 2;
     }));
-    EXPECT_TRUE(std::ranges::all_of(map.values(), [] (int el) {
+    EXPECT_TRUE(WTF::allOf(map.values(), [] (int el) {
         return el < 4;
     }));
-    EXPECT_TRUE(std::ranges::none_of(map.values(), [] (int el) {
+    EXPECT_TRUE(WTF::noneOf(map.values(), [] (int el) {
         return el > 4;
     }));
-    EXPECT_TRUE(std::ranges::any_of(map.values(), [] (int el) {
+    EXPECT_TRUE(WTF::anyOf(map.values(), [] (int el) {
         return el < 2;
     }));
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
@@ -31,6 +31,7 @@
 #include "RefLogger.h"
 #include "Test.h"
 #include <functional>
+#include <wtf/Algorithm.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/MakeString.h>
@@ -946,13 +947,13 @@ TEST(WTF_HashSet, FormSymmetricDifference)
 TEST(WTF_HashSet, RangesAllAnyNoneOf)
 {
     HashSet<int> set1 { 1, 2, 3 };
-    EXPECT_TRUE(std::ranges::all_of(set1, [] (int el) {
+    EXPECT_TRUE(WTF::allOf(set1, [] (int el) {
         return el < 4;
     }));
-    EXPECT_TRUE(std::ranges::none_of(set1, [] (int el) {
+    EXPECT_TRUE(WTF::noneOf(set1, [] (int el) {
         return el > 4;
     }));
-    EXPECT_TRUE(std::ranges::any_of(set1, [] (int el) {
+    EXPECT_TRUE(WTF::anyOf(set1, [] (int el) {
         return el < 2;
     }));
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -1698,7 +1698,7 @@ TEST(WTF_WeakPtr, WeakHashMapIterators)
             ASSERT(pairs.size(), 40U);
             for (unsigned i = 0; i < 50; ++i) {
                 if (!(i % 5))
-                    EXPECT_TRUE(std::ranges::all_of(pairs, [&](auto& item) { return item.first != objects[i].get(); }));
+                    EXPECT_TRUE(WTF::allOf(pairs, [&](auto& item) { return item.first != objects[i].get(); }));
                 else if (!(i % 6))
                     EXPECT_TRUE(pairs.contains(std::pair { objects[i].get(), i * 51 }));
                 else
@@ -1716,7 +1716,7 @@ TEST(WTF_WeakPtr, WeakHashMapIterators)
             ASSERT(pairs.size(), 36U);
             for (unsigned i = 0; i < 50; ++i) {
                 if (!(i % 5) || !(i % 9))
-                    EXPECT_TRUE(std::ranges::all_of(pairs, [&](auto& item) { return item.first != objects[i].get(); }));
+                    EXPECT_TRUE(WTF::allOf(pairs, [&](auto& item) { return item.first != objects[i].get(); }));
                 else if (!(i % 6))
                     EXPECT_TRUE(pairs.contains(std::pair { objects[i].get(), i * 51 }));
                 else


### PR DESCRIPTION
#### ae96037d7eaa0b37cad76a74613b2001d8d39ab2
<pre>
Introduce anyOf() / allOf() / noneOf() in WTF which leverage NOESCAPE
<a href="https://bugs.webkit.org/show_bug.cgi?id=298706">https://bugs.webkit.org/show_bug.cgi?id=298706</a>

Reviewed by NOBODY (OOPS!).

Introduce anyOf() / allOf() / noneOf() in WTF which leverage NOESCAPE,
to play nice with the Safer CPP static analysis.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Algorithm.h: Copied from Source/WebCore/dom/MouseEventTypes.h.
(WTF::anyOf):
(WTF::allOf):
(WTF::noneOf):
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/SortedArrayMap.h:
* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WebCore/Modules/airplay/WebMediaSessionManager.mm:
(WebCore::WebMediaSessionManager::alwaysOnLoggingAllowed const):
* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp:
(WebCore::MediaKeyStatusMap::has):
* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
(WebCore::MediaKeys::hasOpenSessions const):
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::isValidValue):
* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::closeDatabasesForOrigins):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::takeNextRunnableTransaction):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::shouldAbortDueToUnhandledRequestError const):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::haveMicrophoneDevice):
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::setAssociatedRemoteStreams):
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::validateSendEncodings):
(WebCore::RTCPeerConnection::computeConnectionState):
(WebCore::RTCPeerConnection::computeIceConnectionStateFromIceTransports):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(WebCore::RTCRtpSFrameTransformer::hasKey const):
* Source/WebCore/Modules/mediastream/UserMediaController.cpp:
(WebCore::UserMediaController::checkDocumentForVoiceActivity):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::isMediaStreamCorrectlyStarted):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::createTransceiverBackends):
* Source/WebCore/Modules/webcodecs/OpusEncoderConfig.h:
(WebCore::OpusEncoderConfig::isValid):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::handleRemovedInputSources):
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::nextSibling const):
(WebCore::AccessibilityRenderObject::inheritsPresentationalRole const):
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplify):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::operationOnValuesOfSameUnit):
(WebCore::CSSNumericValue::multiplyInternal):
(WebCore::CSSNumericValue::equals):
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::is2D const):
* Source/WebCore/css/values/color/CSSColorLayers.cpp:
(WebCore::CSS::containsCurrentColor):
(WebCore::CSS::containsColorSchemeDependentColor):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::configureSharedLogger):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::button const):
* Source/WebCore/dom/MouseEventTypes.h:
(WebCore::buttonFromShort):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::getCoalescedEvents const):
(WebCore::PointerEvent::getPredictedEvents const):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::isElementWithPendingSVGResources const):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::shouldExcludeElement):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::boundingNeighbors):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::shouldDisableSleep const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadComplete):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createInternal):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::shouldDisableCorsForRequestTo const):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::updateHaveAnyCapturingElement):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup const):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::appliedCommandIsWritingToolsCommand):
(WebCore::WritingToolsController::replaceContentsOfRangeInSession):
* Source/WebCore/platform/RectCorners.h:
(WebCore::RectCorners::anyOf const):
(WebCore::RectCorners::allOf const):
(WebCore::RectCorners::noneOf const):
* Source/WebCore/platform/RectEdges.h:
(WebCore::RectEdges::anyOf const):
(WebCore::RectEdges::allOf const):
(WebCore::RectEdges::noneOf const):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::activeAudioSessionRequired const):
* Source/WebCore/platform/graphics/ContentTypeUtilities.cpp:
(WebCore::contentTypeMeetsContainerAndCodecTypeRequirements):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::hasAudio const):
(WebCore::MediaSourcePrivate::hasVideo const):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMPrivateFairPlayStreaming::supportsConfiguration const):
(WebCore::CDMPrivateFairPlayStreaming::supportsConfigurationWithRestrictions const):
(WebCore::CDMPrivateFairPlayStreaming::supportsInitData const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::sessionForKeyIDs const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::hasSelectedVideo const):
(WebCore::MediaSourcePrivateAVFObjC::waitingForKey const):
(WebCore::MediaSourcePrivateAVFObjC::needsVideoLayer const):
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::hasFilterThatAffectsOpacity const):
(WebCore::FilterOperations::hasFilterThatMovesPixels const):
(WebCore::FilterOperations::hasFilterThatShouldBeRestrictedBySecurityOrigin const):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
(WebCore::FilterOperations::hasFilterOfType const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::needsBackingStore const):
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
(WebCore::TransformOperations::hasTransformOfType const):
* Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp:
(WebCore::MediaEngineConfigurationFactory::hasDecodingConfigurationFactory):
(WebCore::MediaEngineConfigurationFactory::hasEncodingConfigurationFactory):
* Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp:
(WebCore::MediaStreamPrivate::computeActiveState):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::canBePowerEfficient):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::isZoomSupported):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::devicesChanged):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::hasDevice):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::isZoomSupported):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::storageAccessQuirkForDomainPair):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::deleteCookies):
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::computeHash):
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/backgrounds/StyleFillLayers.h:
(WebCore::Style::FillLayers&lt;Layer&gt;::imagesAreLoaded const):
(WebCore::Style::FillLayers&lt;Layer&gt;::hasImageInAnyLayer const):
(WebCore::Style::FillLayers&lt;Layer&gt;::hasImageWithAttachment const):
(WebCore::Style::FillLayers&lt;Layer&gt;::hasHDRContent const):
(WebCore::Style::FillLayers&lt;Layer&gt;::hasEntirelyFixedBackground const):
(WebCore::Style::FillLayers&lt;Layer&gt;::hasAnyBackgroundClipText const):
* Source/WebCore/style/values/color/StyleColorLayers.cpp:
(WebCore::Style::toStyleColor):
(WebCore::Style::containsCurrentColor):
* Source/WebCore/style/values/images/StyleGradient.cpp:
(WebCore::Style::stopsAreCacheable):
(WebCore::Style::isOpaque):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDM::supportsConfiguration const):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::whenRegisterJobsAreFinished):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::recordIsCompleted):
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::setScreenProperties):
* Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp:
(WebKit::NetworkOriginAccessPatterns::anyPatternMatches const):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::hasLocalStorage):
(WebKit::NetworkProcess::shouldDisableCORSForRequestTo const):
* Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp:
(WebKit::NetworkResourceLoadMap::take):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::hasDataInMemory const):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::isEmptyOriginDirectory):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::isEmpty):
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp:
(WebKit::SessionStorageManager::isActive const):
(WebKit::SessionStorageManager::hasDataInMemory const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::isSerializable):
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::updateApplicationBackgroundState):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::setShouldListenToVoiceActivity):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera const):
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrophone const):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::isServiceWorkerPageID const):
(WebKit::WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion):
(WebKit::WebProcessPool::hasServiceWorkerForegroundActivityForTesting const):
(WebKit::WebProcessPool::hasServiceWorkerBackgroundActivityForTesting const):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldDropNearSuspendedAssertionAfterDelay const):
(WebKit::WebProcessProxy::updateAudibleMediaAssertions):
(WebKit::WebProcessProxy::updateMediaStreamingActivity):
(WebKit::WebProcessProxy::updateRemoteWorkerProcessAssertion):
(WebKit::WebProcessProxy::isAlwaysOnLoggingAllowed const):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::isOptInCookiePartitioningEnabled const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::hasServiceWorkerBackgroundActivityForTesting const):
(WebKit::WebsiteDataStore::isOptInCookiePartitioningEnabled const):
(WebKit::WebsiteDataStore::hasActivePages):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):
* Source/WebKit/WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm:
(WebKit::PDFAnnotationTypeHelpers::annotationCheckerInternal):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::toContextMenuItemTag):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::completeTextManipulation):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::checkDocumentsCaptureStateConsistency):
(WebKit::WebProcess::areAllPagesThrottleable const):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::updatePageScreenProperties):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp:
(TestWebKitAPI::TEST(WTF_HashMap, KeysValuesRangesAllAnyNoneOf)):
* Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp:
(TestWebKitAPI::TEST(WTF_HashSet, RangesAllAnyNoneOf)):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST(WTF_WeakPtr, WeakHashMapIterators)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae96037d7eaa0b37cad76a74613b2001d8d39ab2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120436 "27 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72511 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18fbd60c-c9c3-4f11-99af-293037ecd653) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91465 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60755 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4563fb08-f533-4368-8911-4c555c64e6c0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72016 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e6378eb-7809-4bcf-ae84-4d688b6744fe) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/119793 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31640 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70426 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112562 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129692 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/118952 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100084 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99926 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45372 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44003 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52924 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/147651 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46687 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37929 "Found 1 new JSC binary failure: testapi, Found 18670 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->