### PR TITLE
[css-anchor-position-1] revert-layer in @position-try should revert only the position-try origin

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-cascade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-cascade-expected.txt
@@ -5,5 +5,5 @@ PASS @position-try rule wins over inline style
 PASS @position-try rule does not win over !important
 PASS @position-try rule does not win over animations
 PASS @position-try rule does not win over transitions
-FAIL @position-try revert / revert-layer reverts to user / author origin assert_equals: top reverted back to author expected 20 but got 30
+PASS @position-try revert / revert-layer reverts to user / author origin
 

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -188,7 +188,7 @@ struct StyleFeatureSchema : public FeatureSchema {
             auto dummyStyle = RenderStyle::clone(style);
             auto dummyMatchResult = Style::MatchResult::create();
 
-            auto styleBuilder = Style::Builder { dummyStyle, WTFMove(builderContext), dummyMatchResult, { } };
+            auto styleBuilder = Style::Builder { dummyStyle, WTFMove(builderContext), dummyMatchResult };
             return styleBuilder.resolveCustomPropertyForContainerQueries(*featureValue);
         }();
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -42,7 +42,7 @@ class CustomProperty;
 class Builder {
     WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, DeclarationOrigin, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();
@@ -72,7 +72,7 @@ private:
     void applyCascadeProperty(const PropertyCascade::Property&);
     bool applyRollbackCascadeProperty(const PropertyCascade&, CSSPropertyID, SelectorChecker::LinkMatchMask);
     bool applyRollbackCascadeCustomProperty(const PropertyCascade&, const AtomString&);
-    void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, DeclarationOrigin);
+    void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, PropertyCascade::Origin);
     void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&);
 
     Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
@@ -84,7 +84,7 @@ private:
     const PropertyCascade* ensureRollbackCascadeForRevertLayer();
 
     using RollbackCascadeKey = std::tuple<unsigned, unsigned, unsigned>;
-    RollbackCascadeKey makeRollbackCascadeKey(DeclarationOrigin, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
+    RollbackCascadeKey makeRollbackCascadeKey(PropertyCascade::Origin, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
 
     const PropertyCascade m_cascade;
     // Rollback cascades are build on demand to resolve 'revert' and 'revert-layer' keywords.

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -361,10 +361,10 @@ unsigned BuilderState::siblingIndex()
     return count;
 }
 
-void BuilderState::disableNativeAppearanceIfNeeded(CSSPropertyID propertyID, DeclarationOrigin declarationOrigin)
+void BuilderState::disableNativeAppearanceIfNeeded(CSSPropertyID propertyID, PropertyCascade::Origin origin)
 {
     auto shouldDisable = [&] {
-        if (declarationOrigin != DeclarationOrigin::Author)
+        if (origin != PropertyCascade::Origin::Author)
             return false;
         if (!CSSProperty::disablesNativeAppearance(propertyID))
             return false;

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "CSSToStyleMap.h"
-#include "DeclarationOrigin.h"
 #include "PropertyCascade.h"
 #include "RuleSet.h"
 #include "SelectorChecker.h"
@@ -136,7 +135,7 @@ public:
 
     bool isAuthorOrigin() const
     {
-        return m_currentProperty && m_currentProperty->declarationOrigin == DeclarationOrigin::Author;
+        return m_currentProperty && m_currentProperty->origin == PropertyCascade::Origin::Author;
     }
 
     CSSPropertyID cssPropertyID() const;
@@ -201,7 +200,7 @@ public:
     void setFontDescriptionVariantNumericOrdinal(FontVariantNumericOrdinal);
     void setFontDescriptionVariantNumericSlashedZero(FontVariantNumericSlashedZero);
 
-    void disableNativeAppearanceIfNeeded(CSSPropertyID, DeclarationOrigin);
+    void disableNativeAppearanceIfNeeded(CSSPropertyID, PropertyCascade::Origin);
 
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -426,7 +426,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
         collector.matchUserRules();
     }
     collector.addAuthorKeyframeRules(keyframe);
-    Builder builder(*state.style(), builderContext(state), collector.matchResult(), DeclarationOrigin::Author);
+    Builder builder(*state.style(), builderContext(state), collector.matchResult());
     builder.state().setIsBuildingKeyframeStyle();
     builder.applyAllProperties();
 
@@ -620,7 +620,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForPage(int pageIndex)
 
     auto& result = collector.matchResult();
 
-    Builder builder(*state.style(), builderContext(state), result, DeclarationOrigin::Author);
+    Builder builder(*state.style(), builderContext(state), result);
     builder.applyAllProperties();
 
     // Now return the style.
@@ -733,7 +733,7 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
             return;
     }
 
-    Builder builder(style, builderContext(state), matchResult, DeclarationOrigin::Author, WTFMove(includedProperties));
+    Builder builder(style, builderContext(state), matchResult, WTFMove(includedProperties));
 
     // Top priority properties may affect resolution of high priority ones.
     builder.applyTopPriorityProperties();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -930,7 +930,6 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
         *newStyle,
         WTFMove(builderContext),
         *resolvedStyle.matchResult,
-        DeclarationOrigin::Author,
         { properties }
     };
 
@@ -968,7 +967,6 @@ HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderSt
         animatedStyle,
         WTFMove(builderContext),
         matchResult,
-        DeclarationOrigin::Author,
         { isTransition ? PropertyCascade::PropertyType::AfterTransition : PropertyCascade::PropertyType::AfterAnimation },
         &animatedProperties
     };


### PR DESCRIPTION
#### 66dae2714ee4b7b0baa8cc9995af903859837195
<pre>
[css-anchor-position-1] revert-layer in @position-try should revert only the position-try origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=295013">https://bugs.webkit.org/show_bug.cgi?id=295013</a>
<a href="https://rdar.apple.com/154355428">rdar://154355428</a>

Reviewed by Alan Baradlay and Tim Nguyen.

Introduce a separate PropertyCascade::Origin enum so we can cleanly implement cascade origins
other than author/user/user-agent. Use it to implement @position-try as a separate origin.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-cascade-expected.txt:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):

Remove the unneeded origin constructor argument.

(WebCore::Style::PropertyCascade::buildCascade):
(WebCore::Style::PropertyCascade::setPropertyInternal):
(WebCore::Style::PropertyCascade::set):
(WebCore::Style::PropertyCascade::setLogicalGroupProperty):
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::addPositionTryFallbackProperties):
(WebCore::Style::declarationsForOrigin):
(WebCore::Style::PropertyCascade::addNormalMatches):
(WebCore::Style::PropertyCascade::addImportantMatches):
(WebCore::Style::declarationsForDeclarationOrigin): Deleted.
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::PropertyCascade):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):

Remove the unneeded origin constructor argument.

(WebCore::Style::Builder::applyCascadeProperty):
(WebCore::Style::Builder::applyRollbackCascadeProperty):
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::ensureRollbackCascadeForRevert):
(WebCore::Style::Builder::ensureRollbackCascadeForRevertLayer):
(WebCore::Style::Builder::makeRollbackCascadeKey):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::disableNativeAppearanceIfNeeded):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::isAuthorOrigin const):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
(WebCore::Style::Resolver::styleForPage):
(WebCore::Style::Resolver::applyMatchedProperties):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):

Canonical link: <a href="https://commits.webkit.org/299900@main">https://commits.webkit.org/299900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c768ec84f8f2359b1364149a8de4526c2334af12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72706 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b067b555-e633-4d72-9b57-3106338d0ef7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48902 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60881 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/87362179-e4f8-4e61-bbdd-3fa6dba2ead2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32754 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72170 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86df6121-5c11-4a40-8775-f3d80eac6bb1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31783 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70628 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102240 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/26422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129892 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36100 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47919 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/104316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100082 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45525 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44212 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47414 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46883 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50229 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48569 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->