### PR TITLE
REGRESSION (287736@main?): [ iOS ] fast/mediastream/microphone-interruption-and-audio-session.html is constantly failing.

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
+++ b/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
@@ -24,9 +24,13 @@
         });
     }
 
+    const streams = [];
     var context = new AudioContext();
     promise_test(async (test) => {
+        test.add_cleanup(() => streams.forEach(stream => stream.getTracks().forEach(track => track.stop())));
+
         const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+        streams.push(stream);
         if (!window.internals)
             return;
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test1");
@@ -38,6 +42,7 @@
         await onMutePromise1;
         // We clone the capture stream to trigger an audio session category recomputation.
         let clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "AmbientSound", "test2");
 
         const onUnmutePromise1 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise1");
@@ -45,6 +50,7 @@
             internals.setPageMuted("");
         await onUnmutePromise1;
         clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test3");
 
         // PlayAndRecord should stick even with capture interruption.
@@ -53,6 +59,7 @@
             internals.beginAudioSessionInterruption();
         await onMutePromise2;
         clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test4");
 
         const onUnmutePromise2 = wait1sForUnmute(stream.getAudioTracks()[0], "onUnmutePromise2");
@@ -60,6 +67,7 @@
             internals.endAudioSessionInterruption();
         await onUnmutePromise2;
         clone = stream.clone();
+        streams.push(clone);
         assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test5");
     }, "AudioSession category should staty to PlayAndRecord when interrupted, not when muted by user");
     </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7749,8 +7749,6 @@ webkit.org/b/288694 [ Debug arm64 ] fast/multicol/body-stuck-with-dirty-bit-with
 
 webkit.org/b/287569 http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe.html [ Timeout ]
 
-webkit.org/b/287033 fast/mediastream/microphone-interruption-and-audio-session.html [ Failure ]
-
 webkit.org/b/288987 fast/viewport/ios/device-width-viewport-after-changing-view-scale.html [ Pass Failure ]
 
 webkit.org/b/289002 [ Release ] imported/blink/fast/text/international-iteration-simple-text.html [ Pass Failure ]

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -77,12 +77,12 @@ Ref<DOMAudioSession> DOMAudioSession::create(ScriptExecutionContext* context)
 DOMAudioSession::DOMAudioSession(ScriptExecutionContext* context)
     : ActiveDOMObject(context)
 {
-    AudioSession::singleton().addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 DOMAudioSession::~DOMAudioSession()
 {
-    AudioSession::singleton().removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
 }
 
 ExceptionOr<void> DOMAudioSession::setType(Type type)

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -152,14 +152,20 @@ bool AudioSession::tryToSetActive(bool active)
     return true;
 }
 
+static WeakHashSet<AudioSessionInterruptionObserver>& audioSessionInterruptionObserversSingleton()
+{
+    static NeverDestroyed<WeakHashSet<AudioSessionInterruptionObserver>> audioSessionInterruptionObservers;
+    return audioSessionInterruptionObservers.get();
+}
+
 void AudioSession::addInterruptionObserver(AudioSessionInterruptionObserver& observer)
 {
-    m_interruptionObservers.add(observer);
+    audioSessionInterruptionObserversSingleton().add(observer);
 }
 
 void AudioSession::removeInterruptionObserver(AudioSessionInterruptionObserver& observer)
 {
-    m_interruptionObservers.remove(observer);
+    audioSessionInterruptionObserversSingleton().remove(observer);
 }
 
 void AudioSession::beginInterruption()
@@ -170,7 +176,7 @@ void AudioSession::beginInterruption()
         return;
     }
     m_isInterrupted = true;
-    for (auto& observer : m_interruptionObservers)
+    for (auto& observer : audioSessionInterruptionObserversSingleton())
         observer.beginAudioSessionInterruption();
 }
 
@@ -183,13 +189,13 @@ void AudioSession::endInterruption(MayResume mayResume)
     }
     m_isInterrupted = false;
 
-    for (auto& observer : m_interruptionObservers)
+    for (auto& observer : audioSessionInterruptionObserversSingleton())
         observer.endAudioSessionInterruption(mayResume);
 }
 
 void AudioSession::activeStateChanged()
 {
-    for (auto& observer : m_interruptionObservers)
+    for (auto& observer : audioSessionInterruptionObserversSingleton())
         observer.audioSessionActiveStateChanged();
 }
 

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -160,8 +160,8 @@ public:
     virtual void endInterruptionForTesting() { endInterruption(MayResume::Yes); }
     virtual void clearInterruptionFlagForTesting() { }
 
-    virtual void addInterruptionObserver(AudioSessionInterruptionObserver&);
-    virtual void removeInterruptionObserver(AudioSessionInterruptionObserver&);
+    static void addInterruptionObserver(AudioSessionInterruptionObserver&);
+    static void removeInterruptionObserver(AudioSessionInterruptionObserver&);
 
     virtual bool isActive() const { return m_active; }
 
@@ -195,8 +195,6 @@ protected:
     uint64_t logIdentifier() const { return 0; }
 
     mutable RefPtr<Logger> m_logger;
-
-    WeakHashSet<AudioSessionInterruptionObserver> m_interruptionObservers;
 
     WeakPtr<AudioSessionRoutingArbitrationClient> m_routingArbitrationClient;
     AudioSession::CategoryType m_categoryOverride { AudioSession::CategoryType::None };

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -55,7 +55,7 @@ RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::opt
 MediaSessionManageriOS::MediaSessionManageriOS()
     : MediaSessionManagerCocoa()
 {
-    AudioSession::singleton().addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 MediaSessionManageriOS::~MediaSessionManageriOS()
@@ -63,7 +63,7 @@ MediaSessionManageriOS::~MediaSessionManageriOS()
     if (m_isMonitoringWirelessRoutes)
         MediaSessionHelper::sharedHelper().stopMonitoringWirelessRoutes();
     MediaSessionHelper::sharedHelper().removeClient(*this);
-    AudioSession::singleton().removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
 }
 
 #if !PLATFORM(MACCATALYST)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -109,12 +109,12 @@ CaptureSourceOrError CoreAudioCaptureSource::createForTesting(String&& deviceID,
 
 CoreAudioCaptureSourceFactory::CoreAudioCaptureSourceFactory()
 {
-    AudioSession::singleton().addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 CoreAudioCaptureSourceFactory::~CoreAudioCaptureSourceFactory()
 {
-    AudioSession::singleton().removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
 }
 
 void CoreAudioCaptureSourceFactory::beginInterruption()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -56,13 +56,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSessionProxyManager);
 RemoteAudioSessionProxyManager::RemoteAudioSessionProxyManager(GPUProcess& gpuProcess)
     : m_gpuProcess(gpuProcess)
 {
-    AudioSession::singleton().addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
     AudioSession::singleton().addConfigurationChangeObserver(*this);
 }
 
 RemoteAudioSessionProxyManager::~RemoteAudioSessionProxyManager()
 {
-    AudioSession::singleton().removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
     AudioSession::singleton().removeConfigurationChangeObserver(*this);
 }
 
@@ -292,18 +292,18 @@ void RemoteAudioSessionProxyManager::beginInterruptionRemote()
 {
     Ref session = this->session();
     // Temporarily remove as an observer to avoid a spurious IPC back to the web process.
-    session->removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
     session->beginInterruption();
-    session->addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 void RemoteAudioSessionProxyManager::endInterruptionRemote(AudioSession::MayResume mayResume)
 {
     Ref session = this->session();
     // Temporarily remove as an observer to avoid a spurious IPC back to the web process.
-    session->removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
     session->endInterruption(mayResume);
-    session->addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 void RemoteAudioSessionProxyManager::beginAudioSessionInterruption()

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -190,7 +190,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
     , m_localUnit(WebCore::AudioMediaStreamTrackRendererInternalUnit::create(deviceID, *this))
     , m_canUseCaptureUnit(deviceID == WebCore::AudioMediaStreamTrackRenderer::defaultDeviceID())
 {
-    WebCore::AudioSession::singleton().addInterruptionObserver(*this);
+    WebCore::AudioSession::addInterruptionObserver(*this);
     protectedLocalUnit()->retrieveFormatDescription([weakThis = WeakPtr { *this }, this, callback = WTFMove(callback)](auto&& description) mutable {
         if (!weakThis || !description) {
             RELEASE_LOG_IF(!description, WebRTC, "RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit unable to get format description");
@@ -206,7 +206,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
 
 RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit()
 {
-    WebCore::AudioSession::singleton().removeInterruptionObserver(*this);
+    WebCore::AudioSession::removeInterruptionObserver(*this);
     stop();
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -49,7 +49,7 @@ Ref<RemoteAudioSession> RemoteAudioSession::create()
 
 RemoteAudioSession::RemoteAudioSession()
 {
-    addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 RemoteAudioSession::~RemoteAudioSession()
@@ -57,7 +57,7 @@ RemoteAudioSession::~RemoteAudioSession()
     if (auto gpuProcessConnection = m_gpuProcessConnection.get())
         gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteAudioSession::messageReceiverName());
 
-    removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
 }
 
 void RemoteAudioSession::gpuProcessConnectionDidClose(GPUProcessConnection& connection)
@@ -188,16 +188,16 @@ void RemoteAudioSession::configurationChanged(RemoteAudioSessionConfiguration&& 
 
 void RemoteAudioSession::beginInterruptionRemote()
 {
-    removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
     beginInterruption();
-    addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 void RemoteAudioSession::endInterruptionRemote(MayResume mayResume)
 {
-    removeInterruptionObserver(*this);
+    AudioSession::removeInterruptionObserver(*this);
     endInterruption(mayResume);
-    addInterruptionObserver(*this);
+    AudioSession::addInterruptionObserver(*this);
 }
 
 void RemoteAudioSession::beginAudioSessionInterruption()


### PR DESCRIPTION
#### 755ea5bdabcb1ab6b7e6135f7de2370f9cbe4909
<pre>
REGRESSION (287736@main?): [ iOS ] fast/mediastream/microphone-interruption-and-audio-session.html is constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287033">https://bugs.webkit.org/show_bug.cgi?id=287033</a>
<a href="https://rdar.apple.com/144177133">rdar://144177133</a>

Reviewed by Jean-Yves Avenard.

The test is flaky as we sometimes recreate the GPUProcess and the CoreAudioCaptureSourceFactory will register itself as an interruption observer to the dummy AudioSession.
Instead, we are now having a singleton set of interruption observers, used by AudioSession objects when being interrupted/ending interruptions.
Only the shared AudioSession is expected to being interrupted/ending interruptions, so there should be no issue with several AudioSessions doing interruptions in parallel.
We also update the test to make sure capture tracks are stopped explicitly.

* LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::DOMAudioSession):
(WebCore::DOMAudioSession::~DOMAudioSession):
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::audioSessionInterruptionObserversSingleton):
(WebCore::AudioSession::addInterruptionObserver):
(WebCore::AudioSession::removeInterruptionObserver):
(WebCore::AudioSession::beginInterruption):
(WebCore::AudioSession::endInterruption):
(WebCore::AudioSession::activeStateChanged):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::MediaSessionManageriOS):
(WebCore::MediaSessionManageriOS::~MediaSessionManageriOS):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSourceFactory::CoreAudioCaptureSourceFactory):
(WebCore::CoreAudioCaptureSourceFactory::~CoreAudioCaptureSourceFactory):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::RemoteAudioSessionProxyManager):
(WebKit::RemoteAudioSessionProxyManager::~RemoteAudioSessionProxyManager):
(WebKit::RemoteAudioSessionProxyManager::beginInterruptionRemote):
(WebKit::RemoteAudioSessionProxyManager::endInterruptionRemote):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::RemoteAudioSession):
(WebKit::RemoteAudioSession::~RemoteAudioSession):
(WebKit::RemoteAudioSession::beginInterruptionRemote):
(WebKit::RemoteAudioSession::endInterruptionRemote):

Canonical link: <a href="https://commits.webkit.org/300015@main">https://commits.webkit.org/300015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/469ad34e69bf113a213c0103d55c325c07f4ed2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72563 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a3f73229-d2c6-4244-864a-08e60657adfb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91510 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60790 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a9580c9-d2e9-41a6-bdc1-fe204cc5188f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72061 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c4bde97-b2cb-4d43-b7e2-03f5c5064202) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26115 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70481 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129749 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47409 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35990 "Found 1 new test failure: http/tests/websocket/tests/hybi/alert-in-event-handler.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100129 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25465 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45418 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44057 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47271 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52976 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46739 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->