### PR TITLE
REGRESSION(297504@main): [ iOS Release ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html is a constant and flakey text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html
@@ -36,16 +36,16 @@ promise_test(async t => {
   // be a replace navigation.
   iframe.contentWindow.location.search = "?1";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.location.search = "?2";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.location.search = "?3";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.history.back();
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   assert_equals(iframe.contentWindow.location.search, "?2", "we made our way to ?2 for setup");
 
   iframe.contentWindow.history.back();
@@ -69,10 +69,10 @@ promise_test(async t => {
   // be a replace navigation.
   iframe.contentWindow.location.search = "?1";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.location.search = "?2";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
 
   iframe.contentWindow.history.back();
   assert_equals(iframe.contentWindow.location.search, "?2", "must not go back synchronously");
@@ -95,13 +95,13 @@ promise_test(async t => {
   // be a replace navigation.
   iframe.contentWindow.location.search = "?1";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.location.search = "?2";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.location.search = "?3";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
 
   iframe.contentWindow.history.back();
   assert_equals(iframe.contentWindow.location.search, "?3", "must not go back synchronously (1)");
@@ -127,20 +127,20 @@ promise_test(async t => {
   // be a replace navigation.
   iframe.contentWindow.location.search = "?1";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.location.search = "?2";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.location.search = "?3";
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   iframe.contentWindow.history.back();
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   assert_equals(iframe.contentWindow.location.search, "?2", "we made our way to ?2 for setup");
   iframe.contentWindow.history.back();
   await waitForLoad(iframe);
-  await delay(t, 0);
+  await delay(t, 5);
   assert_equals(iframe.contentWindow.location.search, "?1", "we made our way to ?1 for setup");
 
   iframe.contentWindow.history.forward();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8165,8 +8165,6 @@ webkit.org/b/296566 [ Release ] imported/w3c/web-platform-tests/screen-orientati
 
 webkit.org/b/296637 [ Release ] http/tests/dom/noopener-window-not-targetable.html [ Pass Failure ]
 
-webkit.org/b/296639 [ Release ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html [ Pass Failure ]
-
 webkit.org/b/296657 fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element.html [ Pass Failure ]
 
 webkit.org/b/296707 imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html [ Pass Failure ]


### PR DESCRIPTION
#### d542001d0b40075334e7732bf9ee163cb62a0ee0
<pre>
REGRESSION(297504@main): [ iOS Release ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html is a constant and flakey text failure
<a href="https://rdar.apple.com/157035929">rdar://157035929</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296639">https://bugs.webkit.org/show_bug.cgi?id=296639</a>

Reviewed by Charlie Wolfe.

<a href="https://commits.webkit.org/297504@main">https://commits.webkit.org/297504@main</a> introduced a fixed min waiting time for SafeBrowsing.
This affects this paticular test because it relies on using a fixed delay as well. We need to increase
the test&apos;s fixed delay to account for the new safe browsing delay.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/299920@main">https://commits.webkit.org/299920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88264197f0659adf6990d3ed79a370efb0417ef2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72589 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91530 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60806 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72081 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26135 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70507 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129775 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100150 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44083 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47297 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48452 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->