### PR TITLE
[JSC] `Set#isDisjointFrom` and `Set#isSupersetOf` should call `iteratorClose` before return

### DIFF
--- a/JSTests/stress/set-prototype-isDisjointFrom-iterator-close.js
+++ b/JSTests/stress/set-prototype-isDisjointFrom-iterator-close.js
@@ -1,0 +1,73 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error('array length mismatch: ' + actual.length + ' vs ' + expected.length);
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error('array element mismatch at index ' + i + ': ' + actual[i] + ' vs ' + expected[i]);
+    }
+}
+
+{
+    let log = [];
+
+    let keysIter = {
+        next() {
+            log.push("next");
+            return {done: false, value: 2};
+        },
+        return() {
+            log.push("return");
+            return {
+                get value() { throw new Error("Unexpected call to |value| getter"); },
+                get done() { throw new Error("Unexpected call to |done| getter"); },
+            };
+        }
+    };
+
+    let setLike = {
+        size: 1,
+        has() {
+            throw new Error("Unexpected call to |has| method");
+        },
+        keys() {
+            return keysIter;
+        },
+    };
+
+    let result = new Set([1, 2, 3]).isDisjointFrom(setLike);
+    shouldBe(result, false);
+    shouldBeArray(log, ["next", "return"]);
+}
+
+{
+    let returnCalled = false;
+
+    let keysIter = {
+        next() {
+            return {done: true};
+        },
+        return() {
+            returnCalled = true;
+            return {};
+        }
+    };
+
+    let setLike = {
+        size: 0,
+        has() {
+            throw new Error("Unexpected call to |has| method");
+        },
+        keys() {
+            return keysIter;
+        },
+    };
+
+    let result = new Set([1, 2, 3]).isDisjointFrom(setLike);
+    shouldBe(result, true);
+    shouldBe(returnCalled, false);
+}

--- a/JSTests/stress/set-prototype-isSupersetOf-iterator-close.js
+++ b/JSTests/stress/set-prototype-isSupersetOf-iterator-close.js
@@ -1,0 +1,73 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error('array length mismatch: ' + actual.length + ' vs ' + expected.length);
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error('array element mismatch at index ' + i + ': ' + actual[i] + ' vs ' + expected[i]);
+    }
+}
+
+{
+    let log = [];
+
+    let keysIter = {
+        next() {
+            log.push("next");
+            return {done: false, value: 1};
+        },
+        return() {
+            log.push("return");
+            return {
+                get value() { throw new Error("Unexpected call to |value| getter"); },
+                get done() { throw new Error("Unexpected call to |done| getter"); },
+            };
+        }
+    };
+
+    let setLike = {
+        size: 1,
+        has() {
+            throw new Error("Unexpected call to |has| method");
+        },
+        keys() {
+            return keysIter;
+        },
+    };
+
+    let result = new Set([2, 3, 4]).isSupersetOf(setLike);
+    shouldBe(result, false);
+    shouldBeArray(log, ["next", "return"]);
+}
+
+{
+    let returnCalled = false;
+
+    let keysIter = {
+        next() {
+            return {done: true};
+        },
+        return() {
+            returnCalled = true;
+            return {};
+        }
+    };
+
+    let setLike = {
+        size: 0,
+        has() {
+            throw new Error("Unexpected call to |has| method");
+        },
+        keys() {
+            return keysIter;
+        },
+    };
+
+    let result = new Set([1, 2, 3]).isSupersetOf(setLike);
+    shouldBe(result, true);
+    shouldBe(returnCalled, false);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1334,10 +1334,6 @@ test/staging/sm/RegExp/unicode-braced.js:
   default: 'SyntaxError: Invalid regular expression: regular expression too large'
 test/staging/sm/RegExp/unicode-class-braced.js:
   default: 'SyntaxError: Invalid regular expression: regular expression too large'
-test/staging/sm/Set/is-disjoint-from.js:
-  default: 'Test262Error: Actual [next] and expected [next, return] should have the same contents. '
-test/staging/sm/Set/is-superset-of.js:
-  default: 'Test262Error: Actual [next] and expected [next, return] should have the same contents. '
 test/staging/sm/TypedArray/constructor-buffer-sequence.js:
   default: 'Error: Assertion failed: expected exception ExpectedError, got Error: Poisoned Value'
 test/staging/sm/TypedArray/iterator-next-with-detached.js:

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -677,8 +677,11 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
 
         bool thisHasValue = thisSet->has(globalObject, value);
         RETURN_IF_EXCEPTION(scope, { });
-        if (!thisHasValue)
+        if (!thisHasValue) {
+            scope.release();
+            iteratorClose(globalObject, keysResult);
             return JSValue::encode(jsBoolean(false));
+        }
     }
 
     return JSValue::encode(jsBoolean(true));
@@ -846,8 +849,11 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
 
             bool thisHasValue = thisSet->has(globalObject, value);
             RETURN_IF_EXCEPTION(scope, { });
-            if (thisHasValue)
+            if (thisHasValue) {
+                scope.release();
+                iteratorClose(globalObject, keysResult);
                 return JSValue::encode(jsBoolean(false));
+            }
         }
     }
 


### PR DESCRIPTION
#### 341ff8458210e2250c445ada8786e4505e328765
<pre>
[JSC] `Set#isDisjointFrom` and `Set#isSupersetOf` should call `iteratorClose` before return
<a href="https://bugs.webkit.org/show_bug.cgi?id=298761">https://bugs.webkit.org/show_bug.cgi?id=298761</a>

Reviewed by Yusuke Suzuki.

This patch fixes to call `iteratorClose` before return from `Set#isDisjointFrom` and `Set#isSupersetOf`.

* JSTests/stress/set-prototype-isDisjointFrom-iterator-close.js: Added.
(shouldBe):
(shouldBeArray):
(throw.new.Error.let.keysIter.return.return.get value):
(throw.new.Error.let.keysIter.return.return.get done):
(throw.new.Error):
* JSTests/stress/set-prototype-isSupersetOf-iterator-close.js: Added.
(shouldBe):
(shouldBeArray):
(throw.new.Error.let.keysIter.return.return.get value):
(throw.new.Error.let.keysIter.return.return.get done):
(throw.new.Error):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/299883@main">https://commits.webkit.org/299883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/882cae1ada3e245b9a6d547131b560c3affa7d98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72655 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91578 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26188 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70575 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112706 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129841 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119096 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100197 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45479 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23506 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53068 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/148175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46831 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/148175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->