### PR TITLE
[WPE][cross-toolchain-helper] Unable to build with USE_SYSTEM_SYSPROF_CAPTURE=ON after 299709@main

### DIFF
--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -585,6 +585,70 @@ index 0000000..9fa2f9e
 +   dependency('libpanel-1', version: '>= 1.4'),
 + 
 +   libsysprof_static_dep,
+diff --git a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0007-libsysprof-capture-Disallow-unloading-the-capture-li.patch b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0007-libsysprof-capture-Disallow-unloading-the-capture-li.patch
+new file mode 100644
+index 0000000000..8c81011a18
+--- /dev/null
++++ b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0007-libsysprof-capture-Disallow-unloading-the-capture-li.patch
+@@ -0,0 +1,58 @@
++From e712ba35dc14e83bebde401720ec5cca894a2e82 Mon Sep 17 00:00:00 2001
++From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
++Date: Thu, 28 Aug 2025 00:18:01 +0200
++Subject: [PATCH] libsysprof-capture: Disallow unloading the capture library
++
++When a shared library with a built-in libsysprof-capture gets unloaded,
++the `sysprof_collector_free` function which was registered as a TSD
++destructor with `pthread_key_create` will also vanish, causing crashes
++when threads terminate.
++
++See: https://gitlab.freedesktop.org/mesa/mesa/-/issues/13571
++---
++ src/libsysprof-capture/meson.build | 8 ++++++++
++ 1 file changed, 8 insertions(+)
++
++diff --git a/src/libsysprof-capture/meson.build b/src/libsysprof-capture/meson.build
++index 828b8ed2..7a06ed25 100644
++--- a/src/libsysprof-capture/meson.build
+++++ b/src/libsysprof-capture/meson.build
++@@ -48,6 +48,11 @@ libsysprof_capture_deps = [
++   dependency('threads'),
++ ]
++ 
+++libsysprof_capture_link_args = []
+++if cc.has_link_argument('-Wl,-z,nodelete')
+++  libsysprof_capture_link_args += ['-Wl,-z,nodelete']
+++endif
+++
++ libsysprof_capture = static_library(
++   'sysprof-capture-@0@'.format(libsysprof_capture_api_version),
++   (libsysprof_capture_sources +
++@@ -55,6 +60,7 @@ libsysprof_capture = static_library(
++ 
++            dependencies: libsysprof_capture_deps,
++                  c_args: [ '-DSYSPROF_CAPTURE_COMPILATION' ],
+++              link_args: libsysprof_capture_link_args,
++                 install: install_static,
++   gnu_symbol_visibility: 'hidden',
++                     pic: true,
++@@ -66,6 +72,7 @@ libsysprof_capture_dep = declare_dependency(
++            link_whole: libsysprof_capture,
++          dependencies: libsysprof_capture_deps,
++   include_directories: libsysprof_capture_include_dirs,
+++            link_args: libsysprof_capture_link_args,
++ )
++ meson.override_dependency('sysprof-capture-@0@'.format(libsysprof_capture_api_version), libsysprof_capture_dep)
++ 
++@@ -75,6 +82,7 @@ if install_static
++         subdirs: [ sysprof_header_subdir ],
++     description: 'The static capture library for tools that generate profiling capture data',
++       variables: [ 'datadir=' + datadir_for_pc_file ],
+++    libraries: libsysprof_capture_link_args,
++     libraries_private: libsysprof_capture_deps,
++   )
++ endif
++-- 
++2.39.5
++
 diff --git a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_3.44.0.bb b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_3.44.0.bb
 deleted file mode 100644
 index 3523bad..0000000
@@ -636,10 +700,10 @@ index 3523bad..0000000
 -"
 diff --git a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_48.1.bb b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_48.1.bb
 new file mode 100644
-index 0000000..6ffb12d
+index 0000000000..871ec35633
 --- /dev/null
 +++ b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_48.1.bb
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,55 @@
 +SUMMARY = "System-wide Performance Profiler for Linux"
 +HOMEPAGE = "http://www.sysprof.com"
 +LICENSE = "GPL-3.0-or-later"
@@ -666,6 +730,7 @@ index 0000000..6ffb12d
 +           file://0004-sysprof-greeter-fix-environ-with-shadowing.patch \
 +           file://0005-Make-elf-loader-search-for-debug-links-in-.debug-dir.patch \
 +           file://0006-build-Adjust-dependency-versions-in-meson-build-conf.patch \
++           file://0007-libsysprof-capture-Disallow-unloading-the-capture-li.patch \
 +           "
 +SRC_URI[archive.sha256sum] = "54f157fdfef1edf1e2f22e542c462d90e1c21fca8c30eba4127cee739039bbe2"
 +
@@ -694,3 +759,28 @@ index 0000000..6ffb12d
 +    ${datadir}/metainfo \
 +    ${libdir}/libsysprof-6*.so.* \
 +"
+diff --git a/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bb b/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bb
+index 4133ad7..2234c9b 100644
+--- a/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bb
++++ b/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bb
+@@ -83,7 +83,6 @@ IMAGE_INSTALL:append = " \
+     pv \
+     rsync \
+     screen \
+-    sysprof \
+     smem \
+     systemd-analyze \
+     unifdef \
+diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+index 2b9b30f..d2c5fa6 100644
+--- a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
++++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+@@ -132,6 +132,8 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
+     icu \
+     jpeg \
+     sqlite3 \
++    sysprof \
++    sysprof-staticdev \
+     zlib \
+     libpng \
+     libsoup \


### PR DESCRIPTION
#### 307059003e0bf6750338158d94a5ad830f09f2db
<pre>
[WPE][cross-toolchain-helper] Unable to build with USE_SYSTEM_SYSPROF_CAPTURE=ON after 299709@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=298713">https://bugs.webkit.org/show_bug.cgi?id=298713</a>

Unreviewed build-fix.

299709@main updated the sysprof version on the yocto env and switched
USE_SYSTEM_SYSPROF_CAPTURE back to enabled by default.

However this caused a build falure, because sysprof-capture-4 is a static
library (.a), and yocto by default ships that kind of libraries on a -staticdev
package which is not included by default along with the headers on the sysroot.

Fix that by explicitly including the sysprof-staticdev package in this case,
and also backport a fix for issues when unloading the capture library.

* Tools/yocto/meta-openembedded_and_meta-webkit.patch:

Canonical link: <a href="https://commits.webkit.org/299856@main">https://commits.webkit.org/299856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f0a96e19d4c673755f0d0539a9b2b72cf44225a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120444 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/40138 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/30790 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/126819 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/72519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/122320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/40835 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/48715 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/126819 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/72519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/123396 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/40835 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/30790 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/126819 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/40835 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/30790 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/70434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/40835 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/30790 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/47365 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/48715 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/129704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/47731 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/30790 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/30790 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44011 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19122 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/47227 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/46695 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/50042 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/48382 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->