### PR TITLE
Web Inspector: Introduce the Frame target type to prep for site isolation

### DIFF
--- a/LayoutTests/http/tests/inspector/target/provisional-load-cancels-previous-load.html
+++ b/LayoutTests/http/tests/inspector/target/provisional-load-cancels-previous-load.html
@@ -23,7 +23,10 @@ function test()
             WI.Target.prototype._resumeIfPaused = () => {};
 
             WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, (event) => {
-                let target = event.data.target;
+                let { target } = event.data;
+                if (!(target instanceof WI.PageTarget))
+                    return;
+
                 let targetId = targetIdMap.get(target.identifier);
                 InspectorTest.pass(`Should receive TargetAdded event for target ${targetId}.`);
                 InspectorTest.expectTrue(target.isProvisional, `Target ${targetId} should be provisional.`);
@@ -42,11 +45,18 @@ function test()
 
             WI.targetManager.addEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, (event) => {
                 let {previousTargetId, target} = event.data;
+                if (!(target instanceof WI.PageTarget))
+                    return;
+
                 InspectorTest.pass(`Should receive DidCommitProvisionalTarget event ${targetIdMap.get(previousTargetId)} => ${targetIdMap.get(target.identifier)}.`);
             });
 
             WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, (event) =>{
-                let targetId = targetIdMap.get(event.data.target.identifier);
+                let { target } = event.data;
+                if (!(target instanceof WI.PageTarget))
+                    return;
+
+                let targetId = targetIdMap.get(target.identifier);
                 InspectorTest.pass(`Should receive TargetRemoved event for target ${targetId}`);
             });
 

--- a/LayoutTests/http/tests/inspector/target/target-events-for-provisional-page.html
+++ b/LayoutTests/http/tests/inspector/target/target-events-for-provisional-page.html
@@ -18,13 +18,20 @@ function test()
             let reloadPromise = InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
 
             WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, (event) => {
-                newTarget = event.data.target;
+                let target = event.data.target;
+                if (!(target instanceof WI.PageTarget))
+                    return;
+
+                newTarget = target;
                 InspectorTest.pass(`Should receive TargetAdded event.`);
                 InspectorTest.expectTrue(newTarget.isProvisional, "Target should be provisional.");
             });
 
             WI.targetManager.addEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, (event) => {
                 let {previousTargetId, target} = event.data;
+                if (!(target instanceof WI.PageTarget))
+                    return;
+
                 InspectorTest.pass(`Should receive DidCommitProvisionalTarget event.`);
                 InspectorTest.expectEqual(previousTargetId, mainTargetId, "Previous target should be the current one.");
                 InspectorTest.expectEqual(target, newTarget, "Committed target should match provisional target.");
@@ -32,6 +39,9 @@ function test()
 
             WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, (event) =>{
                 let target = event.data.target;
+                if (!(target instanceof WI.PageTarget))
+                    return;
+
                 InspectorTest.pass(`Should receive TargetRemoved event.`);
                 InspectorTest.expectEqual(target.identifier, mainTargetId, "Destroyed target should be previous target.");
 

--- a/LayoutTests/http/tests/site-isolation/inspector/target/resources/leaf-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/resources/leaf-iframe.html
@@ -1,0 +1,1 @@
+<p>Leaf iframe</p>

--- a/LayoutTests/http/tests/site-isolation/inspector/target/resources/middle-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/resources/middle-iframe.html
@@ -1,0 +1,2 @@
+<p>Middle iframe</p>
+<iframe src="http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe"></iframe>

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt
@@ -1,0 +1,8 @@
+
+== Running test suite: SiteIsolation.Target
+-- Running test case: SiteIsolation.Target.FrameTargetLifecycleEvents
+{"eventType":"target-manager-target-added","targetType":"frame"}
+{"eventType":"target-manager-target-added","targetType":"frame"}
+{"eventType":"target-manager-target-removed","targetType":"frame"}
+{"eventType":"target-manager-target-removed","targetType":"frame"}
+

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target.html
@@ -1,0 +1,41 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function appendAndRemoveIframe() {
+    let iframe = document.createElement("iframe");
+    iframe.src = "http://localhost:8000/site-isolation/inspector/target/resources/middle-iframe.html";
+    iframe.addEventListener("load", () => {
+        setTimeout(() => {
+            iframe.remove();
+        }, 0);
+    });
+    document.body.append(iframe);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Target");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Target.FrameTargetLifecycleEvents",
+        description: "Target lifecycle events for frame creation and deletion.",
+        test(resolve) {
+            let eventsSeen = 0;
+            const eventsExpected = 4;
+
+            let handleTargetManagerEvent = (event) => {
+                InspectorTest.log({ eventType: event.type, targetType: event.data.target.type });
+                ++eventsSeen;
+                if (eventsSeen == eventsExpected)
+                    resolve();
+            }
+            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, handleTargetManagerEvent);
+            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, handleTargetManagerEvent);
+
+            InspectorTest.evaluateInPage(`appendAndRemoveIframe();`);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()"></body>

--- a/LayoutTests/inspector/unit-tests/target-manager-expected.txt
+++ b/LayoutTests/inspector/unit-tests/target-manager-expected.txt
@@ -3,10 +3,11 @@ Test for TargetManager and other global WI.Target objects.
 
 == Running test suite: TargetManager
 -- Running test case: TargetManager.MainTarget
-PASS: Targets list should always start out with the main target.
-PASS: Target list should always contain the main target.
+PASS: Targets list should always start out with the main page target and the main frame target.
+PASS: Target list should always contain the main page target.
 PASS: Main target should have an ExecutionContext.
 PASS: Main target should have the page target's RuntimeAgent.
+Target - frame - Frame
 Target - page - Page
 
 -- Running test case: TargetManager.WorkerTarget.Create
@@ -14,10 +15,23 @@ PASS: Added Target should have Worker type.
 PASS: Added Target should have an ExecutionContext.
 PASS: Added Target should have a RuntimeAgent.
 PASS: Added Target RuntimeAgent should not be the global RuntimeAgent.
+Target - frame - Frame
 Target - page - Page
 Target - worker - worker-1.js
 
 -- Running test case: TargetManager.WorkerTarget.Remove
 PASS: Removed Target should have Worker type.
+Target - frame - Frame
+Target - page - Page
+
+-- Running test case: TargetManager.FrameTarget.Create
+PASS: Added Target should have Frame type.
+Target - frame - Frame
+Target - frame - Frame
+Target - page - Page
+
+-- Running test case: TargetManager.FrameTarget.Remove
+PASS: Removed Target should have Frame type.
+Target - frame - Frame
 Target - page - Page
 

--- a/LayoutTests/inspector/unit-tests/target-manager.html
+++ b/LayoutTests/inspector/unit-tests/target-manager.html
@@ -13,11 +13,22 @@ function terminateWorker() {
     worker.terminate();
 }
 
+let iframe;
+
+function appendIframe() {
+    iframe = document.createElement("iframe");
+    document.body.append(iframe);
+}
+
+function removeIframe() {
+    iframe.remove();
+}
+
 function test()
 {
     function dumpTargets() {
-        for (let target of WI.targets)
-            InspectorTest.log(`Target - ${String(target.type)} - ${target.displayName}`);
+        let targetList = WI.targets.map((x) => `Target - ${String(x.type)} - ${x.displayName}`);
+        InspectorTest.log(targetList.sort().join("\n"));
     }
 
     let suite = InspectorTest.createAsyncSuite("TargetManager");
@@ -27,8 +38,8 @@ function test()
         description: "We should always have the main target.",
         async test() {
             InspectorTest.assert(WI.targets === WI.targetManager.targets);
-            InspectorTest.expectEqual(WI.targets.length, 1, "Targets list should always start out with the main target.");
-            InspectorTest.expectEqual([...WI.targets][0], WI.mainTarget, "Target list should always contain the main target.");
+            InspectorTest.expectEqual(WI.targets.length, 2, "Targets list should always start out with the main page target and the main frame target.");
+            InspectorTest.expectThat(WI.targets.includes(WI.mainTarget), "Target list should always contain the main page target.");
             InspectorTest.expectNotNull(WI.mainTarget.executionContext, "Main target should have an ExecutionContext.");
             InspectorTest.expectEqual(WI.mainTarget.RuntimeAgent, WI.pageTarget.RuntimeAgent, "Main target should have the page target's RuntimeAgent.");
             dumpTargets();
@@ -42,7 +53,7 @@ function test()
             InspectorTest.evaluateInPage("createWorker()");
             let event = await WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
             let target = event.data.target;
-            InspectorTest.assert(target instanceof WI.Target);
+            InspectorTest.assert(target instanceof WI.WorkerTarget);
             InspectorTest.expectEqual(target.type, WI.TargetType.Worker, "Added Target should have Worker type.");
             InspectorTest.expectNotNull(target.executionContext, "Added Target should have an ExecutionContext.");
             InspectorTest.expectNotNull(target.RuntimeAgent, "Added Target should have a RuntimeAgent.");
@@ -53,13 +64,40 @@ function test()
 
     suite.addTestCase({
         name: "TargetManager.WorkerTarget.Remove",
-        description: "Creating a Worker should create a new Worker Target.",
+        description: "Removing a Worker should remove the Worker Target.",
         async test() {
             InspectorTest.evaluateInPage("terminateWorker()");
             let event = await WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetRemoved);
             let target = event.data.target;
-            InspectorTest.assert(target instanceof WI.Target);
+            InspectorTest.assert(target instanceof WI.WorkerTarget);
             InspectorTest.expectEqual(target.type, WI.TargetType.Worker, "Removed Target should have Worker type.");
+            dumpTargets();
+        }
+    });
+
+    suite.addTestCase({
+        name: "TargetManager.FrameTarget.Create",
+        description: "Appending an iframe should create a new Frame Target.",
+        async test() {
+            InspectorTest.evaluateInPage("appendIframe()");
+            let event = await WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            let target = event.data.target;
+            InspectorTest.assert(target instanceof WI.FrameTarget);
+            InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Added Target should have Frame type.");
+            // FIXME: <https://webkit.org/b/298977> Consider giving meaningful names to frame targets so we can distinguish them.
+            dumpTargets();
+        }
+    });
+
+    suite.addTestCase({
+        name: "TargetManager.FrameTarget.Remove",
+        description: "Removing an iframe should remove the Frame Target.",
+        async test() {
+            InspectorTest.evaluateInPage("removeIframe()");
+            let event = await WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetRemoved);
+            let target = event.data.target;
+            InspectorTest.assert(target instanceof WI.FrameTarget);
+            InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Removed Target should have Frame type.");
             dumpTargets();
         }
     });

--- a/LayoutTests/inspector/worker/debugger-shared-breakpoint.html
+++ b/LayoutTests/inspector/worker/debugger-shared-breakpoint.html
@@ -46,6 +46,10 @@ function test()
 
     function areAllTargetsPaused() {
         for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298909> Add Debugger support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             let targetData = WI.debuggerManager.dataForTarget(target);
             if (!targetData.paused)
                 return false;

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -440,6 +440,7 @@ storage/storagequota-request-quota.html
 # iOS doesn't have a local inspector
 inspector/ [ Skip ]
 http/tests/inspector/ [ Skip ]
+http/tests/site-isolation/inspector/ [ Skip ]
 http/tests/websocket/tests/hybi/inspector/ [ Skip ]
 
 # Needs testRunner.enableAutoResizeMode()

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1780,6 +1780,10 @@ inspector/heap/getRemoteObject.html [ Skip ]
 inspector/unit-tests/heap-snapshot.html [ Skip ]
 inspector/unit-tests/heap-snapshot-collection-event.html [ Skip ]
 
+# Frame Targets are not supported in WK1.
+# FIXME: <https://webkit.org/b/299207> Add or rewrite tests to account for lack of frame targets in WK1.
+inspector/unit-tests/target-manager.html [ Skip ]
+
 # WK1 Inspector cannot leverage InspectorAdditions runtime enabled features
 inspector/canvas/recording-html-2d.html
 

--- a/Source/JavaScriptCore/inspector/InspectorTarget.h
+++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
@@ -41,10 +41,9 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<Inspector::InspectorT
 
 namespace Inspector {
 
-// FIXME: Add DedicatedWorker Inspector Targets
-// FIXME: Add ServiceWorker Inspector Targets
 enum class InspectorTargetType : uint8_t {
     Page,
+    Frame,
     DedicatedWorker,
     ServiceWorker,
 };

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -102,6 +102,8 @@ static Protocol::Target::TargetInfo::Type targetTypeToProtocolType(InspectorTarg
     switch (type) {
     case InspectorTargetType::Page:
         return Protocol::Target::TargetInfo::Type::Page;
+    case InspectorTargetType::Frame:
+        return Protocol::Target::TargetInfo::Type::Frame;
     case InspectorTargetType::DedicatedWorker:
         return Protocol::Target::TargetInfo::Type::Worker;
     case InspectorTargetType::ServiceWorker:

--- a/Source/JavaScriptCore/inspector/protocol/Target.json
+++ b/Source/JavaScriptCore/inspector/protocol/Target.json
@@ -9,7 +9,7 @@
             "description": "Description of a target.",
             "properties": [
                 { "name": "targetId", "type": "string", "description": "Unique identifier for the target." },
-                { "name": "type", "type": "string", "enum": ["page", "service-worker", "worker"] },
+                { "name": "type", "type": "string", "enum": ["page", "frame", "service-worker", "worker"] },
                 { "name": "isProvisional", "type": "boolean", "optional": true, "description": "Whether this is a provisional page target." },
                 { "name": "isPaused", "type": "boolean", "optional": true, "description": "Whether the target is paused on start and has to be explicitely resumed by inspector." }
             ]

--- a/Source/JavaScriptCore/inspector/scripts/codegen/models.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/models.py
@@ -53,7 +53,7 @@ def validate_target_types(debuggable_types, target_types):
         elif target_type == 'service-worker':
             if 'service-worker' not in debuggable_types:
                 return False
-        elif target_type == 'web-page':
+        elif target_type == 'web-page' or target_type == 'frame':
             if 'web-page' not in debuggable_types:
                 return False
     return True
@@ -95,7 +95,7 @@ _FRAMEWORK_CONFIG_MAP = {
 }
 
 _ALLOWED_DEBUGGABLE_TYPE_STRINGS = ['itml', 'javascript', 'page', 'service-worker', 'web-page']
-_ALLOWED_TARGET_TYPE_STRINGS = ['itml', 'javascript', 'page', 'service-worker', 'web-page', 'worker']
+_ALLOWED_TARGET_TYPE_STRINGS = ['itml', 'javascript', 'page', 'service-worker', 'web-page', 'frame', 'worker']
 
 
 class ParseException(Exception):

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1734,6 +1734,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/track/VideoTrackClient.h
     html/track/WebVTTParser.h
 
+    inspector/FrameInspectorController.h
     inspector/InspectorBackendClient.h
     inspector/InspectorController.h
     inspector/InspectorDebuggableType.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1829,6 +1829,7 @@ inspector/CommandLineAPIHost.cpp
 inspector/CommandLineAPIModule.cpp
 inspector/DOMEditor.cpp
 inspector/DOMPatchSupport.cpp
+inspector/FrameInspectorController.cpp
 inspector/InspectorAuditAccessibilityObject.cpp
 inspector/InspectorAuditDOMObject.cpp
 inspector/InspectorAuditResourcesObject.cpp

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "FrameInspectorController.h"
+
+#include "CommonVM.h"
+#include "InspectorInstrumentation.h"
+#include "InstrumentingAgents.h"
+#include "JSDOMBindingSecurity.h"
+#include "JSDOMWindow.h"
+#include "JSExecState.h"
+#include "WebInjectedScriptHost.h"
+#include "WebInjectedScriptManager.h"
+#include <JavaScriptCore/InspectorAgentBase.h>
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <JavaScriptCore/JSLock.h>
+#include <JavaScriptCore/Strong.h>
+#include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+using namespace JSC;
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameInspectorController);
+
+FrameInspectorController::FrameInspectorController(Frame& frame)
+    : m_frame(frame)
+    , m_instrumentingAgents(InstrumentingAgents::create(*this))
+    , m_injectedScriptManager(makeUniqueRef<WebInjectedScriptManager>(*this, WebInjectedScriptHost::create()))
+    , m_frontendRouter(FrontendRouter::create())
+    , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
+    , m_executionStopwatch(Stopwatch::create())
+{
+}
+
+FrameInspectorController::~FrameInspectorController()
+{
+    m_instrumentingAgents->reset();
+}
+
+void FrameInspectorController::ref() const
+{
+    m_frame->ref();
+}
+
+void FrameInspectorController::deref() const
+{
+    m_frame->deref();
+}
+
+void FrameInspectorController::createLazyAgents()
+{
+    if (m_didCreateLazyAgents)
+        return;
+
+    m_didCreateLazyAgents = true;
+
+    m_injectedScriptManager->connect();
+    if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
+        commandLineAPIHost->init(m_instrumentingAgents.copyRef());
+}
+
+void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& frontendChannel, bool isAutomaticInspection, bool immediatelyPause)
+{
+    UNUSED_PARAM(isAutomaticInspection);
+    UNUSED_PARAM(immediatelyPause);
+
+    if (RefPtr page = m_frame->page())
+        page->settings().setDeveloperExtrasEnabled(true);
+
+    m_frontendRouter->connectFrontend(frontendChannel);
+    InspectorInstrumentation::frontendCreated();
+}
+
+void FrameInspectorController::disconnectFrontend(Inspector::FrontendChannel& frontendChannel)
+{
+    m_frontendRouter->disconnectFrontend(frontendChannel);
+    InspectorInstrumentation::frontendDeleted();
+}
+
+void FrameInspectorController::dispatchMessageFromFrontend(const String& message)
+{
+    m_backendDispatcher->dispatch(message);
+}
+
+bool FrameInspectorController::developerExtrasEnabled() const
+{
+    RefPtr page = m_frame->page();
+    return page && page->settings().developerExtrasEnabled();
+}
+
+bool FrameInspectorController::canAccessInspectedScriptState(JSC::JSGlobalObject* lexicalGlobalObject) const
+{
+    JSLockHolder lock(lexicalGlobalObject);
+
+    auto* inspectedWindow = jsDynamicCast<JSDOMWindow*>(lexicalGlobalObject);
+    if (!inspectedWindow)
+        return false;
+
+    Ref protectedWindow { inspectedWindow->wrapped() };
+    return BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, protectedWindow.get(), DoNotReportSecurityError);
+}
+
+InspectorFunctionCallHandler FrameInspectorController::functionCallHandler() const
+{
+    return WebCore::functionCallHandlerFromAnyThread;
+}
+
+InspectorEvaluateHandler FrameInspectorController::evaluateHandler() const
+{
+    return WebCore::evaluateHandlerFromAnyThread;
+}
+
+void FrameInspectorController::frontendInitialized()
+{
+}
+
+Stopwatch& FrameInspectorController::executionStopwatch() const
+{
+    return m_executionStopwatch;
+}
+
+JSC::Debugger* FrameInspectorController::debugger()
+{
+    // FIXME <https://webkit.org/b/298909> Add Debugger support for frame targets.
+    return nullptr;
+}
+
+JSC::VM& FrameInspectorController::vm()
+{
+    return commonVM();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/InspectorAgentRegistry.h>
+#include <JavaScriptCore/InspectorEnvironment.h>
+#include <WebCore/InspectorOverlay.h>
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
+#include <wtf/text/WTFString.h>
+
+namespace Inspector {
+class BackendDispatcher;
+class FrontendChannel;
+class FrontendRouter;
+}
+
+namespace WebCore {
+
+class Frame;
+class InspectorBackendClient;
+class InspectorFrontendClient;
+class InspectorInstrumentation;
+class InstrumentingAgents;
+class WebInjectedScriptManager;
+
+class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<FrameInspectorController> {
+    WTF_MAKE_NONCOPYABLE(FrameInspectorController);
+    WTF_MAKE_TZONE_ALLOCATED(FrameInspectorController);
+public:
+    FrameInspectorController(Frame&);
+    ~FrameInspectorController() override;
+
+    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void deref() const;
+
+    WEBCORE_EXPORT void connectFrontend(Inspector::FrontendChannel&, bool isAutomaticInspection = false, bool immediatelyPause = false);
+    WEBCORE_EXPORT void disconnectFrontend(Inspector::FrontendChannel&);
+    WEBCORE_EXPORT void dispatchMessageFromFrontend(const String& message);
+
+    // InspectorEnvironment
+    bool developerExtrasEnabled() const override;
+    bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override;
+    Inspector::InspectorFunctionCallHandler functionCallHandler() const override;
+    Inspector::InspectorEvaluateHandler evaluateHandler() const override;
+    void frontendInitialized() override;
+    WTF::Stopwatch& executionStopwatch() const final;
+    JSC::Debugger* debugger() override;
+    JSC::VM& vm() override;
+
+private:
+    friend class InspectorInstrumentation;
+
+    void createLazyAgents();
+
+    WeakRef<Frame> m_frame;
+    const Ref<InstrumentingAgents> m_instrumentingAgents;
+    const UniqueRef<WebInjectedScriptManager> m_injectedScriptManager;
+    const Ref<Inspector::FrontendRouter> m_frontendRouter;
+    const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
+    const Ref<WTF::Stopwatch> m_executionStopwatch;
+    Inspector::AgentRegistry m_agents;
+
+    bool m_didCreateLazyAgents { false };
+    WeakPtr<InspectorFrontendClient> m_inspectorFrontendClient;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -29,6 +29,7 @@
 #include "ContainerNodeInlines.h"
 #include "FrameConsoleClient.h"
 #include "FrameInlines.h"
+#include "FrameInspectorController.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "HTMLFrameOwnerElement.h"
@@ -120,6 +121,7 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
     , m_navigationScheduler(makeUniqueRefWithoutRefCountedCheck<NavigationScheduler>(*this))
     , m_opener(opener)
     , m_frameTreeSyncData(WTFMove(frameTreeSyncData))
+    , m_inspectorController(makeUniqueRefWithoutRefCountedCheck<FrameInspectorController>(*this))
     , m_consoleClient(makeUniqueRef<FrameConsoleClient>(*this))
 {
     relaxAdoptionRequirement();
@@ -336,6 +338,11 @@ bool Frame::frameCanCreatePaymentSession() const
     // Prefer the LocalFrame code path when site isolation is disabled.
     ASSERT(m_settings->siteIsolationEnabled());
     return m_frameTreeSyncData->frameCanCreatePaymentSession;
+}
+
+Ref<FrameInspectorController> Frame::protectedInspectorController()
+{
+    return m_inspectorController.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -41,9 +41,10 @@ namespace WebCore {
 class DOMWindow;
 class Event;
 class FrameConsoleClient;
-class FrameView;
+class FrameInspectorController;
 class FrameLoaderClient;
 class FrameLoadRequest;
+class FrameView;
 class HTMLFrameOwnerElement;
 class NavigationScheduler;
 class Page;
@@ -145,6 +146,8 @@ public:
     FrameTreeSyncData& frameTreeSyncData() const { return m_frameTreeSyncData.get(); }
     WEBCORE_EXPORT virtual RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const = 0;
 
+    FrameInspectorController& inspectorController() { return m_inspectorController.get(); }
+    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController();
     FrameConsoleClient& console() { return m_consoleClient.get(); }
     const FrameConsoleClient& console() const { return m_consoleClient.get(); }
 
@@ -173,6 +176,7 @@ private:
 
     Ref<FrameTreeSyncData> m_frameTreeSyncData;
 
+    const UniqueRef<FrameInspectorController> m_inspectorController;
     const UniqueRef<FrameConsoleClient> m_consoleClient;
 };
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -827,6 +827,7 @@ localizedStrings["Format: Short Hex with Alpha"] = "Format: Short Hex with Alpha
 localizedStrings["Forward (%s)"] = "Forward (%s)";
 localizedStrings["Fragment"] = "Fragment";
 localizedStrings["Fragment Shader"] = "Fragment Shader";
+localizedStrings["Frame"] = "Frame";
 localizedStrings["Frame %d"] = "Frame %d";
 localizedStrings["Frame %d \u2014 %s"] = "Frame %d \u2014 %s";
 localizedStrings["Frames"] = "Frames";

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -2593,30 +2593,43 @@ WI._showTabAtIndexFromShortcut = function(i)
 
 WI._showJavaScriptTypeInformationSettingChanged = function(event)
 {
-    if (WI.settings.showJavaScriptTypeInformation.value) {
-        for (let target of WI.targets)
+    let shouldEnable = WI.settings.showJavaScriptTypeInformation.value;
+    for (let target of WI.targets) {
+        // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+        if (target instanceof WI.FrameTarget)
+            continue;
+
+        if (shouldEnable)
             target.RuntimeAgent.enableTypeProfiler();
-    } else {
-        for (let target of WI.targets)
+        else
             target.RuntimeAgent.disableTypeProfiler();
     }
 };
 
 WI._enableControlFlowProfilerSettingChanged = function(event)
 {
-    if (WI.settings.enableControlFlowProfiler.value) {
-        for (let target of WI.targets)
+    let shouldEnable = WI.settings.enableControlFlowProfiler.value;
+    for (let target of WI.targets) {
+        // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+        if (target instanceof WI.FrameTarget)
+            continue;
+
+        if (shouldEnable)
             target.RuntimeAgent.enableControlFlowProfiler();
-    } else {
-        for (let target of WI.targets)
+        else
             target.RuntimeAgent.disableControlFlowProfiler();
     }
 };
 
 WI._resourceCachingDisabledSettingChanged = function(event)
 {
-    for (let target of WI.targets)
+    for (let target of WI.targets) {
+        // FIXME: <https://webkit.org/b/298979> Add Network support for FrameTarget.
+        if (target instanceof WI.FrameTarget)
+            continue;
+
         target.NetworkAgent.setResourceCachingDisabled(WI.settings.resourceCachingDisabled.value);
+    }
 };
 
 WI._allowInspectingInspectorSettingChanged = function(event)

--- a/Source/WebInspectorUI/UserInterface/Base/TargetType.js
+++ b/Source/WebInspectorUI/UserInterface/Base/TargetType.js
@@ -29,6 +29,7 @@ WI.TargetType = {
     Page: "page",
     ServiceWorker: "service-worker",
     WebPage: "web-page",
+    Frame: "frame",
     Worker: "worker",
 };
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js
@@ -131,8 +131,10 @@ WI.CanvasManager = class CanvasManager extends WI.Object
     {
         console.assert(!isNaN(count) && count >= 0);
 
-        for (let target of WI.targets)
-            target.CanvasAgent.setRecordingAutoCaptureFrameCount(enabled ? count : 0);
+        for (let target of WI.targets) {
+            if (target.hasDomain("Canvas"))
+                target.CanvasAgent.setRecordingAutoCaptureFrameCount(enabled ? count : 0);
+        }
 
         WI.settings.canvasRecordingAutoCaptureEnabled.value = enabled && count;
         WI.settings.canvasRecordingAutoCaptureFrameCount.value = count;

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -90,6 +90,10 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     initializeTarget(target)
     {
+        // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
+        if (target instanceof WI.FrameTarget)
+            return;
+
         // Intentionally defer ConsoleAgent initialization to the end. We do this so that any
         // previous initialization messages will have their responses arrive before a stream
         // of console message added events come in after enabling Console.
@@ -251,8 +255,13 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
     {
         this._clearMessagesRequested = true;
 
-        for (let target of WI.targets)
+        for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             target.ConsoleAgent.clearMessages();
+        }
     }
 
     initializeLogChannels(target)

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js
@@ -375,7 +375,7 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
         this.dispatchEventToListeners(WI.DOMDebuggerManager.Event.EventBreakpointAdded, {breakpoint});
 
         if (!breakpoint.disabled) {
-            for (let target of WI.targets)
+            for (let target of this.#allSupportedTargets())
                 this._setEventBreakpoint(breakpoint, target);
         }
 
@@ -484,7 +484,7 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
         this.dispatchEventToListeners(WI.DOMDebuggerManager.Event.URLBreakpointAdded, {breakpoint});
 
         if (!breakpoint.disabled) {
-            for (let target of WI.targets)
+            for (let target of this.#allSupportedTargets())
                 this._setURLBreakpoint(breakpoint, target);
         }
 
@@ -823,7 +823,7 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
         if (breakpoint.eventListener)
             return;
 
-        for (let target of WI.targets) {
+        for (let target of this.#allSupportedTargets()) {
             if (breakpoint.disabled)
                 this._removeEventBreakpoint(breakpoint, target);
             else
@@ -849,7 +849,7 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
             return;
 
         this._restoringBreakpoints = true;
-        for (let target of WI.targets) {
+        for (let target of this.#allSupportedTargets()) {
             // Clear the old breakpoint from the backend before setting the new one.
             this._removeEventBreakpoint(breakpoint, target);
             this._setEventBreakpoint(breakpoint, target);
@@ -874,7 +874,7 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
     {
         let breakpoint = event.target;
 
-        for (let target of WI.targets) {
+        for (let target of this.#allSupportedTargets()) {
             if (breakpoint.disabled)
                 this._removeURLBreakpoint(breakpoint, target);
             else
@@ -896,7 +896,7 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
             return;
 
         this._restoringBreakpoints = true;
-        for (let target of WI.targets) {
+        for (let target of this.#allSupportedTargets()) {
             // Clear the old breakpoint from the backend before setting the new one.
             this._removeURLBreakpoint(breakpoint, target)
             this._setURLBreakpoint(breakpoint, target);
@@ -1006,6 +1006,14 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
                     break;
                 }
             }
+        }
+    }
+
+    // FIXME: <https://webkit.org/b/298981> Add DOMDebugger support for FrameTarget.
+    *#allSupportedTargets() {
+        for (let target of WI.targets) {
+            if (!(target instanceof WI.FrameTarget))
+                yield target;
         }
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -875,6 +875,10 @@ WI.DOMManager = class DOMManager extends WI.Object
             return;
 
         for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298980> Add DOM support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             // Clear the old breakpoint from the backend before setting the new one.
             this._removeEventBreakpoint(breakpoint, target);
             this._setEventBreakpoint(breakpoint, target);

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -283,8 +283,13 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         this._emulatedCondition = condition;
 
-        for (let target of WI.targets)
+        for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298979> Add Network support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             this._applyEmulatedCondition(target);
+        }
 
         this.dispatchEventToListeners(WI.NetworkManager.Event.EmulatedConditionChanged);
     }

--- a/Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js
@@ -54,6 +54,10 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
 
     initializeTarget(target)
     {
+        // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+        if (target instanceof WI.FrameTarget)
+            return;
+
         target.RuntimeAgent.enable();
 
         if (WI.settings.showJavaScriptTypeInformation.value)

--- a/Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js
@@ -191,6 +191,9 @@ WI.TargetManager = class TargetManager extends WI.Object
         case "serviceworker": // COMPATIBILITY (iOS 13): "serviceworker" was renamed to "service-worker".
         case InspectorBackend.Enum.Target.TargetInfoType.ServiceWorker:
             return new WI.WorkerTarget(parentTarget, targetId, WI.UIString("ServiceWorker"), connection, {isPaused});
+        case InspectorBackend.Enum.Target.TargetInfoType.Frame:
+            // FIXME: <https://webkit.org/b/298977> Consider setting a more meaningful name for the frame target.
+            return new WI.FrameTarget(parentTarget, targetId, WI.UIString("Frame"), connection, {isProvisional});
         }
 
         throw "Unknown Target type: " + type;

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -356,6 +356,7 @@
     <script src="Protocol/DirectBackendTarget.js"></script>
     <script src="Protocol/MultiplexingBackendTarget.js"></script>
     <script src="Protocol/PageTarget.js"></script>
+    <script src="Protocol/FrameTarget.js"></script>
     <script src="Protocol/WorkerTarget.js"></script>
 
     <script src="Protocol/AnimationObserver.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsInstrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsInstrument.js
@@ -45,7 +45,7 @@ WI.HeapAllocationsInstrument = class HeapAllocationsInstrument extends WI.Instru
         // FIXME: Include a periodic snapshot interval option for this instrument.
 
         if (!initiatedByBackend) {
-            for (let target of WI.targets)
+            for (let target of this.#allSupportedTargets())
                 target.HeapAgent.startTracking();
         }
 
@@ -57,7 +57,7 @@ WI.HeapAllocationsInstrument = class HeapAllocationsInstrument extends WI.Instru
     stopInstrumentation(initiatedByBackend)
     {
         if (!initiatedByBackend) {
-            for (let target of WI.targets)
+            for (let target of this.#allSupportedTargets())
                 target.HeapAgent.stopTracking();
         }
 
@@ -69,7 +69,7 @@ WI.HeapAllocationsInstrument = class HeapAllocationsInstrument extends WI.Instru
 
     _takeHeapSnapshot()
     {
-        for (let target of WI.targets) {
+        for (let target of this.#allSupportedTargets()) {
             WI.heapManager.snapshot(target, (error, timestamp, snapshotStringData) => {
                 let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
                 workerProxy.createSnapshot(target.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
@@ -78,6 +78,14 @@ WI.HeapAllocationsInstrument = class HeapAllocationsInstrument extends WI.Instru
                     WI.timelineManager.heapSnapshotAdded(timestamp, snapshot);
                 });
             });
+        }
+    }
+
+    // FIXME: <https://webkit.org/b/298984> Add Heap support for FrameTarget.
+    *#allSupportedTargets() {
+        for (let target of WI.targets) {
+            if (!(target instanceof WI.FrameTarget))
+                yield target;
         }
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.FrameTarget = class FrameTarget extends WI.Target
+{
+    constructor(parentTarget, targetId, name, connection, options = {})
+    {
+        super(parentTarget, targetId, name, WI.TargetType.Frame, connection, options);
+
+        this._executionContext = new WI.ExecutionContext(this, WI.RuntimeManager.TopLevelContextExecutionIdentifier, WI.ExecutionContext.Type.Normal, this.displayName);
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -56,9 +56,12 @@ WI.Target = class Target extends WI.Object
         this._connection.target = this;
 
         // Agents we always expect in every target.
-        console.assert(this.hasDomain("Target") || this.hasDomain("Runtime"));
-        console.assert(this.hasDomain("Target") || this.hasDomain("Debugger"));
-        console.assert(this.hasDomain("Target") || this.hasDomain("Console"));
+        if (!(this instanceof WI.FrameTarget)) {
+            // FIXME: <https://webkit.org/b/298909, https://webkit.org/b/298910, https://webkit.org/b/298911> Add support for Runtime, Debugger, and Console domains for FrameTarget.
+            console.assert(this.hasDomain("Target") || this.hasDomain("Runtime"));
+            console.assert(this.hasDomain("Target") || this.hasDomain("Debugger"));
+            console.assert(this.hasDomain("Target") || this.hasDomain("Console"));
+        }
     }
 
     // Target
@@ -83,7 +86,10 @@ WI.Target = class Target extends WI.Object
         // previous initialization messages will have their responses arrive before a stream
         // of console message added events come in after enabling Console.
         // See WI.ConsoleManager.prototype.initializeTarget.
-        this.ConsoleAgent.enable();
+        if (!(this instanceof WI.FrameTarget)) {
+            // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
+            this.ConsoleAgent.enable();
+        }
 
         setTimeout(() => {
             // Use this opportunity to run any one time frontend initialization

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -82,6 +82,7 @@
     <script src="Protocol/DirectBackendTarget.js"></script>
     <script src="Protocol/MultiplexingBackendTarget.js"></script>
     <script src="Protocol/PageTarget.js"></script>
+    <script src="Protocol/FrameTarget.js"></script>
     <script src="Protocol/WorkerTarget.js"></script>
 
     <script src="Protocol/InspectorObserver.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
@@ -422,6 +422,10 @@ WI.HeapAllocationsTimelineView = class HeapAllocationsTimelineView extends WI.Ti
     _takeHeapSnapshotClicked()
     {
         for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298984> Add Heap support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             WI.heapManager.snapshot(target, (error, timestamp, snapshotStringData) => {
                 let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
                 workerProxy.createSnapshot(target.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -898,8 +898,13 @@ WI.LogContentView = class LogContentView extends WI.ContentView
 
     _garbageCollect()
     {
-        for (let target of WI.targets)
+        for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298984> Add Heap support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             target.HeapAgent.gc();
+        }
     }
 
     _messageShouldBeVisible(message)

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeChainDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeChainDetailsSidebarPanel.js
@@ -293,14 +293,24 @@ WI.ScopeChainDetailsSidebarPanel = class ScopeChainDetailsSidebarPanel extends W
         if (!watchExpressions.length) {
             if (this._usedWatchExpressionsObjectGroup) {
                 this._usedWatchExpressionsObjectGroup = false;
-                for (let target of WI.targets)
+                for (let target of WI.targets) {
+                    // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+                    if (target instanceof WI.FrameTarget)
+                        continue;
+
                     target.RuntimeAgent.releaseObjectGroup(WI.ScopeChainDetailsSidebarPanel.WatchExpressionsObjectGroupName);
+                }
             }
             return Promise.resolve(null);
         }
 
-        for (let target of WI.targets)
+        for (let target of WI.targets) {
+            // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+            if (target instanceof WI.FrameTarget)
+                continue;
+
             target.RuntimeAgent.releaseObjectGroup(WI.ScopeChainDetailsSidebarPanel.WatchExpressionsObjectGroupName);
+        }
         this._usedWatchExpressionsObjectGroup = true;
 
         let watchExpressionsRemoteObject = WI.RemoteObject.createFakeRemoteObject();

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -389,8 +389,13 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
                 let logEditor = consoleSettingsView.addGroupWithCustomSetting(label, WI.SettingEditor.Type.Select, {values: logLevels});
                 logEditor.value = channel.level;
                 logEditor.addEventListener(WI.SettingEditor.Event.ValueDidChange, function(event) {
-                    for (let target of WI.targets)
+                    for (let target of WI.targets) {
+                        // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
+                        if (target instanceof WI.FrameTarget)
+                            continue;
+
                         target.ConsoleAgent.setLoggingChannelLevel(channel.source, this.value);
+                    }
                 }, logEditor);
             }
         }

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -613,12 +613,14 @@ UIProcess/Model/ModelProcessProxy.cpp
 
 UIProcess/Inspector/InspectorTargetProxy.cpp
 UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
 UIProcess/Inspector/WebInspectorBackendProxy.cpp
-UIProcess/Inspector/WebInspectorUIProxy.cpp
 UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+UIProcess/Inspector/WebInspectorUIProxy.cpp
 UIProcess/Inspector/WebInspectorUtilities.cpp
 UIProcess/Inspector/WebPageDebuggable.cpp
 UIProcess/Inspector/WebPageInspectorController.cpp
+UIProcess/Inspector/WebPageInspectorTargetProxy.cpp
 
 UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
 
@@ -718,6 +720,8 @@ WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp @no-unify
 WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp @no-unify
 
 WebProcess/Inspector/RemoteWebInspectorUI.cpp
+WebProcess/Inspector/WebFrameInspectorTarget.cpp
+WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.cpp
 WebProcess/Inspector/WebInspectorBackendClient.cpp
 WebProcess/Inspector/WebInspectorInternal.cpp
 WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
@@ -26,42 +26,24 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorTarget.h>
-#include <wtf/Noncopyable.h>
-#include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
-class ProvisionalPageProxy;
-class WebPageProxy;
-
-// NOTE: This UIProcess side InspectorTarget doesn't care about the frontend channel, since
-// any target -> frontend messages will be routed to the WebPageProxy with a targetId.
-
-class InspectorTargetProxy final : public Inspector::InspectorTarget {
-    WTF_MAKE_TZONE_ALLOCATED(InspectorTargetProxy);
-    WTF_MAKE_NONCOPYABLE(InspectorTargetProxy);
+class InspectorTargetProxy : public Inspector::InspectorTarget {
 public:
-    static std::unique_ptr<InspectorTargetProxy> create(WebPageProxy&, const String& targetId, Inspector::InspectorTargetType);
-    static std::unique_ptr<InspectorTargetProxy> create(ProvisionalPageProxy&, const String& targetId, Inspector::InspectorTargetType);
-    InspectorTargetProxy(WebPageProxy&, const String& targetId, Inspector::InspectorTargetType);
-    ~InspectorTargetProxy() = default;
+    virtual ~InspectorTargetProxy() = default;
 
     Inspector::InspectorTargetType type() const final { return m_type; }
     String identifier() const final { return m_identifier; }
 
-    void didCommitProvisionalTarget();
-    bool isProvisional() const override;
+    virtual void didCommitProvisionalTarget() = 0;
 
-    void connect(Inspector::FrontendChannel::ConnectionType) override;
-    void disconnect() override;
-    void sendMessageToTargetBackend(const String&) override;
+protected:
+    InspectorTargetProxy(const String& targetId, Inspector::InspectorTargetType);
 
 private:
-    WeakRef<WebPageProxy> m_page;
     String m_identifier;
     Inspector::InspectorTargetType m_type;
-    WeakPtr<ProvisionalPageProxy> m_provisionalPage;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebFrameInspectorTargetProxy.h"
+
+#include "InspectorTargetProxy.h"
+#include "MessageSenderInlines.h"
+#include "ProvisionalFrameProxy.h"
+#include "WebFrameMessages.h"
+#include "WebFrameProxy.h"
+#include <JavaScriptCore/InspectorTarget.h>
+#include <memory>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebFrameInspectorTargetProxy);
+
+std::unique_ptr<WebFrameInspectorTargetProxy> WebFrameInspectorTargetProxy::create(WebFrameProxy& frame, const String& targetId)
+{
+    return makeUnique<WebFrameInspectorTargetProxy>(frame, targetId);
+}
+
+std::unique_ptr<WebFrameInspectorTargetProxy> WebFrameInspectorTargetProxy::create(ProvisionalFrameProxy& provisionalFrame, const String& targetId)
+{
+    Ref frame { provisionalFrame.frame() };
+    std::unique_ptr target = WebFrameInspectorTargetProxy::create(frame.get(), targetId);
+    target->m_provisionalFrame = provisionalFrame;
+    return target;
+}
+
+WebFrameInspectorTargetProxy::WebFrameInspectorTargetProxy(WebFrameProxy& frame, const String& targetId)
+    : InspectorTargetProxy(targetId, Inspector::InspectorTargetType::Frame)
+    , m_frame(frame)
+{
+}
+
+WebFrameInspectorTargetProxy::~WebFrameInspectorTargetProxy() = default;
+
+void WebFrameInspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType connectionType)
+{
+    if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
+        provisionalFrame->protectedProcess()->send(Messages::WebFrame::ConnectInspector(connectionType), provisionalFrame->protectedFrame()->frameID());
+        return;
+    }
+
+    Ref frame = m_frame.get();
+    frame->protectedProcess()->send(Messages::WebFrame::ConnectInspector(connectionType), frame->frameID());
+}
+
+void WebFrameInspectorTargetProxy::disconnect()
+{
+    if (isPaused())
+        resume();
+
+    if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
+        provisionalFrame->protectedProcess()->send(Messages::WebFrame::DisconnectInspector(), provisionalFrame->protectedFrame()->frameID());
+        return;
+    }
+
+    Ref frame = m_frame.get();
+    frame->protectedProcess()->send(Messages::WebFrame::DisconnectInspector(), frame->frameID());
+}
+
+void WebFrameInspectorTargetProxy::sendMessageToTargetBackend(const String& message)
+{
+    if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
+        provisionalFrame->protectedProcess()->send(Messages::WebFrame::SendMessageToInspectorTarget(message), provisionalFrame->protectedFrame()->frameID());
+        return;
+    }
+
+    Ref frame = m_frame.get();
+    frame->protectedProcess()->send(Messages::WebFrame::SendMessageToInspectorTarget(message), frame->frameID());
+}
+
+void WebFrameInspectorTargetProxy::didCommitProvisionalTarget()
+{
+    m_provisionalFrame = nullptr;
+}
+
+bool WebFrameInspectorTargetProxy::isProvisional() const
+{
+    return !!m_provisionalFrame;
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorTargetProxy.h"
+#include <JavaScriptCore/InspectorTarget.h>
+#include <memory>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TypeCasts.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class ProvisionalFrameProxy;
+class WebFrameProxy;
+
+class WebFrameInspectorTargetProxy final : public InspectorTargetProxy {
+    WTF_MAKE_TZONE_ALLOCATED(WebFrameInspectorTargetProxy);
+    WTF_MAKE_NONCOPYABLE(WebFrameInspectorTargetProxy);
+public:
+    static std::unique_ptr<WebFrameInspectorTargetProxy> create(WebFrameProxy&, const String& targetId);
+    static std::unique_ptr<WebFrameInspectorTargetProxy> create(ProvisionalFrameProxy&, const String& targetId);
+    WebFrameInspectorTargetProxy(WebFrameProxy&, const String& targetId);
+    ~WebFrameInspectorTargetProxy();
+
+    void didCommitProvisionalTarget() override;
+    bool isProvisional() const override;
+
+    void connect(Inspector::FrontendChannel::ConnectionType) override;
+    void disconnect() override;
+    void sendMessageToTargetBackend(const String&) override;
+
+private:
+    WeakRef<WebFrameProxy> m_frame;
+    WeakPtr<ProvisionalFrameProxy> m_provisionalFrame;
+};
+
+} // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebFrameInspectorTargetProxy)
+static bool isType(const WebKit::WebFrameInspectorTargetProxy& target)
+{
+    return target.type() == Inspector::InspectorTargetType::Frame;
+}
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -1,4 +1,4 @@
-    /*
+/*
  * Copyright (C) 2018-2020 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,9 +29,11 @@
 #include "APIUIClient.h"
 #include "InspectorBrowserAgent.h"
 #include "ProvisionalPageProxy.h"
+#include "WebFrameInspectorTargetProxy.h"
 #include "WebFrameProxy.h"
 #include "WebPageInspectorAgentBase.h"
 #include "WebPageInspectorTarget.h"
+#include "WebPageInspectorTargetProxy.h"
 #include "WebPageProxy.h"
 #include "WebsiteDataStore.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
@@ -73,7 +75,7 @@ Ref<WebPageProxy> WebPageInspectorController::protectedInspectedPage()
 void WebPageInspectorController::init()
 {
     String pageTargetId = WebPageInspectorTarget::toTargetID(m_inspectedPage->webPageIDInMainFrameProcess());
-    createInspectorTarget(pageTargetId, Inspector::InspectorTargetType::Page);
+    createWebPageInspectorTarget(pageTargetId, Inspector::InspectorTargetType::Page);
 }
 
 void WebPageInspectorController::pageClosed()
@@ -166,9 +168,14 @@ void WebPageInspectorController::setIndicating(bool indicating)
 }
 #endif
 
-void WebPageInspectorController::createInspectorTarget(const String& targetId, Inspector::InspectorTargetType type)
+void WebPageInspectorController::createWebPageInspectorTarget(const String& targetId, Inspector::InspectorTargetType type)
 {
-    addTarget(InspectorTargetProxy::create(protectedInspectedPage(), targetId, type));
+    addTarget(WebPageInspectorTargetProxy::create(protectedInspectedPage(), targetId, type));
+}
+
+void WebPageInspectorController::createWebFrameInspectorTarget(WebFrameProxy& frame, const String& targetId)
+{
+    addTarget(WebFrameInspectorTargetProxy::create(frame, targetId));
 }
 
 void WebPageInspectorController::destroyInspectorTarget(const String& targetId)
@@ -204,7 +211,7 @@ void WebPageInspectorController::setContinueLoadingCallback(const ProvisionalPag
 
 void WebPageInspectorController::didCreateProvisionalPage(ProvisionalPageProxy& provisionalPage)
 {
-    addTarget(InspectorTargetProxy::create(provisionalPage, getTargetID(provisionalPage), Inspector::InspectorTargetType::Page));
+    addTarget(WebPageInspectorTargetProxy::create(provisionalPage, getTargetID(provisionalPage), Inspector::InspectorTargetType::Page));
 }
 
 void WebPageInspectorController::willDestroyProvisionalPage(const ProvisionalPageProxy& provisionalPage)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include "InspectorTargetProxy.h"
+#include "ProvisionalPageProxy.h"
 #include <JavaScriptCore/InspectorAgentRegistry.h>
 #include <JavaScriptCore/InspectorTargetAgent.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -44,6 +46,7 @@ class FrontendRouter;
 namespace WebKit {
 
 class InspectorBrowserAgent;
+class ProvisionalPageProxy;
 struct WebPageAgentContext;
 
 class WebPageInspectorController {
@@ -68,7 +71,8 @@ public:
     void setIndicating(bool);
 #endif
 
-    void createInspectorTarget(const String& targetId, Inspector::InspectorTargetType);
+    void createWebPageInspectorTarget(const String& targetId, Inspector::InspectorTargetType);
+    void createWebFrameInspectorTarget(WebFrameProxy&, const String& targetId);
     void destroyInspectorTarget(const String& targetId);
     void sendMessageToInspectorFrontend(const String& targetId, const String& message);
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebPageInspectorTargetProxy.h"
+
+#include "InspectorTargetProxy.h"
+#include "MessageSenderInlines.h"
+#include "ProvisionalPageProxy.h"
+#include "WebPageInspectorTarget.h"
+#include "WebPageMessages.h"
+#include "WebPageProxy.h"
+#include "WebProcessProxy.h"
+#include <JavaScriptCore/InspectorTarget.h>
+#include <memory>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageInspectorTargetProxy);
+
+std::unique_ptr<WebPageInspectorTargetProxy> WebPageInspectorTargetProxy::create(WebPageProxy& page, const String& targetId, Inspector::InspectorTargetType type)
+{
+    return makeUnique<WebPageInspectorTargetProxy>(page, targetId, type);
+}
+
+std::unique_ptr<WebPageInspectorTargetProxy> WebPageInspectorTargetProxy::create(ProvisionalPageProxy& provisionalPage, const String& targetId, Inspector::InspectorTargetType type)
+{
+    RefPtr page = provisionalPage.page();
+    if (!page)
+        return nullptr;
+
+    std::unique_ptr target = WebPageInspectorTargetProxy::create(*page, targetId, type);
+    target->m_provisionalPage = provisionalPage;
+    return target;
+}
+
+WebPageInspectorTargetProxy::WebPageInspectorTargetProxy(WebPageProxy& page, const String& targetId, Inspector::InspectorTargetType type)
+    : InspectorTargetProxy(targetId, type)
+    , m_page(page)
+{
+}
+
+void WebPageInspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType connectionType)
+{
+    if (RefPtr provisionalPage = m_provisionalPage.get()) {
+        provisionalPage->send(Messages::WebPage::ConnectInspector(identifier(), connectionType));
+        return;
+    }
+
+    Ref page = m_page.get();
+    if (page->hasRunningProcess())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::ConnectInspector(identifier(), connectionType), page->webPageIDInMainFrameProcess());
+}
+
+void WebPageInspectorTargetProxy::disconnect()
+{
+    if (isPaused())
+        resume();
+
+    if (RefPtr provisionalPage = m_provisionalPage.get()) {
+        provisionalPage->send(Messages::WebPage::DisconnectInspector(identifier()));
+        return;
+    }
+
+    Ref page = m_page.get();
+    if (page->hasRunningProcess())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::DisconnectInspector(identifier()), page->webPageIDInMainFrameProcess());
+}
+
+void WebPageInspectorTargetProxy::sendMessageToTargetBackend(const String& message)
+{
+    if (RefPtr provisionalPage = m_provisionalPage.get()) {
+        provisionalPage->send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message));
+        return;
+    }
+
+    Ref page = m_page.get();
+    if (page->hasRunningProcess())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message), page->webPageIDInMainFrameProcess());
+}
+
+void WebPageInspectorTargetProxy::didCommitProvisionalTarget()
+{
+    m_provisionalPage = nullptr;
+}
+
+bool WebPageInspectorTargetProxy::isProvisional() const
+{
+    return !!m_provisionalPage;
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorTargetProxy.h"
+#include <JavaScriptCore/InspectorTarget.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TypeCasts.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class ProvisionalPageProxy;
+class WebPageProxy;
+
+class WebPageInspectorTargetProxy final : public InspectorTargetProxy {
+    WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorTargetProxy);
+    WTF_MAKE_NONCOPYABLE(WebPageInspectorTargetProxy);
+public:
+    static std::unique_ptr<WebPageInspectorTargetProxy> create(WebPageProxy&, const String& targetId, Inspector::InspectorTargetType);
+    static std::unique_ptr<WebPageInspectorTargetProxy> create(ProvisionalPageProxy&, const String& targetId, Inspector::InspectorTargetType);
+    WebPageInspectorTargetProxy(WebPageProxy&, const String& targetId, Inspector::InspectorTargetType);
+    ~WebPageInspectorTargetProxy() = default;
+
+    void didCommitProvisionalTarget() override;
+    bool isProvisional() const override;
+
+    void connect(Inspector::FrontendChannel::ConnectionType) override;
+    void disconnect() override;
+    void sendMessageToTargetBackend(const String&) override;
+
+private:
+    WeakRef<WebPageProxy> m_page;
+    WeakPtr<ProvisionalPageProxy> m_provisionalPage;
+};
+
+} // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebPageInspectorTargetProxy)
+static bool isType(const WebKit::WebPageInspectorTargetProxy& target)
+{
+    return target.type() == Inspector::InspectorTargetType::Page;
+}
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -72,6 +72,11 @@ RefPtr<FrameProcess> ProvisionalFrameProxy::takeFrameProcess()
     return std::exchange(m_frameProcess, nullptr).releaseNonNull();
 }
 
+Ref<WebFrameProxy> ProvisionalFrameProxy::protectedFrame() const
+{
+    return m_frame.get();
+}
+
 WebProcessProxy& ProvisionalFrameProxy::process() const
 {
     ASSERT(m_frameProcess);

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -27,6 +27,7 @@
 
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/PageIdentifier.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -37,13 +38,15 @@ class VisitedLinkStore;
 class WebFrameProxy;
 class WebProcessProxy;
 
-class ProvisionalFrameProxy {
+class ProvisionalFrameProxy : public RefCountedAndCanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_TZONE_ALLOCATED(ProvisionalFrameProxy);
 public:
     explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
 
     ~ProvisionalFrameProxy();
 
+    WebFrameProxy& frame() const { return m_frame.get(); }
+    Ref<WebFrameProxy> protectedFrame() const;
     WebProcessProxy& process() const;
     Ref<WebProcessProxy> protectedProcess() const;
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -42,9 +42,11 @@
 #include "ProvisionalPageProxy.h"
 #include "RemotePageProxy.h"
 #include "WebBackForwardListFrameItem.h"
+#include "WebFrameInspectorTarget.h"
 #include "WebFrameMessages.h"
 #include "WebFramePolicyListenerProxy.h"
 #include "WebNavigationState.h"
+#include "WebPageInspectorController.h"
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"
@@ -116,10 +118,15 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIde
     ASSERT(!allFrames().contains(frameID));
     allFrames().set(frameID, *this);
     WebProcessPool::statistics().wkFrameCount++;
+
+    page.inspectorController().createWebFrameInspectorTarget(*this, WebFrameInspectorTarget::toTargetID(frameID));
 }
 
 WebFrameProxy::~WebFrameProxy()
 {
+    if (RefPtr page = m_page.get())
+        page->inspectorController().destroyInspectorTarget(WebFrameInspectorTarget::toTargetID(frameID()));
+
     WebProcessPool::statistics().wkFrameCount--;
 #if PLATFORM(GTK)
     WebPasteboardProxy::singleton().didDestroyFrame(this);
@@ -154,15 +161,15 @@ RefPtr<WebPageProxy> WebFrameProxy::protectedPage() const
     return m_page.get();
 }
 
-std::unique_ptr<ProvisionalFrameProxy> WebFrameProxy::takeProvisionalFrame()
+RefPtr<ProvisionalFrameProxy> WebFrameProxy::takeProvisionalFrame()
 {
     return std::exchange(m_provisionalFrame, nullptr);
 }
 
 WebProcessProxy& WebFrameProxy::provisionalLoadProcess()
 {
-    if (m_provisionalFrame)
-        return m_provisionalFrame->process();
+    if (RefPtr provisionalFrame = m_provisionalFrame)
+        return provisionalFrame->process();
     if (isMainFrame()) {
         if (WeakPtr provisionalPage = m_page ? m_page->provisionalPageProxy() : nullptr)
             return provisionalPage->process();
@@ -493,7 +500,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
     RegistrableDomain mainFrameDomain(page->mainFrame()->url());
 
     m_provisionalFrame = nullptr;
-    m_provisionalFrame = makeUnique<ProvisionalFrameProxy>(*this, group.ensureProcessForSite(navigationSite, process, page->protectedPreferences()));
+    m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(navigationSite, process, page->protectedPreferences())));
     page->protectedWebsiteDataStore()->protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [pageID = page->webPageIDInProcess(process), completionHandler = WTFMove(completionHandler)] mutable {
         completionHandler(pageID);
     });
@@ -826,6 +833,12 @@ void WebFrameProxy::takeSnapshotOfNode(JSHandleIdentifier identifier, Completion
         return completion({ });
 
     sendWithAsyncReply(Messages::WebFrame::TakeSnapshotOfNode(identifier), WTFMove(completion));
+}
+
+void WebFrameProxy::sendMessageToInspectorFrontend(const String& targetId, const String& message)
+{
+    if (RefPtr page = m_page.get())
+        page->inspectorController().sendMessageToInspectorFrontend(targetId, message);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -214,7 +214,7 @@ public:
     FrameProcess& frameProcess() { return m_frameProcess.get(); }
     void removeChildFrames();
     ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
-    std::unique_ptr<ProvisionalFrameProxy> takeProvisionalFrame();
+    RefPtr<ProvisionalFrameProxy> takeProvisionalFrame();
     WebProcessProxy& provisionalLoadProcess();
     std::optional<WebCore::PageIdentifier> webPageIDInCurrentProcess();
     void notifyParentOfLoadCompletion(WebProcessProxy&);
@@ -268,6 +268,8 @@ public:
     template<typename M, typename C> void sendWithAsyncReply(M&&, C&&);
     template<typename M> void send(M&&);
 
+    void sendMessageToInspectorFrontend(const String& targetId, const String& message);
+
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ScrollbarMode, WebFrameProxy*, IsMainFrame);
 
@@ -296,7 +298,7 @@ private:
     WebCore::FrameIdentifier m_frameID;
     ListHashSet<Ref<WebFrameProxy>> m_childFrames;
     WeakPtr<WebFrameProxy> m_parentFrame;
-    std::unique_ptr<ProvisionalFrameProxy> m_provisionalFrame;
+    RefPtr<ProvisionalFrameProxy> m_provisionalFrame;
 #if ENABLE(CONTENT_FILTERING)
     WebCore::ContentFilterUnblockHandler m_contentFilterUnblockHandler;
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2480,10 +2480,14 @@
 		EEA52F482D70545300D578B5 /* WKStageMode.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D3CDD2D3709BE00072978 /* WKStageMode.h */; };
 		EEA52F492D7055A700D578B5 /* WKStageMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D3CDC2D3709BE00072978 /* WKStageMode.swift */; };
 		EEFE72792D64FE5600DC6214 /* StageModeInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */; };
+		F30EE46E2E721ED600935B60 /* WebFrameInspectorTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = F30EE46D2E721ECE00935B60 /* WebFrameInspectorTarget.h */; };
+		F30EE4712E72226700935B60 /* WebPageInspectorTargetProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = F30EE4702E72225D00935B60 /* WebPageInspectorTargetProxy.h */; };
+		F30EE4742E72227500935B60 /* WebFrameInspectorTargetProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = F30EE4732E72226D00935B60 /* WebFrameInspectorTargetProxy.h */; };
 		F3272B802DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */; };
 		F3272B812DB997C6007B3A9A /* BidiScriptAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */; };
 		F3272B822DB997C6007B3A9A /* BidiBrowsingContextAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */; };
 		F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */; };
+		F34877A92E723DC100D97E74 /* WebFrameInspectorTargetFrontendChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = F34877A82E723DB400D97E74 /* WebFrameInspectorTargetFrontendChannel.h */; };
 		F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */; };
 		F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */; };
 		F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */; };
@@ -8444,10 +8448,18 @@
 		EE0D3CDD2D3709BE00072978 /* WKStageMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKStageMode.h; sourceTree = "<group>"; };
 		EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StageModeInteractionState.h; sourceTree = "<group>"; };
 		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
+		F30EE46D2E721ECE00935B60 /* WebFrameInspectorTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebFrameInspectorTarget.h; sourceTree = "<group>"; };
+		F30EE46F2E721EDB00935B60 /* WebFrameInspectorTarget.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebFrameInspectorTarget.cpp; sourceTree = "<group>"; };
+		F30EE4702E72225D00935B60 /* WebPageInspectorTargetProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageInspectorTargetProxy.h; sourceTree = "<group>"; };
+		F30EE4722E72226A00935B60 /* WebPageInspectorTargetProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPageInspectorTargetProxy.cpp; sourceTree = "<group>"; };
+		F30EE4732E72226D00935B60 /* WebFrameInspectorTargetProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebFrameInspectorTargetProxy.h; sourceTree = "<group>"; };
+		F30EE4752E72227800935B60 /* WebFrameInspectorTargetProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebFrameInspectorTargetProxy.cpp; sourceTree = "<group>"; };
 		F3272B7C2DB997C6007B3A9A /* BidiBrowsingContextAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiBrowsingContextAgent.h; sourceTree = "<group>"; };
 		F3272B7D2DB997C6007B3A9A /* BidiBrowsingContextAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiBrowsingContextAgent.cpp; sourceTree = "<group>"; };
 		F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiScriptAgent.h; sourceTree = "<group>"; };
 		F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiScriptAgent.cpp; sourceTree = "<group>"; };
+		F34877A82E723DB400D97E74 /* WebFrameInspectorTargetFrontendChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebFrameInspectorTargetFrontendChannel.h; sourceTree = "<group>"; };
+		F34877AA2E723DC400D97E74 /* WebFrameInspectorTargetFrontendChannel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebFrameInspectorTargetFrontendChannel.cpp; sourceTree = "<group>"; };
 		F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiUserContext.h; sourceTree = "<group>"; };
 		F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiUserContext.cpp; sourceTree = "<group>"; };
 		F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiBrowserAgent.h; sourceTree = "<group>"; };
@@ -14126,6 +14138,8 @@
 				A55BA81B1BA25B1E007CD33D /* RemoteWebInspectorUIProxy.cpp */,
 				A55BA8191BA25B1E007CD33D /* RemoteWebInspectorUIProxy.h */,
 				A55BA81A1BA25B1E007CD33D /* RemoteWebInspectorUIProxy.messages.in */,
+				F30EE4752E72227800935B60 /* WebFrameInspectorTargetProxy.cpp */,
+				F30EE4732E72226D00935B60 /* WebFrameInspectorTargetProxy.h */,
 				FC7104532E0ED23800CC0B24 /* WebInspectorBackendProxy.h */,
 				FC7104512E0ED22A00CC0B24 /* WebInspectorBackendProxy.messages.in */,
 				99B1675D252BBE0A0073140E /* WebInspectorUIExtensionControllerProxy.cpp */,
@@ -14142,6 +14156,8 @@
 				9197940723DBC4CA00257892 /* WebPageInspectorAgentBase.h */,
 				A513F53F2154A5CD00662841 /* WebPageInspectorController.cpp */,
 				A513F53E2154A5CC00662841 /* WebPageInspectorController.h */,
+				F30EE4722E72226A00935B60 /* WebPageInspectorTargetProxy.cpp */,
+				F30EE4702E72225D00935B60 /* WebPageInspectorTargetProxy.h */,
 			);
 			path = Inspector;
 			sourceTree = "<group>";
@@ -14192,6 +14208,10 @@
 				E3D0A93F2D62B1C90094538A /* ServiceWorkerDebuggableFrontendChannel.h */,
 				E3E6297D2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.cpp */,
 				E3E6297C2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.h */,
+				F30EE46F2E721EDB00935B60 /* WebFrameInspectorTarget.cpp */,
+				F30EE46D2E721ECE00935B60 /* WebFrameInspectorTarget.h */,
+				F34877AA2E723DC400D97E74 /* WebFrameInspectorTargetFrontendChannel.cpp */,
+				F34877A82E723DB400D97E74 /* WebFrameInspectorTargetFrontendChannel.h */,
 				1C8E2A1C1277833F00BC7BD0 /* WebInspector.messages.in */,
 				BC111A59112F4FBB00337BAB /* WebInspectorBackendClient.cpp */,
 				BC032D6D10F4378D0058C15A /* WebInspectorBackendClient.h */,
@@ -18092,6 +18112,9 @@
 				BCE469561214E6CB000B98EB /* WebFormSubmissionListenerProxy.h in Headers */,
 				E5227D8427A11261008EAB57 /* WebFoundTextRange.h in Headers */,
 				E55CFD4E279D31E5002F1020 /* WebFoundTextRangeController.h in Headers */,
+				F30EE46E2E721ED600935B60 /* WebFrameInspectorTarget.h in Headers */,
+				F34877A92E723DC100D97E74 /* WebFrameInspectorTargetFrontendChannel.h in Headers */,
+				F30EE4742E72227500935B60 /* WebFrameInspectorTargetProxy.h in Headers */,
 				FAA4E3012A1575A5003F5E50 /* WebFrameLoaderClient.h in Headers */,
 				51FBB8952CCC063700B72464 /* WebFrameMetrics.h in Headers */,
 				9391F2CB121B67AD00EBF7E8 /* WebFrameNetworkingContext.h in Headers */,
@@ -18169,6 +18192,7 @@
 				A543E30C215C8A8D00279CD9 /* WebPageInspectorTarget.h in Headers */,
 				A543E30D215C8A9000279CD9 /* WebPageInspectorTargetController.h in Headers */,
 				A543E307215AD13700279CD9 /* WebPageInspectorTargetFrontendChannel.h in Headers */,
+				F30EE4712E72226700935B60 /* WebPageInspectorTargetProxy.h in Headers */,
 				C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */,
 				2D5C9D0619C81D8F00B3C5C1 /* WebPageOverlay.h in Headers */,
 				939EF86F29D0C17300F23AEE /* WebPageProxy.h in Headers */,

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebFrameInspectorTarget.h"
+
+#include "WebFrame.h"
+#include "WebFrameInspectorTargetFrontendChannel.h"
+#include <WebCore/Frame.h>
+#include <WebCore/FrameInspectorController.h>
+#include <WebCore/InspectorController.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/MakeString.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebFrameInspectorTarget);
+
+WebFrameInspectorTarget::WebFrameInspectorTarget(WebFrame& frame)
+    : m_frame(frame)
+{
+}
+
+WebFrameInspectorTarget::~WebFrameInspectorTarget() = default;
+
+Ref<WebFrame> WebFrameInspectorTarget::protectedFrame()
+{
+    return m_frame.get();
+}
+
+String WebFrameInspectorTarget::identifier() const
+{
+    return toTargetID(m_frame->frameID());
+}
+
+void WebFrameInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType connectionType)
+{
+    if (m_channel)
+        return;
+
+    Ref frame = m_frame.get();
+    m_channel = makeUnique<WebFrameInspectorTargetFrontendChannel>(frame, identifier(), connectionType);
+
+    if (RefPtr coreFrame = frame->coreFrame())
+        coreFrame->protectedInspectorController()->connectFrontend(*m_channel);
+}
+
+void WebFrameInspectorTarget::disconnect()
+{
+    if (!m_channel)
+        return;
+
+    if (RefPtr coreFrame = protectedFrame()->coreFrame())
+        coreFrame->protectedInspectorController()->disconnectFrontend(*m_channel);
+
+    m_channel.reset();
+}
+
+void WebFrameInspectorTarget::sendMessageToTargetBackend(const String& message)
+{
+    if (RefPtr coreFrame = protectedFrame()->coreFrame())
+        coreFrame->protectedInspectorController()->dispatchMessageFromFrontend(message);
+}
+
+String WebFrameInspectorTarget::toTargetID(WebCore::FrameIdentifier frameID)
+{
+    return makeString("frame-"_s, frameID.toUInt64());
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/InspectorTarget.h>
+#include <WebCore/FrameIdentifier.h>
+#include <memory>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
+
+namespace WebKit {
+
+class WebFrame;
+class WebFrameInspectorTargetFrontendChannel;
+
+class WebFrameInspectorTarget final : public Inspector::InspectorTarget {
+    WTF_MAKE_TZONE_ALLOCATED(WebFrameInspectorTarget);
+    WTF_MAKE_NONCOPYABLE(WebFrameInspectorTarget);
+public:
+    explicit WebFrameInspectorTarget(WebFrame&);
+    ~WebFrameInspectorTarget();
+
+    Inspector::InspectorTargetType type() const final { return Inspector::InspectorTargetType::Frame; }
+
+    String identifier() const final;
+
+    void connect(Inspector::FrontendChannel::ConnectionType) override;
+    void disconnect() override;
+    void sendMessageToTargetBackend(const String&) override;
+
+    static String toTargetID(WebCore::FrameIdentifier);
+
+private:
+    Ref<WebFrame> protectedFrame();
+
+    WeakRef<WebFrame> m_frame;
+    std::unique_ptr<WebFrameInspectorTargetFrontendChannel> m_channel;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebFrameInspectorTargetFrontendChannel.h"
+
+#include "MessageSenderInlines.h"
+#include "WebFrame.h"
+#include "WebPage.h"
+#include "WebPageProxyMessages.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebFrameInspectorTargetFrontendChannel);
+
+WebFrameInspectorTargetFrontendChannel::WebFrameInspectorTargetFrontendChannel(WebFrame& frame, const String& targetId, Inspector::FrontendChannel::ConnectionType connectionType)
+    : m_frame(frame)
+    , m_targetId(targetId)
+    , m_connectionType(connectionType)
+{
+}
+
+Ref<WebFrame> WebFrameInspectorTargetFrontendChannel::protectedFrame()
+{
+    return m_frame.get();
+}
+
+void WebFrameInspectorTargetFrontendChannel::sendMessageToFrontend(const String& message)
+{
+    if (RefPtr page = protectedFrame()->page())
+        page->send(Messages::WebPageProxy::SendMessageToInspectorFrontend(m_targetId, message));
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.h
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class WebFrame;
+
+class WebFrameInspectorTargetFrontendChannel final : public Inspector::FrontendChannel {
+    WTF_MAKE_TZONE_ALLOCATED(WebFrameInspectorTargetFrontendChannel);
+    WTF_MAKE_NONCOPYABLE(WebFrameInspectorTargetFrontendChannel);
+public:
+    WebFrameInspectorTargetFrontendChannel(WebFrame&, const String& targetId, Inspector::FrontendChannel::ConnectionType);
+    virtual ~WebFrameInspectorTargetFrontendChannel() = default;
+
+private:
+    Ref<WebFrame> protectedFrame();
+
+    ConnectionType connectionType() const override { return m_connectionType; }
+    void sendMessageToFrontend(const String& message) override;
+
+    WeakRef<WebFrame> m_frame;
+    String m_targetId;
+    Inspector::FrontendChannel::ConnectionType m_connectionType { Inspector::FrontendChannel::ConnectionType::Remote };
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -623,7 +623,8 @@ void WebLocalFrameLoaderClient::dispatchDidReceiveTitle(const StringWithDirectio
 
 void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureContent> hasInsecureContent, std::optional<UsedLegacyTLS> usedLegacyTLSFromPageCache, std::optional<WasPrivateRelayed> wasPrivateRelayedFromPageCache)
 {
-    RefPtr webPage = m_frame->page();
+    Ref frame = m_frame.get();
+    RefPtr webPage = frame->page();
     if (!webPage)
         return;
 
@@ -651,13 +652,13 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
     // Notify the extensions controller.
     if (RefPtr extensionControllerProxy = webPage->webExtensionControllerProxy())
-        extensionControllerProxy->didCommitLoadForFrame(*webPage, m_frame, m_frame->url());
+        extensionControllerProxy->didCommitLoadForFrame(*webPage, frame.get(), frame->url());
 #endif
 
-    m_frame->commitProvisionalFrame();
+    frame->commitProvisionalFrame();
 
     // Notify the UIProcess.
-    webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader->request(), documentLoader->navigationID(), documentLoader->response().mimeType(), m_frameHasCustomContentProvider, m_localFrame->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, documentLoader->response().proxyName(), documentLoader->response().source(), m_localFrame->document()->isPluginDocument(), *hasInsecureContent, documentLoader->mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+    webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(frame->frameID(), frame->info(), documentLoader->request(), documentLoader->navigationID(), documentLoader->response().mimeType(), m_frameHasCustomContentProvider, m_localFrame->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, documentLoader->response().proxyName(), documentLoader->response().source(), m_localFrame->document()->isPluginDocument(), *hasInsecureContent, documentLoader->mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
     webPage->didCommitLoad(m_frame.ptr());
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -70,7 +70,7 @@ WebPermissionController::~WebPermissionController()
 void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::PermissionDescriptor descriptor, const WeakPtr<WebCore::Page>& page, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    if (WebCore::DeprecatedGlobalSettings::builtInNotificationsEnabled() && (descriptor.name == PermissionName::Notifications || descriptor.name == PermissionName::Push)) {
+    if (WebCore::DeprecatedGlobalSettings::builtInNotificationsEnabled() && (descriptor.name == WebCore::PermissionName::Notifications || descriptor.name == WebCore::PermissionName::Push)) {
         Ref connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
         auto notificationPermissionHandler = [completionHandler = WTFMove(completionHandler)](WebCore::PushPermissionState pushPermissionState) mutable {
             auto state = [pushPermissionState]() -> WebCore::PermissionState {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -35,6 +35,7 @@
 #include "WKBase.h"
 #include "WebLocalFrameLoaderClient.h"
 #include <JavaScriptCore/ConsoleTypes.h>
+#include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <JavaScriptCore/JSBase.h>
 #include <WebCore/AdvancedPrivacyProtections.h>
 #include <WebCore/FrameLoaderTypes.h>
@@ -84,6 +85,7 @@ class InjectedBundleHitTestResult;
 class InjectedBundleNodeHandle;
 class InjectedBundleRangeHandle;
 class InjectedBundleScriptWorld;
+class WebFrameInspectorTarget;
 class WebKeyboardEvent;
 class WebImage;
 class WebMouseEvent;
@@ -272,6 +274,10 @@ public:
 
     void takeSnapshotOfNode(WebCore::JSHandleIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
+    void connectInspector(Inspector::FrontendChannel::ConnectionType);
+    void disconnectInspector();
+    void sendMessageToInspectorTarget(const String& message);
+
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);
 
@@ -309,6 +315,8 @@ private:
     SafeBrowsingCheckOngoing m_isSafeBrowsingCheckOngoing { SafeBrowsingCheckOngoing::No };
     Markable<WebCore::LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
     Markable<WebCore::FrameIdentifier> m_frameIDBeforeProvisionalNavigation;
+
+    const UniqueRef<WebFrameInspectorTarget> m_inspectorTarget;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -32,4 +32,8 @@ messages -> WebFrame {
     DestroyProvisionalFrame();
     FindFocusableElementDescendingIntoRemoteFrame(enum:uint8_t WebCore::FocusDirection direction, struct WebCore::FocusEventData focusEventData) -> (enum:bool WebCore::FoundElementInRemoteFrame foundElement)
     TakeSnapshotOfNode(WebCore::JSHandleIdentifier identifier) -> (std::optional<WebCore::ShareableBitmapHandle> snapshot);
+
+    ConnectInspector(Inspector::FrontendChannel::ConnectionType connectionType)
+    DisconnectInspector()
+    SendMessageToInspectorTarget(String message)
 }


### PR DESCRIPTION
#### 06f8ad1a5a66f9ffaa33696a5b9fba4f4c65070b
<pre>
Web Inspector: Introduce the Frame target type to prep for site isolation
<a href="https://rdar.apple.com/143599045">rdar://143599045</a>
bugs.webkit.org/show_bug.cgi?id=298742

Reviewed by BJ Burg.

This patch introduces the frame target type for Web Inspector. A target
represents a object that the inspector inspects, each carrying its own
resources and providing agents, groups of commands and events by domains
of functionalities. For a long time, there exists one page target per
web page, which worked fine with a single web process per page. Now with
site isolation being introduced, a better design is to treat each
individual frame in the page as an inspection unit, so we&apos;re not relying
on them all sharing the same web process to work.

The frame target is intended to eventually be the contact point for most
Web Inspector domains that were originally owned by the page target.
This patch is a step in that direction by introducing the frame target
type and merely making it possible to co-exist with other targets in
the frontend. Apart from existing, the frame target currently has no
domains (not even a Target domain) and relies on its page&apos;s Target
domain to notify its lifecycle events. The plan is to change that while
bringing in other domains in future commits.

The contents of this patch break down into three interlinked components:
1. Define the frame-related objects: FrameInspectorController, WebFrameInspectorTarget,
   and WebFrameInspectorTargetProxy in the backend, and FrameTarget in
   the frontend.
2. Relax parts of the frontend code to work with FrameTarget that has
   missing agents/domains, while updating relevant tests.
3. Add a test case for frames&apos; lifecycle events linked to the creation
   and deletion of frame targets, also as a prototype of inspector tests
   with site isolation.

To summarize the structure of the frame-related objects, in comparison
with the existing page-related objects:
* In WebCore:
  - (old) Page owns InspectorController, which owns the agents
  - (new) Frame owns FrameInspectorController, which will own agents
    that we&apos;ll slowly create or move from the page
* In WebKit, web process:
  - (old) WebPage owns WebPageInspectorTarget through WebPageInspectorTargetController
  - (new) WebFrame owns WebFrameInspectorTarget directly, given we don&apos;t
    think there will be a need for a controller with just one target
    per frame
* In WebKit, UI process:
  - (old) WebPageProxy owns InspectorTargetProxy through WebPageInspectorController,
    which owns the Target agent
  - (new) We rename InspectorTargetProxy to WebPageInspectorTargetProxy
    to more easily introduce a frame-equivalent
  - (new) WebFrameProxy reuses the WebPageInspectorController to manage
    WebFrameInspectorTargetProxy

Test: http/tests/site-isolation/inspector/target/target.html
* LayoutTests/http/tests/inspector/target/provisional-load-cancels-previous-load.html:
* LayoutTests/http/tests/inspector/target/target-events-for-provisional-page.html:
* LayoutTests/http/tests/site-isolation/inspector/target/resources/leaf-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/target/resources/middle-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/target/target.html: Added.
* LayoutTests/inspector/unit-tests/target-manager-expected.txt:
* LayoutTests/inspector/unit-tests/target-manager.html:
* LayoutTests/inspector/worker/debugger-shared-breakpoint.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/JavaScriptCore/inspector/InspectorTarget.h:
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp:
(Inspector::targetTypeToProtocolType):
* Source/JavaScriptCore/inspector/protocol/Target.json:
* Source/JavaScriptCore/inspector/scripts/codegen/models.py:
(validate_target_types):
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp: Added.
(WebCore::FrameInspectorController::FrameInspectorController):
(WebCore::FrameInspectorController::~FrameInspectorController):
(WebCore::FrameInspectorController::ref const):
(WebCore::FrameInspectorController::deref const):
(WebCore::FrameInspectorController::createLazyAgents):
(WebCore::FrameInspectorController::connectFrontend):
(WebCore::FrameInspectorController::disconnectFrontend):
(WebCore::FrameInspectorController::dispatchMessageFromFrontend):
(WebCore::FrameInspectorController::developerExtrasEnabled const):
(WebCore::FrameInspectorController::canAccessInspectedScriptState const):
(WebCore::FrameInspectorController::functionCallHandler const):
(WebCore::FrameInspectorController::evaluateHandler const):
(WebCore::FrameInspectorController::frontendInitialized):
(WebCore::FrameInspectorController::executionStopwatch const):
(WebCore::FrameInspectorController::debugger):
(WebCore::FrameInspectorController::vm):
* Source/WebCore/inspector/FrameInspectorController.h: Added.
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::protectedInspectorController):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::inspectorController):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Base/TargetType.js:
* Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js:
(WI.CanvasManager.prototype.setRecordingAutoCaptureFrameCount):
* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.initializeTarget):
(WI.ConsoleManager.prototype.requestClearMessages):
* Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js:
(WI.DOMDebuggerManager.prototype.addEventBreakpoint):
(WI.DOMDebuggerManager.prototype.addURLBreakpoint):
(WI.DOMDebuggerManager.prototype._handleEventBreakpointDisabledStateChanged):
(WI.DOMDebuggerManager.prototype._handleEventBreakpointEditablePropertyChanged):
(WI.DOMDebuggerManager.prototype._handleURLBreakpointDisabledStateChanged):
(WI.DOMDebuggerManager.prototype._handleURLBreakpointEditablePropertyChanged):
(WI.DOMDebuggerManager.prototype.allSupportedTargets):
(WI.DOMDebuggerManager):
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype._handleEventBreakpointEditablePropertyChanged):
* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.async initializeTarget):
(WI.DebuggerManager.prototype.set breakpointsEnabled):
(WI.DebuggerManager.prototype.setShouldBlackboxScript):
(WI.DebuggerManager.prototype.setShouldBlackboxPattern):
(WI.DebuggerManager.prototype.set asyncStackTraceDepth):
(WI.DebuggerManager.prototype.addSymbolicBreakpoint):
(WI.DebuggerManager.prototype._setBreakpoint):
(WI.DebuggerManager.prototype._removeBreakpoint):
(WI.DebuggerManager.prototype._updateSpecialBreakpoint):
(WI.DebuggerManager.prototype._handleSymbolicBreakpointDisabledStateChanged):
(WI.DebuggerManager.prototype._handleSymbolicBreakpointEditablePropertyChanged):
(WI.DebuggerManager.prototype._handleBlackboxBreakpointEvaluationsChange):
(WI.DebuggerManager.prototype._handleEngineeringPauseForInternalScriptsSettingChanged):
(WI.DebuggerManager.prototype._handleSourceCodeSourceMapAdded):
(WI.DebuggerManager.prototype.allSupportedTargets):
(WI.DebuggerManager):
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.set emulatedCondition):
* Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js:
(WI.RuntimeManager.prototype.initializeTarget):
* Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js:
(WI.TargetManager.prototype._createTarget):
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Models/HeapAllocationsInstrument.js:
(WI.HeapAllocationsInstrument.prototype.startInstrumentation):
(WI.HeapAllocationsInstrument.prototype.stopInstrumentation):
(WI.HeapAllocationsInstrument.prototype._takeHeapSnapshot):
(WI.HeapAllocationsInstrument.prototype.allSupportedTargets):
(WI.HeapAllocationsInstrument):
* Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js: Copied from Source/WebInspectorUI/UserInterface/Base/TargetType.js.
(WI.FrameTarget):
* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.initialize):
* Source/WebInspectorUI/UserInterface/Test.html:
* Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js:
(WI.HeapAllocationsTimelineView.prototype._takeHeapSnapshotClicked):
* Source/WebInspectorUI/UserInterface/Views/LogContentView.js:
(WI.LogContentView.prototype._garbageCollect):
* Source/WebInspectorUI/UserInterface/Views/ScopeChainDetailsSidebarPanel.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createConsoleSettingsView):
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
(WebKit::InspectorTargetProxy::InspectorTargetProxy):
(WebKit::InspectorTargetProxy::create): Deleted.
(WebKit::InspectorTargetProxy::connect): Deleted.
(WebKit::InspectorTargetProxy::disconnect): Deleted.
(WebKit::InspectorTargetProxy::sendMessageToTargetBackend): Deleted.
(WebKit::InspectorTargetProxy::didCommitProvisionalTarget): Deleted.
(WebKit::InspectorTargetProxy::isProvisional const): Deleted.
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp: Added.
(WebKit::WebFrameInspectorTargetProxy::create):
(WebKit::WebFrameInspectorTargetProxy::WebFrameInspectorTargetProxy):
(WebKit::WebFrameInspectorTargetProxy::connect):
(WebKit::WebFrameInspectorTargetProxy::disconnect):
(WebKit::WebFrameInspectorTargetProxy::sendMessageToTargetBackend):
(WebKit::WebFrameInspectorTargetProxy::didCommitProvisionalTarget):
(WebKit::WebFrameInspectorTargetProxy::isProvisional const):
* Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.h: Copied from Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h.
(isType):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::init):
(WebKit::WebPageInspectorController::createWebPageInspectorTarget):
(WebKit::WebPageInspectorController::createWebFrameInspectorTarget):
(WebKit::WebPageInspectorController::didCreateProvisionalPage):
(WebKit::WebPageInspectorController::createInspectorTarget): Deleted.
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.cpp: Copied from Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp.
(WebKit::WebPageInspectorTargetProxy::create):
(WebKit::WebPageInspectorTargetProxy::WebPageInspectorTargetProxy):
(WebKit::WebPageInspectorTargetProxy::connect):
(WebKit::WebPageInspectorTargetProxy::disconnect):
(WebKit::WebPageInspectorTargetProxy::sendMessageToTargetBackend):
(WebKit::WebPageInspectorTargetProxy::didCommitProvisionalTarget):
(WebKit::WebPageInspectorTargetProxy::isProvisional const):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.h: Copied from Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h.
(isType):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::protectedFrame const):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
(WebKit::ProvisionalFrameProxy::frame const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::~WebFrameProxy):
(WebKit::WebFrameProxy::takeProvisionalFrame):
(WebKit::WebFrameProxy::provisionalLoadProcess):
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
(WebKit::WebFrameProxy::sendMessageToInspectorFrontend):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::setFindClient):
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::createInspectorTarget):
(WebKit::WebPageProxy::viewWillStartLiveResize):
(WebKit::WebPageProxy::wheelEventHandlingCompleted):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::listenForLayoutMilestones):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrame):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::nonEphemeralWebPageProxy):
(WebKit::WebPageProxy::logFrameNavigation):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::didPerformClientRedirectShared):
(WebKit::WebPageProxy::didPerformServerRedirectShared):
(WebKit::WebPageProxy::setMediaVolume):
(WebKit::WebPageProxy::Internals::currentlyProcessedMouseDownEvent):
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::updateEditorState):
(WebKit::WebPageProxy::processDidBecomeResponsive):
(WebKit::WebPageProxy::setScrollPinningBehavior):
(WebKit::WebPageProxy::resetSpeechSynthesizer):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp: Added.
(WebKit::WebFrameInspectorTarget::WebFrameInspectorTarget):
(WebKit::WebFrameInspectorTarget::protectedFrame):
(WebKit::WebFrameInspectorTarget::identifier const):
(WebKit::WebFrameInspectorTarget::connect):
(WebKit::WebFrameInspectorTarget::disconnect):
(WebKit::WebFrameInspectorTarget::sendMessageToTargetBackend):
(WebKit::WebFrameInspectorTarget::toTargetID):
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h: Copied from Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h.
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.cpp: Copied from Source/WebKit/UIProcess/ProvisionalFrameProxy.h.
(WebKit::WebFrameInspectorTargetFrontendChannel::WebFrameInspectorTargetFrontendChannel):
(WebKit::WebFrameInspectorTargetFrontendChannel::protectedFrame):
(WebKit::WebFrameInspectorTargetFrontendChannel::sendMessageToFrontend):
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.h: Copied from Source/WebKit/UIProcess/ProvisionalFrameProxy.h.
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidCommitLoad):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::WebFrame):
(WebKit::WebFrame::connectInspector):
(WebKit::WebFrame::disconnectInspector):
(WebKit::WebFrame::sendMessageToInspectorTarget):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:

Canonical link: <a href="https://commits.webkit.org/300338@main">https://commits.webkit.org/300338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c906311750eb5cf304ba3acc4d75c7bd5c705b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74093 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77661959-ae42-4d9a-a3e0-ccd17d426fbc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92719 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61603 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6f4e8f5-e776-449c-928a-261660253262) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124952 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73394 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0443f213-6a07-4a33-9261-878f0b744981) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27413 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72057 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114148 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131324 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120526 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101279 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45640 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54530 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48266 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38556 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51616 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49946 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->