### PR TITLE
[MiniBrowser] Add --site-isolation flag to run-minibrowser command.

### DIFF
--- a/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
@@ -47,6 +47,7 @@ def main(argv):
 
     option_parser.add_argument('url', metavar='url', type=lambda s: decode(s, 'utf8'), nargs='?',
                                help='Website URL to load')
+    option_parser.add_argument('--site-isolation', action=argparse.BooleanOptionalAction, default=None, help='Enable Site Isolation')
     options, args = option_parser.parse_known_args(argv)
 
     if not options.platform:
@@ -56,7 +57,12 @@ def main(argv):
     # URL. convert_arg_line_to_args() returns a list containing a single
     # string, so it needs to be split again.
     browser_args = [decode(s, "utf-8") for s in option_parser.convert_arg_line_to_args(' '.join(args))[0].split()]
+    if options.platform == "mac" and options.site_isolation is not None:
+        browser_args.append('--force-site-isolation')
+        browser_args.append('YES' if options.site_isolation else 'NO')
     if options.url:
+        if options.platform == "mac":
+            browser_args.append('--url')
         browser_args.append(options.url)
 
     try:


### PR DESCRIPTION
#### 98d197bba00f715200acaa6f0e1f352eb4ace974
<pre>
[MiniBrowser] Add --site-isolation flag to run-minibrowser command.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298724">https://bugs.webkit.org/show_bug.cgi?id=298724</a>
<a href="https://rdar.apple.com/160382439">rdar://160382439</a>

Reviewed by Ryan Reno.

Add --site-isolation/--no-site-isolation flag to run-minibrowser script. This forces
MiniBrowser to run with or without Site Isolation for Mac port. This allows developers
to test WebKit&apos;s site isolation implementation more easily.

* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate awakeFromNib]):
(-[BrowserAppDelegate _parseArguments]):
(-[BrowserAppDelegate defaultConfiguration]):
* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):

Canonical link: <a href="https://commits.webkit.org/299873@main">https://commits.webkit.org/299873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4305821238df26cdd168ab4420cd2c255068e32f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72599 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6c8c2d8-b853-4e5a-b226-a67a9bbafdf8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48795 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f9b12cc-ff8c-4f08-aa55-7c31069af018) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72086 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92116259-b46e-40e2-bfc2-bfdbe48ad8af) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/119881 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70517 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129785 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47445 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99996 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25383 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23466 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44093 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47307 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46775 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50122 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->