### PR TITLE
[WebDriver][BiDi] Event timestamps should be an integral number

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1007,7 +1007,7 @@ static String navigationIDToProtocolString(std::optional<WebCore::NavigationIden
 void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID, WallTime timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
-    m_bidiProcessor->browsingContextDomainNotifier().domContentLoaded(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    m_bidiProcessor->browsingContextDomainNotifier().domContentLoaded(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), bidiTimestampMilliseconds(timestamp), frame.url().string());
 #endif
 
     if (frame.isMainFrame()) {
@@ -1030,7 +1030,7 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, st
 void WebAutomationSession::loadCompletedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID, WallTime timestamp)
 {
 #if ENABLE(WEBDRIVER_BIDI)
-    m_bidiProcessor->browsingContextDomainNotifier().load(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), std::trunc(timestamp.secondsSinceEpoch().milliseconds()), frame.url().string());
+    m_bidiProcessor->browsingContextDomainNotifier().load(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), bidiTimestampMilliseconds(timestamp), frame.url().string());
 #endif
 }
 
@@ -1079,27 +1079,27 @@ void WebAutomationSession::didCreatePage(WebPageProxy& page)
 
 void WebAutomationSession::navigationStartedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationStarted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->browsingContextDomainNotifier().navigationStarted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), bidiTimestampMilliseconds(WallTime::now()), frame.url().string());
 }
 
 void WebAutomationSession::navigationCommittedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), bidiTimestampMilliseconds(WallTime::now()), frame.url().string());
 }
 
 void WebAutomationSession::navigationFailedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationFailed(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->browsingContextDomainNotifier().navigationFailed(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), bidiTimestampMilliseconds(WallTime::now()), frame.url().string());
 }
 
 void WebAutomationSession::navigationAbortedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().navigationAborted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->browsingContextDomainNotifier().navigationAborted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), bidiTimestampMilliseconds(WallTime::now()), frame.url().string());
 }
 
 void WebAutomationSession::fragmentNavigatedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
-    m_bidiProcessor->browsingContextDomainNotifier().fragmentNavigated(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+    m_bidiProcessor->browsingContextDomainNotifier().fragmentNavigated(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), bidiTimestampMilliseconds(WallTime::now()), frame.url().string());
 }
 
 void WebAutomationSession::emitContextCreatedEvent(const WebPageProxy& page)
@@ -2961,7 +2961,7 @@ void WebAutomationSession::logEntryAdded(const JSC::MessageSource& messageSource
     auto level = logEntryLevelForMessage(messageType, messageLevel);
     auto method = logEntryMethodNameForMessage(messageType, messageLevel);
     auto type = logEntryTypeForMessage(messageSource);
-    auto milliseconds =  timestamp.secondsSinceEpoch().milliseconds();
+    auto milliseconds = bidiTimestampMilliseconds(timestamp);
 
     // FIXME Get browsing context handle and source info
     // https://bugs.webkit.org/show_bug.cgi?id=282981

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -30,8 +30,10 @@
 #include "WebDriverBidiBackendDispatchers.h"
 #include "WebDriverBidiFrontendDispatchers.h"
 #include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <cmath>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WallTime.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -43,6 +45,11 @@ class BidiScriptAgent;
 class BidiStorageAgent;
 class WebAutomationSession;
 class WebPageProxy;
+
+inline double bidiTimestampMilliseconds(WallTime timestamp)
+{
+    return std::trunc(timestamp.secondsSinceEpoch().milliseconds());
+}
 
 class WebDriverBidiProcessor final : public Inspector::FrontendChannel {
     WTF_MAKE_TZONE_ALLOCATED(WebDriverBidiProcessor);

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2583,16 +2583,22 @@
                 "expected": { "wpe": { "status": ["PASS"], "bug": "webkit.org/b/287929"}}
             },
             "test_subscribe": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/298656"}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/302345"}}
             },
             "test_timestamp": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/298656"}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/302345"}}
+            },
+            "test_redirect_http_equiv": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_redirect_navigation": {
+                "expected": { "all": { "status": ["PASS"]}}
             },
             "test_base_element": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/298656"}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/302345"}}
             },
             "test_navigate_to_about_blank": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/298656"}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/302345"}}
             },
             "test_window_open_with_url": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/287934"}}


### PR DESCRIPTION
#### e38882f6ad6142df61e0cef2f8ee24fb1314c15d
<pre>
[WebDriver][BiDi] Event timestamps should be an integral number
<a href="https://bugs.webkit.org/show_bug.cgi?id=298656">https://bugs.webkit.org/show_bug.cgi?id=298656</a>

Reviewed by NOBODY (OOPS!).

The spec states &quot;time values&quot; are represented as js-uint, which go from
0 to 2^53-1 (JS Max Safe integer). And, accordingly, client libraries
like the WPT tests and Selenium Python expect them to be integers.

On our side, currently we&apos;re using `number`/`double` for them, as the
&quot;integer&quot; primitive type is just a plain int. This works fine as long as
we ensure the fractional part is zero, so the JSON conversion drops it.

This commit adds a helper to truncate the timestamp values before
passing them to the inspector protocol code, as they&apos;ll likely still
contain a fractional part after the conversion to milliseconds.

Also, text expectations are updated where applicable. Some previously
failing tests due to this issue are still failing due to other issues,
like navigation ID&apos;s, for example.

In a follow-up commit, ideally we would add a primitive type to
the inspector protocol that would map to uint64_t to better enforce
this.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::documentLoadedForFrame):
(WebKit::WebAutomationSession::loadCompletedForFrame):
(WebKit::WebAutomationSession::navigationStartedForFrame):
(WebKit::WebAutomationSession::navigationCommittedForFrame):
(WebKit::WebAutomationSession::navigationFailedForFrame):
(WebKit::WebAutomationSession::navigationAbortedForFrame):
(WebKit::WebAutomationSession::fragmentNavigatedForFrame):
(WebKit::WebAutomationSession::logEntryAdded):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
(WebKit::bidiTimestampMilliseconds):
* WebDriverTests/TestExpectations.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e38882f6ad6142df61e0cef2f8ee24fb1314c15d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118623 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19947 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17890 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10017 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129594 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164656 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126685 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126850 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82685 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14190 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89921 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->