### PR TITLE
[CG] radius of CGGaussianBlurStyle is not in the BaseCTM coordinates

### DIFF
--- a/LayoutTests/css3/filters/effect-unaccelerated-graphics-context-blur-expected.html
+++ b/LayoutTests/css3/filters/effect-unaccelerated-graphics-context-blur-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AcceleratedDrawingEnabled=true deviceScaleFactor=2.0 ] -->
+<html>
+<head>
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+    <script>
+        if (window.internals)
+            internals.settings.setGraphicsContextBlurFilterEnabled?.(true);
+    </script>
+</head>
+<body>
+    <img src="resources/reference.png" style="filter: blur(0)">
+    <img src="resources/reference.png" style="filter: blur(2px)">
+    <img src="resources/reference.png" style="filter: blur(3px)">
+    <img src="resources/reference.png" style="filter: blur(10px)"> 
+</body>
+</html>

--- a/LayoutTests/css3/filters/effect-unaccelerated-graphics-context-blur.html
+++ b/LayoutTests/css3/filters/effect-unaccelerated-graphics-context-blur.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AcceleratedDrawingEnabled=false deviceScaleFactor=2.0 ] -->
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-12; totalPixels=0-57927" />
+    <link rel="stylesheet" href="resources/filter-helpers.css">
+    <script>
+        if (window.internals)
+            internals.settings.setGraphicsContextBlurFilterEnabled?.(true);
+    </script>
+</head>
+<body>
+    <img src="resources/reference.png" style="filter: blur(0)">
+    <img src="resources/reference.png" style="filter: blur(2px)">
+    <img src="resources/reference.png" style="filter: blur(3px)">
+    <img src="resources/reference.png" style="filter: blur(10px)"> 
+</body>
+</html>


### PR DESCRIPTION
#### 763d7464624792d31e7aa952bcab3213616ea406
<pre>
[CG] radius of CGGaussianBlurStyle is not in the BaseCTM coordinates
<a href="https://bugs.webkit.org/show_bug.cgi?id=298725">https://bugs.webkit.org/show_bug.cgi?id=298725</a>
<a href="https://rdar.apple.com/160383014">rdar://160383014</a>

Reviewed by Simon Fraser.

In /299740@main, the radius of the CGGaussianBlurStyle was scaled by the device
scale factor as a work around for a CG bug on accelerated drawing.

The radius should not be scaled by the device scale factor. In other words it
should be in the BaseCTM coordinates. This is the behavior of the unaccelerated
drawing.

The workaround should stay for the accelerated drawing till the CG bug is fixed.

* LayoutTests/css3/filters/effect-unaccelerated-graphics-context-blur-expected.html: Added.
* LayoutTests/css3/filters/effect-unaccelerated-graphics-context-blur.html: Added.
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::createGraphicsStyle const):

Canonical link: <a href="https://commits.webkit.org/299903@main">https://commits.webkit.org/299903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7147a8f962b9aa48cde628775e8441c8018390a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72546 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ae0f391-6443-4699-ae65-d683ce6ab598) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91496 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60781 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/494b5e92-af08-4d4c-9dc3-e0c65a84ecdd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/012a300c-7700-4bbc-b71f-c7f4bb804cb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70463 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129732 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100115 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25407 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45401 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44040 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52959 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46722 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48409 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->