### PR TITLE
prepare-ChangeLogs doesn't ask for tests anymore

### DIFF
--- a/Tools/Scripts/prepare-ChangeLog
+++ b/Tools/Scripts/prepare-ChangeLog
@@ -597,10 +597,12 @@ sub generateNewChangeLogs($$$$$$$$$$$$$$$)
 {
     my ($prefixes, $filesInChangeLog, $addedRegressionTests, $requiresTests, $functionLists, $bugURL, $bugDescription, $bugRadarURL, $name, $emailAddress, $gitReviewer, $gitCommit, $writeChangeLogs, $delimiters, $onlyFiles) = @_;
 
-    my $hasWebCoreChange = 0;
-    foreach my $prefix (@$prefixes) {
-        if (unixPath($prefix) =~ m|/WebCore/$|) {
-            $hasWebCoreChange = 1;
+    my $hasSourceChange = 0;
+    while (my ($prefix, $files) = each(%$filesInChangeLog)) {
+        foreach my $file (@$files) {
+            if (unixPath($file) =~ m|Source/|) {
+                $hasSourceChange = 1;
+            }
         }
     }
 
@@ -654,9 +656,7 @@ sub generateNewChangeLogs($$$$$$$$$$$$$$$)
             print CHANGE_LOG normalizeLineEndings($description . "\n", $endl) if $description;
         }
 
-        my $shouldMentionTests = @$requiresTests;
-        $shouldMentionTests |= !$hasWebCoreChange && unixPath($prefix) =~ m|/WebKit/$|;
-        $shouldMentionTests |= unixPath($prefix) =~ m|/WebCore/$|;
+        my $shouldMentionTests = @$requiresTests || $hasSourceChange;
 
         if ($shouldMentionTests) {
             if (@$addedRegressionTests) {
@@ -2163,7 +2163,7 @@ sub generateFileList(\%$$$\%)
             } elsif (attributeCommand($attributeCache, $file, "test")) {
                 push @addedRegressionTests, $file;
             } elsif (attributeCommand($attributeCache, $file, "requiresTests")) {
-                push @requiresTests, $file
+                push @requiresTests, $file;
             }
             push @changedFiles, $file if $components[$#components] ne "ChangeLog";
         } elsif (isConflictStatus($status, $gitCommit, $gitIndex) || isConflictStatus($propertyStatus, $gitCommit, $gitIndex)) {


### PR DESCRIPTION
#### ed9dd0741be2f62a9c946cc4908a013ec3db2335
<pre>
prepare-ChangeLogs doesn&apos;t ask for tests anymore
<a href="https://bugs.webkit.org/show_bug.cgi?id=298734">https://bugs.webkit.org/show_bug.cgi?id=298734</a>

Reviewed by Simon Fraser and Jonathan Bedard.

* Tools/Scripts/prepare-ChangeLog:
(generateNewChangeLogs):
(generateFileList):
Once we removed physical ChangeLog files from the project, the prepare-ChangeLogs
mechanism to group files by prefixes (which were defined by the location of ChangeLog files)
no longer works.

This had the knock-on effect of breaking our detection of patches that need tests.
Fix this by looking at the file paths instead.

Also relax the requirement a bit and ask for any test in Source/, not just WebCore and WebKit,
since we no longer have to edit/delete the OOPS from many places.

Canonical link: <a href="https://commits.webkit.org/299869@main">https://commits.webkit.org/299869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19c9d4ba1e69d9e3215c796c5228d333f335047b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72580 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/845d88fe-ce48-47e7-af8f-ec07492d8d32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc8002cf-b06d-4a9f-aa72-05f544024dd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32659 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72072 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd1d2839-ac1c-4c22-9e81-b0acb6e5144f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26126 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70498 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129766 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47426 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/35997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99980 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45430 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47288 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->