### PR TITLE
[WPE] Allow to run layout-tests with the wayland display

### DIFF
--- a/Tools/Scripts/webkitpy/port/headlessdriver.py
+++ b/Tools/Scripts/webkitpy/port/headlessdriver.py
@@ -39,6 +39,6 @@ _log = logging.getLogger(__name__)
 class HeadlessDriver(Driver):
     def _setup_environ_for_test(self):
         driver_environment = super(HeadlessDriver, self)._setup_environ_for_test()
-        driver_environment['WPE_USE_HEADLESS_VIEW_BACKEND'] = "1"
-        driver_environment['EGL_PLATFORM'] = "wayland"
+        driver_environment['WPE_DISPLAY'] = 'wpe-display-headless'
+        driver_environment['EGL_PLATFORM'] = 'wayland'
         return driver_environment

--- a/Tools/Scripts/webkitpy/port/headlessdriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/headlessdriver_unittest.py
@@ -51,9 +51,11 @@ class HeadlessDriverTest(unittest.TestCase):
 
     def make_environment(self):
         environment_user = {'DISPLAY': ':0.0',
-                           'XAUTHORITY': '/home/igalia/.Xauthority',
-                           'WAYLAND_DISPLAY': 'wayland-0',
-                           'WAYLAND_SOCKET': 'wayland-0'}
+                            'WAYLAND_DISPLAY': 'wayland-0',
+                            'WAYLAND_SOCKET': 'wayland-0',
+                            'WPE_DISPLAY':  'wpe-display-drm',
+                            'WPE_DRM_DEVICE': 'drm1',
+                            'XAUTHORITY': '/home/igalia/.Xauthority'}
         return environment_user
 
     def test_environment_needed_variables(self):
@@ -61,8 +63,10 @@ class HeadlessDriverTest(unittest.TestCase):
         environment_user = self.make_environment()
         with patch('os.environ', environment_user):
             driver_environment = driver._setup_environ_for_test()
-            self.assertIn('WPE_USE_HEADLESS_VIEW_BACKEND', driver_environment)
-            self.assertEqual(driver_environment['WPE_USE_HEADLESS_VIEW_BACKEND'], '1')
+            self.assertIn('WPE_DISPLAY', driver_environment)
+            self.assertEqual(driver_environment['WPE_DISPLAY'], 'wpe-display-headless')
+            self.assertIn('EGL_PLATFORM', driver_environment)
+            self.assertEqual(driver_environment['EGL_PLATFORM'], 'wayland')
 
     def test_environment_forbidden_variables(self):
         driver = self.make_driver()
@@ -73,3 +77,4 @@ class HeadlessDriverTest(unittest.TestCase):
             self.assertNotIn('XAUTHORITY', driver_environment)
             self.assertNotIn('WAYLAND_DISPLAY', driver_environment)
             self.assertNotIn('WAYLAND_SOCKET', driver_environment)
+            self.assertNotIn('WPE_DRM_DEVICE', driver_environment)

--- a/Tools/Scripts/webkitpy/port/waylanddriver.py
+++ b/Tools/Scripts/webkitpy/port/waylanddriver.py
@@ -45,9 +45,10 @@ class WaylandDriver(Driver):
         return True
 
     def _setup_environ_for_test(self):
-        driver_environment = super(WaylandDriver, self)._setup_environ_for_test()
+        driver_environment = super()._setup_environ_for_test()
         self._port._copy_value_from_environ_if_set(driver_environment, 'WAYLAND_DISPLAY')
         self._port._copy_value_from_environ_if_set(driver_environment, 'WAYLAND_SOCKET')
         driver_environment['GDK_BACKEND'] = 'wayland'
         driver_environment['EGL_PLATFORM'] = 'wayland'
+        driver_environment['WPE_DISPLAY'] = 'wpe-display-wayland'
         return driver_environment

--- a/Tools/Scripts/webkitpy/port/waylanddriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/waylanddriver_unittest.py
@@ -51,9 +51,11 @@ class WaylandDriverTest(unittest.TestCase):
 
     def make_environment(self):
         environment_user = {'DISPLAY': ':0.0',
-                           'XAUTHORITY': '/home/igalia/.Xauthority',
-                           'WAYLAND_DISPLAY': 'wayland-0',
-                           'WAYLAND_SOCKET': 'wayland-0'}
+                            'WAYLAND_DISPLAY': 'wayland-0',
+                            'WAYLAND_SOCKET': 'wayland-0',
+                            'WPE_DISPLAY':  'wpe-display-drm',
+                            'WPE_DRM_DEVICE': 'drm1',
+                            'XAUTHORITY': '/home/igalia/.Xauthority'}
         return environment_user
 
     def test_checkdriver(self):
@@ -75,9 +77,11 @@ class WaylandDriverTest(unittest.TestCase):
             self.assertIn('WAYLAND_DISPLAY', driver_environment)
             self.assertIn('WAYLAND_SOCKET', driver_environment)
             self.assertIn('GDK_BACKEND', driver_environment)
+            self.assertIn('WPE_DISPLAY', driver_environment)
             self.assertEqual(driver_environment['WAYLAND_DISPLAY'], environment_user['WAYLAND_DISPLAY'])
             self.assertEqual(driver_environment['WAYLAND_SOCKET'], environment_user['WAYLAND_SOCKET'])
-            self.assertEqual(driver_environment['GDK_BACKEND'], 'wayland', )
+            self.assertEqual(driver_environment['GDK_BACKEND'], 'wayland')
+            self.assertEqual(driver_environment['WPE_DISPLAY'], 'wpe-display-wayland')
 
     def test_environment_forbidden_variables(self):
         driver = self.make_driver()

--- a/Tools/Scripts/webkitpy/port/westondriver.py
+++ b/Tools/Scripts/webkitpy/port/westondriver.py
@@ -80,6 +80,8 @@ class WestonDriver(Driver):
 
         driver_environment['WAYLAND_DISPLAY'] = weston_socket
         driver_environment['GDK_BACKEND'] = 'wayland'
+        driver_environment['EGL_PLATFORM'] = 'wayland'
+        driver_environment['WPE_DISPLAY'] = 'wpe-display-wayland'
         if driver_environment.get('DISPLAY'):
             del driver_environment['DISPLAY']
         return driver_environment

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -36,6 +36,8 @@ from webkitpy.common.memoized import memoized
 from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.glib import GLibPort
 from webkitpy.port.headlessdriver import HeadlessDriver
+from webkitpy.port.westondriver import WestonDriver
+from webkitpy.port.waylanddriver import WaylandDriver
 
 from webkitcorepy import decorators
 
@@ -62,10 +64,15 @@ class WPEPort(GLibPort):
 
     @memoized
     def _driver_class(self):
+        if self._display_server == "wayland":
+            return WaylandDriver
+        if self._display_server == "weston":
+            return WestonDriver
         return HeadlessDriver
 
     def setup_environ_for_server(self, server_name=None):
         environment = super(WPEPort, self).setup_environ_for_server(server_name)
+        self._copy_values_from_environ_with_prefix(environment, 'WPE_')
         environment['LIBGL_ALWAYS_SOFTWARE'] = '1'
         # Run WPE tests with Skia CPU (usual configuration on embedded)
         # to help catching issues/crashes <https://webkit.org/b/287632>

--- a/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
@@ -27,7 +27,7 @@
 #include "PlatformWebViewClientWPE.h"
 
 #if ENABLE(WPE_PLATFORM)
-#include <wpe/headless/wpe-headless.h>
+#include <wpe/wpe-platform.h>
 #include <wtf/glib/GUniquePtr.h>
 
 #if USE(CAIRO)
@@ -42,9 +42,11 @@ IGNORE_CLANG_WARNINGS_END
 namespace WTR {
 
 PlatformWebViewClientWPE::PlatformWebViewClientWPE(WKPageConfigurationRef configuration)
-    : m_display(adoptGRef(wpe_display_headless_new()))
 {
-    m_view = WKViewCreate(m_display.get(), configuration);
+    WPEDisplay* display = wpe_display_get_default();
+    if (!display)
+        g_error("Failed to get the default WPE display\n");
+    m_view = WKViewCreate(display, configuration);
     auto* wpeView = WKViewGetView(m_view);
     wpe_view_focus_in(wpeView);
     wpe_toplevel_resize(wpe_view_get_toplevel(wpeView), 800, 600);

--- a/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h
@@ -41,8 +41,6 @@ public:
     PlatformWebViewClientWPE(WKPageConfigurationRef);
     ~PlatformWebViewClientWPE();
 
-    WPEDisplay* display() const { return m_display.get(); }
-
 private:
     void addToWindow() override;
     void removeFromWindow() override;
@@ -51,7 +49,6 @@ private:
 
     PlatformImage snapshot() override;
 
-    GRefPtr<WPEDisplay> m_display;
     GRefPtr<WPEBuffer> m_buffer;
 };
 


### PR DESCRIPTION
#### b198a2b9d6bc310d093dea65bfb105b16ab2d7a3
<pre>
[WPE] Allow to run layout-tests with the wayland display
<a href="https://bugs.webkit.org/show_bug.cgi?id=298719">https://bugs.webkit.org/show_bug.cgi?id=298719</a>

Reviewed by Nikolas Zimmermann.

This allows to see the browser window when running layout
tests with WPE if the optional --display-server=wayland
 parameter is passed.

Previously the code was always forcing the headless driver
(ignoring the user selection of display-server) and WTR
was not connecting to the wayland display.

This patch modifies the display-server drivers to pass the
corresponding WPE_DISPLAY environment variable that WPE uses
to select one or other display backend as default.

As a side effect of this, now is possible (for example) to run
WebDriver tests headless with without having to pass manually
the --headless flag to MiniBrowser.

* Tools/Scripts/webkitpy/port/headlessdriver.py:
(HeadlessDriver._setup_environ_for_test):
* Tools/Scripts/webkitpy/port/headlessdriver_unittest.py:
(HeadlessDriverTest.make_environment):
(HeadlessDriverTest.test_environment_needed_variables):
(HeadlessDriverTest.test_environment_forbidden_variables):
* Tools/Scripts/webkitpy/port/waylanddriver.py:
(WaylandDriver._setup_environ_for_test):
* Tools/Scripts/webkitpy/port/waylanddriver_unittest.py:
(WaylandDriverTest.make_environment):
(WaylandDriverTest.test_environment_needed_variables):
* Tools/Scripts/webkitpy/port/westondriver.py:
(WestonDriver._setup_environ_for_test):
* Tools/Scripts/webkitpy/port/westondriver_unittest.py:
(WestonDriverTest.test_driver_start):
(WestonDriverTest.test_driver_stop):
(WestonDriverTest):
(WestonDriverTest.test_environment_needed_variables):
(WestonDriverTest.test_start): Deleted.
(WestonDriverTest.test_stop): Deleted.
(WestonDriverTest.test_stop.FakeWestonProcess): Deleted.
(WestonDriverTest.test_stop.FakeWestonProcess.terminate): Deleted.
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort._driver_class):
(WPEPort.setup_environ_for_server):
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_get_browser_path):
(WPEPortTest):
(WPEPortTest.test_setup_environ_for_test_wpe_prefix):
* Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp:
(WTR::PlatformWebViewClientWPE::PlatformWebViewClientWPE):
* Tools/glib/api_test_runner.py:
(TestRunner._setup_testing_environment_for_driver):
(TestRunner.run_tests):
(TestRunner._setup_testing_environment): Deleted.

Canonical link: <a href="https://commits.webkit.org/299949@main">https://commits.webkit.org/299949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f5bd7037b7cbdcdb60057ee90fb257eeb1708ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91610 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60876 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72159 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/119977 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26226 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70617 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129881 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100236 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100077 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44201 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19172 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47403 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->