### PR TITLE
Start migrating functions using postMessageWithAsyncReply from the web content process to the UI process

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -97,7 +97,6 @@ interface TestRunner {
     undefined setPrinting();
 
     // Special DOM functions.
-    Promise<undefined> clearBackForwardList();
     undefined execCommand(DOMString name, DOMString showUI, DOMString value);
     boolean isCommandEnabled(DOMString name);
     unsigned long windowCount();
@@ -109,7 +108,6 @@ interface TestRunner {
     undefined testRepaint();
     undefined repaintSweepHorizontally();
     undefined display();
-    Promise<undefined> displayAndTrackRepaints();
     undefined displayOnLoadFinish();
     undefined dontForceRepaint();
 
@@ -164,24 +162,13 @@ interface TestRunner {
     readonly attribute boolean didReceiveServerRedirectForProvisionalNavigation;
     undefined clearDidReceiveServerRedirectForProvisionalNavigation();
 
-    // Focus testing.
-    undefined addChromeInputField(object callback);
-    undefined removeChromeInputField(object callback);
-    undefined focusWebView(object callback);
-    undefined setTextInChromeInputField(DOMString text, object callback);
-    undefined getSelectedTextInChromeInputField(object callback);
-    undefined selectChromeInputField(object callback);
-
     // Window/view state
-    undefined setBackingScaleFactor(double backingScaleFactor, object callback);
-
     undefined setWindowIsKey(boolean isKey);
     undefined setViewSize(double width, double height);
 
     // Cookies testing
     undefined setAlwaysAcceptCookies(boolean accept);
     undefined setOnlyAcceptFirstPartyCookies(boolean accept);
-    undefined removeAllCookies(object callback);
 
     // Page Visibility API
     undefined setPageVisibility(DOMString state);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -96,11 +96,6 @@ void TestRunner::display()
     WKBundlePageForceRepaint(page());
 }
 
-void TestRunner::displayAndTrackRepaints(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "DisplayAndTrackRepaints", callback);
-}
-
 static WKRetainPtr<WKDoubleRef> toWK(double value)
 {
     return adoptWK(WKDoubleCreate(value));
@@ -477,11 +472,6 @@ unsigned TestRunner::windowCount()
     return InjectedBundle::singleton().pageCount();
 }
 
-void TestRunner::clearBackForwardList(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "ClearBackForwardList", callback);
-}
-
 void TestRunner::makeWindowObject(JSContextRef context)
 {
     setGlobalObjectProperty(context, "testRunner", this);
@@ -644,41 +634,6 @@ void TestRunner::accummulateLogsForChannel(JSStringRef)
     // FIXME: Implement getting the call to all processes.
 }
 
-void TestRunner::addChromeInputField(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "AddChromeInputField", callback);
-}
-
-void TestRunner::removeChromeInputField(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "RemoveChromeInputField", callback);
-}
-
-void TestRunner::setTextInChromeInputField(JSContextRef context, JSStringRef text, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "SetTextInChromeInputField", toWK(text), callback);
-}
-
-void TestRunner::selectChromeInputField(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "SelectChromeInputField", callback);
-}
-
-void TestRunner::getSelectedTextInChromeInputField(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "GetSelectedTextInChromeInputField", callback);
-}
-
-void TestRunner::focusWebView(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "FocusWebView", callback);
-}
-
-void TestRunner::setBackingScaleFactor(JSContextRef context, double backingScaleFactor, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "SetBackingScaleFactor", adoptWK(WKDoubleCreate(backingScaleFactor)), callback);
-}
-
 void TestRunner::setWindowIsKey(bool isKey)
 {
     InjectedBundle::singleton().postSetWindowIsKey(isKey);
@@ -697,11 +652,6 @@ void TestRunner::setAlwaysAcceptCookies(bool accept)
 void TestRunner::setOnlyAcceptFirstPartyCookies(bool accept)
 {
     postSynchronousMessage("SetOnlyAcceptFirstPartyCookies", accept);
-}
-
-void TestRunner::removeAllCookies(JSContextRef context, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "RemoveAllCookies", callback);
 }
 
 double TestRunner::preciseTime()

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -161,7 +161,6 @@ public:
     void setCustomUserAgent(JSStringRef);
 
     // Special DOM functions.
-    void clearBackForwardList(JSContextRef, JSValueRef callback);
     void execCommand(JSStringRef name, JSStringRef showUI, JSStringRef value);
     bool isCommandEnabled(JSStringRef name);
     unsigned windowCount();
@@ -170,7 +169,6 @@ public:
     void testRepaint() { m_testRepaint = true; }
     void repaintSweepHorizontally() { m_testRepaintSweepHorizontally = true; }
     void display();
-    void displayAndTrackRepaints(JSContextRef, JSValueRef callback);
     void displayOnLoadFinish() { m_displayOnLoadFinish = true; }
     bool shouldDisplayOnLoadFinish() { return m_displayOnLoadFinish; }
     void dontForceRepaint() { m_forceRepaint = false; }
@@ -279,16 +277,6 @@ public:
     double databaseMaxQuota() const { return m_databaseMaxQuota; }
     void setDatabaseMaxQuota(double quota) { m_databaseMaxQuota = quota; }
 
-    void addChromeInputField(JSContextRef, JSValueRef);
-    void removeChromeInputField(JSContextRef, JSValueRef);
-    void focusWebView(JSContextRef, JSValueRef);
-
-    void setTextInChromeInputField(JSContextRef, JSStringRef text, JSValueRef callback);
-    void selectChromeInputField(JSContextRef, JSValueRef callback);
-    void getSelectedTextInChromeInputField(JSContextRef, JSValueRef callback);
-
-    void setBackingScaleFactor(JSContextRef, double, JSValueRef);
-
     void setWindowIsKey(bool);
 
     void setViewSize(double width, double height);
@@ -298,7 +286,6 @@ public:
     // Cookies testing
     void setAlwaysAcceptCookies(bool);
     void setOnlyAcceptFirstPartyCookies(bool);
-    void removeAllCookies(JSContextRef, JSValueRef callback);
 
     // Web notifications.
     void grantWebNotificationPermission(JSStringRef origin);


### PR DESCRIPTION
#### 355afe3587aabdc67b9e6f04ddadc7ed31905d97
<pre>
Start migrating functions using postMessageWithAsyncReply from the web content process to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=298731">https://bugs.webkit.org/show_bug.cgi?id=298731</a>
<a href="https://rdar.apple.com/160392755">rdar://160392755</a>

Reviewed by Alex Christensen.

Started moving the first 10 functions using postMessageWithAsyncReply to the UI process.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::displayAndTrackRepaints): Deleted.
(WTR::TestRunner::clearBackForwardList): Deleted.
(WTR::TestRunner::addChromeInputField): Deleted.
(WTR::TestRunner::removeChromeInputField): Deleted.
(WTR::TestRunner::setTextInChromeInputField): Deleted.
(WTR::TestRunner::selectChromeInputField): Deleted.
(WTR::TestRunner::getSelectedTextInChromeInputField): Deleted.
(WTR::TestRunner::focusWebView): Deleted.
(WTR::TestRunner::setBackingScaleFactor): Deleted.
(WTR::TestRunner::removeAllCookies): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::if):
(WTR::CompletionHandler&lt;void):

Canonical link: <a href="https://commits.webkit.org/300064@main">https://commits.webkit.org/300064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a540b0ce2d3bf2405dceeeb48e37aaa39015d76d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92057 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26731 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102716 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100656 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25489 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44803 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47967 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->