### PR TITLE
[GTK][WPE] WebXR tests fail to be run in EWS due to assertions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/idlharness.https.window-expected.txt
@@ -7,6 +7,7 @@ PASS Partial interface XRSession[2]: original interface defined
 PASS Partial interface XRSession[2]: member names are unique
 PASS Partial interface XRView: original interface defined
 PASS Partial interface XRView: member names are unique
+PASS XRView includes XRViewGeometry: member names are unique
 PASS XRSession interface: attribute environmentBlendMode
 PASS XRSession interface: attribute interactionMode
 PASS XRSession interface: xrSession must inherit property "environmentBlendMode" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hand-input/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hand-input/idlharness.https.window-expected.txt
@@ -1,0 +1,35 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface XRInputSource: original interface defined
+PASS Partial interface XRInputSource: member names are unique
+PASS Partial interface XRFrame: original interface defined
+PASS Partial interface XRFrame: member names are unique
+PASS XRHand interface: existence and properties of interface object
+PASS XRHand interface object length
+PASS XRHand interface object name
+PASS XRHand interface: existence and properties of interface prototype object
+PASS XRHand interface: existence and properties of interface prototype object's "constructor" property
+PASS XRHand interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRHand interface: iterable<XRHandJoint, XRJointSpace>
+PASS XRHand interface: attribute size
+PASS XRHand interface: operation get(XRHandJoint)
+PASS XRJointSpace interface: existence and properties of interface object
+PASS XRJointSpace interface object length
+PASS XRJointSpace interface object name
+PASS XRJointSpace interface: existence and properties of interface prototype object
+PASS XRJointSpace interface: existence and properties of interface prototype object's "constructor" property
+PASS XRJointSpace interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRJointSpace interface: attribute jointName
+PASS XRJointPose interface: existence and properties of interface object
+PASS XRJointPose interface object length
+PASS XRJointPose interface object name
+PASS XRJointPose interface: existence and properties of interface prototype object
+PASS XRJointPose interface: existence and properties of interface prototype object's "constructor" property
+PASS XRJointPose interface: existence and properties of interface prototype object's @@unscopables property
+PASS XRJointPose interface: attribute radius
+PASS XRFrame interface: operation getJointPose(XRJointSpace, XRSpace)
+PASS XRFrame interface: operation fillJointRadii(sequence<XRJointSpace>, Float32Array)
+PASS XRFrame interface: operation fillPoses(sequence<XRSpace>, XRSpace, Float32Array)
+PASS XRInputSource interface: attribute hand
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2873,16 +2873,25 @@ webkit.org/b/215912 http/tests/websocket/tests/hybi/handshake-fail-by-no-cr.html
 
 webkit.org/b/208988 http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html [ Timeout ]
 
-# Assertion failure if ASSERT_ENABLED
-webkit.org/b/298434 [ Debug ] imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Skip ]
-webkit.org/b/298434 [ Release ] imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Crash Pass ]
-webkit.org/b/298434 [ Debug ] imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html [ Skip ]
-webkit.org/b/298434 [ Release ] imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html [ Crash Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Failure ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html [ Failure ]
 
-# WebXROpaqueFramebuffer is not able to properly setup gfx resources
-webkit.org/b/296681 imported/w3c/web-platform-tests/webxr [ Skip ]
+webkit.org/b/296681 imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_isSessionSupported_immersive-ar.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_immersive.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_inline.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrDevice_disconnect_ends.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_requiredFeatures_unknown.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrFrame_getViewerPose_getPose_identities.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrSession_input_events_end.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrSession_requestReferenceSpace_features.https.html [ Pass ]
+webkit.org/b/227086 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_constructor.https.html [ Pass ]
 
-webkit.org/b/208988 http/wpt/webxr [ Skip ]
+imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https.html [ Failure ]
+
+imported/w3c/web-platform-tests/webxr/hand-input/ [ Pass ]
+
+http/wpt/webxr [ Pass ]
+webxr [ Pass ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebXR-related bugs

--- a/LayoutTests/platform/wpe/http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https-expected.txt
+++ b/LayoutTests/platform/wpe/http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https-expected.txt
@@ -1,6 +1,0 @@
-
-Harness Error (FAIL), message = Error: assert_equals: expected (object) null but got (undefined) undefined
-
-TIMEOUT requestSession should not grant previously enabled features if not requested - webgl Test timed out
-NOTRUN requestSession should not grant previously enabled features if not requested - webgl2
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_immersive.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_immersive.https-expected.txt
@@ -1,5 +1,0 @@
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT XRSession resetpose from a device properly fires off the right events for immersive sessions Test timed out
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_inline.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_inline.https-expected.txt
@@ -1,5 +1,0 @@
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT XRSession resetpose from a device properly fires off the right events for non-immersive sessions Test timed out
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_disconnect_ends.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_disconnect_ends.https-expected.txt
@@ -1,5 +1,0 @@
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Immersive session ends when device is disconnected Test timed out
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_input_events_end.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_input_events_end.https-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Calling end during an input callback stops processing at the right time assert_equals: Expected end event, but got selectstart event instead expected "end" but got "selectstart"
-

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -153,6 +153,7 @@ private:
     uint64_t m_renderingFrameIndex { ~0u };
     bool m_usingFoveation { false };
     bool m_blitDepth { false };
+    bool m_isForTesting { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -326,6 +326,7 @@ struct FrameData {
         std::optional<ExternalTextureData> textureData;
         // FIXME: <rdar://134998122> Remove when new CC lands.
         bool requestDepth { false };
+        bool isForTesting { false };
     };
 
     struct InputSourceButton {

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -158,7 +158,8 @@ void SimulatedXRDevice::frameTimerFired()
             .layerSetup = layerSetupData,
             .renderingFrameIndex = 0,
             .textureData = std::nullopt,
-            .requestDepth = false
+            .requestDepth = false,
+            .isForTesting = true
         });
         data.layers.add(layer.key, WTFMove(layerData));
     }


### PR DESCRIPTION
#### 6897555e1af0f4dc68573367bf67f8784bb39306
<pre>
[GTK][WPE] WebXR tests fail to be run in EWS due to assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=298726">https://bugs.webkit.org/show_bug.cgi?id=298726</a>

Reviewed by Dan Glastonbury.

Some of the assertions in WebXROpaqueFramebuffer do not make sense when testing the WebXR API
because we&apos;re using a fake XR device that does not render anything, so it does not provide
platform images/surfaces for WebGL to render into.

That was preventing us from enabling WebXR testing as some EWS run with all ASSERTs enabled
(even with release builds). We can pass a isTesting parameter via the structs used to
exchange XR information between the UI and Web processes that will be used later in
conditional assertions. That parametter is not used for production code so we don&apos;t
need to encode/decode it in IPC.

This allows us to run almost 100 WebXR passing tests and to remove old expectations that
are no longer needed as those tests run as expected.

* LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/idlharness.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/hand-input/idlharness.https.window-expected.txt: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https-expected.txt: Removed.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_immersive.https-expected.txt: Removed.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_inline.https-expected.txt: Removed.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_disconnect_ends.https-expected.txt: Removed.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_input_events_end.https-expected.txt: Removed.
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::blitShared):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):

Canonical link: <a href="https://commits.webkit.org/299948@main">https://commits.webkit.org/299948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2229ec652bdb48ee4e266a9b731292b451e30f73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72558 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91506 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70476 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129744 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100125 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99967 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45410 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44052 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52971 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->