### PR TITLE
Rename CascadeLevel to DeclarationOrigin

### DIFF
--- a/Source/WebCore/style/DeclarationOrigin.h
+++ b/Source/WebCore/style/DeclarationOrigin.h
@@ -30,25 +30,11 @@
 namespace WebCore {
 namespace Style {
 
-enum class CascadeLevel : uint8_t {
-    UserAgent   = 1 << 0,
-    User        = 1 << 1,
-    Author      = 1 << 2
+enum class DeclarationOrigin : uint8_t {
+    UserAgent,
+    User,
+    Author
 };
-
-inline CascadeLevel& operator--(CascadeLevel& level)
-{
-    switch (level) {
-    case CascadeLevel::Author:
-        return level = CascadeLevel::User;
-    case CascadeLevel::User:
-        return level = CascadeLevel::UserAgent;
-    case CascadeLevel::UserAgent:
-        ASSERT_NOT_REACHED();
-        return level;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
 
 }
 }

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -37,7 +37,7 @@ namespace WebCore::Style {
 class ScopeRuleSets;
 struct MatchRequest;
 struct SelectorMatchingState;
-enum class CascadeLevel : uint8_t;
+enum class DeclarationOrigin : uint8_t;
 
 struct MatchedRule {
     const RuleData* ruleData { nullptr };
@@ -84,15 +84,15 @@ private:
 
     void addElementInlineStyleProperties(bool includeSMILProperties);
 
-    void matchUserAgentPartRules(CascadeLevel);
-    void matchHostPseudoClassRules(CascadeLevel);
-    void matchSlottedPseudoElementRules(CascadeLevel);
-    void matchPartPseudoElementRules(CascadeLevel);
-    void matchPartPseudoElementRulesForScope(const Element& partMatchingElement, CascadeLevel);
+    void matchUserAgentPartRules(DeclarationOrigin);
+    void matchHostPseudoClassRules(DeclarationOrigin);
+    void matchSlottedPseudoElementRules(DeclarationOrigin);
+    void matchPartPseudoElementRules(DeclarationOrigin);
+    void matchPartPseudoElementRulesForScope(const Element& partMatchingElement, DeclarationOrigin);
 
     void collectMatchingUserAgentPartRules(const MatchRequest&);
 
-    void collectMatchingRules(CascadeLevel);
+    void collectMatchingRules(DeclarationOrigin);
     void collectMatchingRules(const MatchRequest&);
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
     bool isFirstMatchModeAndHasMatchedAnyRules() const;
@@ -107,7 +107,6 @@ private:
 
     void sortMatchedRules();
 
-    enum class DeclarationOrigin { UserAgent, User, Author };
     Vector<MatchedProperties>& declarationsForOrigin(DeclarationOrigin);
     void sortAndTransferMatchedRules(DeclarationOrigin);
     void transferMatchedRules(DeclarationOrigin, std::optional<ScopeOrdinal> forScope = { });

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -43,10 +43,10 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PropertyCascade);
 
-PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, IncludedProperties&& includedProperties, const HashSet<AnimatableCSSProperty>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
+PropertyCascade::PropertyCascade(const MatchResult& matchResult, DeclarationOrigin maximumDeclarationOrigin, IncludedProperties&& includedProperties, const HashSet<AnimatableCSSProperty>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
     : m_matchResult(matchResult)
     , m_includedProperties(WTFMove(includedProperties))
-    , m_maximumCascadeLevel(maximumCascadeLevel)
+    , m_maximumDeclarationOrigin(maximumDeclarationOrigin)
     , m_animationLayer(animatedProperties ? std::optional { AnimationLayer { *animatedProperties } } : std::nullopt)
 {
     ASSERT(!m_includedProperties.isEmpty());
@@ -57,10 +57,10 @@ PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel ma
     buildCascade();
 }
 
-PropertyCascade::PropertyCascade(const PropertyCascade& parent, CascadeLevel maximumCascadeLevel, std::optional<ScopeOrdinal> rollbackScope, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback)
+PropertyCascade::PropertyCascade(const PropertyCascade& parent, DeclarationOrigin maximumDeclarationOrigin, std::optional<ScopeOrdinal> rollbackScope, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback)
     : m_matchResult(parent.m_matchResult)
     , m_includedProperties(normalProperties()) // Include all properties to the rollback cascade, lower prority layers may not get included otherwise.
-    , m_maximumCascadeLevel(maximumCascadeLevel)
+    , m_maximumDeclarationOrigin(maximumDeclarationOrigin)
     , m_rollbackScope(rollbackScope)
     , m_maximumCascadeLayerPriorityForRollback(maximumCascadeLayerPriorityForRollback)
     , m_animationLayer(parent.m_animationLayer)
@@ -84,53 +84,53 @@ PropertyCascade::AnimationLayer::AnimationLayer(const HashSet<AnimatableCSSPrope
 
 void PropertyCascade::buildCascade()
 {
-    OptionSet<CascadeLevel> cascadeLevelsWithImportant;
+    std::array<bool, 3> declarationOriginsWithImportant = { };
 
-    for (auto cascadeLevel : { CascadeLevel::UserAgent, CascadeLevel::User, CascadeLevel::Author }) {
-        if (cascadeLevel > m_maximumCascadeLevel)
+    for (auto declarationOrigin : { DeclarationOrigin::UserAgent, DeclarationOrigin::User, DeclarationOrigin::Author }) {
+        if (declarationOrigin > m_maximumDeclarationOrigin)
             break;
-        bool hasImportant = addNormalMatches(cascadeLevel);
+        bool hasImportant = addNormalMatches(declarationOrigin);
         if (hasImportant)
-            cascadeLevelsWithImportant.add(cascadeLevel);
+            declarationOriginsWithImportant[enumToUnderlyingType(declarationOrigin)] = true;
     }
 
     if (m_positionTryFallbackProperties)
         addPositionTryFallbackProperties();
 
-    for (auto cascadeLevel : { CascadeLevel::Author, CascadeLevel::User, CascadeLevel::UserAgent }) {
-        if (!cascadeLevelsWithImportant.contains(cascadeLevel))
+    for (auto declarationOrigin : { DeclarationOrigin::Author, DeclarationOrigin::User, DeclarationOrigin::UserAgent }) {
+        if (!declarationOriginsWithImportant[enumToUnderlyingType(declarationOrigin)])
             continue;
-        addImportantMatches(cascadeLevel);
+        addImportantMatches(declarationOrigin);
     }
 
     sortLogicalGroupPropertyIDs();
 }
 
-void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)
+void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, DeclarationOrigin declarationOrigin)
 {
     ASSERT(matchedProperties.linkMatchType <= SelectorChecker::MatchAll);
     property.id = id;
-    property.cascadeLevel = cascadeLevel;
+    property.declarationOrigin = declarationOrigin;
     property.styleScopeOrdinal = matchedProperties.styleScopeOrdinal;
     property.cascadeLayerPriority = matchedProperties.cascadeLayerPriority;
     property.fromStyleAttribute = matchedProperties.fromStyleAttribute;
 
     if (matchedProperties.linkMatchType == SelectorChecker::MatchAll) {
-        property.cascadeLevels[SelectorChecker::MatchDefault] = cascadeLevel;
+        property.declarationOrigins[SelectorChecker::MatchDefault] = declarationOrigin;
         property.cssValue[SelectorChecker::MatchDefault] = &cssValue;
 
-        property.cascadeLevels[SelectorChecker::MatchLink] = cascadeLevel;
+        property.declarationOrigins[SelectorChecker::MatchLink] = declarationOrigin;
         property.cssValue[SelectorChecker::MatchLink] = &cssValue;
 
-        property.cascadeLevels[SelectorChecker::MatchVisited] = cascadeLevel;
+        property.declarationOrigins[SelectorChecker::MatchVisited] = declarationOrigin;
         property.cssValue[SelectorChecker::MatchVisited] = &cssValue;
     } else {
-        property.cascadeLevels[matchedProperties.linkMatchType] = cascadeLevel;
+        property.declarationOrigins[matchedProperties.linkMatchType] = declarationOrigin;
         property.cssValue[matchedProperties.linkMatchType] = &cssValue;
     }
 }
 
-void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)
+void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, DeclarationOrigin declarationOrigin)
 {
     ASSERT(!CSSProperty::isInLogicalPropertyGroup(id));
     ASSERT(id < firstLogicalGroupProperty);
@@ -142,21 +142,21 @@ void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedPro
         auto result = m_customProperties.ensure(customValue.name(), [&]() {
             Property property;
             property.cssValue = { };
-            setPropertyInternal(property, id, cssValue, matchedProperties, cascadeLevel);
+            setPropertyInternal(property, id, cssValue, matchedProperties, declarationOrigin);
             return property;
         });
         if (!result.isNewEntry)
-            setPropertyInternal(result.iterator->value, id, cssValue, matchedProperties, cascadeLevel);
+            setPropertyInternal(result.iterator->value, id, cssValue, matchedProperties, declarationOrigin);
         return;
     }
 
     auto& property = m_properties[id];
     if (!m_propertyIsPresent.testAndSet(id))
         property.cssValue = { };
-    setPropertyInternal(property, id, cssValue, matchedProperties, cascadeLevel);
+    setPropertyInternal(property, id, cssValue, matchedProperties, declarationOrigin);
 }
 
-void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)
+void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, DeclarationOrigin declarationOrigin)
 {
     ASSERT(id >= firstLogicalGroupProperty);
     ASSERT(id <= lastLogicalGroupProperty);
@@ -168,7 +168,7 @@ void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssVal
         m_highestSeenLogicalGroupProperty = std::max(m_highestSeenLogicalGroupProperty, id);
     }
     setLogicalGroupPropertyIndex(id, ++m_lastIndexForLogicalGroup);
-    setPropertyInternal(property, id, cssValue, matchedProperties, cascadeLevel);
+    setPropertyInternal(property, id, cssValue, matchedProperties, declarationOrigin);
 }
 
 bool PropertyCascade::hasProperty(CSSPropertyID propertyID, const CSSValue& value)
@@ -212,12 +212,12 @@ const PropertyCascade::Property* PropertyCascade::lastPropertyResolvingLogicalPr
     return nullptr;
 }
 
-bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel, IsImportant important)
+bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, DeclarationOrigin declarationOrigin, IsImportant important)
 {
     auto includePropertiesForRollback = [&] {
         if (m_rollbackScope && matchedProperties.styleScopeOrdinal > *m_rollbackScope)
             return true;
-        if (cascadeLevel < m_maximumCascadeLevel)
+        if (declarationOrigin < m_maximumDeclarationOrigin)
             return true;
         if (matchedProperties.fromStyleAttribute == FromStyleAttribute::Yes)
             return false;
@@ -288,9 +288,9 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             continue;
 
         if (propertyID < firstLogicalGroupProperty)
-            set(propertyID, *current.value(), matchedProperties, cascadeLevel);
+            set(propertyID, *current.value(), matchedProperties, declarationOrigin);
         else
-            setLogicalGroupProperty(propertyID, *current.value(), matchedProperties, cascadeLevel);
+            setLogicalGroupProperty(propertyID, *current.value(), matchedProperties, declarationOrigin);
     }
 
     return hasImportantProperties;
@@ -344,30 +344,30 @@ void PropertyCascade::addPositionTryFallbackProperties()
     // a new cascade origin that lies between the Author Origin and the Animation Origin"
     // https://drafts.csswg.org/css-anchor-position-1/#fallback-rule
     // FIXME: Use own cascade origin. This matters for revert-layer.
-    if (m_maximumCascadeLevel < CascadeLevel::Author)
+    if (m_maximumDeclarationOrigin < DeclarationOrigin::Author)
         return;
 
     // "It is invalid to use !important on the properties in the <declaration-list>."
     // FIXME: "Doing so causes the property it is used on to become invalid."
-    addMatch(*m_positionTryFallbackProperties, CascadeLevel::Author, IsImportant::No);
+    addMatch(*m_positionTryFallbackProperties, DeclarationOrigin::Author, IsImportant::No);
 }
 
-static auto& declarationsForCascadeLevel(const MatchResult& matchResult, CascadeLevel cascadeLevel)
+static auto& declarationsForDeclarationOrigin(const MatchResult& matchResult, DeclarationOrigin declarationOrigin)
 {
-    switch (cascadeLevel) {
-    case CascadeLevel::UserAgent: return matchResult.userAgentDeclarations;
-    case CascadeLevel::User: return matchResult.userDeclarations;
-    case CascadeLevel::Author: return matchResult.authorDeclarations;
+    switch (declarationOrigin) {
+    case DeclarationOrigin::UserAgent: return matchResult.userAgentDeclarations;
+    case DeclarationOrigin::User: return matchResult.userDeclarations;
+    case DeclarationOrigin::Author: return matchResult.authorDeclarations;
     }
     ASSERT_NOT_REACHED();
     return matchResult.authorDeclarations;
 }
 
-bool PropertyCascade::addNormalMatches(CascadeLevel cascadeLevel)
+bool PropertyCascade::addNormalMatches(DeclarationOrigin declarationOrigin)
 {
     bool hasImportant = false;
-    for (auto& matchedDeclarations : declarationsForCascadeLevel(m_matchResult, cascadeLevel))
-        hasImportant |= addMatch(matchedDeclarations, cascadeLevel, IsImportant::No);
+    for (auto& matchedDeclarations : declarationsForDeclarationOrigin(m_matchResult, declarationOrigin))
+        hasImportant |= addMatch(matchedDeclarations, declarationOrigin, IsImportant::No);
 
     return hasImportant;
 }
@@ -381,7 +381,7 @@ static bool hasImportantProperties(const StyleProperties& properties)
     return false;
 }
 
-void PropertyCascade::addImportantMatches(CascadeLevel cascadeLevel)
+void PropertyCascade::addImportantMatches(DeclarationOrigin declarationOrigin)
 {
     struct ImportantMatch {
         unsigned index;
@@ -392,7 +392,7 @@ void PropertyCascade::addImportantMatches(CascadeLevel cascadeLevel)
     Vector<ImportantMatch> importantMatches;
     bool hasMatchesFromOtherScopesOrLayers = false;
 
-    auto& matchedDeclarations = declarationsForCascadeLevel(m_matchResult, cascadeLevel);
+    auto& matchedDeclarations = declarationsForDeclarationOrigin(m_matchResult, declarationOrigin);
 
     for (unsigned i = 0; i < matchedDeclarations.size(); ++i) {
         const MatchedProperties& matchedProperties = matchedDeclarations[i];
@@ -423,7 +423,7 @@ void PropertyCascade::addImportantMatches(CascadeLevel cascadeLevel)
     }
 
     for (auto& match : importantMatches)
-        addMatch(matchedDeclarations[match.index], cascadeLevel, IsImportant::Yes);
+        addMatch(matchedDeclarations[match.index], declarationOrigin, IsImportant::Yes);
 }
 
 void PropertyCascade::sortLogicalGroupPropertyIDs()

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CascadeLevel.h"
+#include "DeclarationOrigin.h"
 #include "MatchResult.h"
 #include "WebAnimationTypes.h"
 #include <wtf/BitSet.h>
@@ -65,19 +65,19 @@ public:
 
     static IncludedProperties normalProperties() { return { normalPropertyTypes() }; }
 
-    PropertyCascade(const MatchResult&, CascadeLevel, IncludedProperties&&, const HashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
-    PropertyCascade(const PropertyCascade&, CascadeLevel, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
+    PropertyCascade(const MatchResult&, DeclarationOrigin, IncludedProperties&&, const HashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
+    PropertyCascade(const PropertyCascade&, DeclarationOrigin, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
 
     ~PropertyCascade();
 
     struct Property {
         CSSPropertyID id;
-        CascadeLevel cascadeLevel;
+        DeclarationOrigin declarationOrigin;
         ScopeOrdinal styleScopeOrdinal;
         CascadeLayerPriority cascadeLayerPriority;
         FromStyleAttribute fromStyleAttribute;
         std::array<CSSValue*, 3> cssValue; // Values for link match states MatchDefault, MatchLink and MatchVisited
-        std::array<CascadeLevel, 3> cascadeLevels;
+        std::array<DeclarationOrigin, 3> declarationOrigins;
     };
 
     bool isEmpty() const { return m_propertyIsPresent.isEmpty() && !m_seenLogicalGroupPropertyCount; }
@@ -104,15 +104,15 @@ public:
 
 private:
     void buildCascade();
-    bool addNormalMatches(CascadeLevel);
-    void addImportantMatches(CascadeLevel);
-    bool addMatch(const MatchedProperties&, CascadeLevel, IsImportant);
+    bool addNormalMatches(DeclarationOrigin);
+    void addImportantMatches(DeclarationOrigin);
+    bool addMatch(const MatchedProperties&, DeclarationOrigin, IsImportant);
     bool shouldApplyAfterAnimation(const StyleProperties::PropertyReference&);
     void addPositionTryFallbackProperties();
 
-    void set(CSSPropertyID, CSSValue&, const MatchedProperties&, CascadeLevel);
-    void setLogicalGroupProperty(CSSPropertyID, CSSValue&, const MatchedProperties&, CascadeLevel);
-    static void setPropertyInternal(Property&, CSSPropertyID, CSSValue&, const MatchedProperties&, CascadeLevel);
+    void set(CSSPropertyID, CSSValue&, const MatchedProperties&, DeclarationOrigin);
+    void setLogicalGroupProperty(CSSPropertyID, CSSValue&, const MatchedProperties&, DeclarationOrigin);
+    static void setPropertyInternal(Property&, CSSPropertyID, CSSValue&, const MatchedProperties&, DeclarationOrigin);
 
     bool hasProperty(CSSPropertyID, const CSSValue&);
     bool mayOverrideExistingProperty(CSSPropertyID, const CSSValue&);
@@ -123,7 +123,7 @@ private:
 
     const MatchResult& m_matchResult;
     const IncludedProperties m_includedProperties;
-    const CascadeLevel m_maximumCascadeLevel;
+    const DeclarationOrigin m_maximumDeclarationOrigin;
     const std::optional<ScopeOrdinal> m_rollbackScope;
     const std::optional<CascadeLayerPriority> m_maximumCascadeLayerPriorityForRollback;
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -42,7 +42,7 @@ class CustomProperty;
 class Builder {
     WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, DeclarationOrigin, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();
@@ -72,7 +72,7 @@ private:
     void applyCascadeProperty(const PropertyCascade::Property&);
     bool applyRollbackCascadeProperty(const PropertyCascade&, CSSPropertyID, SelectorChecker::LinkMatchMask);
     bool applyRollbackCascadeCustomProperty(const PropertyCascade&, const AtomString&);
-    void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, CascadeLevel);
+    void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, DeclarationOrigin);
     void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&);
 
     Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
@@ -84,7 +84,7 @@ private:
     const PropertyCascade* ensureRollbackCascadeForRevertLayer();
 
     using RollbackCascadeKey = std::tuple<unsigned, unsigned, unsigned>;
-    RollbackCascadeKey makeRollbackCascadeKey(CascadeLevel, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
+    RollbackCascadeKey makeRollbackCascadeKey(DeclarationOrigin, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
 
     const PropertyCascade m_cascade;
     // Rollback cascades are build on demand to resolve 'revert' and 'revert-layer' keywords.

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -361,10 +361,10 @@ unsigned BuilderState::siblingIndex()
     return count;
 }
 
-void BuilderState::disableNativeAppearanceIfNeeded(CSSPropertyID propertyID, CascadeLevel cascadeLevel)
+void BuilderState::disableNativeAppearanceIfNeeded(CSSPropertyID propertyID, DeclarationOrigin declarationOrigin)
 {
     auto shouldDisable = [&] {
-        if (cascadeLevel != CascadeLevel::Author)
+        if (declarationOrigin != DeclarationOrigin::Author)
             return false;
         if (!CSSProperty::disablesNativeAppearance(propertyID))
             return false;

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "CSSToStyleMap.h"
-#include "CascadeLevel.h"
+#include "DeclarationOrigin.h"
 #include "PropertyCascade.h"
 #include "RuleSet.h"
 #include "SelectorChecker.h"
@@ -136,7 +136,7 @@ public:
 
     bool isAuthorOrigin() const
     {
-        return m_currentProperty && m_currentProperty->cascadeLevel == CascadeLevel::Author;
+        return m_currentProperty && m_currentProperty->declarationOrigin == DeclarationOrigin::Author;
     }
 
     CSSPropertyID cssPropertyID() const;
@@ -201,7 +201,7 @@ public:
     void setFontDescriptionVariantNumericOrdinal(FontVariantNumericOrdinal);
     void setFontDescriptionVariantNumericSlashedZero(FontVariantNumericSlashedZero);
 
-    void disableNativeAppearanceIfNeeded(CSSPropertyID, CascadeLevel);
+    void disableNativeAppearanceIfNeeded(CSSPropertyID, DeclarationOrigin);
 
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -426,7 +426,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
         collector.matchUserRules();
     }
     collector.addAuthorKeyframeRules(keyframe);
-    Builder builder(*state.style(), builderContext(state), collector.matchResult(), CascadeLevel::Author);
+    Builder builder(*state.style(), builderContext(state), collector.matchResult(), DeclarationOrigin::Author);
     builder.state().setIsBuildingKeyframeStyle();
     builder.applyAllProperties();
 
@@ -620,7 +620,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForPage(int pageIndex)
 
     auto& result = collector.matchResult();
 
-    Builder builder(*state.style(), builderContext(state), result, CascadeLevel::Author);
+    Builder builder(*state.style(), builderContext(state), result, DeclarationOrigin::Author);
     builder.applyAllProperties();
 
     // Now return the style.
@@ -733,7 +733,7 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
             return;
     }
 
-    Builder builder(style, builderContext(state), matchResult, CascadeLevel::Author, WTFMove(includedProperties));
+    Builder builder(style, builderContext(state), matchResult, DeclarationOrigin::Author, WTFMove(includedProperties));
 
     // Top priority properties may affect resolution of high priority ones.
     builder.applyTopPriorityProperties();

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -32,7 +32,7 @@
 #include "CSSPropertyParser.h"
 #include "CSSStyleSheet.h"
 #include "CSSViewTransitionRule.h"
-#include "CascadeLevel.h"
+#include "DeclarationOrigin.h"
 #include "DocumentInlines.h"
 #include "ExtensionStyleSheets.h"
 #include "FrameLoader.h"
@@ -97,16 +97,16 @@ RuleSet* ScopeRuleSets::userStyle() const
     return m_userStyle.get();
 }
 
-RuleSet* ScopeRuleSets::styleForCascadeLevel(CascadeLevel level)
+RuleSet* ScopeRuleSets::styleForDeclarationOrigin(DeclarationOrigin origin)
 {
-    switch (level) {
-    case CascadeLevel::Author:
+    switch (origin) {
+    case DeclarationOrigin::Author:
         return m_authorStyle.get();
 
-    case CascadeLevel::User:
+    case DeclarationOrigin::User:
         return userStyle();
 
-    case CascadeLevel::UserAgent:
+    case DeclarationOrigin::UserAgent:
         return userAgentMediaQueryStyle();
     }
 

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -42,7 +42,7 @@ class MediaQueryEvaluator;
 
 namespace Style {
 
-enum class CascadeLevel : uint8_t;
+enum class DeclarationOrigin : uint8_t;
 class InspectorCSSOMWrappers;
 class Resolver;
 
@@ -69,7 +69,7 @@ public:
     RuleSet* dynamicViewTransitionsStyle() const;
     RuleSet& authorStyle() const { return *m_authorStyle; }
     RuleSet* userStyle() const;
-    RuleSet* styleForCascadeLevel(CascadeLevel);
+    RuleSet* styleForDeclarationOrigin(DeclarationOrigin);
 
     const RuleFeatureSet& features() const;
     RuleSet* scopeBreakingHasPseudoClassInvalidationRuleSet() const { return m_scopeBreakingHasPseudoClassInvalidationRuleSet.get(); }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -930,7 +930,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
         *newStyle,
         WTFMove(builderContext),
         *resolvedStyle.matchResult,
-        CascadeLevel::Author,
+        DeclarationOrigin::Author,
         { properties }
     };
 
@@ -968,7 +968,7 @@ HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderSt
         animatedStyle,
         WTFMove(builderContext),
         matchResult,
-        CascadeLevel::Author,
+        DeclarationOrigin::Author,
         { isTransition ? PropertyCascade::PropertyType::AfterTransition : PropertyCascade::PropertyType::AfterAnimation },
         &animatedProperties
     };


### PR DESCRIPTION
#### f6a22c7d8e3ca8f785bedc64768553b5d9ecdf4b
<pre>
Rename CascadeLevel to DeclarationOrigin
<a href="https://bugs.webkit.org/show_bug.cgi?id=298716">https://bugs.webkit.org/show_bug.cgi?id=298716</a>
<a href="https://rdar.apple.com/160371187">rdar://160371187</a>

Reviewed by Sam Weinig.

Remove a duplicate enum and rename to better match spec text.
Also it does not need to be a OptionSet style enum.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/style/DeclarationOrigin.h: Renamed from Source/WebCore/style/CascadeLevel.h.
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
(WebCore::Style::ElementRuleCollector::matchAuthorRules):
(WebCore::Style::ElementRuleCollector::matchesAnyAuthorRules):
(WebCore::Style::ElementRuleCollector::matchUserAgentPartRules):
(WebCore::Style::ElementRuleCollector::matchHostPseudoClassRules):
(WebCore::Style::ElementRuleCollector::matchSlottedPseudoElementRules):
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRules):
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRulesForScope):
(WebCore::Style::ElementRuleCollector::matchUserRules):
(WebCore::Style::ElementRuleCollector::matchAllRules):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::buildCascade):
(WebCore::Style::PropertyCascade::setPropertyInternal):
(WebCore::Style::PropertyCascade::set):
(WebCore::Style::PropertyCascade::setLogicalGroupProperty):
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::addPositionTryFallbackProperties):
(WebCore::Style::declarationsForDeclarationOrigin):
(WebCore::Style::PropertyCascade::addNormalMatches):
(WebCore::Style::PropertyCascade::addImportantMatches):
(WebCore::Style::declarationsForCascadeLevel): Deleted.
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::PropertyCascade):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
(WebCore::Style::Builder::applyCascadeProperty):
(WebCore::Style::Builder::applyRollbackCascadeProperty):
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::ensureRollbackCascadeForRevert):
(WebCore::Style::Builder::ensureRollbackCascadeForRevertLayer):
(WebCore::Style::Builder::makeRollbackCascadeKey):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::disableNativeAppearanceIfNeeded):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::isAuthorOrigin const):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
(WebCore::Style::Resolver::styleForPage):
(WebCore::Style::Resolver::applyMatchedProperties):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::styleForDeclarationOrigin):
(WebCore::Style::ScopeRuleSets::styleForCascadeLevel): Deleted.
* Source/WebCore/style/StyleScopeRuleSets.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):

Canonical link: <a href="https://commits.webkit.org/299890@main">https://commits.webkit.org/299890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0c8079dad4b55bd9761ecd82cfd96332f378a20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72668 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2efcaec0-5dc4-44a7-afbe-1f0272a2fd88) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91586 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e6e502a-3993-4b5d-be4a-a816d3f5604d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72136 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e9aa38d-3f0d-4686-a6fa-363772fb3c19) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26200 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129854 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100205 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100046 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25395 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23518 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44165 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47376 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53081 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->