### PR TITLE
[World Leaks] - Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/anchor-position-does-not-leak-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-position-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that anchor positioning functionality does not leak the document object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/css-anchor-position/anchor-position-does-not-leak.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-position-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/document-leak-test.js"></script>
+<script>
+    description("Tests that anchor positioning functionality does not leak the document object");
+    onload = () => runDocumentLeakTest({ frameURL: "anchor-size-page-zoom.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom.html
@@ -43,4 +43,6 @@ Test passes if no red is visible.
 <script>
     if (window.internals)
         window.internals.setPageZoomFactor(2);
+    if (window.parent !== window)
+        window.parent.postMessage("testCompleted", "*");
 </script>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1270,7 +1270,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
                     });
                 }
                 document.styleScope().anchorPositionedToAnchorMap().set(*element, AnchorPositionedToAnchorEntry {
-                    .key = elementAndState.key,
+                    .pseudoElementIdentifier = elementAndState.key.second,
                     .anchors = WTFMove(anchors)
                 });
             }

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -148,9 +148,10 @@ struct ResolvedAnchor {
 };
 
 struct AnchorPositionedToAnchorEntry {
-    // This key can be used to access the AnchorPositionedState struct of the current element
-    // in an AnchorPositionedStates map.
-    AnchorPositionedKey key;
+    // The pseudo-element identifier can be used to access the AnchorPositionedState struct
+    // of the current element in an AnchorPositionedStates map, in combination with the relevant
+    // Element object.
+    std::optional<PseudoElementIdentifier> pseudoElementIdentifier;
 
     Vector<ResolvedAnchor> anchors;
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1456,7 +1456,8 @@ std::unique_ptr<Update> TreeResolver::resolve()
                 // If the anchor-positioned element is currently being tracked for resolution,
                 // reset the resolution stage to FindAnchor. This re-runs anchor resolution to
                 // pick up new anchor name changes.
-                auto stateIt = m_treeResolutionState.anchorPositionedStates.find(anchors.key);
+                AnchorPositionedKey anchorPositionedKey { anchorPositionedElement.ptr(), anchors.pseudoElementIdentifier };
+                auto stateIt = m_treeResolutionState.anchorPositionedStates.find(anchorPositionedKey);
                 if (stateIt != m_treeResolutionState.anchorPositionedStates.end()) {
                     ASSERT(stateIt->value);
                     stateIt->value->stage = AnchorPositionResolutionStage::FindAnchors;


### PR DESCRIPTION
#### b710a47a6e5332cbbdecacd2df9aa69355e5f95b
<pre>
[World Leaks] - Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/
<a href="https://bugs.webkit.org/show_bug.cgi?id=298733">https://bugs.webkit.org/show_bug.cgi?id=298733</a>
<a href="https://rdar.apple.com/160328982">rdar://160328982</a>

Reviewed by Ryan Reno and Antti Koivisto.

This leak was found to be caused by WebCore::Style::Scope::m_anchorPositionedToAnchorMap,
which contains AnchorPositionedToAnchorEntry as its value. AnchorPositionedToAnchorEntry
is a struct which holds AnchorPositionedKey as a member, which itself holds
RefPtr&lt;const Element&gt;. Because Element holds a strong reference to Document, which holds
a strong reference to Style::Scope through Document::m_styleScope, we have a reference cycle.
This change breaks the cycle by changing the definition of AnchorPositionedToAnchorEntry so
that it no longer holds AnchorPositionedKey. This change should fix leaks in approximately
270 tests in LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/.

Test: fast/css/css-anchor-position/anchor-position-does-not-leak.html
* LayoutTests/fast/css/css-anchor-position/anchor-position-does-not-leak-expected.txt: Added.
* LayoutTests/fast/css/css-anchor-position/anchor-position-does-not-leak.html: Added.
* LayoutTests/fast/css/css-anchor-position/anchor-size-page-zoom.html:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):

Canonical link: <a href="https://commits.webkit.org/300880@main">https://commits.webkit.org/300880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cff8ddaf552d64088950608edbc6a176ab07b15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94425 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29201 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74448 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133635 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102897 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102705 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26307 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47941 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56693 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50376 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->