### PR TITLE
[GTK][Canary] Update llvm flatpak extension to 25.08

### DIFF
--- a/Tools/flatpak/flatpakutils.py
+++ b/Tools/flatpak/flatpakutils.py
@@ -544,17 +544,15 @@ class GnomeSDK(SDKBase):
         self.sdk_repo = FlatpakRepo("gnome-sdk", url=url, repo_file=repo_file)
         self.flathub_repo = FlatpakRepo("flathub", url="https://dl.flathub.org/repo/",
                                         repo_file="https://dl.flathub.org/repo/flathub.flatpakrepo")
-        self.flathub_beta_repo = FlatpakRepo("flathub-beta", url="https://dl.flathub.org/beta-repo/",
-                                             repo_file="https://dl.flathub.org/beta-repo/flathub-beta.flatpakrepo")
 
         arch = platform.machine()
         self.runtime = FlatpakPackage("org.gnome.Platform", self.branch, self.sdk_repo, arch)
         self.sdk = FlatpakPackage("org.gnome.Sdk", self.branch, self.sdk_repo, arch)
-        self.repos = FlatpakRepos([self.sdk_repo, self.flathub_repo, self.flathub_beta_repo])
+        self.repos = FlatpakRepos([self.sdk_repo, self.flathub_repo])
         self.packages = [self.runtime, self.sdk]
         self.packages.append(FlatpakPackage('org.gnome.Sdk.Debug', self.branch, self.sdk_repo, arch))
-        self.packages.append(FlatpakPackage("org.freedesktop.Sdk.Extension.llvm20", "25.08beta",
-                                            self.flathub_beta_repo, arch))
+        self.packages.append(FlatpakPackage("org.freedesktop.Sdk.Extension.llvm20", "25.08",
+                                            self.flathub_repo, arch))
 
     def programs_lookup_paths(self):
         return "/usr/lib/sdk/llvm20/bin:/usr/bin"


### PR DESCRIPTION
#### 05a89c7e6ec6668c2ee0e531a85f74b26dacd381
<pre>
[GTK][Canary] Update llvm flatpak extension to 25.08
<a href="https://bugs.webkit.org/show_bug.cgi?id=298738">https://bugs.webkit.org/show_bug.cgi?id=298738</a>

Reviewed by Adrian Perez de Castro.

* Tools/flatpak/flatpakutils.py:
(GnomeSDK.__init__): The GNOME SDK switched to FDO 25.08 as base on September 1st, so there&apos;s no
need for the beta LLVM extension version anymore.

Canonical link: <a href="https://commits.webkit.org/299888@main">https://commits.webkit.org/299888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/205933f0ca414dc04834384b52acf56b367ddcca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91522 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60799 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26127 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129767 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100140 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99982 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44075 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19137 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47289 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46757 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->