### PR TITLE
SVG patterns might get blurred and pixellated when zooming in

### DIFF
--- a/LayoutTests/svg/as-image/resources/circle-pattern-embeded-image.svg
+++ b/LayoutTests/svg/as-image/resources/circle-pattern-embeded-image.svg
@@ -1,0 +1,13 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="100%" fill="lavender"/>
+    <rect x="5" y="5" width="40" height="40" fill="url(#pattern)"/>
+    <defs>
+        <pattern id="pattern" patternContentUnits="objectBoundingBox" width="1" height="1">
+            <use href="#image" transform="scale(0.0025)"/>
+        </pattern>
+        <image id="image" height="400" width="400" preserveAspectRatio="none" href="data:image/svg+xml,
+            &lt;svg width='400' height='400' xmlns='http://www.w3.org/2000/svg'&gt;
+                &lt;circle cx='50%' cy='50%' r='50%' fill='green'/&gt;
+            &lt;/svg&gt;"/>
+    </defs>
+</svg>

--- a/LayoutTests/svg/as-image/svg-as-image-pattern-scale-expected.html
+++ b/LayoutTests/svg/as-image/svg-as-image-pattern-scale-expected.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<style>
+    body {
+        zoom: 800%;
+    }
+    .container {
+        display: inline-block;
+        width: 50px;
+        height: 50px;
+        background-color: lavender;
+    }
+    .circle {
+        display: inline-block;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background-color: green;
+        margin: 5px;
+    }
+</style>
+<body>
+    <div class="container">
+        <div class="circle"></div>
+    </div>
+</body>

--- a/LayoutTests/svg/as-image/svg-as-image-pattern-scale.html
+++ b/LayoutTests/svg/as-image/svg-as-image-pattern-scale.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<meta name="fuzzy" content="maxDifference=0-10; totalPixels=0-963">
+<style>
+    body {
+        zoom: 800%;
+    }
+</style>
+<body>
+    <img src="resources/circle-pattern-embeded-image.svg">
+</body>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -260,7 +260,7 @@ RefPtr<ImageBuffer> LegacyRenderSVGResourcePattern::createTileImage(GraphicsCont
     auto tileSize = roundedUnscaledImageBufferSize(size, scale);
 
     // FIXME: Use createImageBuffer(rect, scale), delete the above calculations and fix 'tileImageTransform'
-    auto tileImage = context.createScaledImageBuffer(tileSize, scale);
+    auto tileImage = context.createScaledImageBuffer(tileSize, scale.expandedTo(context.scaleFactor()));
     if (!tileImage)
         return nullptr;
 


### PR DESCRIPTION
#### 1cc5b31eb1ca1648cd07af6ab48e31db1862ba5e
<pre>
SVG patterns might get blurred and pixellated when zooming in
<a href="https://bugs.webkit.org/show_bug.cgi?id=298753">https://bugs.webkit.org/show_bug.cgi?id=298753</a>
<a href="https://rdar.apple.com/159202567">rdar://159202567</a>

Reviewed by Simon Fraser.

When drawing an SVG pattern, a tileImage is created from the referenced element.
This tileImage is currently scaled by the patternTransform only. So although the
referenced element might be an SVG image or a large bitmap image, the resulted
tileImage will not be scaled well when the coordinate system is scaled like zoom
in or printing for example.

Although the tileImage of the pattern should be scaled by patternTransform, it has
to be scaled by at least GraphicsContext.scaleFactor. This ensures the tileImage
scales properly with the scaled coordinate system.

Test: svg/as-image/svg-as-image-pattern-scale.html
* LayoutTests/svg/as-image/resources/circle-pattern-embeded-image.svg: Added.
* LayoutTests/svg/as-image/svg-as-image-pattern-scale-expected.html: Added.
* LayoutTests/svg/as-image/svg-as-image-pattern-scale.html: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::createTileImage const):

Canonical link: <a href="https://commits.webkit.org/300357@main">https://commits.webkit.org/300357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fe3fa1d3955dba67e262dc57aecc42885f8a985

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128836 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9ded4cf-bbda-4920-a2f3-498128a96307) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92928 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da1ce36a-29ba-4f70-a4e1-905825941378) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73582 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5713028-5627-499a-b4d1-0f3c01aa7007) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27636 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131583 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101493 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101363 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24849 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49055 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54790 "Failed to build and analyze WebKit") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->