### PR TITLE
Address safer cpp warnings in QualifiedName.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -27,7 +27,6 @@ css/values/primitives/CSSPrimitiveData.h
 dom/CollectionIndexCache.h
 dom/Node.cpp
 dom/Node.h
-dom/QualifiedName.h
 dom/TreeScope.h
 editing/cocoa/NodeHTMLConverter.mm
 html/FormListedElement.cpp

--- a/Source/WebCore/dom/QualifiedName.h
+++ b/Source/WebCore/dom/QualifiedName.h
@@ -33,14 +33,14 @@ enum class Namespace : uint8_t;
 enum class NodeName : uint16_t;
 
 struct QualifiedNameComponents {
-    AtomStringImpl* m_prefix;
-    AtomStringImpl* m_localName;
-    AtomStringImpl* m_namespaceURI;
+    RefPtr<AtomStringImpl> m_prefix;
+    RefPtr<AtomStringImpl> m_localName;
+    RefPtr<AtomStringImpl> m_namespaceURI;
 };
 
 inline void add(Hasher& hasher, const QualifiedNameComponents& components)
 {
-    add(hasher, components.m_prefix, components.m_localName, components.m_namespaceURI);
+    add(hasher, components.m_prefix.get(), components.m_localName.get(), components.m_namespaceURI.get());
 }
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(QualifiedName);

--- a/Source/WebCore/dom/QualifiedNameCache.cpp
+++ b/Source/WebCore/dom/QualifiedNameCache.cpp
@@ -48,7 +48,7 @@ struct QNameComponentsTranslator {
 
     static void translate(QualifiedName::QualifiedNameImpl*& location, const QualifiedNameComponents& components, unsigned)
     {
-        location = &QualifiedName::QualifiedNameImpl::create(components.m_prefix, components.m_localName, components.m_namespaceURI).leakRef();
+        location = &QualifiedName::QualifiedNameImpl::create(components.m_prefix.get(), components.m_localName.get(), components.m_namespaceURI.get()).leakRef();
     }
 };
 
@@ -66,8 +66,8 @@ Ref<QualifiedName::QualifiedNameImpl> QualifiedNameCache::getOrCreate(const Qual
     auto& impl = **addResult.iterator;
 
     if (addResult.isNewEntry) {
-        auto nodeNamespace = findNamespace(components.m_namespaceURI);
-        auto nodeName = findNodeName(nodeNamespace, components.m_localName);
+        auto nodeNamespace = findNamespace(components.m_namespaceURI.get());
+        auto nodeName = findNodeName(nodeNamespace, components.m_localName.get());
         updateImplWithNamespaceAndElementName(impl, nodeNamespace, nodeName);
         return adoptRef(impl);
     }


### PR DESCRIPTION
#### 39c09098cbade92bd85d6fcb99bf77b06745842e
<pre>
Address safer cpp warnings in QualifiedName.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=298755">https://bugs.webkit.org/show_bug.cgi?id=298755</a>

Reviewed by Ryosuke Niwa.

This seems to be performance neutral on Speedometer 3.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/dom/QualifiedName.h:
(WebCore::add):
* Source/WebCore/dom/QualifiedNameCache.cpp:
(WebCore::QNameComponentsTranslator::translate):
(WebCore::QualifiedNameCache::getOrCreate):

Canonical link: <a href="https://commits.webkit.org/299889@main">https://commits.webkit.org/299889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774d1a1086602c29681864bd61fd0294eb6d32d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72631 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0de1e04-d65f-44ad-be23-cd05cc95e4db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48827 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91560 "2 flakes 54 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60827 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b19da603-906b-4465-9b0f-91cabcea14d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72110 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b9334ad-8862-42c9-9eec-929a7ab80fe0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26169 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70550 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102175 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100175 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100017 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25397 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44125 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53044 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46807 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->