### PR TITLE
Fix minibrowser build for public toolchain

### DIFF
--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -1087,7 +1087,10 @@
 #define ENABLE_MACH_PORT_LAYER_HOSTING 1
 #endif
 
+// TODO(webkit.org/b/297336): Re-enable for public sdks when the build is fixed,
+// i.e. when usages of NSScrollPocket are properly #ifdefed.
 #if !defined(ENABLE_CONTENT_INSET_BACKGROUND_FILL) \
+    && defined(USE_APPLE_INTERNAL_SDK)
     && ((PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 160000) \
     || ((PLATFORM(IOS) || PLATFORM(MACCATALYST)) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 190000) \
     || (PLATFORM(VISION) && __VISION_OS_VERSION_MIN_REQUIRED >= 30000) \

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1704,7 +1704,11 @@
 #define HAVE_NWSETTINGS_UNIFIED_HTTP 1
 #endif
 
+// TODO(webkit.org/b/297329): Re-enable for public sdks when the build is fixed,
+// i.e. when WKMaterialHostingSupport.swift properly ifdefs uses of internal
+// APIs.
 #if !defined(HAVE_MATERIAL_HOSTING) \
+    && defined(USE_APPLE_INTERNAL_SDK)
     && ((PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 160000) \
     || ((PLATFORM(IOS) || PLATFORM(MACCATALYST)) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 190000))
 #define HAVE_MATERIAL_HOSTING 1
@@ -1755,7 +1759,10 @@
 #define HAVE_DRAGGING_ITEM_INIT_WITH_PASTEBOARD_ITEM 1
 #endif
 
+// TODO(webkit.org/b/297336): Re-enable for public sdks when the build is fixed,
+// i.e. when usages of NSScrollPocket are properly #ifdefed.
 #if !defined(HAVE_LIQUID_GLASS) \
+    && defined(USE_APPLE_INTERNAL_SDK)
     && ((PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000) \
     || ((PLATFORM(IOS) || PLATFORM(MACCATALYST)) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 260000) \
     || (PLATFORM(VISION) && __VISION_OS_VERSION_MIN_REQUIRED >= 260000) \

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1673,14 +1673,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 }
 
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-
 - (NSScrollPocket *)_topScrollPocket
 {
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     return _impl->topScrollPocket();
+#else
+    // Tools/Scripts/check-for-inappropriate-macros-in-external-headers
+    // prevents ifdefing the method declaration based on an ENABLE() macro. So
+    // the best we can do is return nil here.
+    return nil;
+#endif
 }
 
-#endif
 
 - (void)_setUsesAutomaticContentInsetBackgroundFill:(BOOL)value
 {


### PR DESCRIPTION
#### 99b159767ff4564ec0a184a13d9dcb27d2693fb1
<pre>
Fix minibrowser build for public toolchain
<a href="https://bugs.webkit.org/show_bug.cgi?id=297329">https://bugs.webkit.org/show_bug.cgi?id=297329</a>

Reviewed by NOBODY (OOPS!).

This is a no-op for Apple employees, who use the
apple-internal toolchain. For others users, this
change temporarily fixes the build by disabling
buildflags ENABLE_CONTENT_INSET_BACKGROUND_FILL
HAVE_MATERIAL_HOSTING and HAVE_LIQUID_GLASS.
TODOs are added to investigate further and
re-enable the buildflags.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99b159767ff4564ec0a184a13d9dcb27d2693fb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91811 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26464 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70886 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113010 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130152 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119400 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100429 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104535 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100332 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23775 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44495 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53372 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149538 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47138 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149538 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->