### PR TITLE
[export-w3c-test-changes] should gracefully handle the 'nothing to commit' case

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py
@@ -57,11 +57,18 @@ class PopenBase(object):
 
         self.returncode = None
 
-        self.stdin = string_utils.BytesIO() if stdin is None or stdin == -1 else stdin
-        self.stdout = string_utils.BytesIO() if stdout == -1 else stdout
-        self._stdout_type = bytes if stdout == -1 else str
-        self.stderr = string_utils.BytesIO() if stderr == -1 else stderr
-        self._stderr_type = bytes if stderr == -1 else str
+        self.stdin = string_utils.BytesIO() if stdin is None or stdin == subprocess.PIPE else stdin
+        self.stdout = string_utils.BytesIO() if stdout == subprocess.PIPE else stdout
+        self._stdout_type = bytes if stdout == subprocess.PIPE else str
+        if stderr == subprocess.STDOUT:
+            self.stderr = self.stdout
+            self._stderr_type = self._stdout_type
+        elif stderr == subprocess.PIPE:
+            self.stderr = string_utils.BytesIO()
+            self._stderr_type = bytes
+        else:
+            self.stderr = stderr
+            self._stderr_type = str
 
         Subprocess.completion_generator_for(args[0])
 


### PR DESCRIPTION
#### ef97d89d09d3a684677f12e74cfaaf96f06a642a
<pre>
[export-w3c-test-changes] should gracefully handle the &apos;nothing to commit&apos; case
<a href="https://bugs.webkit.org/show_bug.cgi?id=298688">https://bugs.webkit.org/show_bug.cgi?id=298688</a>
<a href="https://rdar.apple.com/160325435">rdar://160325435</a>

Reviewed by Sam Sneddon.

If there are no changes to commit, we shouldn&apos;t fail the script.
Instead, we just exit early.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/popen.py:
(PopenBase.__init__): Add mock support for setting stderr to stdout.
                      Reformat the logic to be more easily read.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
    - Add mocks for new commands: `git commit -m`, `git add --all`, and `git diff --cached --quiet`.

* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter._run_wpt_git):
    - Add support for passing in stderr.
(WebPlatformTestExporter.create_branch_with_patch):
    - Also add error handling to applying the patch and only print stdout if it fails.
(WebPlatformTestExporter.delete_local_branch):
    - Suppress some logging to make the script output clearer.

Canonical link: <a href="https://commits.webkit.org/300242@main">https://commits.webkit.org/300242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b29cb3933567176a8c1d284ebade4b9c39f72ebc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73473 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2c783ea-8ea3-44e1-9d27-23b0503a88a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92208 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61354 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2eae318b-e0a4-44af-998a-3cf3d3ee9216) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72884 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d0441fe-81d2-4aa9-a99c-10976e554c29) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120747 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26910 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71411 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130664 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100802 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/120810 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100707 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45014 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48176 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47648 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->