### PR TITLE
[WIP]

### DIFF
--- a/LayoutTests/fast/css/link-disabled-attr-expected.txt
+++ b/LayoutTests/fast/css/link-disabled-attr-expected.txt
@@ -6,7 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 notsheet
 PASS link.sheet is null
-FAIL link.disabled should be false. Was true.
+PASS link.disabled is false
 sheet
 PASS link.sheet is non-null.
 FAIL link.disabled should be true. Was false.

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -260,9 +260,13 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
             m_styleScope->didChangeActiveStyleSheetCandidates();
         break;
     }
-    case AttributeNames::disabledAttr:
+    case AttributeNames::disabledAttr: {
+        bool disabledValue = !newValue.isNull();
+        if (disabledValue && rel() != "stylesheet"_s)
+            setBooleanAttribute(name, false);
         setDisabledState(!newValue.isNull());
         break;
+    }
     case AttributeNames::titleAttr:
         if (m_sheet && !isInShadowTree())
             m_sheet->setTitle(newValue);


### PR DESCRIPTION
#### bdbd913d3fe5223590c1e508f90cd652e855db05
<pre>
[WIP]
<a href="https://bugs.webkit.org/show_bug.cgi?id=298757">https://bugs.webkit.org/show_bug.cgi?id=298757</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/fast/css/link-disabled-attr-expected.txt:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::attributeChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdbd913d3fe5223590c1e508f90cd652e855db05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30911 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126947 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48836 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/126947 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60830 "Found 3 new test failures: fast/css/stylesheet-enable-first-alternate-link.html fast/css/stylesheet-enable-first-alternate-on-load-link.html fast/dom/boolean-attribute-reflection.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123517 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32696 "Found 4 new test failures: fast/css/stylesheet-enable-first-alternate-link.html fast/css/stylesheet-enable-first-alternate-on-load-link.html fast/dom/boolean-attribute-reflection.html http/tests/subresource-integrity/sri-style.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108072 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/126947 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31726 "Found 7 new test failures: imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-003.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-004.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-005.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-007.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate.html imported/w3c/web-platform-tests/subresource-integrity/subresource-integrity.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26177 "Found 11 new test failures: fast/css/stylesheet-enable-first-alternate-link.html fast/css/stylesheet-enable-first-alternate-on-load-link.html fast/dom/boolean-attribute-reflection.html http/tests/subresource-integrity/sri-style.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-003.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-004.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-005.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-007.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70560 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112691 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102181 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26359 "Found 11 new test failures: fast/css/stylesheet-enable-first-alternate-link.html fast/css/stylesheet-enable-first-alternate-on-load-link.html fast/dom/boolean-attribute-reflection.html http/tests/subresource-integrity/sri-style.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-003.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-004.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-005.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-007.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47486 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36041 "Found 11 new test failures: fast/css/stylesheet-enable-first-alternate-link.html fast/css/stylesheet-enable-first-alternate-on-load-link.html fast/dom/boolean-attribute-reflection.html http/tests/subresource-integrity/sri-style.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-003.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-004.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-005.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-007.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100182 "Found 11 new test failures: fast/css/stylesheet-enable-first-alternate-link.html fast/css/stylesheet-enable-first-alternate-on-load-link.html fast/dom/boolean-attribute-reflection.html http/tests/subresource-integrity/sri-style.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-003.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-004.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-005.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-007.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100024 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45465 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23495 "Found 11 new test failures: fast/css/stylesheet-enable-first-alternate-link.html fast/css/stylesheet-enable-first-alternate-on-load-link.html fast/dom/boolean-attribute-reflection.html http/tests/subresource-integrity/sri-style.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-003.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-004.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-005.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-007.html imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53053 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->