### PR TITLE
Missing _WebKit_SwiftUI.framework breaks back-deployed build

### DIFF
--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -124,9 +124,8 @@ OTHER_SWIFT_FLAGS = $(inherited) -no-warnings-as-errors -Xfrontend -experimental
 OTHER_SWIFT_FLAGS_XCODE_BEFORE_16 = -Xfrontend -enable-experimental-concurrency -Xfrontend -enable-upcoming-feature -Xfrontend IsolatedDefaultValues;
 
 WK_ENABLE_SWIFTUI = YES;
-WK_ENABLE_SWIFTUI[sdk=macosx*] = $(WK_ENABLE_SWIFTUI$(WK_MACOS_2600));
-WK_ENABLE_SWIFTUI_MACOS_SINCE_2600 = YES;
-WK_ENABLE_SWIFTUI_MACOS_BEFORE_2600 = NO;
+WK_ENABLE_SWIFTUI[sdk=macosx14*] = NO;
+WK_ENABLE_SWIFTUI[sdk=macosx15*] = NO;
 WK_ENABLE_SWIFTUI[sdk=iphone*18.*] = NO;
 WK_ENABLE_SWIFTUI[sdk=watch*] = NO;
 WK_ENABLE_SWIFTUI[sdk=appletv*] = NO;

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 import Foundation
 public import SwiftUI
 
@@ -155,3 +157,5 @@ extension View {
         environment(\.webViewScrollInputBehaviorContext, .init(behavior: behavior, input: input))
     }
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 import Foundation
 public import SwiftUI
 @_spi(CrossImportOverlay) import WebKit
@@ -41,3 +43,5 @@ extension WebPage {
         }
     }
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebPageNavigationAction+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebPageNavigationAction+SwiftUI.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 import Foundation
 public import SwiftUI
 @_spi(CrossImportOverlay) import WebKit
@@ -32,3 +34,5 @@ extension WebPage.NavigationAction {
     @available(tvOS, unavailable)
     public var modifierFlags: EventModifiers { EventModifiers(wrapped.modifierFlags) }
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 public import SwiftUI
 public import WebKit
 
@@ -263,3 +265,5 @@ extension WebView {
         }
     }
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/CrossImportOverlay.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/CrossImportOverlay.swift
@@ -21,6 +21,10 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 import SwiftUI
 // This is a cross-import overlay of WebKit. Do not remove this @_exported import:
 @_exported import WebKit
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 public import SwiftUI
 @_spi(Private) @_spi(CrossImportOverlay) import WebKit
 
@@ -331,3 +333,5 @@ extension CocoaWebViewAdapter: WebPageWebView.Delegate {
         onScrollGeometryChange.action(transformedOld, transformedNew)
     }
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 import Foundation
 public import SwiftUI
 
@@ -55,3 +57,5 @@ extension EnvironmentValues {
     @Entry
     var webViewScrollInputBehaviorContext: ScrollInputBehaviorContext? = nil
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/Foundation+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/Foundation+Extras.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 import Foundation
 import SwiftUI
 
@@ -44,3 +46,5 @@ extension NSDirectionalRectEdge {
             }
     }
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/PlatformTextSearching.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/PlatformTextSearching.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 import Foundation
 
 @MainActor
@@ -72,5 +74,7 @@ struct UIFindInteractionAdapter: PlatformFindInteraction {
         wrapped.dismissFindNavigator()
     }
 }
+
+#endif
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 public import SwiftUI
 @_spi(CrossImportOverlay) public import WebKit
 
@@ -82,3 +84,5 @@ extension EventModifiers {
     }
     #endif
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 internal import SwiftUI
 @_spi(Private) internal import WebKit
 
@@ -43,3 +45,5 @@ struct ScrollInputBehaviorContext {
     let behavior: ScrollInputBehavior
     let input: ScrollInputKind
 }
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE_SWIFTUI
+
 internal import SwiftUI
 @_spi(CrossImportOverlay) import WebKit
 
@@ -280,3 +282,5 @@ struct EquatableScrollBounceBehavior: Equatable {
         unsafeBitCast(lhs.behavior, to: Int8.self) == unsafeBitCast(rhs.behavior, to: Int8.self)
     }
 }
+
+#endif


### PR DESCRIPTION
#### c8f542cb99c6db4a01923f1c6fa71ee7d0c21c06
<pre>
Missing _WebKit_SwiftUI.framework breaks back-deployed build
<a href="https://bugs.webkit.org/show_bug.cgi?id=298692">https://bugs.webkit.org/show_bug.cgi?id=298692</a>
<a href="https://rdar.apple.com/158788933">rdar://158788933</a>

Reviewed by NOBODY (OOPS!).

On downlevel builds prior to macOS Tahoe, we skip installing the
framework. This breaks the back-deployed downlevel build, because
clients like Safari load a stale version of the library in their SDK
which is incompatible with the built WebKit. Since Swift loads cross-import
frameworks automatically based on other libraries imported, it&apos;s
difficult to prevent clients from loading _WebKit_SwiftUI accidentally,
even when we know they don&apos;t need it.

Fix by changing the downlevel build to always [1] install
_WebKit_SwiftUI. On pre-Tahoe configurations that would previously skip
the install, the library now compiles with no code (i.e. produces an
empty module).

[1]: The existing WK_ENABLE_SWIFTUI build setting still exists, but it&apos;s
now based off of SDK version. So back-deployed downlevels will see
WK_ENABLE_SWIFTUI as active, and therefore install the library, but the
WTF conditional (ENABLE_SWIFTUI) which guards the code is still based on
the deployment target version.

* Source/WebKit/Configurations/Base.xcconfig:
* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebPageNavigationAction+SwiftUI.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:
* Source/WebKit/_WebKit_SwiftUI/CrossImportOverlay.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/Foundation+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/PlatformTextSearching.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8f542cb99c6db4a01923f1c6fa71ee7d0c21c06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72533 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a428e8a7-c884-40b8-9324-75bc769ce821) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91486 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60770 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb5eb4fd-0b2f-4879-ab97-e5760917f6e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1b80e86-4d86-4736-b93e-9177016b3371) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31657 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70450 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129719 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100107 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25376 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44027 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47241 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52946 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46709 "Hash c8f542cb for PR 50606 does not build (failure)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50056 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->