### PR TITLE
[JSC] Cache Table0 buffer and size in JSWebAssemblyInstance

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -32,6 +32,7 @@
 #include "JSCJSValueInlines.h"
 #include "JSWebAssemblyInstance.h"
 #include "WasmTypeDefinitionInlines.h"
+#include "WeakGCSetInlines.h"
 #include <type_traits>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -92,7 +93,7 @@ Table::Table(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType, T
     ASSERT(!m_maximum || *m_maximum >= m_length);
 }
 
-RefPtr<Table> Table::tryCreate(uint32_t initial, std::optional<uint32_t> maximum, TableElementType type, Type wasmType)
+RefPtr<Table> Table::tryCreate(VM& vm, uint32_t initial, std::optional<uint32_t> maximum, TableElementType type, Type wasmType)
 {
     if (!isValidLength(initial))
         return nullptr;
@@ -102,9 +103,9 @@ RefPtr<Table> Table::tryCreate(uint32_t initial, std::optional<uint32_t> maximum
     case TableElementType::Funcref: {
         if (maximum && maximum.value() == initial) {
             // If the table is fixed-sized, we should put table slots inline to avoid one-level indirection.
-            return FuncRefTable::createFixedSized(initial, wasmType);
+            return FuncRefTable::createFixedSized(vm, initial, wasmType);
         }
-        return adoptRef(new FuncRefTable(initial, maximum, wasmType));
+        return adoptRef(new FuncRefTable(vm, initial, maximum, wasmType));
     }
     }
 
@@ -154,6 +155,7 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
         });
         if (!success) [[unlikely]]
             return std::nullopt;
+        setLength(newLength);
         break;
     }
     case TableElementType::Funcref: {
@@ -162,11 +164,14 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
         });
         if (!success) [[unlikely]]
             return std::nullopt;
+        setLength(newLength);
+        for (auto& instance : static_cast<FuncRefTable*>(this)->m_instances) {
+            if (auto* strongReference = instance.get())
+                strongReference->updateCachedTable0();
+        }
         break;
     }
     }
-
-    setLength(newLength);
     return newLength;
 }
 
@@ -256,8 +261,9 @@ void ExternOrAnyRefTable::set(uint32_t index, JSValue value)
     m_jsValues.get()[index].set(m_owner->vm(), m_owner, value);
 }
 
-FuncRefTable::FuncRefTable(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType)
+FuncRefTable::FuncRefTable(VM& vm, uint32_t initial, std::optional<uint32_t> maximum, Type wasmType)
     : Table(initial, maximum, wasmType, TableElementType::Funcref)
+    , m_instances(vm)
 {
     ASSERT(isSubtype(wasmType, funcrefType()));
     // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
@@ -284,9 +290,9 @@ FuncRefTable::~FuncRefTable()
     }
 }
 
-Ref<FuncRefTable> FuncRefTable::createFixedSized(uint32_t size, Type wasmType)
+Ref<FuncRefTable> FuncRefTable::createFixedSized(VM& vm, uint32_t size, Type wasmType)
 {
-    return adoptRef(*new (NotNull, fastMalloc(allocationSize(allocatedLength(size)))) FuncRefTable(size, size, wasmType));
+    return adoptRef(*new (NotNull, fastMalloc(allocationSize(allocatedLength(size)))) FuncRefTable(vm, size, size, wasmType));
 }
 
 void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function)
@@ -330,6 +336,11 @@ void FuncRefTable::set(uint32_t index, JSValue value)
         clear(index);
     else
         setFunction(index, jsCast<WebAssemblyFunctionBase*>(value));
+}
+
+void FuncRefTable::registerInstance(JSWebAssemblyInstance& instance)
+{
+    m_instances.add(&instance);
 }
 
 } } // namespace JSC::Table

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -52,7 +52,7 @@ class Table : public ThreadSafeRefCounted<Table> {
     WTF_MAKE_NONCOPYABLE(Table);
     WTF_MAKE_TZONE_ALLOCATED(Table);
 public:
-    static RefPtr<Table> tryCreate(uint32_t initial, std::optional<uint32_t> maximum, TableElementType, Type);
+    static RefPtr<Table> tryCreate(VM&, uint32_t initial, std::optional<uint32_t> maximum, TableElementType, Type);
 
     JS_EXPORT_PRIVATE ~Table() = default;
 
@@ -128,6 +128,9 @@ class FuncRefTable final : public Table {
 public:
     friend class Table;
 
+    using JSWebAssemblyInstanceWeakCGSet = WeakGCSet<JSWebAssemblyInstance>;
+
+
     JS_EXPORT_PRIVATE ~FuncRefTable();
 
     struct Function {
@@ -145,6 +148,13 @@ public:
     static constexpr ptrdiff_t offsetOfTail() { return WTF::roundUpToMultipleOf<alignof(Function)>(sizeof(FuncRefTable)); }
     static constexpr ptrdiff_t offsetOfFunctionsForFixedSizedTable() { return offsetOfTail(); }
 
+    Function* functions()
+    {
+        if (isFixedSized())
+            return std::bit_cast<Function*>(std::bit_cast<uint8_t*>(this) + offsetOfFunctionsForFixedSizedTable());
+        return m_importableFunctions.get();
+    }
+
     static size_t allocationSize(uint32_t size)
     {
         return offsetOfTail() + sizeof(Function) * size;
@@ -154,14 +164,17 @@ public:
     void set(uint32_t, JSValue);
     JSValue get(uint32_t index) const { return m_importableFunctions.get()[index].m_value.get(); }
 
+    void registerInstance(JSWebAssemblyInstance&);
+
 private:
-    FuncRefTable(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType);
+    FuncRefTable(VM&, uint32_t initial, std::optional<uint32_t> maximum, Type wasmType);
 
     Function* tailPointer() { return std::bit_cast<Function*>(std::bit_cast<uint8_t*>(this) + offsetOfTail()); }
 
-    static Ref<FuncRefTable> createFixedSized(uint32_t size, Type wasmType);
+    static Ref<FuncRefTable> createFixedSized(VM&, uint32_t size, Type wasmType);
 
     MallocPtr<Function, VMMalloc> m_importableFunctions;
+    JSWebAssemblyInstanceWeakCGSet m_instances;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -195,6 +195,11 @@ public:
         }
     }
 
+    uint32_t cachedTable0Length() const { return m_cachedTable0Length; }
+    Wasm::FuncRefTable::Function* cachedTable0Buffer() const { return m_cachedTable0Buffer; }
+
+    void updateCachedTable0();
+
     int32_t loadI32Global(unsigned i) const
     {
         Wasm::Global::Value* slot = m_globals + i;
@@ -267,6 +272,8 @@ public:
     static constexpr ptrdiff_t offsetOfCachedMemory() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedMemory); }
     static constexpr ptrdiff_t offsetOfCachedBoundsCheckingSize() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedBoundsCheckingSize); }
     static constexpr ptrdiff_t offsetOfCachedMemorySize() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedMemorySize); }
+    static constexpr ptrdiff_t offsetOfCachedTable0Buffer() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedTable0Buffer); }
+    static constexpr ptrdiff_t offsetOfCachedTable0Length() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedTable0Length); }
     static constexpr ptrdiff_t offsetOfTemporaryCallFrame() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_temporaryCallFrame); }
     static constexpr ptrdiff_t offsetOfBuiltinCalleeBits() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_builtinCalleeBits); }
 
@@ -394,6 +401,8 @@ private:
     CagedPtr<Gigacage::Primitive, void> m_cachedMemory;
     size_t m_cachedBoundsCheckingSize { 0 };
     size_t m_cachedMemorySize { 0 };
+    Wasm::FuncRefTable::Function* m_cachedTable0Buffer { nullptr };
+    uint32_t m_cachedTable0Length { 0 };
     const Ref<Wasm::Module> m_module;
     const Ref<const Wasm::ModuleInformation> m_moduleInformation;
     const Ref<Wasm::ProfileCollection> m_profiles;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -604,7 +604,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         if (!m_instance->table(i)) {
             RELEASE_ASSERT(!moduleInformation.tables[i].isImport());
             // We create a Table when it's a Table definition.
-            RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(moduleInformation.tables[i].initial(), moduleInformation.tables[i].maximum(), moduleInformation.tables[i].type(), moduleInformation.tables[i].wasmType());
+            RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(vm, moduleInformation.tables[i].initial(), moduleInformation.tables[i].maximum(), moduleInformation.tables[i].type(), moduleInformation.tables[i].wasmType());
             if (!wasmTable)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, "couldn't create Table"_s));
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -104,7 +104,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObj
             return throwVMRangeError(globalObject, throwScope, "'maximum' property must be greater than or equal to the 'initial' property"_s);
     }
 
-    RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(initial, maximum, type, type == Wasm::TableElementType::Funcref ? Wasm::funcrefType() : Wasm::externrefType());
+    RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(vm, initial, maximum, type, type == Wasm::TableElementType::Funcref ? Wasm::funcrefType() : Wasm::externrefType());
     if (!wasmTable)
         return throwVMRangeError(globalObject, throwScope, "couldn't create Table"_s);
 


### PR DESCRIPTION
#### 5812ab7155d979de14ef1b54449c0966511a50cd
<pre>
[JSC] Cache Table0 buffer and size in JSWebAssemblyInstance
<a href="https://bugs.webkit.org/show_bug.cgi?id=298752">https://bugs.webkit.org/show_bug.cgi?id=298752</a>
<a href="https://rdar.apple.com/160419088">rdar://160419088</a>

Reviewed by Yijia Huang.

This patch caches table0&apos;s buffer and size in the same way to the wasm memory.
We record weak reference to JSWebAssemblyInstance to Wasm::Table. And it
reports size &amp; buffer update when it happens. This eliminates some
dependent load from Wasm::Table for each CallIndirect sequence. Also
this paves a way to cache this buffer well based on more precise
clobberizing model in wasm.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::tryCreate):
(JSC::Wasm::Table::grow):
(JSC::Wasm::FuncRefTable::FuncRefTable):
(JSC::Wasm::FuncRefTable::createFixedSized):
(JSC::Wasm::FuncRefTable::registerInstance):
* Source/JavaScriptCore/wasm/WasmTable.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::setTable):
(JSC::JSWebAssemblyInstance::updateCachedTable0):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/299902@main">https://commits.webkit.org/299902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25509a4c6a6ee7dec9d86b4fbf4511aac0424e55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30986 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/127032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72715 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48911 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/127032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123592 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/32765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/127032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70637 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/112766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/26423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119156 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/47561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/129901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47928 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/104317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/129901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/45531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19143 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53128 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/148354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/46892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/148354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/50238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/48578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->