### PR TITLE
Address Safer CPP warnings in

### DIFF
--- a/Source/WebCore/PAL/pal/ThreadGlobalData.h
+++ b/Source/WebCore/PAL/pal/ThreadGlobalData.h
@@ -47,15 +47,15 @@ protected:
     PAL_EXPORT ThreadGlobalData();
 
 private:
-    PAL_EXPORT friend ThreadGlobalData& threadGlobalData();
+    PAL_EXPORT friend ThreadGlobalData& threadGlobalDataSingleton();
 
     const UniqueRef<ICUConverterWrapper> m_cachedConverterICU;
 };
 
 #if USE(WEB_THREAD)
-PAL_EXPORT ThreadGlobalData& threadGlobalData();
+PAL_EXPORT ThreadGlobalData& threadGlobalDataSingleton();
 #else
-PAL_EXPORT ThreadGlobalData& threadGlobalData() PURE_FUNCTION;
+PAL_EXPORT ThreadGlobalData& threadGlobalDataSingleton() PURE_FUNCTION;
 #endif
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -150,7 +150,7 @@ TextCodecICU::~TextCodecICU()
 {
     if (m_converter) {
         ucnv_reset(m_converter.get());
-        threadGlobalData().cachedConverterICU().converter = WTFMove(m_converter);
+        threadGlobalDataSingleton().cachedConverterICU().converter = WTFMove(m_converter);
     }
 }
 
@@ -158,7 +158,7 @@ void TextCodecICU::createICUConverter() const
 {
     ASSERT(!m_converter);
 
-    auto& cachedConverter = threadGlobalData().cachedConverterICU().converter;
+    auto& cachedConverter = threadGlobalDataSingleton().cachedConverterICU().converter;
     if (cachedConverter) {
         UErrorCode error = U_ZERO_ERROR;
         const char* cachedConverterName = ucnv_getName(cachedConverter.get(), &error);

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -676,7 +676,6 @@ page/writing-tools/WritingToolsController.mm
 platform/Cursor.h
 platform/DragImage.cpp
 platform/Length.cpp
-platform/MIMETypeRegistry.cpp
 platform/ScrollAnimationSmooth.cpp
 platform/ScrollAnimator.cpp
 platform/ScrollView.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -57,7 +57,6 @@ page/mac/ServicesOverlayController.mm
 page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
-platform/LocalizedStrings.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/AudioSampleBufferConverter.mm
 platform/audio/cocoa/AudioSessionCocoa.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -22,7 +22,6 @@ page/mac/EventHandlerMac.mm
 page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
-platform/MIMETypeRegistry.cpp
 platform/VideoFrame.mm
 platform/audio/cocoa/AudioEncoderCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp

--- a/Source/WebCore/bindings/js/JSExecState.h
+++ b/Source/WebCore/bindings/js/JSExecState.h
@@ -47,7 +47,7 @@ class JSExecState {
 public:
     static JSC::JSGlobalObject* currentState()
     {
-        return threadGlobalData().currentState();
+        return threadGlobalDataSingleton().currentState();
     }
     
     static JSC::JSValue call(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue functionObject, const JSC::CallData& callData, JSC::JSValue thisValue, const JSC::ArgList& args, NakedPtr<JSC::Exception>& returnedException)
@@ -178,7 +178,7 @@ private:
 
     static void setCurrentState(JSC::JSGlobalObject* lexicalGlobalObject)
     {
-        threadGlobalData().setCurrentState(lexicalGlobalObject);
+        threadGlobalDataSingleton().setCurrentState(lexicalGlobalObject);
     }
 
     JSC::JSGlobalObject* const m_previousState;

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -401,7 +401,7 @@ const EventListenerVector& EventTarget::eventListeners(const AtomString& eventTy
 
 void EventTarget::removeAllEventListeners()
 {
-    Ref threadData = threadGlobalData();
+    Ref threadData = threadGlobalDataSingleton();
     RELEASE_ASSERT(!threadData->isInRemoveAllEventListeners());
 
     threadData->setIsInRemoveAllEventListeners(true);

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -123,7 +123,7 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
     JSC::JSLockHolder locker(vm);
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
     {
-        SUPPRESS_UNCOUNTED_ARG auto& data = threadGlobalData();
+        SUPPRESS_UNCOUNTED_ARG auto& data = threadGlobalDataSingleton();
         auto* previousState = data.currentState();
         m_microtaskQueue.performMicrotaskCheckpoint(vm,
             [&](JSC::QueuedTask& task) ALWAYS_INLINE_LAMBDA {

--- a/Source/WebCore/dom/QualifiedName.cpp
+++ b/Source/WebCore/dom/QualifiedName.cpp
@@ -48,18 +48,18 @@ static QualifiedNameComponents makeComponents(const AtomString& prefix, const At
 }
 
 QualifiedName::QualifiedName(const AtomString& prefix, const AtomString& localName, const AtomString& namespaceURI)
-    : m_impl(threadGlobalData().qualifiedNameCache().getOrCreate(makeComponents(prefix, localName, namespaceURI)))
+    : m_impl(threadGlobalDataSingleton().qualifiedNameCache().getOrCreate(makeComponents(prefix, localName, namespaceURI)))
 {
 }
 
 QualifiedName::QualifiedName(const AtomString& prefix, const AtomString& localName, const AtomString& namespaceURI, Namespace nodeNamespace, NodeName nodeName)
-    : m_impl(threadGlobalData().qualifiedNameCache().getOrCreate(makeComponents(prefix, localName, namespaceURI), nodeNamespace, nodeName))
+    : m_impl(threadGlobalDataSingleton().qualifiedNameCache().getOrCreate(makeComponents(prefix, localName, namespaceURI), nodeNamespace, nodeName))
 {
 }
 
 QualifiedName::QualifiedNameImpl::~QualifiedNameImpl()
 {
-    threadGlobalData().qualifiedNameCache().remove(*this);
+    threadGlobalDataSingleton().qualifiedNameCache().remove(*this);
 }
 
 // Global init routines

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -290,7 +290,7 @@ void WindowEventLoop::breakToAllowRenderingUpdate()
     // Avoid running timers and doing other work (like processing asyncronous IPC) until it is completed.
 
     // FIXME: Also bail out from the task loop in EventLoop::run().
-    threadGlobalData().threadTimers().breakFireLoopForRenderingUpdate();
+    threadGlobalDataSingleton().threadTimers().breakFireLoopForRenderingUpdate();
 
     RunLoop::mainSingleton().suspendFunctionDispatchForCurrentCycle();
 #endif

--- a/Source/WebCore/dom/make-event-names.py
+++ b/Source/WebCore/dom/make-event-names.py
@@ -177,7 +177,7 @@ const EventNames& eventNames();
 
 inline const EventNames& eventNames()
 {
-    return threadGlobalData().eventNames();
+    return threadGlobalDataSingleton().eventNames();
 }
 
 inline EventTypeInfo EventNames::typeInfoForEvent(const AtomString& eventType) const

--- a/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
@@ -48,7 +48,7 @@ private:
 
 inline const CachedResourceRequestInitiatorTypes& cachedResourceRequestInitiatorTypes()
 {
-    return threadGlobalData().cachedResourceRequestInitiatorTypes();
+    return threadGlobalDataSingleton().cachedResourceRequestInitiatorTypes();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -152,9 +152,9 @@ CaptionUserPreferencesMediaAF::~CaptionUserPreferencesMediaAF()
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     if (m_observer) {
         if (kMAXCaptionAppearanceSettingsChangedNotification)
-            CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), kMAXCaptionAppearanceSettingsChangedNotification, 0);
+            CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), RetainPtr { kMAXCaptionAppearanceSettingsChangedNotification }.get(), 0);
         if (kMAAudibleMediaSettingsChangedNotification)
-            CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), kMAAudibleMediaSettingsChangedNotification, 0);
+            CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), RetainPtr { kMAAudibleMediaSettingsChangedNotification }.get(), 0);
     }
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 }
@@ -288,10 +288,10 @@ void CaptionUserPreferencesMediaAF::setInterestedInCaptionPreferenceChanges()
         lazyInitialize(m_observer, createWeakObserver(this));
     auto suspensionBehavior = static_cast<CFNotificationSuspensionBehavior>(CFNotificationSuspensionBehaviorCoalesce | _CFNotificationObserverIsObjC);
     if (kMAXCaptionAppearanceSettingsChangedNotification)
-        CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), userCaptionPreferencesChangedNotificationCallback, kMAXCaptionAppearanceSettingsChangedNotification, 0, suspensionBehavior);
+        CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), userCaptionPreferencesChangedNotificationCallback, RetainPtr { kMAXCaptionAppearanceSettingsChangedNotification }.get(), 0, suspensionBehavior);
 
     if (canLoad_MediaAccessibility_kMAAudibleMediaSettingsChangedNotification())
-        CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), userCaptionPreferencesChangedNotificationCallback, kMAAudibleMediaSettingsChangedNotification, 0, suspensionBehavior);
+        CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), userCaptionPreferencesChangedNotificationCallback, RetainPtr { kMAAudibleMediaSettingsChangedNotification }.get(), 0, suspensionBehavior);
     m_registeringForNotification = false;
 
     // Generating and registering the caption stylesheet can be expensive and this method is called indirectly when the parser creates an audio or
@@ -489,10 +489,10 @@ String CaptionUserPreferencesMediaAF::captionsDefaultFontCSS() const
     builder.append("font-family: \""_s, name.get(), '"');
     if (RetainPtr cascadeList = adoptCF(static_cast<CFArrayRef>(CTFontDescriptorCopyAttribute(font.get(), kCTFontCascadeListAttribute)))) {
         for (CFIndex i = 0; i < CFArrayGetCount(cascadeList.get()); i++) {
-            auto fontCascade = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(cascadeList.get(), i));
+            RetainPtr fontCascade = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(cascadeList.get(), i));
             if (!fontCascade)
                 continue;
-            RetainPtr fontCascadeName = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontCascade, kCTFontNameAttribute)));
+            RetainPtr fontCascadeName = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontCascade.get(), kCTFontNameAttribute)));
             if (!fontCascadeName)
                 continue;
             builder.append(", \""_s, fontCascadeName.get(), '"');
@@ -806,9 +806,9 @@ Vector<RefPtr<AudioTrack>> CaptionUserPreferencesMediaAF::sortedTrackListForMenu
     Vector<RefPtr<AudioTrack>> tracksForMenu;
     
     for (unsigned i = 0, length = trackList->length(); i < length; ++i) {
-        AudioTrack* track = trackList->item(i);
+        RefPtr track = trackList->item(i);
         String language = displayNameForLanguageLocale(track->validBCP47Language());
-        tracksForMenu.append(track);
+        tracksForMenu.append(WTFMove(track));
     }
 
     Collator collator;

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -90,7 +90,7 @@ String formatLocalizedString(const char* format, ...)
 #endif
 
 #if PLATFORM(COCOA)
-static CFBundleRef webCoreBundle()
+static CFBundleRef webCoreBundleSingleton()
 {
     static LazyNeverDestroyed<RetainPtr<CFBundleRef>> bundle;
     static std::once_flag flag;
@@ -105,7 +105,7 @@ RetainPtr<CFStringRef> copyLocalizedString(CFStringRef key)
 {
     static CFStringRef notFound = CFSTR("localized string not found");
 
-    auto result = adoptCF(CFBundleCopyLocalizedString(webCoreBundle(), key, notFound, nullptr));
+    auto result = adoptCF(CFBundleCopyLocalizedString(webCoreBundleSingleton(), key, notFound, nullptr));
 
 #if ASSERT_ENABLED
     if (result.get() == notFound) {

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -477,10 +477,10 @@ std::unique_ptr<MIMETypeRegistryThreadGlobalData> MIMETypeRegistry::createMIMETy
     HashSet<String, ASCIICaseInsensitiveHash> supportedImageMIMETypesForEncoding;
     CFIndex count = CFArrayGetCount(supportedTypes.get());
     for (CFIndex i = 0; i < count; i++) {
-        CFStringRef supportedType = reinterpret_cast<CFStringRef>(CFArrayGetValueAtIndex(supportedTypes.get(), i));
-        if (!isSupportedImageType(supportedType))
+        RetainPtr supportedType = reinterpret_cast<CFStringRef>(CFArrayGetValueAtIndex(supportedTypes.get(), i));
+        if (!isSupportedImageType(supportedType.get()))
             continue;
-        String mimeType = MIMETypeForImageType(supportedType);
+        String mimeType = MIMETypeForImageType(supportedType.get());
         if (mimeType.isEmpty())
             continue;
         supportedImageMIMETypesForEncoding.add(mimeType);
@@ -516,7 +516,7 @@ bool MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(const String& mimeTyp
 {
     if (mimeType.isEmpty())
         return false;
-    return threadGlobalData().mimeTypeRegistryThreadGlobalData().supportedImageMIMETypesForEncoding().contains(mimeType);
+    return threadGlobalDataSingleton().mimeTypeRegistryThreadGlobalData().supportedImageMIMETypesForEncoding().contains(mimeType);
 }
 
 bool MIMETypeRegistry::isSupportedJavaScriptMIMEType(const String& mimeType)

--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -67,12 +67,12 @@ static ThreadGlobalData* sharedMainThreadStaticData { nullptr };
 void ThreadGlobalData::setWebCoreThreadData()
 {
     ASSERT(isWebThread());
-    ASSERT(&threadGlobalData() != sharedMainThreadStaticData);
+    ASSERT(&threadGlobalDataSingleton() != sharedMainThreadStaticData);
 
     // Set WebThread's ThreadGlobalData object to be the same as the main UI thread.
     Thread::currentSingleton().m_clientData = adoptRef(sharedMainThreadStaticData);
 
-    ASSERT(&threadGlobalData() == sharedMainThreadStaticData);
+    ASSERT(&threadGlobalDataSingleton() == sharedMainThreadStaticData);
 }
 
 ThreadGlobalData& threadGlobalDataSlow()
@@ -144,9 +144,9 @@ void ThreadGlobalData::initializeFontCache()
 
 namespace PAL {
 
-ThreadGlobalData& threadGlobalData()
+ThreadGlobalData& threadGlobalDataSingleton()
 {
-    return WebCore::threadGlobalData();
+    return WebCore::threadGlobalDataSingleton();
 }
 
 } // namespace PAL

--- a/Source/WebCore/platform/ThreadGlobalData.h
+++ b/Source/WebCore/platform/ThreadGlobalData.h
@@ -129,7 +129,7 @@ private:
 
     bool m_isInRemoveAllEventListeners { false };
 
-    friend ThreadGlobalData& threadGlobalData();
+    friend ThreadGlobalData& threadGlobalDataSingleton();
 };
 
 
@@ -140,9 +140,9 @@ WEBCORE_EXPORT ThreadGlobalData& threadGlobalDataSlow() PURE_FUNCTION;
 #endif
 
 #if USE(WEB_THREAD)
-inline ThreadGlobalData& threadGlobalData()
+inline ThreadGlobalData& threadGlobalDataSingleton()
 #else
-inline PURE_FUNCTION ThreadGlobalData& threadGlobalData()
+inline PURE_FUNCTION ThreadGlobalData& threadGlobalDataSingleton()
 #endif
 {
 #if HAVE(FAST_TLS)

--- a/Source/WebCore/platform/ThreadTimers.cpp
+++ b/Source/WebCore/platform/ThreadTimers.cpp
@@ -70,7 +70,7 @@ void ThreadTimers::setSharedTimer(SharedTimer* sharedTimer)
     m_sharedTimer = sharedTimer;
     
     if (sharedTimer) {
-        sharedTimer->setFiredFunction([] { threadGlobalData().threadTimers().sharedTimerFiredInternal(); });
+        sharedTimer->setFiredFunction([] { threadGlobalDataSingleton().threadTimers().sharedTimerFiredInternal(); });
         updateSharedTimer();
     }
 }

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -61,7 +61,7 @@ class TimerHeapReference;
 #if ASSERT_ENABLED
 static ThreadTimerHeap& threadGlobalTimerHeap()
 {
-    return threadGlobalData().threadTimers().timerHeap();
+    return threadGlobalDataSingleton().threadTimers().timerHeap();
 }
 #endif
 
@@ -70,7 +70,7 @@ WTF_MAKE_COMPACT_TZONE_OR_ISO_ALLOCATED_IMPL(ThreadTimerHeapItem);
 inline ThreadTimerHeapItem::ThreadTimerHeapItem(TimerBase& timer, MonotonicTime time, unsigned insertionOrder)
     : time(time)
     , insertionOrder(insertionOrder)
-    , m_threadTimers(threadGlobalData().threadTimers())
+    , m_threadTimers(threadGlobalDataSingleton().threadTimers())
     , m_timer(&timer)
 {
     ASSERT(m_timer);
@@ -534,7 +534,7 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
     }
 
     if (oldTime != newTime) {
-        auto newOrder = threadGlobalData().threadTimers().nextHeapInsertionCount();
+        auto newOrder = threadGlobalDataSingleton().threadTimers().nextHeapInsertionCount();
 
         RefPtr item = m_heapItemWithBitfields.pointer();
         if (!item) {
@@ -551,7 +551,7 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
         bool isFirstTimerInHeap = item->isFirstInHeap();
 
         if (wasFirstTimerInHeap || isFirstTimerInHeap)
-            threadGlobalData().threadTimers().updateSharedTimer();
+            threadGlobalDataSingleton().threadTimers().updateSharedTimer();
     }
 
     checkConsistency();
@@ -560,7 +560,7 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
 void TimerBase::fireTimersInNestedEventLoop()
 {
     // Redirect to ThreadTimers.
-    threadGlobalData().threadTimers().fireTimersInNestedEventLoop();
+    threadGlobalDataSingleton().threadTimers().fireTimersInNestedEventLoop();
 }
 
 void TimerBase::didChangeAlignmentInterval()

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -136,17 +136,17 @@ struct FontCache::FontDataCaches {
 
 CheckedRef<FontCache> FontCache::forCurrentThread()
 {
-    return threadGlobalData().fontCache();
+    return threadGlobalDataSingleton().fontCache();
 }
 
 FontCache* FontCache::forCurrentThreadIfExists()
 {
-    return threadGlobalData().fontCacheIfExists();
+    return threadGlobalDataSingleton().fontCacheIfExists();
 }
 
 FontCache* FontCache::forCurrentThreadIfNotDestroyed()
 {
-    return threadGlobalData().fontCacheIfNotDestroyed();
+    return threadGlobalDataSingleton().fontCacheIfNotDestroyed();
 }
 
 FontCache::FontCache()

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -648,7 +648,7 @@ static void* RunWebThread(void*)
     WebCore::populateJITOperations();
     
     // Make sure that the WebThread and the main thread share the same ThreadGlobalData objects.
-    WebCore::threadGlobalData().setWebCoreThreadData();
+    WebCore::threadGlobalDataSingleton().setWebCoreThreadData();
 
 #if HAVE(PTHREAD_SETNAME_NP)
     pthread_setname_np("WebThread");
@@ -696,7 +696,7 @@ static void StartWebThread()
 
     // Initialize ThreadGlobalData on the main UI thread so that the WebCore thread
     // can later set it's thread-specific data to point to the same objects.
-    WebCore::ThreadGlobalData& unused = WebCore::threadGlobalData();
+    WebCore::ThreadGlobalData& unused = WebCore::threadGlobalDataSingleton();
     UNUSED_PARAM(unused);
 
     // register class for WebThread deallocation

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -172,7 +172,7 @@ MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, AtomString&&
 MockRealtimeVideoSource::~MockRealtimeVideoSource()
 {
     m_runLoop->dispatch([] {
-        threadGlobalData().destroy();
+        threadGlobalDataSingleton().destroy();
         RunLoop::currentSingleton().stop();
     });
 

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -232,7 +232,7 @@ void WorkerOrWorkletThread::destroyWorkerGlobalScope(Ref<WorkerOrWorkletThread>&
         callOnMainThread(WTFMove(stoppedCallback));
 
     // Clean up WebCore::ThreadGlobalData before WTF::Thread goes away!
-    threadGlobalData().destroy();
+    threadGlobalDataSingleton().destroy();
 
     // Send the last WorkerThread Ref to be Deref'ed on the main thread.
     callOnMainThread([protectedThis = WTFMove(protectedThis)] { });

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -142,7 +142,7 @@ public:
     {
         if (!m_runLoop.m_nestedCount) {
             m_runLoop.m_sharedTimer = makeUnique<WorkerSharedTimer>();
-            threadGlobalData().threadTimers().setSharedTimer(m_runLoop.m_sharedTimer.get());
+            threadGlobalDataSingleton().threadTimers().setSharedTimer(m_runLoop.m_sharedTimer.get());
         }
         m_runLoop.m_nestedCount++;
         if (m_isForDebugging == IsForDebugging::Yes)
@@ -153,7 +153,7 @@ public:
     {
         m_runLoop.m_nestedCount--;
         if (!m_runLoop.m_nestedCount) {
-            threadGlobalData().threadTimers().setSharedTimer(nullptr);
+            threadGlobalDataSingleton().threadTimers().setSharedTimer(nullptr);
             m_runLoop.m_sharedTimer = nullptr;
         }
         if (m_isForDebugging == IsForDebugging::Yes)


### PR DESCRIPTION
#### f6664cbf0e56a16bc8df28d7016eda37834ec8af
<pre>
Address Safer CPP warnings in MIMETypeRegistry.cpp and LocalizedStrings.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298760">https://bugs.webkit.org/show_bug.cgi?id=298760</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/PAL/pal/ThreadGlobalData.h:
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::~TextCodecICU):
(PAL::TextCodecICU::createICUConverter const):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/bindings/js/JSExecState.h:
(WebCore::JSExecState::currentState):
(WebCore::JSExecState::setCurrentState):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::removeAllEventListeners):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/QualifiedName.cpp:
(WebCore::QualifiedName::QualifiedName):
(WebCore::QualifiedName::QualifiedNameImpl::~QualifiedNameImpl):
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::breakToAllowRenderingUpdate):
* Source/WebCore/dom/make-event-names.py:
* Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h:
(WebCore::cachedResourceRequestInitiatorTypes):
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::webCoreBundleSingleton):
(WebCore::copyLocalizedString):
(WebCore::webCoreBundle): Deleted.
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::createMIMETypeRegistryThreadGlobalData):
(WebCore::MIMETypeRegistry::isSupportedImageMIMETypeForEncoding):
* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::ThreadGlobalData::setWebCoreThreadData):
(PAL::threadGlobalDataSingleton):
(PAL::threadGlobalData): Deleted.
* Source/WebCore/platform/ThreadGlobalData.h:
(WebCore::threadGlobalDataSingleton):
(WebCore::threadGlobalData): Deleted.
* Source/WebCore/platform/ThreadTimers.cpp:
(WebCore::ThreadTimers::setSharedTimer):
* Source/WebCore/platform/Timer.cpp:
(WebCore::threadGlobalTimerHeap):
(WebCore::ThreadTimerHeapItem::ThreadTimerHeapItem):
(WebCore::TimerBase::setNextFireTime):
(WebCore::TimerBase::fireTimersInNestedEventLoop):
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::forCurrentThread):
(WebCore::FontCache::forCurrentThreadIfExists):
(WebCore::FontCache::forCurrentThreadIfNotDestroyed):
* Source/WebCore/platform/ios/wak/WebCoreThread.mm:
(RunWebThread):
(StartWebThread):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::~MockRealtimeVideoSource):
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::destroyWorkerGlobalScope):
* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::RunLoopSetup::RunLoopSetup):
(WebCore::RunLoopSetup::~RunLoopSetup):
</pre>
----------------------------------------------------------------------
#### d4294448816c196a624b61b996aed75412543327
<pre>
Address Safer CPP warnings in CaptionUserPreferencesMediaAF.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298759">https://bugs.webkit.org/show_bug.cgi?id=298759</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::~CaptionUserPreferencesMediaAF):
(WebCore::CaptionUserPreferencesMediaAF::setInterestedInCaptionPreferenceChanges):
(WebCore::CaptionUserPreferencesMediaAF::captionsDefaultFontCSS const):
(WebCore::CaptionUserPreferencesMediaAF::sortedTrackListForMenu):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6664cbf0e56a16bc8df28d7016eda37834ec8af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120574 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72649 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/672a46e4-d365-4d0a-aca6-7a72a5dc50fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91572 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60833 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e57e51e-bf9f-4428-9450-344fb5884873) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72122 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7116a716-c406-4d70-9b43-6832bbe64f2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26185 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70569 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129835 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100192 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100033 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44143 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53062 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->