### PR TITLE
Enable Navigation API

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5399,7 +5399,7 @@ MuteCameraOnMicrophoneInterruptionEnabled:
 
 NavigationAPIEnabled:
   type: bool
-  status: preview
+  status: stable
   category: dom
   humanReadableName: "Navigation API"
   humanReadableDescription: "Enable Navigation API"
@@ -5407,8 +5407,10 @@ NavigationAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 NavigatorUserAgentDataJavaScriptAPIEnabled:

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -317,6 +317,8 @@ public:
 
     const NavigationAction& triggeringAction() const { return m_triggeringAction; }
     void setTriggeringAction(NavigationAction&&);
+    void setTriggeringNavigationAPIType(NavigationNavigationType type) { m_triggeringAction.setNavigationAPIType(type); };
+
     void setOverrideEncoding(const String& encoding) { m_overrideEncoding = encoding; }
     void setLastCheckedRequest(ResourceRequest&& request) { m_lastCheckedRequest = WTFMove(request); }
     const ResourceRequest& lastCheckedRequest()  { return m_lastCheckedRequest; }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2064,6 +2064,7 @@ void FrameLoader::reload(OptionSet<ReloadOption> options, bool isRequestFromClie
         loader->setTriggeringAction({ m_frame->protectedDocument().releaseNonNull(), request, InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), NavigationType::FormResubmitted });
 
     loader->setOverrideEncoding(documentLoader->overrideEncoding());
+    loader->setTriggeringNavigationAPIType(NavigationNavigationType::Reload);
 
     auto frameLoadTypeForReloadOptions = [] (auto options) {
         if (options & ReloadOption::FromOrigin)

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -161,6 +161,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
 
                 m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
 
+                ASSERT(navigationType);
                 m_activation = NavigationActivation::create(*navigationType, *currentEntry(), WTFMove(previousEntry));
 
                 return;


### PR DESCRIPTION
#### a3e994b8cd8c92bc8827c17e56e759b960641b3a
<pre>
Enable Navigation API
<a href="https://bugs.webkit.org/show_bug.cgi?id=298730">https://bugs.webkit.org/show_bug.cgi?id=298730</a>
<a href="https://rdar.apple.com/160389651">rdar://160389651</a>

Reviewed by Charlie Wolfe.

Enable the Navigation API on Cocoa, GTK, WPE now that the PLT regression is
fixed (299858@main).

Enabling this API results in the ProcessSwap.SwapOnFormSubmission API test
failing. It fails because on [webView reload], the web process changes rather
than staying the same.

The issue is that on [webView reload], we call FrameLoader::reload which ends
up calling Navigation::initializeForNewWindow. Since there is a previous window
with previous navigation entries we should process, we go down the
shouldProcessPreviousNavigationEntries path. Then, since the navigation type is
not Traverse or Push, we end up in the last else case, which dereferences the
navigationType.

Turns out, no navigationType has been set. So the process crashes, which causes
a new process to be spun up and reload is called in that process. Hence the
process ID in the API test is not equal to the old one.

To fix this, we make FrameLoader::reload set the NavigationNavigationType as it
should have been doing before.

This issue did not arise earlier since API tests are not run with non-stable
feature flags enabled. Now that we&apos;re enabling it, this case will continue to be
tested by ProcessSwap.SwapOnFormSubmission.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::setTriggeringNavigationAPIType):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::reload):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):

Canonical link: <a href="https://commits.webkit.org/299927@main">https://commits.webkit.org/299927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09353fed74955d0edaf242406e388bbf097f0808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72784 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd02bd81-03ee-42d4-b37d-060f5d037bd2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91686 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60937 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a0c2e88-aceb-485c-b765-429d690149a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72233 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c41969b-dd30-4007-87d0-2766d5fb3858) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70708 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112835 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129970 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119225 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100300 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100139 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44290 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19160 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47492 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53197 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/148560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46961 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/148560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->