### PR TITLE
[GFC] GridLayout should take in UnplacedItems as input

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1921,6 +1921,7 @@ layout/formattingContexts/flex/FlexFormattingUtils.cpp
 layout/formattingContexts/flex/FlexLayout.cpp
 layout/formattingContexts/grid/GridFormattingContext.cpp
 layout/formattingContexts/grid/GridLayout.cpp
+layout/formattingContexts/grid/UnplacedGridItem.cpp
 layout/formattingContexts/inline/AbstractLineBuilder.cpp
 layout/formattingContexts/inline/InlineContentAligner.cpp
 layout/formattingContexts/inline/InlineContentBreaker.cpp

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -34,6 +34,9 @@ namespace Layout {
 
 class ElementBox;
 
+class UnplacedGridItem;
+using UnplacedGridItems = Vector<UnplacedGridItem>;
+
 class GridFormattingContext : public CanMakeCheckedPtr<GridFormattingContext> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GridFormattingContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GridFormattingContext);
@@ -47,6 +50,10 @@ public:
     GridFormattingContext(const ElementBox& gridBox);
 
     void layout(GridLayoutConstraints);
+private:
+    UnplacedGridItems constructUnplacedGridItems() const;
+
+    const CheckedRef<const ElementBox> m_gridBox;
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -33,6 +33,6 @@ GridLayout::GridLayout(const GridFormattingContext& gridFormattingContext)
 {
 }
 
-void GridLayout::layout(GridFormattingContext::GridLayoutConstraints) { }
+void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, UnplacedGridItems) { }
 } // namespace Layout
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -30,15 +30,17 @@
 namespace WebCore {
 namespace Layout {
 
+class UnplacedGridItem;
+using UnplacedGridItems = Vector<UnplacedGridItem>;
+
 class GridLayout {
 public:
     GridLayout(const GridFormattingContext&);
 
-    void layout(GridFormattingContext::GridLayoutConstraints);
+    void layout(GridFormattingContext::GridLayoutConstraints, UnplacedGridItems);
 private:
     const CheckedRef<const GridFormattingContext> m_gridFormattingContext;
 };
-
 
 }
 }

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "UnplacedGridItem.h"
+
+namespace WebCore {
+namespace Layout {
+UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox)
+    : m_layoutBox(layoutBox)
+{
+}
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayoutElementBox.h"
+#include "StyleGridPosition.h"
+
+namespace WebCore {
+namespace Layout {
+
+class UnplacedGridItem {
+public:
+    UnplacedGridItem(const ElementBox&);
+private:
+    const CheckedRef<const ElementBox> m_layoutBox;
+};
+
+}
+}


### PR DESCRIPTION
#### 78fafefd106fe8a3a0849ec800a0d20fec799de0
<pre>
[GFC] GridLayout should take in UnplacedItems as input
<a href="https://bugs.webkit.org/show_bug.cgi?id=298729">https://bugs.webkit.org/show_bug.cgi?id=298729</a>
<a href="https://rdar.apple.com/160319995">rdar://160319995</a>

Reviewed by Alan Baradlay.

GridLayout will need some sort of input from GridFormattingContext in
in order to represent the set of items that it will need to run grid
layout on. Since the first step of the grid layout algorithm will be to
perform item placement (<a href="https://drafts.csswg.org/css-grid-1/#layout-algorithm)">https://drafts.csswg.org/css-grid-1/#layout-algorithm)</a>,
we can pass in a set of &quot;unplaced items,&quot; which will get transformed
into a set of &quot;placed items,&quot; as a result of item placement.

In this patch, we introduce the concept of an UnplacedItem, which gets
passed in as part of a list to grid layout. As of right now, this class
is just a simple wrapper around the layout box but in theory will get
populated with enough information about it that allows grid layout to
perform placement. I defer populating the class with that information
until the initial implementation of placement, which is when we will need
it.

Finally, the list which gets sent to grid layout is also logical from
the perspective of the order property. GridFormattingContext sorts this
list based upon the order value so that GridLayout does not have to
worry about it and can just simply iterate over the list without having
to worry about making sure that the order is correct.

Canonical link: <a href="https://commits.webkit.org/300052@main">https://commits.webkit.org/300052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5da5076d66b63b357154ea2b2c6730de3a9a902a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72707 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b05340d-e632-468a-b906-24fd10515aac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91621 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60882 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/395eeb20-f7a1-4a17-b29a-3779df874fbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72169 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae45849d-a652-4cc4-854a-d71fb749a484) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129893 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100242 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44213 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53120 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->