### PR TITLE
[MiniBrowser] Add flag to open Web Inspector by default in `run-minibrowser` script.

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.m
+++ b/Tools/MiniBrowser/mac/AppDelegate.m
@@ -46,10 +46,13 @@
 
 static const NSString * const kURLArgumentString = @"--url";
 static const NSString * const kSiteIsolationArgumentString = @"--force-site-isolation";
+static const NSString * const kWebInspectorArgumentString = @"--web-inspector";
 
 // Force MiniBrowser to run with or without site isolation.
 static BOOL sForceSiteIsolationSetting = NO;
 static BOOL sShouldEnableSiteIsolation = NO;
+
+static BOOL sOpenWebInspector = NO;
 
 enum {
     WebKit1NewWindowTag = 1,
@@ -263,6 +266,9 @@ static NSNumber *_currentBadge;
         else
             NSLog(@"Force disabling Site Isolation.");
     }
+
+    const NSUInteger webInspectorIndex = [args indexOfObject:kWebInspectorArgumentString];
+    sOpenWebInspector = (webInspectorIndex != NSNotFound);
 }
 
 - (WKWebViewConfiguration *)defaultConfiguration
@@ -382,6 +388,9 @@ static NSNumber *_currentBadge;
 
     [[controller window] makeKeyAndOrderFront:sender];
     [controller loadURLString:[self targetURLOrDefaultURL]];
+
+    if (sOpenWebInspector)
+        [controller showHideWebInspector:sender];
 }
 
 - (IBAction)newPrivateWindow:(id)sender
@@ -395,6 +404,9 @@ static NSNumber *_currentBadge;
     [_browserWindowControllers addObject:controller];
 
     [controller loadURLString:_settingsController.defaultURL];
+
+    if (sOpenWebInspector)
+        [controller showHideWebInspector:sender];
 }
 
 - (IBAction)newEditorWindow:(id)sender
@@ -461,6 +473,10 @@ static NSNumber *_currentBadge;
 
     [controller.window makeKeyAndOrderFront:self];
     [controller loadURLString:url.absoluteString];
+
+    if (sOpenWebInspector)
+        [controller showHideWebInspector:nil];
+
     _openNewWindowAtStartup = false;
     return YES;
 }
@@ -477,6 +493,9 @@ static NSNumber *_currentBadge;
 
             NSURL *url = [openPanel.URLs objectAtIndex:0];
             [browserWindowController loadURLString:[url absoluteString]];
+
+            if (sOpenWebInspector)
+                [browserWindowController showHideWebInspector:sender];
         }];
         return;
     }
@@ -491,6 +510,9 @@ static NSNumber *_currentBadge;
 
         NSURL *url = [openPanel.URLs objectAtIndex:0];
         [controller loadURLString:[url absoluteString]];
+
+        if (sOpenWebInspector)
+            [controller showHideWebInspector:sender];
     }];
 }
 

--- a/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
@@ -48,6 +48,7 @@ def main(argv):
     option_parser.add_argument('url', metavar='url', type=lambda s: decode(s, 'utf8'), nargs='?',
                                help='Website URL to load')
     option_parser.add_argument('--site-isolation', action=argparse.BooleanOptionalAction, default=None, help='Enable Site Isolation')
+    option_parser.add_argument('--web-inspector', '-i', action="store_true", default=False, help='Open Web Inspector')
     options, args = option_parser.parse_known_args(argv)
 
     if not options.platform:
@@ -60,6 +61,8 @@ def main(argv):
     if options.platform == "mac" and options.site_isolation is not None:
         browser_args.append('--force-site-isolation')
         browser_args.append('YES' if options.site_isolation else 'NO')
+    if options.web_inspector:
+        browser_args.append('--web-inspector')
     if options.url:
         if options.platform == "mac":
             browser_args.append('--url')


### PR DESCRIPTION
#### 00f5b635291b0b719ec22d04b0f639420ba2a55e
<pre>
[MiniBrowser] Add flag to open Web Inspector by default in `run-minibrowser` script.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298777">https://bugs.webkit.org/show_bug.cgi?id=298777</a>
<a href="https://rdar.apple.com/160468794">rdar://160468794</a>

Reviewed by BJ Burg and Alex Christensen.

Add --web-inspector (-i) command-line option to run-minibrowser script that automatically
opens the Web Inspector when launching MiniBrowser. This helps developers for debugging
Web Inspector related features.

* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate _parseArguments]):
(-[BrowserAppDelegate newWindow:]):
(-[BrowserAppDelegate newPrivateWindow:]):
(-[BrowserAppDelegate application:openFile:]):
(-[BrowserAppDelegate openDocument:]):
* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):

Canonical link: <a href="https://commits.webkit.org/300118@main">https://commits.webkit.org/300118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b94f2a829c5e57437f1bd4aa898e76a18210ff6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72700 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a092b246-c22a-42d0-bc86-fec5b153e555) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91614 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60874 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dbd5d2a7-461e-462c-9943-cd7c3bb435e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72163 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3aeade68-e34a-4e72-9313-a202bf484a82) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/119982 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26229 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70622 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129886 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100235 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100075 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25529 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23547 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44206 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47408 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46877 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48563 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->