### PR TITLE
Address Safer CPP warnings in InspectorFrontendClientLocal.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -290,7 +290,6 @@ inspector/InspectorAuditAccessibilityObject.cpp
 inspector/InspectorCanvas.cpp
 inspector/InspectorController.cpp
 inspector/InspectorFrontendAPIDispatcher.cpp
-inspector/InspectorFrontendClientLocal.cpp
 inspector/InspectorFrontendHost.cpp
 inspector/InspectorInstrumentation.cpp
 inspector/InspectorInstrumentation.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -522,7 +522,6 @@ inspector/InspectorCanvas.h
 inspector/InspectorCanvasCallTracer.cpp
 inspector/InspectorController.cpp
 inspector/InspectorFrontendAPIDispatcher.cpp
-inspector/InspectorFrontendClientLocal.cpp
 inspector/InspectorFrontendHost.cpp
 inspector/InspectorInstrumentation.cpp
 inspector/InspectorInstrumentation.h

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -415,6 +415,11 @@ Page& InspectorController::inspectedPage() const
     return m_page;
 }
 
+Ref<Page> InspectorController::protectedInspectedPage() const
+{
+    return inspectedPage();
+}
+
 void InspectorController::dispatchMessageFromFrontend(const String& message)
 {
     m_backendDispatcher->dispatch(message);

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -78,6 +78,7 @@ public:
 
     WEBCORE_EXPORT bool enabled() const;
     Page& inspectedPage() const;
+    Ref<Page> protectedInspectedPage() const;
 
     WEBCORE_EXPORT void show();
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -167,8 +167,8 @@ InspectorFrontendClientLocal::InspectorFrontendClientLocal(InspectorController* 
 
 InspectorFrontendClientLocal::~InspectorFrontendClientLocal()
 {
-    if (m_frontendHost)
-        m_frontendHost->disconnectClient();
+    if (RefPtr frontendHost = m_frontendHost)
+        frontendHost->disconnectClient();
     m_frontendPage = nullptr;
     m_inspectedPageController = nullptr;
     m_dispatchTask->reset();
@@ -186,11 +186,12 @@ Page* InspectorFrontendClientLocal::frontendPage()
 
 void InspectorFrontendClientLocal::windowObjectCleared()
 {
-    if (m_frontendHost)
-        m_frontendHost->disconnectClient();
+    if (RefPtr frontendHost = m_frontendHost)
+        frontendHost->disconnectClient();
     
-    m_frontendHost = InspectorFrontendHost::create(this, frontendPage());
-    m_frontendHost->addSelfToGlobalObjectInWorld(debuggerWorldSingleton());
+    Ref frontendHost = InspectorFrontendHost::create(this, RefPtr { frontendPage() }.get());
+    m_frontendHost = frontendHost.copyRef();
+    frontendHost->addSelfToGlobalObjectInWorld(debuggerWorldSingleton());
 }
 
 void InspectorFrontendClientLocal::frontendLoaded()
@@ -247,8 +248,9 @@ bool InspectorFrontendClientLocal::canAttachWindow()
 
     // Don't allow the attach if the window would be too small to accommodate the minimum inspector size.
     Ref mainFrame = inspectedPageController->inspectedPage().mainFrame();
-    unsigned inspectedPageHeight = mainFrame->virtualView()->visibleHeight();
-    unsigned inspectedPageWidth = mainFrame->virtualView()->visibleWidth();
+    RefPtr view = mainFrame->virtualView();
+    unsigned inspectedPageHeight = view->visibleHeight();
+    unsigned inspectedPageWidth = view->visibleWidth();
     unsigned maximumAttachedHeight = inspectedPageHeight * maximumAttachedHeightRatio;
     return minimumAttachedHeight <= maximumAttachedHeight && minimumAttachedWidth <= inspectedPageWidth;
 }
@@ -263,9 +265,14 @@ RefPtr<InspectorController> InspectorFrontendClientLocal::protectedInspectedPage
     return m_inspectedPageController.get();
 }
 
+RefPtr<Page> InspectorFrontendClientLocal::protectedFrontendPage() const
+{
+    return m_frontendPage.get();
+}
+
 void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 {
-    unsigned totalHeight = m_frontendPage->mainFrame().virtualView()->visibleHeight() + protectedInspectedPageController()->inspectedPage().mainFrame().virtualView()->visibleHeight();
+    unsigned totalHeight = protectedFrontendPage()->protectedMainFrame()->protectedVirtualView()->visibleHeight() + protectedInspectedPageController()->protectedInspectedPage()->protectedMainFrame()->protectedVirtualView()->visibleHeight();
     unsigned attachedHeight = constrainedAttachedWindowHeight(height, totalHeight);
     m_settings->setProperty(inspectorAttachedHeightSetting, String::number(attachedHeight));
     setAttachedWindowHeight(attachedHeight);
@@ -273,7 +280,7 @@ void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 
 void InspectorFrontendClientLocal::changeAttachedWindowWidth(unsigned width)
 {
-    unsigned totalWidth = m_frontendPage->mainFrame().virtualView()->visibleWidth() + protectedInspectedPageController()->inspectedPage().mainFrame().virtualView()->visibleWidth();
+    unsigned totalWidth = protectedFrontendPage()->protectedMainFrame()->protectedVirtualView()->visibleWidth() + protectedInspectedPageController()->protectedInspectedPage()->protectedMainFrame()->protectedVirtualView()->visibleWidth();
     unsigned attachedWidth = constrainedAttachedWindowWidth(width, totalWidth);
     setAttachedWindowWidth(attachedWidth);
 }
@@ -285,14 +292,15 @@ void InspectorFrontendClientLocal::changeSheetRect(const FloatRect& rect)
 
 void InspectorFrontendClientLocal::openURLExternally(const String& url)
 {
-    RefPtr localMainFrame = protectedInspectedPageController()->inspectedPage().localMainFrame();
+    RefPtr localMainFrame = protectedInspectedPageController()->protectedInspectedPage()->localMainFrame();
     if (!localMainFrame)
         return;
     Ref mainFrame = *localMainFrame;
+    RefPtr mainFrameDocument = mainFrame->document();
 
-    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, mainFrame->document() };
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, mainFrameDocument.get() };
 
-    FrameLoadRequest frameLoadRequest { *mainFrame->document(), mainFrame->document()->securityOrigin(), { }, blankTargetFrameName(), InitiatedByMainFrame::Unknown };
+    FrameLoadRequest frameLoadRequest { *mainFrameDocument, mainFrameDocument->securityOrigin(), { }, blankTargetFrameName(), InitiatedByMainFrame::Unknown };
 
     auto [frame, created] = WebCore::createWindow(mainFrame, WTFMove(frameLoadRequest), { });
     if (!frame)
@@ -302,12 +310,13 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
         return;
 
     ASSERT(localFrame->opener() == mainFrame.ptr());
-    localFrame->page()->setOpenedByDOM();
-    localFrame->page()->setOpenedByDOMWithOpener(true);
+    RefPtr page = localFrame->page();
+    page->setOpenedByDOM();
+    page->setOpenedByDOMWithOpener(true);
 
     // FIXME: Why do we compute the absolute URL with respect to |frame| instead of |mainFrame|?
-    ResourceRequest resourceRequest { localFrame->document()->completeURL(url) };
-    FrameLoadRequest frameLoadRequest2 { mainFrame->protectedDocument().releaseNonNull(), mainFrame->document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
+    ResourceRequest resourceRequest { localFrame->protectedDocument()->completeURL(url) };
+    FrameLoadRequest frameLoadRequest2 { *mainFrameDocument, mainFrameDocument->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
     localFrame->loader().changeLocation(WTFMove(frameLoadRequest2));
 }
 
@@ -341,7 +350,7 @@ void InspectorFrontendClientLocal::setAttachedWindow(DockSide dockSide)
 
 void InspectorFrontendClientLocal::restoreAttachedWindowHeight()
 {
-    unsigned inspectedPageHeight = protectedInspectedPageController()->inspectedPage().mainFrame().virtualView()->visibleHeight();
+    unsigned inspectedPageHeight = protectedInspectedPageController()->protectedInspectedPage()->protectedMainFrame()->protectedVirtualView()->visibleHeight();
     String value = m_settings->getProperty(inspectorAttachedHeightSetting);
     unsigned preferredHeight = value.isEmpty() ? defaultAttachedHeight : parseIntegerAllowingTrailingJunk<unsigned>(value).value_or(0);
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -145,6 +145,7 @@ private:
     friend class FrontendMenuProvider;
     std::optional<bool> evaluationResultToBoolean(InspectorFrontendAPIDispatcher::EvaluationResult);
 
+    RefPtr<Page> protectedFrontendPage() const;
     RefPtr<InspectorController> protectedInspectedPageController() const;
 
     WeakPtr<InspectorController> m_inspectedPageController;


### PR DESCRIPTION
#### 5c0025cddbb739618615787c9e51d396d5549d65
<pre>
Address Safer CPP warnings in InspectorFrontendClientLocal.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298758">https://bugs.webkit.org/show_bug.cgi?id=298758</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::protectedInspectedPage const):
* Source/WebCore/inspector/InspectorController.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::~InspectorFrontendClientLocal):
(WebCore::InspectorFrontendClientLocal::windowObjectCleared):
(WebCore::InspectorFrontendClientLocal::canAttachWindow):
(WebCore::InspectorFrontendClientLocal::protectedFrontendPage const):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowHeight):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowWidth):
(WebCore::InspectorFrontendClientLocal::openURLExternally):
(WebCore::InspectorFrontendClientLocal::restoreAttachedWindowHeight):
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:

Canonical link: <a href="https://commits.webkit.org/299887@main">https://commits.webkit.org/299887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6536b1552fd5f4812fe3d36a38b7c66bb99fc5af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72654 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1cdde36-ac0f-4c45-82c2-036eae76efbe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91576 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60837 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c10a427-bab1-4dd6-b81c-7931f3865009) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72126 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7eae69ea-9669-496c-a34d-9c749ae6e03d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26189 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129840 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100195 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100036 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25396 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23507 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44148 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47362 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53067 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46830 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50177 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48517 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->