### PR TITLE
[WebAuthn] Completion handler not called outside of tests after 299725@main

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -308,6 +308,15 @@ void AuthenticatorManager::respondReceived(Respond&& respond)
         restartDiscovery();
 }
 
+void AuthenticatorManager::respondReceivedInternal(Respond&& respond, bool shouldComplete)
+{
+    if (shouldComplete) {
+        invokePendingCompletionHandler(WTFMove(respond));
+        clearStateAsync();
+        m_requestTimeOutTimer.stop();
+    }
+}
+
 void AuthenticatorManager::downgrade(Authenticator& id, Ref<Authenticator>&& downgradedAuthenticator)
 {
     RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, id = Ref { id }] {

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -116,7 +116,7 @@ private:
     // Overriden by MockAuthenticatorManager.
     virtual Ref<AuthenticatorTransportService> createService(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&) const;
     // Overriden to return every exception for tests to confirm.
-    virtual void respondReceivedInternal(Respond&&, bool shouldComplete) { }
+    virtual void respondReceivedInternal(Respond&&, bool shouldComplete);
     virtual void filterTransports(TransportSet&) const;
     virtual void runPresenterInternal(const TransportSet&);
 


### PR DESCRIPTION
#### d05c1022b9e5d80566b923db44221768800e70bd
<pre>
[WebAuthn] Completion handler not called outside of tests after 299725@main
<a href="https://rdar.apple.com/157668547">rdar://157668547</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298751">https://bugs.webkit.org/show_bug.cgi?id=298751</a>

Reviewed by Charlie Wolfe.

In 299725@main, we did test development to ensure we don&apos;t regress that change.
However, we also introduced a bug where the completion handler is not called
outside the test enviornment. This patch fixes that.

* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::respondReceivedInternal):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
(WebKit::AuthenticatorManager::respondReceivedInternal): Deleted.

Canonical link: <a href="https://commits.webkit.org/299898@main">https://commits.webkit.org/299898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/280d6a18d9e80a567b07263d94c9fbd8a24cb720

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72628 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/762ba9f9-3d2f-42b9-8711-9433b9d990b0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48824 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91556 "13 flakes 57 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60820 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a878f7e1-080f-4124-8e60-2ed72eb06bb4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72106 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13e106e2-3dfb-492c-b609-f214e116f9a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31716 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70546 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129814 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100172 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44122 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53041 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->