### PR TITLE
[libpas] Compress PGM stack traces

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -150,6 +150,7 @@ set(bmalloc_C_SOURCES
     libpas/src/libpas/pas_page_sharing_participant.c
     libpas/src/libpas/pas_page_sharing_pool.c
     libpas/src/libpas/pas_payload_reservation_page_list.c
+    libpas/src/libpas/pas_pgm_trace.c
     libpas/src/libpas/pas_physical_memory_transaction.c
     libpas/src/libpas/pas_primitive_heap_ref.c
     libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -500,6 +501,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_page_sharing_pool_scavenge_result.h
     libpas/src/libpas/pas_page_sharing_pool_take_result.h
     libpas/src/libpas/pas_payload_reservation_page_list.h
+    libpas/src/libpas/pas_pgm_trace.h
     libpas/src/libpas/pas_physical_memory_synchronization_style.h
     libpas/src/libpas/pas_physical_memory_transaction.h
     libpas/src/libpas/pas_platform.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		14DD78CE18F48D7500950799 /* valgrind.h in Headers */ = {isa = PBXBuildFile; fileRef = 1417F64F18B7280C0076FA99 /* valgrind.h */; };
 		14DD78CF18F48D7500950702 /* Vector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1479E21217A1A255006D4E9D /* Vector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14DD78D018F48D7500950702 /* VMAllocate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1479E21417A1A63E006D4E9D /* VMAllocate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		19DEA66D2E72271A005DFA40 /* pas_pgm_trace.h in Headers */ = {isa = PBXBuildFile; fileRef = 19DEA66B2E72271A005DFA40 /* pas_pgm_trace.h */; };
+		19DEA66E2E72271A005DFA40 /* pas_pgm_trace.c in Sources */ = {isa = PBXBuildFile; fileRef = 19DEA66C2E72271A005DFA40 /* pas_pgm_trace.c */; };
 		2B6EB7A029EE102E00F10400 /* pas_report_crash_pgm_report.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B6EB79F29EE102E00F10400 /* pas_report_crash_pgm_report.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2BDF4F4C29E8B8BA0056BF50 /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF4F4A29E8B8BA0056BF50 /* pas_report_crash.c */; };
 		2BDF4F4D29E8B8BA0056BF50 /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F4B29E8B8BA0056BF50 /* pas_report_crash.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1175,6 +1177,8 @@
 		14C919C818FCC59F0028DB43 /* BPlatform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BPlatform.h; path = bmalloc/BPlatform.h; sourceTree = "<group>"; };
 		14CC394418EA8743004AFE34 /* libmbmalloc.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libmbmalloc.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		14F271BE18EA3963008C152F /* libbmalloc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libbmalloc.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		19DEA66B2E72271A005DFA40 /* pas_pgm_trace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_pgm_trace.h; path = libpas/src/libpas/pas_pgm_trace.h; sourceTree = "<group>"; };
+		19DEA66C2E72271A005DFA40 /* pas_pgm_trace.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pas_pgm_trace.c; path = libpas/src/libpas/pas_pgm_trace.c; sourceTree = "<group>"; };
 		2B6EB79F29EE102E00F10400 /* pas_report_crash_pgm_report.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_report_crash_pgm_report.h; path = libpas/src/libpas/pas_report_crash_pgm_report.h; sourceTree = "<group>"; };
 		2BDF4F4A29E8B8BA0056BF50 /* pas_report_crash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_report_crash.c; path = libpas/src/libpas/pas_report_crash.c; sourceTree = "<group>"; };
 		2BDF4F4B29E8B8BA0056BF50 /* pas_report_crash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_report_crash.h; path = libpas/src/libpas/pas_report_crash.h; sourceTree = "<group>"; };
@@ -1684,6 +1688,8 @@
 				0FC40A732451498A00876DA0 /* pas_page_sharing_pool_take_result.h */,
 				0F87004C25AF8A19000E1ABF /* pas_payload_reservation_page_list.c */,
 				0F87005C25AF8A1A000E1ABF /* pas_payload_reservation_page_list.h */,
+				19DEA66C2E72271A005DFA40 /* pas_pgm_trace.c */,
+				19DEA66B2E72271A005DFA40 /* pas_pgm_trace.h */,
 				0FC40A372451498600876DA0 /* pas_physical_memory_synchronization_style.h */,
 				0FC40A6C2451498A00876DA0 /* pas_physical_memory_transaction.c */,
 				0FC40A352451498600876DA0 /* pas_physical_memory_transaction.h */,
@@ -2282,6 +2288,7 @@
 				DD4BED7D29CBA49700398E35 /* pas_page_sharing_pool_scavenge_result.h in Headers */,
 				DD4BED2C29CBA49700398E35 /* pas_page_sharing_pool_take_result.h in Headers */,
 				DD4BED7629CBA49700398E35 /* pas_payload_reservation_page_list.h in Headers */,
+				19DEA66D2E72271A005DFA40 /* pas_pgm_trace.h in Headers */,
 				DD4BEDF129CBA49700398E35 /* pas_physical_memory_synchronization_style.h in Headers */,
 				DD4BED8329CBA49700398E35 /* pas_physical_memory_transaction.h in Headers */,
 				DD4BEC6029CBA49700398E35 /* pas_platform.h in Headers */,
@@ -2690,6 +2697,7 @@
 				DD4BED2129CBA49700398E35 /* pas_page_sharing_participant.c in Sources */,
 				DD4BED8129CBA49700398E35 /* pas_page_sharing_pool.c in Sources */,
 				DD4BEDA429CBA49700398E35 /* pas_payload_reservation_page_list.c in Sources */,
+				19DEA66E2E72271A005DFA40 /* pas_pgm_trace.c in Sources */,
 				DD4BECD529CBA49700398E35 /* pas_physical_memory_transaction.c in Sources */,
 				DD4BED7729CBA49700398E35 /* pas_primitive_heap_ref.c in Sources */,
 				DD4BED5329CBA49700398E35 /* pas_probabilistic_guard_malloc_allocator.c in Sources */,

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -554,6 +554,9 @@
 		0FF8D62722C04A7700EC72FE /* pas_segregated_page_config_kind.def in Headers */ = {isa = PBXBuildFile; fileRef = 0FF8D62622C04A6D00EC72FE /* pas_segregated_page_config_kind.def */; };
 		0FF8D62922C166F500EC72FE /* pas_segregated_page_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF8D62822C166F500EC72FE /* pas_segregated_page_inlines.h */; };
 		0FFFD515256B0FBD001EB94C /* pas_deallocation_mode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFD514256B0FBC001EB94C /* pas_deallocation_mode.h */; };
+		192BBBB52E73724A003461C0 /* pas_pgm_trace.h in Headers */ = {isa = PBXBuildFile; fileRef = 192BBBB32E73724A003461C0 /* pas_pgm_trace.h */; };
+		192BBBB72E73724A003461C0 /* pas_pgm_trace.c in Sources */ = {isa = PBXBuildFile; fileRef = 192BBBB42E73724A003461C0 /* pas_pgm_trace.c */; };
+		192BBBB92E737272003461C0 /* PGMTraceTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 192BBBB82E737272003461C0 /* PGMTraceTests.cpp */; };
 		2B2A58992742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */; };
 		2B2A589A2742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */; };
 		2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A589B2742D815005EE07C /* PGMTests.cpp */; };
@@ -1283,6 +1286,9 @@
 		0FF8D62622C04A6D00EC72FE /* pas_segregated_page_config_kind.def */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; path = pas_segregated_page_config_kind.def; sourceTree = "<group>"; };
 		0FF8D62822C166F500EC72FE /* pas_segregated_page_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_segregated_page_inlines.h; sourceTree = "<group>"; };
 		0FFFD514256B0FBC001EB94C /* pas_deallocation_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_deallocation_mode.h; sourceTree = "<group>"; };
+		192BBBB32E73724A003461C0 /* pas_pgm_trace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_pgm_trace.h; sourceTree = "<group>"; };
+		192BBBB42E73724A003461C0 /* pas_pgm_trace.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_pgm_trace.c; sourceTree = "<group>"; };
+		192BBBB82E737272003461C0 /* PGMTraceTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PGMTraceTests.cpp; sourceTree = "<group>"; };
 		2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_probabilistic_guard_malloc_allocator.h; sourceTree = "<group>"; };
 		2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_probabilistic_guard_malloc_allocator.c; sourceTree = "<group>"; };
 		2B2A589B2742D815005EE07C /* PGMTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PGMTests.cpp; sourceTree = "<group>"; };
@@ -1465,6 +1471,7 @@
 				2C734C8F277680EF0017BFFE /* MemalignTests.cpp */,
 				0FD22D0722CD8A7500B21841 /* MinHeapTests.cpp */,
 				2B2A589B2742D815005EE07C /* PGMTests.cpp */,
+				192BBBB82E737272003461C0 /* PGMTraceTests.cpp */,
 				0F5E483923D69F610046DA5C /* RaceTests.cpp */,
 				0FF08F3522A59DB300386575 /* RedBlackTreeTests.cpp */,
 				0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp */,
@@ -1854,6 +1861,8 @@
 				0FF248F822FC9EDB0077202E /* pas_page_sharing_pool_take_result.h */,
 				0F4F61C925A4CD3B008B4A82 /* pas_payload_reservation_page_list.c */,
 				0F4F61C825A4CD3B008B4A82 /* pas_payload_reservation_page_list.h */,
+				192BBBB42E73724A003461C0 /* pas_pgm_trace.c */,
+				192BBBB32E73724A003461C0 /* pas_pgm_trace.h */,
 				0F6D547323C573E000F40DBB /* pas_physical_memory_synchronization_style.h */,
 				0FF248F722FC9EDA0077202E /* pas_physical_memory_transaction.c */,
 				0F78088622FA2E4900F37451 /* pas_physical_memory_transaction.h */,
@@ -2367,6 +2376,7 @@
 				0FCBD03426ADF92500D26D68 /* pas_page_sharing_pool_scavenge_result.h in Headers */,
 				0FF248FA22FC9EDB0077202E /* pas_page_sharing_pool_take_result.h in Headers */,
 				0F4F61CA25A4CD3B008B4A82 /* pas_payload_reservation_page_list.h in Headers */,
+				192BBBB52E73724A003461C0 /* pas_pgm_trace.h in Headers */,
 				0F6D547B23C573E100F40DBB /* pas_physical_memory_synchronization_style.h in Headers */,
 				0F78088722FA2E4900F37451 /* pas_physical_memory_transaction.h in Headers */,
 				0FE7EE2922960142004F4166 /* pas_primitive_heap_ref.h in Headers */,
@@ -2759,6 +2769,7 @@
 				2C734C90277680EF0017BFFE /* MemalignTests.cpp in Sources */,
 				0FD22D0822CD8A7500B21841 /* MinHeapTests.cpp in Sources */,
 				2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */,
+				192BBBB92E737272003461C0 /* PGMTraceTests.cpp in Sources */,
 				0F5E483A23D69F610046DA5C /* RaceTests.cpp in Sources */,
 				0FF08F3622A59DB300386575 /* RedBlackTreeTests.cpp in Sources */,
 				0FA18546236B3C82003609A7 /* ScavengerExternalWorkTests.cpp in Sources */,
@@ -2884,6 +2895,7 @@
 				0F19326222F1193D00FBA713 /* pas_page_sharing_participant.c in Sources */,
 				0FD22D0022CC01D300B21841 /* pas_page_sharing_pool.c in Sources */,
 				0F4F61CB25A4CD3B008B4A82 /* pas_payload_reservation_page_list.c in Sources */,
+				192BBBB72E73724A003461C0 /* pas_pgm_trace.c in Sources */,
 				0FF248F922FC9EDB0077202E /* pas_physical_memory_transaction.c in Sources */,
 				0FE7EDCC22960142004F4166 /* pas_primitive_heap_ref.c in Sources */,
 				2B2A589A2742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_pgm_trace.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_pgm_trace.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
+#include "pas_pgm_trace.h"
+
+#include <string.h>
+
+/* PlayStation does not currently support the backtrace API. Android API versions < 33 don't, either. Windows does not either. Linux only with GLibc and not uCLibc/Musl. */
+#if (PAS_OS(ANDROID) && __ANDROID_API__ >= 33) || PAS_OS(DARWIN) || (PAS_OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__))
+#include <execinfo.h>
+#else
+static size_t backtrace(void** buffer, size_t size)
+{
+    PAS_UNUSED_PARAM(buffer);
+    PAS_UNUSED_PARAM(size);
+    return 0;
+}
+#endif
+
+// step 1. collect all the backtraces
+// output_buffer: our empty uint8_t buffer for compressed backtrace data
+// buffer_size: size of our buffer
+size_t collect_backtrace(uint8_t* output_buffer, size_t buffer_size)
+{
+    if (!output_buffer || !buffer_size)
+        return 0;
+
+    vm_address_t collected_frames[PAS_PGM_BACKTRACE_MAX_FRAMES];
+    int total_frames = backtrace((void **)collected_frames, PAS_PGM_BACKTRACE_MAX_FRAMES);
+
+    if (total_frames <= 1 || total_frames > PAS_PGM_BACKTRACE_MAX_FRAMES)
+        return 0; // No frames to compress after skipping the current function, or invalid return
+
+    // we dump the first element of the collected frame buffer to not have this function call pollute our stacktrace.
+    return compress_backtrace(output_buffer, buffer_size, &collected_frames[1], (uint32_t)(total_frames - 1));
+}
+
+// step 1b. start compression (when collecting backtrace)
+size_t compress_backtrace(uint8_t* output_buffer, size_t buffer_size, vm_address_t* collected_frames, uint32_t frame_count)
+{
+    // Store first frame explicitly, then delta encoding -> byte_align -> zigzag -> var_length for the rest
+    size_t bytes_written = 0;
+
+    if (!output_buffer || !collected_frames || !frame_count || !buffer_size)
+        return 0;
+
+    // First, store the base frame address (first frame) as-is
+    if (buffer_size < sizeof(vm_address_t))
+        return 0; // Not enough space for even the base address
+
+    // Store first frame directly (uncompressed)
+    memcpy(&output_buffer[bytes_written], &collected_frames[0], sizeof(vm_address_t));
+    bytes_written += sizeof(vm_address_t);
+
+    // Now compress deltas between consecutive frames
+    for (uint32_t i = 1; i < frame_count; ++i) {
+        vm_address_t current_frame = collected_frames[i-1];
+        vm_address_t next_frame = collected_frames[i];
+        intptr_t delta = delta_encode(current_frame, next_frame);
+
+        intptr_t byte_aligned_delta = byte_align_encode(delta);
+        uintptr_t zigzag_delta = zig_zag_encode(byte_aligned_delta);
+
+        size_t encoded_bytes = variable_len_encode(zigzag_delta, &output_buffer[bytes_written], buffer_size - bytes_written);
+        // we have ran out of space in our output buffer, can no longer pack anything else in. return.
+        if (!encoded_bytes)
+            return bytes_written;
+        bytes_written += encoded_bytes;
+    }
+    return bytes_written;
+}
+
+// final step. decompress (when doing crash report collection)
+void decompress_backtrace(const uint8_t* compressed_buffer, size_t buffer_size, vm_address_t* output_frames, uint32_t frame_count)
+{
+    // First extract base address, then: var_length -> zigzag -> byte_align -> delta decoding
+    size_t bytes_read = 0;
+
+    if (!compressed_buffer || !output_frames || !frame_count || !buffer_size)
+        return;
+
+    // Extract the first frame (base address) that was stored uncompressed
+    if (buffer_size < sizeof(vm_address_t))
+        return; // Not enough data
+
+    memcpy(&output_frames[0], &compressed_buffer[bytes_read], sizeof(vm_address_t));
+    bytes_read += sizeof(vm_address_t);
+
+    // Decompress the rest using delta decoding
+    for (uint32_t i = 1; i < frame_count; ++i) {
+        if (bytes_read >= buffer_size)
+            return; // Not enough data for more frames
+
+        uintptr_t zigzag_delta;
+        size_t decoded_bytes = variable_len_decode(&compressed_buffer[bytes_read], buffer_size - bytes_read, &zigzag_delta);
+        // if we have decoded all traces, we are done. return early.
+        if (!decoded_bytes)
+            return;
+
+        intptr_t byte_aligned_delta = zig_zag_decode(zigzag_delta);
+        intptr_t delta = byte_align_decode(byte_aligned_delta);
+
+        vm_address_t final_address = delta_decode(output_frames[i-1], delta);
+
+        output_frames[i] = final_address;
+        bytes_read += decoded_bytes;
+    }
+}
+
+// step 2. compute offsets of each pointer
+intptr_t delta_encode(vm_address_t current_frame, vm_address_t next_frame)
+{
+    return (intptr_t)(next_frame - current_frame);
+}
+
+vm_address_t delta_decode(vm_address_t prev_frame, intptr_t delta)
+{
+    return prev_frame + (vm_address_t)delta;
+}
+
+// step 3. byte align them (ARM64 instructions are 4-byte aligned, x86 instructions are 1-byte aligned)
+intptr_t byte_align_encode(intptr_t raw_delta)
+{
+    intptr_t aligned_delta = raw_delta;
+    #if __PAS_ARM64
+        aligned_delta /= 4; // ARM64 instructions are 4-byte aligned
+    #endif
+    return aligned_delta;
+}
+
+intptr_t byte_align_decode(intptr_t aligned_delta)
+{
+    intptr_t raw_delta = aligned_delta;
+    #if __PAS_ARM64
+        raw_delta *= 4; // ARM64 instructions are 4-byte aligned
+    #endif
+    return raw_delta;
+}
+
+// step 4. apply zigzag encoding
+uintptr_t zig_zag_encode(intptr_t signed_input)
+{
+    // Convert signed to unsigned, then apply zigzag encoding
+    uintptr_t unsigned_input = (uintptr_t)signed_input;
+    uintptr_t shifted = unsigned_input << 1;
+    return (signed_input < 0) ? ~shifted : shifted;
+}
+
+intptr_t zig_zag_decode(uintptr_t zigzag_input)
+{
+    uintptr_t shifted = zigzag_input >> 1;
+    uintptr_t decoded = (zigzag_input & 1) ? ~shifted : shifted;
+    return (intptr_t)decoded;
+}
+
+// step 5. variable length integer encoding.
+size_t variable_len_encode(uintptr_t value, uint8_t* output_buffer, size_t buffer_size)
+{
+    if (!output_buffer || !buffer_size)
+        return 0;
+
+    for (size_t i = 0; i < buffer_size; i++) {
+        output_buffer[i] = value & 0x7f;
+        value >>= 7;
+        if (!value)
+            return i + 1; // Return number of bytes written
+        output_buffer[i] |= 0x80; // Set the continuation bit
+    }
+    return 0; // we ran out of space
+}
+
+size_t variable_len_decode(const uint8_t* input_buffer, size_t buffer_size, uintptr_t* output_value)
+{
+    if (!input_buffer || !output_value || !buffer_size)
+        return 0;
+
+    uintptr_t result = 0;
+    size_t shift = 0;
+    for (size_t i = 0; i < buffer_size; i++) {
+        // Disallow overflowing the range of the output integer.
+        if (shift >= sizeof(uintptr_t) * 8)
+            return 0;
+
+        result |= (uintptr_t)(input_buffer[i] & 0x7f) << shift;
+        if (input_buffer[i] < 0x80) {
+            *output_value = result;
+            return i + 1;
+        }
+
+        shift += 7;
+    }
+
+    return 0;
+}
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_pgm_trace.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_pgm_trace.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "pas_report_crash_pgm_report.h"
+#include "pas_utils.h"
+#include <stdint.h>
+
+#if PAS_OS(DARWIN)
+#include <mach/vm_types.h>
+#else
+typedef uintptr_t vm_address_t;
+#endif
+
+PAS_BEGIN_EXTERN_C;
+
+size_t collect_backtrace(uint8_t* output_buffer, size_t buffer_size);
+
+size_t compress_backtrace(uint8_t* output_buffer, size_t buffer_size, vm_address_t* collected_frames, uint32_t frame_count);
+void decompress_backtrace(const uint8_t* compressed_buffer, size_t buffer_size, vm_address_t* output_frames, uint32_t frame_count);
+
+uintptr_t zig_zag_encode(intptr_t signed_input);
+intptr_t zig_zag_decode(uintptr_t zigzag_input);
+
+size_t variable_len_encode(uintptr_t value, uint8_t* output_buffer, size_t buffer_size);
+size_t variable_len_decode(const uint8_t* input_buffer, size_t buffer_size, uintptr_t* output_value);
+
+intptr_t delta_encode(vm_address_t current_frame, vm_address_t next_frame);
+vm_address_t delta_decode(vm_address_t prev_frame, intptr_t delta);
+
+intptr_t byte_align_encode(intptr_t raw_delta);
+intptr_t byte_align_decode(intptr_t aligned_delta);
+
+PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/test/PGMTraceTests.cpp
+++ b/Source/bmalloc/libpas/src/test/PGMTraceTests.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TestHarness.h"
+
+#include "pas_pgm_trace.h"
+
+namespace {
+
+// Test basic compression and decompression functionality
+void testPGMTraceBasicCompressionDecompression()
+{
+    // Test with a simple sequence of addresses
+    vm_address_t original_frames[4] = {
+        0x100000000, // Base address
+        0x100000004, // +4 bytes
+        0x100000008, // +4 bytes
+        0x10000000C // +4 bytes
+    };
+
+    uint8_t compressed_buffer[64];
+    vm_address_t decompressed_frames[4];
+
+    // Compress the frames
+    size_t compressed_size = compress_backtrace(compressed_buffer, sizeof(compressed_buffer),
+                                              original_frames, 4);
+    CHECK_GREATER(compressed_size, 0);
+
+    // Decompress and verify
+    decompress_backtrace(compressed_buffer, compressed_size, decompressed_frames, 4);
+
+    // Verify all frames match
+    for (int i = 0; i < 4; i++)
+        CHECK_EQUAL(original_frames[i], decompressed_frames[i]);
+}
+
+// Test zigzag encoding with positive and negative deltas
+void testPGMTraceZigZagEncoding()
+{
+    // Test positive values
+    CHECK_EQUAL(zig_zag_encode(0), 0U);
+    CHECK_EQUAL(zig_zag_encode(1), 2U);
+    CHECK_EQUAL(zig_zag_encode(2), 4U);
+
+    // Test negative values
+    CHECK_EQUAL(zig_zag_encode(-1), 1U);
+    CHECK_EQUAL(zig_zag_encode(-2), 3U);
+
+    // Test round trip
+    for (intptr_t test_val : { -1000, -1, 0, 1, 1000, 0x7FFFFFFF }) {
+        uintptr_t encoded = zig_zag_encode(test_val);
+        intptr_t decoded = zig_zag_decode(encoded);
+        CHECK_EQUAL(test_val, decoded);
+    }
+}
+
+// Test variable length encoding
+void testPGMTraceVariableLengthEncoding()
+{
+    uint8_t buffer[16];
+    uintptr_t decoded_value;
+
+    // Test small values (single byte)
+    CHECK_EQUAL(variable_len_encode(0x00, buffer, sizeof(buffer)), 1);
+    CHECK_EQUAL(buffer[0], 0x00);
+    CHECK_EQUAL(variable_len_decode(buffer, 1, &decoded_value), 1);
+    CHECK_EQUAL(decoded_value, 0x00U);
+
+    CHECK_EQUAL(variable_len_encode(0x7F, buffer, sizeof(buffer)), 1);
+    CHECK_EQUAL(buffer[0], 0x7F);
+    CHECK_EQUAL(variable_len_decode(buffer, 1, &decoded_value), 1);
+    CHECK_EQUAL(decoded_value, 0x7FU);
+
+    // Test multi-byte values
+    CHECK_EQUAL(variable_len_encode(0x80, buffer, sizeof(buffer)), 2);
+    CHECK_EQUAL(buffer[0], 0x80); // 0x80 | 0x80 (continuation bit)
+    CHECK_EQUAL(buffer[1], 0x01);
+    CHECK_EQUAL(variable_len_decode(buffer, 2, &decoded_value), 2);
+    CHECK_EQUAL(decoded_value, 0x80U);
+
+    // Test larger value
+    CHECK_EQUAL(variable_len_encode(0x4000, buffer, sizeof(buffer)), 3);
+    CHECK_EQUAL(variable_len_decode(buffer, 3, &decoded_value), 3);
+    CHECK_EQUAL(decoded_value, 0x4000U);
+}
+
+// Test compression with decreasing sequence (negative deltas)
+void testPGMTraceDecreasingSequence()
+{
+    vm_address_t original_frames[3] = {
+        0x100000010,
+        0x100000008, // -8 delta
+        0x100000004 // -4 delta
+    };
+
+    uint8_t compressed_buffer[32];
+    vm_address_t decompressed_frames[3];
+
+    size_t compressed_size = compress_backtrace(compressed_buffer, sizeof(compressed_buffer),
+                                              original_frames, 3);
+    CHECK_GREATER(compressed_size, 0);
+
+    decompress_backtrace(compressed_buffer, compressed_size, decompressed_frames, 3);
+
+    for (int i = 0; i < 3; i++)
+        CHECK_EQUAL(original_frames[i], decompressed_frames[i]);
+}
+
+// Test edge cases and error handling
+void testPGMTraceErrorHandling()
+{
+    vm_address_t frames[2] = { 0x1000, 0x1004 };
+    uint8_t small_buffer[4]; // Too small for compression
+    vm_address_t output[2];
+
+    // Test nullptr pointer inputs
+    CHECK_EQUAL(compress_backtrace(nullptr, 10, frames, 2), 0);
+    CHECK_EQUAL(compress_backtrace(small_buffer, 10, nullptr, 2), 0);
+
+    // Test zero frame count
+    CHECK_EQUAL(compress_backtrace(small_buffer, sizeof(small_buffer), frames, 0), 0);
+
+    // Test buffer too small (need at least sizeof(vm_address_t) for base address)
+    CHECK_EQUAL(compress_backtrace(small_buffer, sizeof(vm_address_t) - 1, frames, 2), 0);
+
+    // Test decompression with nullptr inputs
+    uint8_t valid_buffer[16] = { 0 };
+    decompress_backtrace(nullptr, 10, output, 2); // Should not crash
+    decompress_backtrace(valid_buffer, 10, nullptr, 2); // Should not crash
+}
+
+// Test single frame compression/decompression
+void testPGMTraceSingleFrame()
+{
+    vm_address_t original_frame[1] = { 0x123456789ABCDEF0 };
+    uint8_t compressed_buffer[16];
+    vm_address_t decompressed_frame[1];
+
+    size_t compressed_size = compress_backtrace(compressed_buffer, sizeof(compressed_buffer),
+                                              original_frame, 1);
+
+    // Should be exactly sizeof(vm_address_t) since no deltas to encode
+    CHECK_EQUAL(compressed_size, sizeof(vm_address_t));
+
+    decompress_backtrace(compressed_buffer, compressed_size, decompressed_frame, 1);
+    CHECK_EQUAL(original_frame[0], decompressed_frame[0]);
+}
+
+// Test large delta compression
+void testPGMTraceLargeDeltas()
+{
+    vm_address_t original_frames[3] = {
+        0x100000000,
+        0x200000000, // Large positive delta
+        0x50000000 // Large negative delta
+    };
+
+    uint8_t compressed_buffer[64];
+    vm_address_t decompressed_frames[3];
+
+    size_t compressed_size = compress_backtrace(compressed_buffer, sizeof(compressed_buffer),
+                                              original_frames, 3);
+    CHECK_GREATER(compressed_size, 0);
+
+    decompress_backtrace(compressed_buffer, compressed_size, decompressed_frames, 3);
+
+    for (int i = 0; i < 3; i++)
+        CHECK_EQUAL(original_frames[i], decompressed_frames[i]);
+}
+
+// Test buffer overflow protection in variable length encoding
+void testPGMTraceBufferOverflowProtection()
+{
+    uint8_t buffer[1]; // Very small buffer
+    uintptr_t large_value = 0x8000; // Requires 2+ bytes to encode
+
+    // Should fail gracefully
+    size_t result = variable_len_encode(large_value, buffer, sizeof(buffer));
+    CHECK_EQUAL(result, 0); // Should indicate failure
+
+    // Test decoding with malformed data (all continuation bits)
+    uint8_t bad_buffer[10];
+    for (int i = 0; i < 10; i++)
+        bad_buffer[i] = 0x80; // All continuation bits
+
+    uintptr_t decoded_value;
+    result = variable_len_decode(bad_buffer, sizeof(bad_buffer), &decoded_value);
+    CHECK_EQUAL(result, 0); // Should indicate failure
+}
+
+// Test realistic backtrace compression (simulating real stack addresses)
+void testPGMTraceRealisticBacktrace()
+{
+    // Simulate realistic stack frame addresses (close together)
+    vm_address_t realistic_frames[5] = {
+        0x0000000100001000, // main function
+        0x0000000100001040, // +64 bytes
+        0x0000000100001080, // +64 bytes
+        0x0000000100001020, // back -96 bytes (tail call)
+        0x0000000100001060 // +64 bytes
+    };
+
+    uint8_t compressed_buffer[64];
+    vm_address_t decompressed_frames[5];
+
+    size_t compressed_size = compress_backtrace(compressed_buffer, sizeof(compressed_buffer),
+                                              realistic_frames, 5);
+    CHECK_GREATER(compressed_size, 0);
+
+    // Should compress well due to small deltas
+    CHECK_LESS(compressed_size, sizeof(realistic_frames));
+
+    decompress_backtrace(compressed_buffer, compressed_size, decompressed_frames, 5);
+
+    for (int i = 0; i < 5; i++)
+        CHECK_EQUAL(realistic_frames[i], decompressed_frames[i]);
+}
+
+// Test the full collect_backtrace function
+void testPGMTraceCollectBacktrace()
+{
+    uint8_t compressed_buffer[256];
+
+    // This should collect a real backtrace and compress it
+    size_t compressed_size = collect_backtrace(compressed_buffer, sizeof(compressed_buffer));
+
+    // Should have captured at least some frames (unless backtrace() fails)
+    // We can't guarantee this will always work on all platforms, but on supported ones it should
+    if (compressed_size > 0) {
+        CHECK_GREATER(compressed_size, sizeof(vm_address_t)); // At least the base frame
+        CHECK_LESS(compressed_size, sizeof(compressed_buffer)); // Shouldn't fill entire buffer
+    }
+
+    // Test with nullptr buffer
+    CHECK_EQUAL(collect_backtrace(nullptr, 100), 0);
+
+    // Test with zero size
+    CHECK_EQUAL(collect_backtrace(compressed_buffer, 0), 0);
+}
+
+} // anonymous namespace
+
+void addPGMTraceTests()
+{
+    ADD_TEST(testPGMTraceBasicCompressionDecompression());
+    ADD_TEST(testPGMTraceZigZagEncoding());
+    ADD_TEST(testPGMTraceVariableLengthEncoding());
+    ADD_TEST(testPGMTraceDecreasingSequence());
+    ADD_TEST(testPGMTraceErrorHandling());
+    ADD_TEST(testPGMTraceSingleFrame());
+    ADD_TEST(testPGMTraceLargeDeltas());
+    ADD_TEST(testPGMTraceBufferOverflowProtection());
+    ADD_TEST(testPGMTraceRealisticBacktrace());
+    ADD_TEST(testPGMTraceCollectBacktrace());
+}

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -392,6 +392,7 @@ void addMARTests();
 void addMemalignTests();
 void addMinHeapTests();
 void addPGMTests();
+void addPGMTraceTests();
 void addRaceTests();
 void addRedBlackTreeTests();
 void addScavengerExternalWorkTests();
@@ -883,6 +884,7 @@ int main(int argc, char** argv)
     ADD_SUITE(Memalign);
     ADD_SUITE(MinHeap);
     ADD_SUITE(PGM);
+    ADD_SUITE(PGMTrace);
     ADD_SUITE(Race);
     ADD_SUITE(RedBlackTree);
     ADD_SUITE(TLCDecommit);


### PR DESCRIPTION
#### f5de232586cc1125746665ec14d70a146b1ead62
<pre>
[libpas] Compress PGM stack traces
<a href="https://bugs.webkit.org/show_bug.cgi?id=286784">https://bugs.webkit.org/show_bug.cgi?id=286784</a>
<a href="https://rdar.apple.com/143927975">rdar://143927975</a>

Co-authored-by: Brandon Stewart &lt;brandonstewart@apple.com&gt;

Reviewed by NOBODY (OOPS!).

Add logic for compressing and decompressing backtraces collected during
PGM allocations and deallocations.

* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_pgm_trace.c: Added.
(backtrace):
(collect_backtrace):
(compress_backtrace):
(decompress_backtrace):
(delta_encode):
(delta_decode):
(byte_align_encode):
(byte_align_decode):
(zig_zag_encode):
(zig_zag_decode):
(variable_len_encode):
(variable_len_decode):
* Source/bmalloc/libpas/src/libpas/pas_pgm_trace.h: Added.
* Source/bmalloc/libpas/src/test/PGMTraceTests.cpp: Added.
(addPGMTraceTests):
* Source/bmalloc/libpas/src/test/TestHarness.cpp:
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5de232586cc1125746665ec14d70a146b1ead62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145549 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99186 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4acda4d-8c5d-4df8-8af1-c6201438b1e0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111929 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80200 "2 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/985794dc-e5f7-46b7-93ce-244beebb5627) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92834 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8ab0d8d-5a02-43ae-8d22-558713889e27) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13615 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11384 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1668 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137540 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156534 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6358 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18081 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119933 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120280 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16017 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128803 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73810 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17702 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6996 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17439 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45438 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17647 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->