### PR TITLE
ASSERTION FAILED: !std::isnan(value) - RTCRtpReceiver-track-settings.tentative.html WPT test case

### DIFF
--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
@@ -93,8 +93,8 @@ promise_test(async (t) => {
     const writer = generator.writable.getWriter();
     let settings = generator.track.getSettings();
     let capabilities = generator.track.getCapabilities();
-    assert_equals(settings.width, 0, "width 1");
-    assert_equals(settings.height, 0, "height 1");
+    assert_equals(settings.width, undefined, "width 1");
+    assert_equals(settings.height, undefined, "height 1");
     assert_equals(capabilities.width.min, 0, "min width 1");
     assert_equals(capabilities.width.max, 0, "max width 1");
     assert_equals(capabilities.height.min, 0, "min height 1");

--- a/LayoutTests/webrtc/video.html
+++ b/LayoutTests/webrtc/video.html
@@ -69,6 +69,9 @@ promise_test(async (test) => {
                 assert_equals(trackEvent.streams[1].id, localStream2.id, "second stream id");
                 assert_equals(trackEvent.track.id, localStream.getVideoTracks()[0].id);
                 assert_equals(trackEvent.track, trackEvent.streams[0].getVideoTracks()[0]);
+                assert_equals(trackEvent.track.getSettings().aspectRatio, undefined);
+                assert_equals(trackEvent.track.getSettings().width, undefined);
+                assert_equals(trackEvent.track.getSettings().height, undefined);
                 resolve(trackEvent.streams[0]);
             };
         });

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -272,9 +272,9 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
 {
     auto& settings = m_private->settings();
     TrackSettings result;
-    if (settings.supportsWidth())
+    if (settings.supportsWidth() && settings.width())
         result.width = settings.width();
-    if (settings.supportsHeight())
+    if (settings.supportsHeight() && settings.height())
         result.height = settings.height();
     if (settings.supportsAspectRatio() && result.height && result.width)
         result.aspectRatio = *result.width / static_cast<double>(*result.height);


### PR DESCRIPTION
#### 547b9eb67f0c5c00195b4b34a8bb854d84df17f6
<pre>
ASSERTION FAILED: !std::isnan(value) - RTCRtpReceiver-track-settings.tentative.html WPT test case
<a href="https://bugs.webkit.org/show_bug.cgi?id=298060">https://bugs.webkit.org/show_bug.cgi?id=298060</a>
<a href="https://rdar.apple.com/159882460">rdar://159882460</a>

Reviewed by Jean-Yves Avenard.

We do not expose width and height if their value is zero.
This also prevents aspectration value to be NaN.
Instead they will be undefined, which aligns with Chrome and Firefox.

* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js:
(promise_test.async t):
* LayoutTests/webrtc/video.html:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getSettings const):

Canonical link: <a href="https://commits.webkit.org/300017@main">https://commits.webkit.org/300017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5717fecd7c8bfd9427680988c5e1af03cbef859b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72976 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/158f9644-2124-4c4f-b670-692a873f92fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91823 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61070 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad76c81f-0805-471f-bf5d-459d9dd34ef1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108372 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72519 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11994523-c1bc-44db-b0a0-d089484ad683) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26475 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70902 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130168 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100439 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53388 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->