### PR TITLE
Array allocation sinking should split allocations into two, an Array allocation and a Butterfly allocation

### DIFF
--- a/JSTests/stress/array-allocation-elimination-closure-capture.js
+++ b/JSTests/stress/array-allocation-elimination-closure-capture.js
@@ -1,0 +1,207 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Test array allocation with closure capture scenarios
+
+// Function that creates a closure value
+function createClosureValue(multiplier) {
+    return function(x) {
+        return x * multiplier;
+    };
+}
+
+// Function that allocates an array with fixed size
+function allocateArrayForClosure(baseValue) {
+    const arr = new Array(5);
+    for (let i = 0; i < 5; i++) {
+        arr[i] = baseValue + i;
+    }
+    return arr;
+}
+
+// Function that uses array and captures closure
+function processWithClosure(closureFn, arr) {
+    let result = 0;
+    for (let i = 0; i < arr.length; i++) {
+        result += closureFn(arr[i]);
+    }
+    return result;
+}
+
+// Complex scenario: array allocation, closure capture, and usage all in different functions
+function complexClosureTest(multiplier, baseValue) {
+    const closureFn = createClosureValue(multiplier);
+    const arr = allocateArrayForClosure(baseValue);
+    return processWithClosure(closureFn, arr);
+}
+
+// Scenario where closure modifies array behavior
+function closureModifiesArray(capturedValue) {
+    return function(baseValue) {
+        const arr = new Array(4);
+        for (let i = 0; i < 4; i++) {
+            arr[i] = (baseValue + i) + capturedValue;
+        }
+
+        // Array usage within the closure
+        let sum = 0;
+        for (let i = 0; i < arr.length; i++) {
+            sum += arr[i] * 2;
+        }
+        return sum;
+    };
+}
+
+// Nested closure with array
+function nestedClosureWithArray(outerValue) {
+    return function(middleValue) {
+        return function(baseValue) {
+            const arr = new Array(3);
+            for (let i = 0; i < 3; i++) {
+                arr[i] = baseValue + i + outerValue + middleValue;
+            }
+
+            // Process array using captured values
+            let product = 1;
+            for (let i = 0; i < arr.length; i++) {
+                product *= (arr[i] % 10) || 1; // avoid zero
+            }
+            return product;
+        };
+    };
+}
+
+let escapedArray = null;
+// Array that sometimes escapes through closure
+function conditionalEscapeViaClosure(shouldEscape) {
+
+    return function(baseValue) {
+        const arr = new Array(4);
+        for (let i = 0; i < 4; i++) {
+            arr[i] = baseValue + i * 2;
+        }
+
+        if (shouldEscape) {
+            escapedArray = arr;
+            return arr.length;
+        } else {
+            // Use array locally
+            let sum = 0;
+            for (let i = 0; i < arr.length; i++) {
+                sum += arr[i];
+            }
+            return sum;
+        }
+    };
+}
+
+// Closure that captures array from outer scope
+function captureArrayInClosure(baseValue) {
+    const arr = new Array(6);
+    for (let i = 0; i < 6; i++) {
+        arr[i] = baseValue + i;
+    }
+
+    // Return closure that uses the captured array
+    return function(multiplier) {
+        let result = 0;
+        for (let i = 0; i < arr.length; i++) {
+            result += arr[i] * multiplier;
+        }
+        return result;
+    };
+}
+
+// Multiple arrays with closure interactions
+function multiArrayClosure(factor1, factor2) {
+    return function(baseValue) {
+        const arr1 = new Array(3);
+        const arr2 = new Array(3);
+
+        for (let i = 0; i < 3; i++) {
+            arr1[i] = (baseValue + i) * factor1;
+            arr2[i] = (baseValue + i) * factor2;
+        }
+
+        // Combine arrays using closure variables
+        let combined = 0;
+        for (let i = 0; i < 3; i++) {
+            combined += arr1[i] + arr2[i];
+        }
+        return combined;
+    };
+}
+
+noInline(complexClosureTest);
+noInline(closureModifiesArray);
+noInline(nestedClosureWithArray);
+noInline(conditionalEscapeViaClosure);
+noInline(captureArrayInClosure);
+noInline(multiArrayClosure);
+
+// Run tests
+for (let i = 0; i < testLoopCount; i++) {
+    const baseValue = i % 8;
+    const multiplier = 1 + (i % 3); // multipliers 1-3
+
+    // Test complex closure scenario (array size 5)
+    let result1 = complexClosureTest(multiplier, baseValue);
+    let expected1 = 0;
+    for (let j = 0; j < 5; j++) {
+        expected1 += (baseValue + j) * multiplier;
+    }
+    assert(result1 === expected1, `complexClosureTest(${multiplier}, ${baseValue}) failed: got ${result1}, expected ${expected1}`);
+
+    // Test closure that modifies array behavior (array size 4)
+    const closureFn = closureModifiesArray(i % 5);
+    let result2 = closureFn(baseValue);
+    let expected2 = 0;
+    for (let j = 0; j < 4; j++) {
+        expected2 += (baseValue + j + (i % 5)) * 2;
+    }
+    assert(result2 === expected2, `closureModifiesArray test failed: got ${result2}, expected ${expected2}`);
+
+    // Test nested closure (array size 3)
+    const nestedFn = nestedClosureWithArray(i % 3)(i % 4);
+    let result3 = nestedFn(baseValue);
+    let expected3 = 1;
+    for (let j = 0; j < 3; j++) {
+        let val = (baseValue + j + (i % 3) + (i % 4)) % 10;
+        if (val !== 0) expected3 *= val;
+    }
+    assert(result3 === expected3, `nestedClosureWithArray test failed: got ${result3}, expected ${expected3}`);
+
+    // Test conditional escape via closure - non-escaping case (array size 4)
+    const condEscapeFn = conditionalEscapeViaClosure(false);
+    let result4 = condEscapeFn(baseValue);
+    let expected4 = 0;
+    for (let j = 0; j < 4; j++) {
+        expected4 += baseValue + j * 2;
+    }
+    assert(result4 === expected4, `conditionalEscapeViaClosure(false) test failed: got ${result4}, expected ${expected4}`);
+
+    // Test conditional escape via closure - escaping case (array size 4)
+    const condEscapeFn2 = conditionalEscapeViaClosure(true);
+    let result5 = condEscapeFn2(baseValue);
+    assert(result5 === 4, `conditionalEscapeViaClosure(true) test failed: got ${result5}, expected 4`);
+
+    // Test capture array in closure (array size 6)
+    const capturedFn = captureArrayInClosure(baseValue);
+    let result6 = capturedFn(multiplier);
+    let expected6 = 0;
+    for (let j = 0; j < 6; j++) {
+        expected6 += (baseValue + j) * multiplier;
+    }
+    assert(result6 === expected6, `captureArrayInClosure test failed: got ${result6}, expected ${expected6}`);
+
+    // Test multiple arrays with closure (arrays size 3 each)
+    const multiArrayFn = multiArrayClosure(2, 3);
+    let result7 = multiArrayFn(baseValue);
+    let expected7 = 0;
+    for (let j = 0; j < 3; j++) {
+        expected7 += (baseValue + j) * 2 + (baseValue + j) * 3; // factor1 + factor2
+    }
+    assert(result7 === expected7, `multiArrayClosure test failed: got ${result7}, expected ${expected7}`);
+}

--- a/JSTests/stress/array-allocation-elimination-conditional-usage.js
+++ b/JSTests/stress/array-allocation-elimination-conditional-usage.js
@@ -1,0 +1,108 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Test conditional array usage - some branches use array, others don't
+function testConditionalArrayUsage(useArray, writeValue) {
+    const arr = new Array(5);
+
+    if (useArray) {
+        // Branch that uses the array
+        arr[0] = writeValue;
+        arr[2] = writeValue + 10;
+        arr[4] = writeValue + 20;
+
+        let sum = 0;
+        for (let i = 0; i < 5; i++) {
+            if (arr[i] !== undefined) {
+                sum += arr[i];
+            }
+        }
+        return sum;
+    } else {
+        // Branch that doesn't use the array at all
+        return writeValue * 3 + 30; // Same result as the sum above when writeValue = 0
+    }
+}
+
+// Test with nested conditionals
+function testNestedConditionalArray(outer, inner, value) {
+    const arr = new Array(3);
+
+    if (outer) {
+        arr[0] = value;
+
+        if (inner) {
+            arr[1] = value * 2;
+            arr[2] = value * 3;
+            return arr[0] + arr[1] + arr[2]; // value * 6
+        } else {
+            // Only use first element
+            return arr[0]; // value
+        }
+    } else {
+        // Don't use array at all
+        return inner ? value * 6 : value;
+    }
+}
+
+// Test with early return that skips array usage
+function testEarlyReturnArray(shouldReturn, value) {
+    const arr = new Array(4);
+
+    if (shouldReturn) {
+        return value * 42;
+    }
+
+    // This array usage should be eliminated when shouldReturn is true
+    arr[0] = value;
+    arr[1] = value + 1;
+    arr[3] = value + 3;
+
+    return arr[0] + arr[1] + arr[3]; // value * 3 + 4
+}
+
+noInline(testConditionalArrayUsage);
+noInline(testNestedConditionalArray);
+noInline(testEarlyReturnArray);
+
+// Run tests to trigger optimization
+for (let i = 0; i < testLoopCount; i++) {
+    // Test the branch that uses the array
+    let result1 = testConditionalArrayUsage(true, i % 100);
+    let expected1 = (i % 100) + (i % 100 + 10) + (i % 100 + 20);
+    assert(result1 === expected1, `testConditionalArrayUsage(true, ${i % 100}) failed: got ${result1}, expected ${expected1}`);
+
+    // Test the branch that doesn't use the array
+    let result2 = testConditionalArrayUsage(false, i % 100);
+    let expected2 = (i % 100) * 3 + 30;
+    assert(result2 === expected2, `testConditionalArrayUsage(false, ${i % 100}) failed: got ${result2}, expected ${expected2}`);
+
+    // Test nested conditionals
+    let val = i % 10;
+
+    // outer=true, inner=true
+    let result3 = testNestedConditionalArray(true, true, val);
+    assert(result3 === val * 6, `testNestedConditionalArray(true, true, ${val}) failed: got ${result3}, expected ${val * 6}`);
+
+    // outer=true, inner=false
+    let result4 = testNestedConditionalArray(true, false, val);
+    assert(result4 === val, `testNestedConditionalArray(true, false, ${val}) failed: got ${result4}, expected ${val}`);
+
+    // outer=false, inner=true
+    let result5 = testNestedConditionalArray(false, true, val);
+    assert(result5 === val * 6, `testNestedConditionalArray(false, true, ${val}) failed: got ${result5}, expected ${val * 6}`);
+
+    // outer=false, inner=false
+    let result6 = testNestedConditionalArray(false, false, val);
+    assert(result6 === val, `testNestedConditionalArray(false, false, ${val}) failed: got ${result6}, expected ${val}`);
+
+    // Test early return
+    let result7 = testEarlyReturnArray(true, val);
+    assert(result7 === val * 42, `testEarlyReturnArray(true, ${val}) failed: got ${result7}, expected ${val * 42}`);
+
+    let result8 = testEarlyReturnArray(false, val);
+    let expected8 = val * 3 + 4;
+    assert(result8 === expected8, `testEarlyReturnArray(false, ${val}) failed: got ${result8}, expected ${expected8}`);
+}

--- a/JSTests/stress/array-allocation-elimination-cross-function.js
+++ b/JSTests/stress/array-allocation-elimination-cross-function.js
@@ -1,0 +1,165 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Function that allocates and returns an array
+function allocateArray(size, fillValue) {
+    const arr = new Array(size);
+    for (let i = 0; i < size; i++) {
+        arr[i] = fillValue + i;
+    }
+    return arr;
+}
+
+// Function that processes an array but doesn't escape it
+function processArray(arr) {
+    let sum = 0;
+    for (let i = 0; i < arr.length; i++) {
+        sum += arr[i] * 2;
+    }
+    return sum;
+}
+
+// Function that modifies an array in place
+function modifyArray(arr, multiplier) {
+    for (let i = 0; i < arr.length; i++) {
+        arr[i] *= multiplier;
+    }
+}
+
+// Function that escapes the array by storing it globally
+let globalArray = null;
+function escapeArray(arr) {
+    globalArray = arr;
+    return arr.length;
+}
+noInline(escapeArray);
+
+// Simple allocation + usage pattern
+function allocateAndUse(size, value) {
+    const arr = allocateArray(size, value);
+    return processArray(arr);
+}
+
+// Allocation + modification + usage pattern
+function allocateModifyAndUse(size, value) {
+    const arr = allocateArray(size, value);
+    modifyArray(arr, 3);
+    return processArray(arr);
+}
+
+// Pattern where array sometimes escapes
+function conditionalEscape(shouldEscape, size, value) {
+    const arr = allocateArray(size, value);
+
+    if (shouldEscape) {
+        return escapeArray(arr);
+    } else {
+        return processArray(arr);
+    }
+}
+
+// Chain of functions passing array
+function chainedProcessing(size, value) {
+    function step1(arr) {
+        // Double all values
+        for (let i = 0; i < arr.length; i++) {
+            arr[i] *= 2;
+        }
+        return arr;
+    }
+
+    function step2(arr) {
+        // Add index to each value
+        for (let i = 0; i < arr.length; i++) {
+            arr[i] += i;
+        }
+        return arr;
+    }
+
+    function step3(arr) {
+        // Sum all values
+        let sum = 0;
+        for (let i = 0; i < arr.length; i++) {
+            sum += arr[i];
+        }
+        return sum;
+    }
+
+    const initial = allocateArray(size, value);
+    const after1 = step1(initial);
+    const after2 = step2(after1);
+    return step3(after2);
+}
+
+// Array allocated in inner function, used in outer
+function nestedAllocation(size, value) {
+    function innerAllocate() {
+        return new Array(size).fill(value);
+    }
+
+    const arr = innerAllocate();
+    let product = 1;
+    for (let i = 0; i < arr.length; i++) {
+        product *= arr[i];
+    }
+    return product;
+}
+
+noInline(allocateAndUse);
+noInline(allocateModifyAndUse);
+noInline(conditionalEscape);
+noInline(chainedProcessing);
+noInline(nestedAllocation);
+
+// Test the cross-function scenarios
+for (let i = 0; i < testLoopCount; i++) {
+    const size = 3 + (i % 5); // sizes 3-7
+    const value = i % 10;
+
+    // Test simple allocation and usage
+    let result1 = allocateAndUse(size, value);
+    let expected1 = 0;
+    for (let j = 0; j < size; j++) {
+        expected1 += (value + j) * 2;
+    }
+    assert(result1 === expected1, `allocateAndUse(${size}, ${value}) failed: got ${result1}, expected ${expected1}`);
+
+    // Test allocation, modification, and usage
+    let result2 = allocateModifyAndUse(size, value);
+    let expected2 = 0;
+    for (let j = 0; j < size; j++) {
+        expected2 += (value + j) * 3 * 2; // modified by 3, then doubled in processArray
+    }
+    assert(result2 === expected2, `allocateModifyAndUse(${size}, ${value}) failed: got ${result2}, expected ${expected2}`);
+
+    // Test conditional escape - non-escaping case
+    let result3 = conditionalEscape(false, size, value);
+    let expected3 = expected1; // same as allocateAndUse
+    assert(result3 === expected3, `conditionalEscape(false, ${size}, ${value}) failed: got ${result3}, expected ${expected3}`);
+
+    // Test conditional escape - escaping case
+    globalArray = null;
+    let result4 = conditionalEscape(true, size, value);
+    assert(result4 === size, `conditionalEscape(true, ${size}, ${value}) failed: got ${result4}, expected ${size}`);
+    assert(globalArray !== null && globalArray.length === size, "Array was not properly escaped");
+
+    // Test chained processing
+    let result5 = chainedProcessing(size, value);
+    let expected5 = 0;
+    for (let j = 0; j < size; j++) {
+        // step1: (value + j) * 2
+        // step2: (value + j) * 2 + j
+        // step3: sum all
+        expected5 += (value + j) * 2 + j;
+    }
+    assert(result5 === expected5, `chainedProcessing(${size}, ${value}) failed: got ${result5}, expected ${expected5}`);
+
+    // Test nested allocation (only when value > 0 to avoid zero product)
+    if (value > 0) {
+        let result6 = nestedAllocation(size, value);
+        let expected6 = Math.pow(value, size);
+        assert(result6 === expected6, `nestedAllocation(${size}, ${value}) failed: got ${result6}, expected ${expected6}`);
+    }
+}

--- a/JSTests/stress/array-allocation-elimination-loop-unroll-materialize-at-osr.js
+++ b/JSTests/stress/array-allocation-elimination-loop-unroll-materialize-at-osr.js
@@ -1,0 +1,25 @@
+function test(obj) {
+    let array = new Array(4);
+    array[0] = 42;
+    array[1] = array;
+    for (let i = 2; i < array.length; ++i)
+        array[i] = array[0];
+
+    if (obj.foo === 1)
+        return 0;
+    let property = array[1];
+    if (property !== array)
+        throw new Error(property);
+    return array[0] + array[2] - array[3];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let result = test({foo: i % 2});
+    if (result !== 42 && result !== 0)
+        throw new Error(result);
+}
+
+let result = test({foo: "hello"});
+if (result !== 42)
+    throw new Error(result);

--- a/JSTests/stress/array-allocation-sink-with-osr-exit-materialization.js
+++ b/JSTests/stress/array-allocation-sink-with-osr-exit-materialization.js
@@ -1,0 +1,31 @@
+function escape(array) {
+    return 0;
+}
+noInline(escape);
+
+function test(obj) {
+    let array = new Array(4);
+    array[0] = 42;
+    array[1] = array;
+    for (let i = 2; i < array.length; ++i) {
+        array[i] = array[0];
+    }
+    if (obj.foo === 1)
+        return escape(array);
+    // It would be nice to test this here but it seems like the above escape causes strength reduction to not eliminate the compare.
+    // let property = array[1];
+    // if (property !== array)
+    //     throw new Error(property);
+    return array[0] + array[2] - array[3];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let result = test({foo: i % 2});
+    if (result !== 42 && result !== 0)
+        throw new Error(result);
+}
+
+let result = test({foo: "hello"});
+if (result !== 42)
+    throw new Error(result);

--- a/JSTests/stress/array-sink-osr-materialization-self-reference-in-butterfly.js
+++ b/JSTests/stress/array-sink-osr-materialization-self-reference-in-butterfly.js
@@ -1,0 +1,22 @@
+function test(obj) {
+    let array = new Array(4);
+    array[0] = 42;
+    array[1] = array;
+    if (obj.foo === 1)
+        return 0;
+    let property = array[1];
+    if (property !== array)
+        throw new Error(property);
+    return array[0];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let result = test({foo: i % 2});
+    if (result !== 42 && result !== 0)
+        throw new Error(result);
+}
+
+let result = test({foo: "hello"});
+if (result !== 42)
+    throw new Error(result);

--- a/JSTests/stress/array-sink-osr-materialization.js
+++ b/JSTests/stress/array-sink-osr-materialization.js
@@ -1,0 +1,13 @@
+function test(obj) {
+    let array = new Array(4);
+    array[0] = {};
+    if (obj.foo === 1)
+        return 0;
+    return array[0];
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i)
+    test({foo: i % 2});
+
+test({foo: "hello"});

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3714,10 +3714,31 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
-    case NewArrayWithConstantSize:
-    case MaterializeNewArrayWithConstantSize:
+
+    case NewButterflyWithSize:
+        // We don't represent storage/butterflies in AI.
+        clearForNode(node);
+        break;
+
+    case MaterializeNewArrayWithButterfly: {
+        SpeculatedType validTypes = [&]() {
+            switch (node->indexingType()) {
+            case ALL_INT32_INDEXING_TYPES: return SpecInt32Only;
+            case ALL_DOUBLE_INDEXING_TYPES: return SpecBytecodeNumber;
+            case ALL_CONTIGUOUS_INDEXING_TYPES: return SpecBytecodeTop;
+            default: break;
+            }
+            RELEASE_ASSERT_NOT_REACHED();
+        }();
+        for (unsigned i = 2; i < node->numChildren(); ++i)
+            RELEASE_ASSERT(isSubtypeSpeculation(forNode(m_graph.varArgChild(node, i)).m_type, validTypes));
+
+        [[fallthrough]];
+    }
+    case NewArrayWithButterfly: {
         setForNode(node, m_graph.globalObjectFor(node->origin.semantic)->arrayStructureForIndexingTypeDuringAllocation(node->indexingMode()));
         break;
+    }
 
     case NewTypedArray: {
         switch (node->child1().useKind()) {
@@ -3979,7 +4000,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewButterflyWithSize:
+    case PhantomNewArrayWithButterfly:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -525,7 +525,6 @@ private:
         case NewTypedArray:
         case NewTypedArrayBuffer:
         case NewArrayWithSize:
-        case NewArrayWithConstantSize:
         case NewArrayWithSpecies:
         case NewArrayWithSizeAndStructure: {
             // Negative zero is not observable. NaN versus undefined are only observable

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1924,12 +1924,25 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         write(HeapObjectCount);
         return;
 
-    case NewArrayWithConstantSize:
-    case PhantomNewArrayWithConstantSize:
-    case MaterializeNewArrayWithConstantSize:
+    case NewButterflyWithSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize: {
         read(HeapObjectCount);
         write(HeapObjectCount);
-        def(HeapLocation(ArrayLengthLoc, Butterfly_publicLength, node), LazyNode(graph.freeze(jsNumber(node->newArraySize()))));
+        // FIXME: In this phase we say the Array is where the length of the array is def'd but this differs from ObjectAllocationSinking.
+        return;
+    }
+
+    case MaterializeNewArrayWithButterfly:
+        read(HeapObjectCount);
+        write(HeapObjectCount);
+        def(HeapLocation(ArrayLengthLoc, Butterfly_publicLength, node), LazyNode(graph.varArgChild(node, 0).node()));
+        return;
+
+    case NewArrayWithButterfly:
+        read(HeapObjectCount);
+        write(HeapObjectCount);
+        def(HeapLocation(ArrayLengthLoc, Butterfly_publicLength, node), LazyNode(node->child1().node()));
         return;
 
     case NewTypedArray:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -288,7 +288,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(MultiPutByOffset, Common) \
     CLONE_STATUS(NewArray, Common) \
     CLONE_STATUS(NewArrayBuffer, Common) \
-    CLONE_STATUS(NewArrayWithConstantSize, Common) \
+    CLONE_STATUS(NewArrayWithButterfly, Common) \
     CLONE_STATUS(NewArrayWithSize, Common) \
     CLONE_STATUS(NewArrayWithSpread, Common) \
     CLONE_STATUS(NewFunction, Common) \

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1106,10 +1106,14 @@ private:
                 if (m_graph.isWatchingHavingABadTimeWatchpoint(node)) {
                     if (node->child1().useKind() == Int32Use && node->child1()->isInt32Constant()) {
                         int32_t length = node->child1()->asInt32();
-                        if (length >= 0
+                        if (0 <= length
                             && length < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH
-                            && isNewArrayWithConstantSizeIndexingType(node->indexingType())) {
-                                node->convertToNewArrayWithConstantSize(m_graph, length);
+                            && !hasAnyArrayStorage(node->indexingType())) {
+                                m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
+                                alreadyHandled = true; // Don't allow the default constant folder to do things to this.
+
+                                Node* butterfly = m_insertionSet.insertNode(indexInBlock, SpecNone, NewButterflyWithSize, node->origin, OpInfo(node->indexingType()), node->child1());
+                                node->convertToNewArrayWithButterfly(m_graph, butterfly);
                                 changed = true;
                         }
                     }
@@ -1676,7 +1680,8 @@ private:
             }
 
             case PhantomNewObject:
-            case PhantomNewArrayWithConstantSize:
+            case PhantomNewArrayWithButterfly:
+            case PhantomNewButterflyWithSize:
             case PhantomNewFunction:
             case PhantomNewGeneratorFunction:
             case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -225,7 +225,8 @@ bool doesGC(Graph& graph, Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -413,8 +414,9 @@ bool doesGC(Graph& graph, Node* node)
     case NewArrayWithSpread:
     case NewInternalFieldObject:
     case Spread:
+    case NewButterflyWithSize:
     case NewArrayWithSize:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case NewArrayBuffer:
@@ -440,7 +442,7 @@ bool doesGC(Graph& graph, Node* node)
     case EnumeratorNextUpdatePropertyName:
     case EnumeratorNextUpdateIndexAndMode:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewArrayWithButterfly:
     case MaterializeNewInternalFieldObject:
     case MaterializeCreateActivation:
     case SetFunctionName:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1974,7 +1974,7 @@ private:
             
             for (unsigned i = m_graph.varArgNumChildren(node); i--;) {
                 node->setIndexingType(
-                    leastUpperBoundOfIndexingTypeAndType(
+                    leastUpperBoundOfIndexingTypeAndTypeForSpeculation(
                         node->indexingType(), m_graph.varArgChild(node, i)->prediction()));
             }
             switch (node->indexingType()) {
@@ -2061,11 +2061,6 @@ private:
         case NewArrayWithSizeAndStructure: {
             watchHavingABadTime(node);
             fixEdge<Int32Use>(node->child1());
-            break;
-        }
-
-        case NewArrayWithConstantSize: {
-            watchHavingABadTime(node);
             break;
         }
 
@@ -2664,8 +2659,11 @@ private:
         case Int52Constant:
         case Identity: // This should have been cleaned up.
         case BooleanToNumber:
+        case NewArrayWithButterfly:
+        case NewButterflyWithSize:
         case PhantomNewObject:
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewButterflyWithSize:
+        case PhantomNewArrayWithButterfly:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -2687,7 +2685,7 @@ private:
         case CheckStructureOrEmpty:
         case CheckArrayOrEmpty:
         case MaterializeNewObject:
-        case MaterializeNewArrayWithConstantSize:
+        case MaterializeNewArrayWithButterfly:
         case MaterializeCreateActivation:
         case MaterializeNewInternalFieldObject:
         case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -651,7 +651,7 @@ bool LoopUnrollingPhase::LoopData::isProfitableToUnroll()
         // Avoid unrolling loops that only perform stores. These tend to increase code size
         // without improving performance, since they are often memory-bound and unrolling
         // doesn't expose additional optimization opportunities. (e.g., rdar://150524264)
-        dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *header(), " since putByValCount=", putByValCount, " getByValCount=", getByValCount);
+        dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *header(), " since loop only has stores putByValCount=", putByValCount, " getByValCount=", getByValCount);
         return false;
     }
 
@@ -863,7 +863,8 @@ bool LoopUnrollingPhase::LoopData::isMaterialNode(Graph& graph, Node* node)
     case ZombieHint:
     case ExitOK:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -71,8 +71,9 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case BottomValue:
     case PutHint:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
     case PhantomNewInternalFieldObject:
+    case PhantomNewButterflyWithSize:
     case PutStack:
     case KillStack:
     case GetStack:
@@ -172,7 +173,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case CreateActivation:
     case MaterializeCreateActivation:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewArrayWithButterfly:
     case MaterializeNewInternalFieldObject:
     case NewFunction:
     case NewGeneratorFunction:
@@ -184,7 +185,8 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case NewRegExp:
     case NewMap:
     case NewSet:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
+    case NewButterflyWithSize:
     case ToNumber:
     case ToNumeric:
     case ToObject:

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -268,12 +268,14 @@ void Node::convertToNewArrayWithSize()
     m_opInfo = indexingType;
 }
 
-void Node::convertToNewArrayWithConstantSize(Graph&, uint32_t size)
+void Node::convertToNewArrayWithButterfly(Graph&, Node* butterfly)
 {
     ASSERT(op() == NewArrayWithSize);
-    ASSERT(size < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
-    setOpAndDefaultFlags(NewArrayWithConstantSize);
-    m_opInfo2 = size;
+    IndexingType indexingType = this->indexingType();
+    setOpAndDefaultFlags(NewArrayWithButterfly);
+    ASSERT(child1()->asInt32() < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+    children.child2() = Edge(butterfly);
+    ASSERT_UNUSED(indexingType, indexingType == this->indexingType());
 }
 
 void Node::convertToNewArrayWithSizeAndStructure(Graph& graph, RegisteredStructure structure)

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -727,17 +727,22 @@ public:
         children.setChild1(index);
     }
 
-    void convertToPhantomNewArrayWithConstantSize()
+    void convertToPhantomNewArrayWithButterfly()
     {
-        ASSERT(m_op == NewArrayWithConstantSize);
-        m_op = PhantomNewArrayWithConstantSize;
-        m_flags &= ~NodeHasVarArgs;
-        m_flags |= NodeMustGenerate;
-        // No need to clear the infos, as the indexing type and array
-        // size are still required for materialization when an OSR exit occurs.
-        children = AdjacencyList();
+        ASSERT(m_op == NewArrayWithButterfly);
+        setOpAndDefaultFlags(PhantomNewArrayWithButterfly);
+        // OpInfo/children shouldn't change and are needed for OSR exit.
+        ASSERT(child1().useKind() == Int32Use);
     }
     
+    void convertToPhantomNewButterflyWithSize()
+    {
+        ASSERT(m_op == NewButterflyWithSize);
+        setOpAndDefaultFlags(PhantomNewButterflyWithSize);
+        // OpInfo/children shouldn't change and are needed for OSR exit.
+        ASSERT(child1().useKind() == Int32Use);
+    }
+
     void convertToPhantomNewObject()
     {
         ASSERT(m_op == NewObject);
@@ -916,7 +921,7 @@ public:
 
     void convertToNewArrayBuffer(FrozenValue* immutableButterfly);
     void convertToNewArrayWithSize();
-    void convertToNewArrayWithConstantSize(Graph&, uint32_t);
+    void convertToNewArrayWithButterfly(Graph&, Node* butterfly);
     void convertToNewArrayWithSizeAndStructure(Graph&, RegisteredStructure);
 
     void convertToNewBoundFunction(FrozenValue*);
@@ -1454,32 +1459,16 @@ public:
         return newArrayBufferData().vectorLengthHint;
     }
 
-    unsigned hasNewArraySize()
-    {
-        switch (op()) {
-        case NewArrayWithConstantSize:
-        case PhantomNewArrayWithConstantSize:
-        case MaterializeNewArrayWithConstantSize:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    unsigned newArraySize()
-    {
-        ASSERT(hasNewArraySize());
-        return op() == MaterializeNewArrayWithConstantSize ? objectMaterializationData().m_newArraySize : m_opInfo2.as<unsigned>();
-    }
-
     bool hasIndexingType()
     {
         switch (op()) {
         case NewArray:
         case NewArrayWithSize:
-        case NewArrayWithConstantSize:
-        case PhantomNewArrayWithConstantSize:
-        case MaterializeNewArrayWithConstantSize:
+        case NewArrayWithButterfly:
+        case NewButterflyWithSize:
+        case PhantomNewArrayWithButterfly:
+        case PhantomNewButterflyWithSize:
+        case MaterializeNewArrayWithButterfly:
         case NewArrayBuffer:
         case PhantomNewArrayBuffer:
         case NewArrayWithSpecies:
@@ -2514,7 +2503,7 @@ public:
     {
         switch (op()) {
         case MaterializeNewObject:
-        case MaterializeNewArrayWithConstantSize:
+        case MaterializeNewArrayWithButterfly:
         case MaterializeNewInternalFieldObject:
         case MaterializeCreateActivation:
             return true;
@@ -2602,7 +2591,8 @@ public:
     bool isPhantomAllocation()
     {
         switch (op()) {
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewArrayWithButterfly:
+        case PhantomNewButterflyWithSize:
         case PhantomNewObject:
         case PhantomDirectArguments:
         case PhantomCreateRest:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -403,13 +403,15 @@ namespace JSC { namespace DFG {
     macro(NewObject, NodeResultJS) \
     macro(NewGenerator, NodeResultJS) \
     macro(NewAsyncGenerator, NodeResultJS) \
+    /* FIXME: A lot of these could likely be consolidated but there's some subtle differences between them, particularly when having a bad time. */ \
     macro(NewArray, NodeResultJS | NodeHasVarArgs) \
     macro(NewArrayWithSpread, NodeResultJS | NodeHasVarArgs) \
     macro(NewArrayWithSpecies, NodeResultJS | NodeMustGenerate) \
     macro(NewArrayWithSize, NodeResultJS | NodeMustGenerate) \
-    macro(NewArrayWithConstantSize, NodeResultJS | NodeMustGenerate) \
     macro(NewArrayWithSizeAndStructure, NodeResultJS | NodeMustGenerate) \
     macro(NewArrayBuffer, NodeResultJS) \
+    macro(NewArrayWithButterfly, NodeResultJS) \
+    macro(NewButterflyWithSize, NodeResultStorage) \
     macro(NewInternalFieldObject, NodeResultJS) \
     macro(NewTypedArray, NodeResultJS | NodeMustGenerate) \
     macro(NewTypedArrayBuffer, NodeResultJS | NodeMustGenerate) \
@@ -425,8 +427,10 @@ namespace JSC { namespace DFG {
     \
     macro(Spread, NodeResultJS | NodeMustGenerate) \
     /* Support for allocation sinking. */\
-    macro(PhantomNewArrayWithConstantSize, NodeResultJS | NodeMustGenerate) \
-    macro(MaterializeNewArrayWithConstantSize, NodeResultJS | NodeHasVarArgs) \
+    macro(PhantomNewButterflyWithSize, NodeResultStorage | NodeMustGenerate) \
+    /* PhantomNewButterflyWithSize can materialize back to NewButterflyWithSize since it doesn't track any properties */ \
+    macro(PhantomNewArrayWithButterfly, NodeResultJS | NodeMustGenerate) \
+    macro(MaterializeNewArrayWithButterfly, NodeResultJS | NodeHasVarArgs) \
     macro(PhantomNewObject, NodeResultJS | NodeMustGenerate) \
     macro(PutHint, NodeMustGenerate) \
     macro(CheckStructureImmediate, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -189,12 +189,12 @@ public:
         set(descriptor, nullptr);
     }
 
-    IndexingType indexingType()
+    IndexingType indexingType() const
     {
         return m_indexingType;
     }
 
-    unsigned length()
+    unsigned length() const
     {
         return m_length;
     }
@@ -260,11 +260,6 @@ public:
         return m_kind == Kind::Array;
     }
 
-    bool isArrayButterfly() const
-    {
-        return m_kind == Kind::ArrayButterfly;
-    }
-
     bool isObjectAllocation() const
     {
         return m_kind == Kind::Object;
@@ -310,15 +305,12 @@ public:
         out.print(")"_s);
     }
 
-    unsigned arrayButterflyId() { return m_arrayButterflyId++; }
-
 private:
     Node* m_identifier; // This is the actual node that created the allocation
     Kind m_kind;
     Fields m_fields;
     IndexingType m_indexingType { NoIndexingShape };
     unsigned m_length { 0 };
-    unsigned m_arrayButterflyId { 0 };
 
     // This set of structures is the intersection of structures seen at control flow edges. It's used
     // for checks and speculation since it can't be widened.
@@ -849,6 +841,8 @@ private:
                 m_heapAtHead[block].setReached();
                 m_heap = m_heapAtHead[block];
 
+                dataLogLnIf(Options::verboseObjectAllocationSinking(), "LocalHeap of ", block, " at head: ", m_heap);
+
                 for (Node* node : *block) {
                     handleNode(
                         node,
@@ -858,6 +852,7 @@ private:
                         });
                 }
 
+                dataLogLnIf(Options::verboseObjectAllocationSinking(), "LocalHeap of ", block, " at tail: ", m_heap);
                 if (m_heap == m_heapAtTail[block])
                     continue;
 
@@ -879,6 +874,7 @@ private:
                 // non-dominating allocation in the successor will
                 // trigger an escape and get pruned during the merge.
                 m_heap.pruneByLiveness(m_combinedLiveness.liveAtTail[block]);
+                dataLogLnIf(Options::verboseObjectAllocationSinking(), "LocalHeap of ", block, " after pruning by liveness: ", m_heap);
 
                 for (BasicBlock* successorBlock : block->successors()) {
                     // FIXME: Maybe we should:
@@ -917,6 +913,23 @@ private:
         }).iterator->value;
     }
 
+    bool isReasonableArraySinkingCandidate(Node* node)
+    {
+        if (!m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node))
+            return false;
+
+        if (hasAnyArrayStorage(node->indexingType()) || hasUndecided(node->indexingType()))
+            return false;
+
+        if (!node->child1()->isInt32Constant())
+            return false;
+        unsigned arraySize = node->child1()->asInt32();
+
+        if (arraySize >= MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH)
+            return false;
+        return true;
+    }
+
     template<typename WriteFunctor, typename ResolveFunctor>
     void handleNode(
         Node* node,
@@ -931,116 +944,55 @@ private:
         PromotedLocationDescriptor exactRead;
 
         switch (node->op()) {
-        case NewArrayWithConstantSize:
-            //    D@1 Array()
-            //    D@2 GetButterfly(D@1)
-            //    D@3 GetArrayLength(D@1, D@2) <- others
-            //    D@4 CheckInBounds(@index, D@3)
-            //    D@5 PutByVal(D@1, @index, @value, D@2, D@4)
-            //    D@6 GetByVal(D@1, @index, D@2, D@4)
-            //
-            //               D@1
-            //        -----------------
-            //         ^      ^      ^
-            //         |      |      |
-            //         |     D@2 <- D@3 <- others
-            //         |      ^      ^
-            //         |      |      |
-            //         |      |     D@4
-            //         |      |      ^
-            //         |      |      |
-            //        -----------------
-            //            D@5   D@6
-            //
-            // This is the dependency graph for an array with common usage patterns in the wild.
-            // Before converting D@1 (NewArrayWithConstantSize) into a phantom node, we must
-            // first lower its dependent nodes to ensure correctness.
-            //
-            // 1. D@5 (PutByVal) and D@6 (GetByVal) are leaf nodes and the only ones that reference
-            //    D@2 (GetButterfly) and D@4 (CheckInBounds). These must be lowered first.
-            //    - For the first implementation, we only handle in-bounds reads and writes with constant
-            //      index access, since these guarantee no array hole accesses.
-            //    - Every in-bounds read with a constant index can be safely replaced with its resolved value.
-            //
-            // 2. Since only D@5 and D@6 reference D@4, D@4 (CheckInBounds) must be removed when lowering them.
-            //
-            // 3. D@3 (GetArrayLength) may be referenced by other nodes, so we replace it with a constant size node.
-            //    - This is valid because we only sink arrays where all accesses are in-bounds,
-            //      ensuring that the array size remains a known constant.
-            //
-            // 4. Since D@2 (GetButterfly) is only referenced by D@5 and D@6, it will be eliminated
-            //    once those nodes are lowered.
-            //
-            // 5. Once all dependent nodes have been properly handled, D@1 can be safely converted
-            //    into a phantom node.
-            //
-            // 6. **If any other node in the program uses D@1 as an input (other than the cases listed above),**
-            //    **sinking will be disabled.** This ensures that no other operation:
-            //    - Adds new properties to the array.
-            //    - Modifies the array’s length.
-            //    - Updates any existing fields in a way that would break our assumptions about the array.
-            //    If such an operation exists, we **must not** sink the allocation, as it would lead to
-            //    incorrect behavior.
+        // We model sinking of Arrays by splitting the allocation of the Butterfly and the Array itself into two nodes.
+        // This is necessary because this phase only considers one allocation per Node and the butterfly is not an implementation
+        // detail in FTL (i.e. the GetButterfly Node exists). This phase tries to faithfully represent the real memory layout of
+        // Arrays in the heap as it can. Thus, the length and indexed properties are stored as fields of the butterfly and the
+        // only field on the Array itself is the butterfly.
+        //
+        // We have to be careful no node escapes the Butterfly without also escaping the Array. this is subtly important, since we
+        // don't want to end up storing/reading from a Butterfly if the Array has been eliminated. If we did, the following could
+        // lead to a UAF since the GC doesn't scan Butterflies it finds on the stack (only when they're part of an object).
+        //
+        // Consider:
+        // 1: NewButterflyWithSize
+        // 2: PhantomNewArrayWithButterfly
+        // 3: NewObject
+        // -: PutByVal(@2, 1, @3, @1)
+        // ... GC
+        // 4: GetByVal(@2, 1, @1)
+        // -: Use(@4) <-- UAF
+        case NewButterflyWithSize: {
             if (Options::useArrayAllocationSinking()) {
-                if (!m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node))
+                if (!isReasonableArraySinkingCandidate(node))
                     goto escapeChildren;
-                unsigned arraySize = node->newArraySize();
+
+                unsigned arraySize = node->child1()->asInt32();
+                target = &m_heap.newAllocation(node, Allocation::Kind::ArrayButterfly, node->indexingType(), arraySize);
+                writes.add(PromotedLocationDescriptor(ArrayButterflyPublicLengthPLoc), LazyNode(ensureConstant(arraySize)));
+            }
+            break;
+        }
+
+        case NewArrayWithButterfly:
+            if (Options::useArrayAllocationSinking()) {
+                if (!isReasonableArraySinkingCandidate(node))
+                    goto escapeChildren;
+
+                unsigned arraySize = node->child1()->asInt32();
                 target = &m_heap.newAllocation(node, Allocation::Kind::Array, node->indexingType(), arraySize);
-                writes.add(PromotedLocationDescriptor(ArrayLengthPropertyPLoc), LazyNode(ensureConstant(arraySize)));
+                writes.add(PromotedLocationDescriptor(ArrayButterflyPLoc), LazyNode(node->child2().node()));
+                // FIXME: We don't bother tracking writes to initialize holes in the array. Maybe we should because
+                // there's probably code that reads from the holes before initializing each entry.
             } else
                 goto escapeChildren;
             break;
 
         case GetButterfly: {
-            // D@2 (GetButterfly) is subtle because PutByVal/GetByVal can cause the associated Array to escape and be materialized.
-            // In such cases, GetButterfly must also be materialized at the same site as the Array, since it depends on the materialized Array.
-            // That is, when PutByVal/GetByVal triggers materialization, GetButterfly must be lowered at the same location and maintain
-            // a dependency on the materialized Array to ensure correctness.
-            //
-            // Below, we enumerate all possible interaction cases between GetButterfly and Array:
-            //
-            //         GetButterfly state (rows) vs Array state (columns)
-            //
-            //                   |     S     |    SEM    |     E     |
-            //           ---------------------------------------------
-            //            S      |    OK     |    OK     |    OK     |
-            //           SEM     |   Error   |    OK     |    OK     |
-            //            E      |    n/a    |   Error   |    OK     |
-            //
-            // Allocation Kinds:
-            //   Sink-only (S): Allocation is purely local and can be eliminated during optimization.
-            //   Escape-only (E): Allocation escapes the local context; cannot be sunk.
-            //   Sink + Escape + Materialize (SEM):
-            //      Allocation starts as sinkable but later escapes; it must be materialized at a specific point
-            //      while preserving dependency ordering.
-            //
-            // Cases:
-            //  (1)     S\S S\SEM: Fine. Let it sink. (e.g. [2])
-            //  (2) S\E SEM\E E/E: Fine. But not profitable to sink GetButterfly.
-            //  (3)       SEM\SEM: Fine iff they materialize at the same site due to PutByVal/GetByVal. (e.g. [1])
-            //
-            //  (4)         SEM\S: Not fine since GetButterfly(Array). (e.g. [4])
-            //  (5)         E\SEM: Not fine similar to (4). (e.g. [3])
-            //  (6)           E\S: Not possible since PutByVal/GetByVal can escape-only GetButterfly.
-            //
-            //
-            // [1] array-allocation-sink-escape-materialize-1.js
-            // [2] array-allocation-sink-escape-materialize-2.js
-            // [3] array-allocation-sink-escape-materialize-3.js
-            // [4] array-allocation-sink-upsilon-with-double-value.js
             Node* base = node->child1().node();
-            Allocation* array = m_heap.onlyLocalAllocation(base);
-            if (array && array->isArrayAllocation()) {
-                // Treat GetButterfly as a separate allocation to track its dependency on the Array.
-                // 1. If PutByVal/GetByVal cause escape, materialize both at the same site.
-                // 2. If the Array escapes, also escape the ArrayButterfly since sinking it isn't beneficial.
-                m_heap.newAllocation(node, Allocation::Kind::ArrayButterfly);
-
-                // Re-get the array after potential HashMap modifications in above newAllocation() call which
-                // can trigger HashMap rehash in m_allocations.
-                array = m_heap.onlyLocalAllocation(base);
-                ASSERT(array && array->isArrayAllocation());
-                array->set(PromotedLocationDescriptor(ArrayButterflyPropertyPLoc, array->arrayButterflyId()), node);
+            target = m_heap.onlyLocalAllocation(base);
+            if (target && target->kind() == Allocation::Kind::Array) {
+                exactRead = ArrayButterflyPLoc;
             } else
                 goto escapeChildren;
             break;
@@ -1048,9 +1000,13 @@ private:
 
         case GetArrayLength: {
             Node* base = node->child1().node();
-            target = m_heap.onlyLocalAllocation(base);
-            if (target && target->isArrayAllocation())
-                exactRead = PromotedLocationDescriptor(ArrayLengthPropertyPLoc);
+            Allocation* baseAllocation = m_heap.onlyLocalAllocation(base);
+            if (!baseAllocation || baseAllocation->kind() != Allocation::Kind::Array)
+                goto escapeChildren;
+
+            target = m_heap.onlyLocalAllocation(node->child2().node());
+            if (target && target->kind() == Allocation::Kind::ArrayButterfly)
+                exactRead = PromotedLocationDescriptor(ArrayButterflyPublicLengthPLoc);
             else
                 goto escapeChildren;
             break;
@@ -1061,8 +1017,17 @@ private:
             ArrayMode arrayMode = node->arrayMode();
             Node* base = m_graph.varArgChild(node, 0).node();
             Node* index = m_graph.varArgChild(node, 1).node();
-            target = m_heap.onlyLocalAllocation(base);
+            Node* storage = m_graph.varArgChild(node, node->storageChildIndex()).node();
 
+            if (!storage)
+                goto escapeChildren;
+
+            Allocation* butterflyAllocation = m_heap.onlyLocalAllocation(storage);
+            if (!butterflyAllocation || butterflyAllocation->kind() != Allocation::Kind::ArrayButterfly)
+                goto escapeChildren;
+
+            // FIXME: Do we actually need this? For PutByVal the useKindEnsuresValidityForIndexingType check should
+            // ensure validity. For GetByVal subsequent uses do any UseKind type checking.
             auto matchesIndexingTypeWithArrayMode = [&](IndexingType indexingType, Array::Type type) {
                 switch (indexingType) {
                 case ALL_DOUBLE_INDEXING_TYPES:
@@ -1077,17 +1042,20 @@ private:
                 }
             };
 
-            auto isWithinBounds = [&](int32_t index, unsigned length) {
-                return index >= 0 && static_cast<unsigned>(index) < length;
+            auto isWithinBounds = [](int32_t index, unsigned length) {
+                return 0 <= index && static_cast<unsigned>(index) < length;
             };
 
-            if (target && target->isArrayAllocation()
+            target = m_heap.onlyLocalAllocation(base);
+            if (target && target->kind() == Allocation::Kind::Array
                 && arrayMode.isInBounds()
                 && matchesIndexingTypeWithArrayMode(target->indexingType(), arrayMode.type())
                 && index->isInt32Constant()
                 && isWithinBounds(index->asInt32(), target->length())) {
                 if (node->op() == PutByVal) {
                     Edge value = m_graph.varArgChild(node, 2);
+                    if (!isProvenValidTypeForIndexingShapeStorage(target->indexingType(), typeFilterFor(value.useKind())))
+                        goto escapeChildren;
                     writes.add(PromotedLocationDescriptor(ArrayIndexedPropertyPLoc, index->asInt32()), LazyNode(value.node()));
                 } else
                     exactRead = PromotedLocationDescriptor(ArrayIndexedPropertyPLoc, index->asInt32());
@@ -1464,6 +1432,7 @@ escapeChildren:
         m_materializationSiteToMaterializations.clear();
         m_materializationSiteToRecoveries.clear();
         m_materializationSiteToHints.clear();
+        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Determining sink candidates");
 
         // Logically we wish to consider every allocation and sink
         // it. However, it is probably not profitable to sink an
@@ -1510,6 +1479,7 @@ escapeChildren:
         bool hasUnescapedReads = false;
         for (BasicBlock* block : m_graph.blocksInPreOrder()) {
             m_heap = m_heapAtHead[block];
+            dataLogLnIf(Options::verboseObjectAllocationSinking(), "LocalHeap of ", block, " at head: ", m_heap);
 
             for (Node* node : *block) {
                 handleNode(
@@ -1544,30 +1514,7 @@ escapeChildren:
             }
         }
 
-        auto fixGetButterflyEscapees = [&](auto& escapees) {
-            // Case (4): Remove GetButterfly if its base Array didn’t escape.
-            escapees.removeIf([&] (const auto& entry) {
-                return entry.key->op() == GetButterfly && !escapees.contains(entry.key->child1().node());
-            });
-
-            // Case (5): Ensure ArrayButterfly SEM when its parent Array does.
-            Vector<std::pair<Node*, Allocation*>> toAdd;
-            for (const auto& entry : escapees) {
-                if (entry.value.kind() != Allocation::Kind::Array)
-                    continue;
-                for (const auto& field : entry.value.fields()) {
-                    if (field.key.kind() != ArrayButterflyPropertyPLoc)
-                        continue;
-                    if (Allocation* allocation = m_heap.onlyLocalAllocation(field.value))
-                        toAdd.append({ field.value, allocation });
-                }
-            }
-
-            for (const auto& pair : toAdd) {
-                m_sinkCandidates.add(pair.first);
-                escapees.add(pair.first, *pair.second);
-            }
-        };
+        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Initial candidates: ", listDump(m_sinkCandidates));
 
         auto forEachEscapee = [&] (auto callback) {
             for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
@@ -1583,7 +1530,6 @@ escapeChildren:
                         });
                     auto escapees = m_heap.takeEscapees();
                     escapees.removeIf([&] (const auto& entry) { return !m_sinkCandidates.contains(entry.key); });
-                    fixGetButterflyEscapees(escapees);
                     callback(escapees, node);
                 }
 
@@ -1605,7 +1551,6 @@ escapeChildren:
                         if (mustEscape && m_sinkCandidates.contains(entry.key))
                             escapingOnEdge.add(entry.key, entry.value);
                     }
-                    fixGetButterflyEscapees(escapingOnEdge);
                     callback(escapingOnEdge, block->terminal());
                 }
             }
@@ -1627,8 +1572,10 @@ escapeChildren:
                     InlineCallFrame* inlineCallFrame = allocation->origin.semantic.inlineCallFrame();
                     if (!inlineCallFrame)
                         continue;
-                    if ((inlineCallFrame->isClosureCall || inlineCallFrame->isVarargs()) && inlineCallFrame != where->origin.semantic.inlineCallFrame())
+                    if ((inlineCallFrame->isClosureCall || inlineCallFrame->isVarargs()) && inlineCallFrame != where->origin.semantic.inlineCallFrame()) {
+                        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Removing candidate because it escapes from a frame that has a closure: ", allocation);
                         m_sinkCandidates.remove(allocation);
+                    }
                 }
             });
         }
@@ -1705,13 +1652,13 @@ escapeChildren:
         // (vertex) feedback set problem. Unfortunately, this is a
         // NP-hard problem, which we don't want to solve exactly.
         //
-        // Instead, we use a simple greedy procedure, that procedes as
+        // Instead, we use a simple greedy procedure, that proceeds as
         // follow:
         //  - While there is at least one node with no outgoing edge
         //    amongst the remaining materializations, materialize it
         //    first
         //
-        //  - Similarily, while there is at least one node with no
+        //  - Similarly, while there is at least one node with no
         //    incoming edge amongst the remaining materializations,
         //    materialize it last.
         //
@@ -1731,36 +1678,16 @@ escapeChildren:
         UncheckedKeyHashMap<Node*, NodeSet> dependencies;
         UncheckedKeyHashMap<Node*, NodeSet> reverseDependencies;
         UncheckedKeyHashMap<Node*, NodeSet> forMaterialization;
-        auto addDependency = [&](Node* a, Node* b, bool neededForMaterialization) {
-            dependencies.add(a, NodeSet()).iterator->value.addVoid(b);
-            reverseDependencies.add(b, NodeSet()).iterator->value.addVoid(a);
-            if (neededForMaterialization)
-                forMaterialization.add(a, NodeSet()).iterator->value.addVoid(b);
-        };
-
-        // FIXME: A better model for materialized Array and ArrayButterfly would be:
-        //     D@x MaterializeButterfly(...)
-        //     D@y MaterializeNewArrayWithConstantSize(@x)
-        // In this model, D@x materializes the actual butterfly, and D@y wraps D@x.
-        // They then behave like regular GetButterfly and Array nodes. Additionally, PutByVal/GetByVal
-        // would conceptually operate on the Butterfly’s abstract Allocation rather than the Array’s.
-        // In that case, requiresReverseDependency would no longer be necessary.
-        auto requiresReverseDependency = [&] (Allocation::Kind allocationKind, PromotedLocationKind fieldKind) {
-            return allocationKind == Allocation::Kind::Array && fieldKind == ArrayButterflyPropertyPLoc;
-        };
-
-        for (auto& [escape, escapeAllocation] : escapees) {
-            dependencies.add(escape, NodeSet());
-            forMaterialization.add(escape, NodeSet());
-            reverseDependencies.add(escape, NodeSet());
-            for (auto& [fieldLocation, field] : escapeAllocation.fields()) {
-                if (escapees.contains(field) && field != escape) {
-                    Node* from = escape;
-                    Node* to = field;
-                    // Swap to ensure that Array is materialized before ArrayButterfly.
-                    if (requiresReverseDependency(escapeAllocation.kind(), fieldLocation.kind()))
-                        std::swap(from, to);
-                    addDependency(from, to, fieldLocation.neededForMaterialization());
+        for (const auto& entry : escapees) {
+            auto& myDependencies = dependencies.add(entry.key, NodeSet()).iterator->value;
+            auto& myDependenciesForMaterialization = forMaterialization.add(entry.key, NodeSet()).iterator->value;
+            reverseDependencies.add(entry.key, NodeSet());
+            for (const auto& field : entry.value.fields()) {
+                if (escapees.contains(field.value) && field.value != entry.key) {
+                    myDependencies.addVoid(field.value);
+                    reverseDependencies.add(field.value, NodeSet()).iterator->value.addVoid(entry.key);
+                    if (field.key.neededForMaterialization())
+                        myDependenciesForMaterialization.addVoid(field.value);
                 }
             }
         }
@@ -1870,13 +1797,8 @@ escapeChildren:
             escaped.addVoid(allocation.identifier());
         for (const Allocation& allocation : toMaterialize) {
             for (const auto& field : allocation.fields()) {
-                if (escaped.contains(field.value) && !materialized.contains(field.value)) {
-                    // Skip recovery for ArrayButterfly fields since they have reverse dependencies
-                    // and will be handled by their parent Array's materialization
-                    if (requiresReverseDependency(allocation.kind(), field.key.kind()))
-                        continue;
+                if (escaped.contains(field.value) && !materialized.contains(field.value))
                     toRecover.append(PromotedHeapLocation(allocation.identifier(), field.key));
-                }
             }
             materialized.addVoid(allocation.identifier());
         }
@@ -1910,18 +1832,17 @@ escapeChildren:
         case Allocation::Kind::Array: {
             Node* node = allocation.identifier();
             ObjectMaterializationData* data = m_graph.m_objectMaterializationData.add();
-            data->m_newArraySize = node->newArraySize();
-
             return m_graph.addNode(
-                node->prediction(), Node::VarArg, MaterializeNewArrayWithConstantSize,
+                node->prediction(), Node::VarArg, MaterializeNewArrayWithButterfly,
                 where->origin.withSemantic(node->origin.semantic),
                 OpInfo(node->indexingType()), OpInfo(data), 0, 0);
         }
 
         case Allocation::Kind::ArrayButterfly: {
             Node* node = allocation.identifier();
-            return m_graph.addNode(node->prediction(), GetButterfly,
-                where->origin.withSemantic(node->origin.semantic), node->child1());
+
+            return m_graph.addNode(node->prediction(),  NewButterflyWithSize,
+                where->origin.withSemantic(node->origin.semantic), OpInfo(node->indexingType()));
         }
 
         case Allocation::Kind::Object: {
@@ -2346,8 +2267,12 @@ escapeChildren:
 
                 if (m_sinkCandidates.contains(node) || doLower) {
                     switch (node->op()) {
-                    case NewArrayWithConstantSize:
-                        node->convertToPhantomNewArrayWithConstantSize();
+                    case NewButterflyWithSize:
+                        node->convertToPhantomNewButterflyWithSize();
+                        break;
+
+                    case NewArrayWithButterfly:
+                        node->convertToPhantomNewArrayWithButterfly();
                         break;
 
                     case NewObject:
@@ -2424,6 +2349,9 @@ escapeChildren:
 
             m_insertionSet.execute(block);
         }
+
+        // Materializations can insert constants (e.g. for PutByVal)
+        m_rootInsertionSet.execute(m_graph.block(0));
     }
 
     NEVER_INLINE Node* resolve(BasicBlock* block, PromotedHeapLocation location)
@@ -2543,22 +2471,28 @@ escapeChildren:
     {
         Allocation& allocation = m_heap.getAllocation(escapee);
         switch (node->op()) {
-        case MaterializeNewArrayWithConstantSize: {
+        case MaterializeNewArrayWithButterfly: {
             ObjectMaterializationData& data = node->objectMaterializationData();
-            unsigned firstChild = m_graph.m_varArgChildren.size();
+            unsigned lengthChild = m_graph.m_varArgChildren.size();
+            // Save space for it in case it's not the first value we find.
+            m_graph.m_varArgChildren.append(m_bottom);
 
-            auto useKind = [&](IndexingType indexingType) {
-                switch (indexingType) {
+            unsigned butterflyChild = m_graph.m_varArgChildren.size();
+            m_graph.m_varArgChildren.append(m_bottom);
+
+            auto useKind = [&]() {
+                switch (node->indexingType()) {
                 case ALL_DOUBLE_INDEXING_TYPES:
+                    // FIXME: There's no KnownDoubleRepRealUse
                     return DoubleRepRealUse;
                 case ALL_INT32_INDEXING_TYPES:
-                    return Int32Use;
+                    return KnownInt32Use;
                 default:
                     return UntypedUse;
                 }
-            };
+            }();
 
-            Vector<PromotedHeapLocation> locations = m_locationsForAllocation.get(escapee);
+            const Vector<PromotedHeapLocation>& locations = m_locationsForAllocation.get(escapee);
             for (PromotedHeapLocation location : locations) {
                 switch (location.kind()) {
                 case ArrayIndexedPropertyPLoc: {
@@ -2568,27 +2502,41 @@ escapeChildren:
                     if (m_sinkCandidates.contains(value))
                         m_graph.m_varArgChildren.append(m_bottom);
                     else
-                        m_graph.m_varArgChildren.append(Edge(value, useKind(node->indexingType())));
+                        m_graph.m_varArgChildren.append(Edge(value, useKind));
                     break;
                 }
-                case ArrayLengthPropertyPLoc:
-                    // No need to do anything here since it's used for read only.
+                case ArrayButterflyPLoc: {
+                    Node* butterfly = resolve(block, location);
+                    m_graph.m_varArgChildren[butterflyChild] = Edge(butterfly);
+
+                    ASSERT(butterfly->op() == NewButterflyWithSize);
+                    m_graph.m_varArgChildren[lengthChild] = butterfly->child1();
                     break;
+                }
                 default:
                     DFG_CRASH(m_graph, node, "Bad location kind");
                 }
             }
 
+            ASSERT(m_graph.m_varArgChildren.size() - lengthChild == locations.size() + 1);
             node->children = AdjacencyList(
                 AdjacencyList::Variable,
-                firstChild, m_graph.m_varArgChildren.size() - firstChild);
+                lengthChild, m_graph.m_varArgChildren.size() - lengthChild);
+
+            // Right now this is constant. If we ever support out-of-bounds insertion we will need to remove this assert.
+            ASSERT(m_graph.varArgChild(node, 0)->asInt32() == escapee->child1()->asInt32());
             break;
         }
 
-        case GetButterfly: {
-            Edge& base = node->child1();
-            base.setNode(resolve(block, base.node()));
-            ASSERT(base->op() == MaterializeNewArrayWithConstantSize);
+        case NewButterflyWithSize: {
+            const auto& locations = m_locationsForAllocation.get(escapee);
+            ASSERT(locations.size() == 1);
+            ASSERT(locations[0].kind() == ArrayButterflyPublicLengthPLoc);
+            Node* size = resolve(block, locations[0]);
+            // Right now this is constant. If we ever support out-of-bounds insertion we will need to remove this assert
+            // and figure out how to teach handleNode's PutByVal case to have more than one write target.
+            ASSERT(size->isInt32Constant());
+            node->child1() = Edge(size, KnownInt32Use);
             break;
         }
 
@@ -2596,7 +2544,7 @@ escapeChildren:
             ObjectMaterializationData& data = node->objectMaterializationData();
             unsigned firstChild = m_graph.m_varArgChildren.size();
 
-            Vector<PromotedHeapLocation> locations = m_locationsForAllocation.get(escapee);
+            const Vector<PromotedHeapLocation>& locations = m_locationsForAllocation.get(escapee);
 
             PromotedHeapLocation structure(StructurePLoc, allocation.identifier());
             ASSERT(locations.contains(structure));
@@ -2858,6 +2806,49 @@ escapeChildren:
                 value->defaultEdge());
         }
 
+        case ArrayIndexedPropertyPLoc: {
+            Node* butterfly = resolve(block, PromotedHeapLocation(ArrayButterflyPLoc, location.base()));
+
+            unsigned index = location.info();
+
+            ArrayMode mode = [&] {
+                switch (base->indexingType()) {
+                case ALL_INT32_INDEXING_TYPES: return ArrayMode(Array::Int32, Array::Write);
+                case ALL_DOUBLE_INDEXING_TYPES: return ArrayMode(Array::Double, Array::Write);
+                case ALL_CONTIGUOUS_INDEXING_TYPES: return ArrayMode(Array::Contiguous, Array::Write);
+                default: break;
+                }
+                RELEASE_ASSERT_NOT_REACHED();
+            }();
+
+            auto useKind = [&]() {
+                switch (base->indexingType()) {
+                case ALL_DOUBLE_INDEXING_TYPES:
+                    // FIXME: There's no KnownDoubleRepRealUse
+                    return DoubleRepRealUse;
+                case ALL_INT32_INDEXING_TYPES:
+                    return KnownInt32Use;
+                default:
+                    return UntypedUse;
+                }
+            }();
+
+            unsigned start = m_graph.m_varArgChildren.size();
+            m_graph.m_varArgChildren.append(Edge(base, KnownCellUse));
+            m_graph.m_varArgChildren.append(Edge(ensureConstant(index), KnownInt32Use));
+            m_graph.m_varArgChildren.append(Edge(value, useKind));
+            m_graph.m_varArgChildren.append(Edge(butterfly));
+            m_graph.m_varArgChildren.append(Edge()); // length, unused by Arrays.
+
+            // We should have a sane chain so this doesn't matter.
+            ECMAMode strict = ECMAMode::strict();
+
+            return m_graph.addNode(Node::VarArg, PutByVal, origin.takeValidExit(canExit),
+                OpInfo(mode.asWord()), OpInfo(strict),
+                start, m_graph.m_varArgChildren.size() - start);
+        }
+
+
         case ClosureVarPLoc: {
             return m_graph.addNode(
                 PutClosureVar,
@@ -2942,25 +2933,6 @@ escapeChildren:
                     break;
                 }
 
-                case MaterializeNewArrayWithConstantSize: {
-                    for (unsigned i = 0; i < node->numChildren(); ++i) {
-                        switch (node->indexingType()) {
-                        case ALL_DOUBLE_INDEXING_TYPES:
-                            m_graph.child(node, i).setUseKind(DoubleRepRealUse);
-                            break;
-                        case ALL_INT32_INDEXING_TYPES:
-                            m_graph.child(node, i).setUseKind(Int32Use);
-                            break;
-                        case ALL_CONTIGUOUS_INDEXING_TYPES:
-                            m_graph.child(node, i).setUseKind(UntypedUse);
-                            break;
-                        default:
-                            break;
-                        }
-                    }
-                    break;
-                }
-
                 default:
                     break;
                 }
@@ -2998,7 +2970,9 @@ escapeChildren:
 
     UncheckedKeyHashMap<JSCell*, bool> m_validInferredValues;
 
+    // This maps from a MaterializeXYZ node to the allocation identifier.
     UncheckedKeyHashMap<Node*, Node*> m_materializationToEscapee;
+    // This maps from the node where an allocation escapes to the various MaterializeXYZ nodes.
     UncheckedKeyHashMap<Node*, Vector<Node*>> m_materializationSiteToMaterializations;
     UncheckedKeyHashMap<Node*, Vector<PromotedHeapLocation>> m_materializationSiteToRecoveries;
     UncheckedKeyHashMap<Node*, Vector<std::pair<PromotedHeapLocation, Node*>>> m_materializationSiteToHints;

--- a/Source/JavaScriptCore/dfg/DFGObjectMaterializationData.h
+++ b/Source/JavaScriptCore/dfg/DFGObjectMaterializationData.h
@@ -38,7 +38,6 @@ namespace JSC { namespace DFG {
 struct ObjectMaterializationData {
     // Determines the meaning of the passed nodes.
     Vector<PromotedLocationDescriptor> m_properties;
-    unsigned m_newArraySize { 0 };
     void dump(PrintStream&) const;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2199,9 +2199,10 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSize, char*, (JSGlobalObject* glob
     }
 
     JSArray* result;
-    if (butterfly)
+    if (butterfly) {
+        ASSERT(butterfly->publicLength() <= butterfly->vectorLength());
         result = JSArray::createWithButterfly(vm, nullptr, arrayStructure, butterfly);
-    else {
+    } else {
         result = JSArray::tryCreate(vm, arrayStructure, size);
         if (!result) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
@@ -2597,6 +2598,27 @@ JSC_DEFINE_JIT_OPERATION(operationAllocateComplexPropertyStorage, Butterfly*, (V
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     OPERATION_RETURN(scope, object->allocateMoreOutOfLineStorage(vm, object->structure()->outOfLineCapacity(), newSize));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationAllocateUnitializedAuxiliaryBase, void*, (VM* vmPointer, size_t allocationSize))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // allocationSize accounts for IndexingHeader already.
+    unsigned indexingPayloadInBytes = allocationSize - sizeof(IndexingHeader);
+    // If we wanted to lift this restriction we'd need to teach DFG's NewArrayWithButterfly and the Phantom/Materialize friends
+    // about converting the new Array's IndexingType / Structure.
+    ASSERT(indexingPayloadInBytes / sizeof(JSValue) < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+    constexpr bool hasIndexingHeader = true;
+    unsigned preCapacity = 0;
+    unsigned propertyCapacity = 0;
+    Butterfly* result = Butterfly::createUninitialized(vm, nullptr, preCapacity, propertyCapacity, hasIndexingHeader, indexingPayloadInBytes);
+
+
+    OPERATION_RETURN(scope, result->base(preCapacity, propertyCapacity));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationEnsureInt32, Butterfly*, (VM* vmPointer, JSCell* cell))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -265,6 +265,8 @@ JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorageWithInitialCapac
 JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorage, Butterfly*, (VM*, size_t newSize));
 JSC_DECLARE_JIT_OPERATION(operationAllocateComplexPropertyStorageWithInitialCapacity, Butterfly*, (VM*, JSObject*));
 JSC_DECLARE_JIT_OPERATION(operationAllocateComplexPropertyStorage, Butterfly*, (VM*, JSObject*, size_t newSize));
+// Note: This doesn't return a `Butterfly*` because it's not shifted properly so you'll have to do `Butterfly::fromBase` yourself. Hence the `Base` suffix.
+JSC_DECLARE_JIT_OPERATION(operationAllocateUnitializedAuxiliaryBase, void*, (VM*, size_t allocationSizeInBytes));
 JSC_DECLARE_JIT_OPERATION(operationEnsureInt32, Butterfly*, (VM*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationEnsureDouble, Butterfly*, (VM*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationEnsureContiguous, Butterfly*, (VM*, JSCell*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1331,7 +1331,6 @@ private:
         case NewArrayWithSpread:
         case NewArray:
         case NewArrayWithSize:
-        case NewArrayWithConstantSize:
         case NewArrayWithSizeAndStructure:
         case CreateRest:
         case NewArrayBuffer:
@@ -1573,6 +1572,8 @@ private:
             break;
         }
 
+        case NewArrayWithButterfly:
+        case NewButterflyWithSize:
         case PutByValAlias:
         case DoubleAsInt32:
         case CheckTypeInfoFlags:
@@ -1593,7 +1594,8 @@ private:
         case Identity:
         case BooleanToNumber:
         case PhantomNewObject:
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewArrayWithButterfly:
+        case PhantomNewButterflyWithSize:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -1614,7 +1616,7 @@ private:
         case CheckStructureOrEmpty:
         case CheckArrayOrEmpty:
         case MaterializeNewObject:
-        case MaterializeNewArrayWithConstantSize:
+        case MaterializeNewArrayWithButterfly:
         case MaterializeCreateActivation:
         case MaterializeNewInternalFieldObject:
         case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
@@ -53,18 +53,20 @@ enum PromotedLocationKind {
     ArgumentCountPLoc,
     ArgumentPLoc,
     ArgumentsCalleePLoc,
-    ArrayPLoc,
-    ArrayLengthPropertyPLoc,
-    ArrayButterflyPropertyPLoc,
+    // FIXME: All these Array/ArrayButterfly properties don't need to be exclusive to Arrays and could work just as well on objects.
+    ArrayButterflyPLoc,
+    // FIXME: This is the same as IndexedPropertyPLoc and should be deduplicated.
     ArrayIndexedPropertyPLoc,
+    // This is distinct from PublicLengthPLoc because PhantomNewButterflyWithSize needs to know how big the Array is.
+    ArrayButterflyPublicLengthPLoc,
     ClosureVarPLoc,
     InternalFieldObjectPLoc,
     FunctionActivationPLoc,
     FunctionExecutablePLoc,
     IndexedPropertyPLoc,
     NamedPropertyPLoc,
-    PublicLengthPLoc,
     StructurePLoc,
+    PublicLengthPLoc,
     VectorLengthPLoc,
     SpreadPLoc,
     NewArrayWithSpreadArgumentPLoc,
@@ -110,10 +112,14 @@ public:
         return m_kind == InvalidPromotedLocationKind && m_info;
     }
 
+    // These are the locations / values that are strictly needed to allocate the object. When
+    // object allocation sinking is breaking cycles for materialization, edges marked
+    // !neededForMaterialization are prioritized.
     bool neededForMaterialization() const
     {
         switch (kind()) {
         case NamedPropertyPLoc:
+        case ArrayIndexedPropertyPLoc:
         case ClosureVarPLoc:
         case RegExpObjectLastIndexPLoc:
         case InternalFieldObjectPLoc:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -652,7 +652,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NewAsyncGenerator:
     case NewArray:
     case NewArrayWithSize:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
+    case NewButterflyWithSize:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case NewArrayBuffer:
@@ -733,7 +734,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case MultiDeleteByOffset:
     case GetPropertyEnumerator:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:
@@ -743,7 +745,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case PhantomNewRegExp:
     case PutHint:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewArrayWithButterfly:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PhantomDirectArguments:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13700,52 +13700,6 @@ void SpeculativeJIT::compileLazyJSConstant(Node* node)
     jsValueResult(resultRegs, node);
 }
 
-void SpeculativeJIT::compileMaterializeNewArrayWithConstantSize(Node* node)
-{
-    ObjectMaterializationData& data = node->objectMaterializationData();
-
-    GPRTemporary size(this);
-    GPRTemporary result(this);
-
-    GPRReg sizeGPR = size.gpr();
-    GPRReg storageGPR = result.gpr();
-    GPRReg resultGPR = result.gpr();
-
-    // Step 1: Speculate appropriately on all of the children.
-    for (unsigned i = 0; i < node->numChildren(); ++i)
-        speculate(node, m_graph.varArgChild(node, i));
-
-    // Step 1: Create a new array with constant size.
-    compileNewArrayWithConstantSizeImpl(node, sizeGPR, resultGPR);
-
-    // Step 2: Get the butterfly storage and fill the slots.
-    loadPtr(Address(resultGPR, JSObject::butterflyOffset()), storageGPR);
-    ASSERT(node->numChildren() == data.m_properties.size());
-    for (unsigned i = 0; i < node->numChildren(); ++i) {
-        Edge edge = m_graph.varArgChild(node, i);
-        unsigned index = data.m_properties[i].info();
-        switch (node->indexingType()) {
-        case ALL_DOUBLE_INDEXING_TYPES: {
-            SpeculateDoubleOperand value(this, edge);
-            storeDouble(value.fpr(), Address(storageGPR, sizeof(double) * index));
-            break;
-        }
-        case ALL_INT32_INDEXING_TYPES:
-        case ALL_CONTIGUOUS_INDEXING_TYPES: {
-            JSValueOperand value(this, edge, ManualOperandSpeculation); // We already speculated. So this does not require speculation.
-            JSValueRegs valueRegs = value.jsValueRegs();
-            storeValue(valueRegs, Address(storageGPR, sizeof(EncodedJSValue) * index));
-            break;
-        }
-        default:
-            DFG_CRASH(m_graph, node, "Bad indexing type");
-            break;
-        }
-    }
-
-    cellResult(resultGPR, node);
-}
-
 void SpeculativeJIT::compileMaterializeNewObject(Node* node)
 {
     RegisteredStructure structure = node->structureSet().at(0);
@@ -14888,27 +14842,78 @@ void SpeculativeJIT::compileNewArrayWithSize(Node* node)
     cellResult(resultGPR, node);
 }
 
-void SpeculativeJIT::compileNewArrayWithConstantSizeImpl(Node* node, GPRReg sizeGPR, GPRReg resultGPR)
+void SpeculativeJIT::compileNewButterflyWithSize(Node* node)
 {
-    ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(node));
-    ASSERT(!hasAnyArrayStorage(node->indexingType()));
+    GPRTemporary storage(this);
+    JSValueRegsTemporary scratch(this);
+    GPRTemporary scratch2(this);
 
-    move(TrustedImm32(node->newArraySize()), sizeGPR);
+    GPRReg storageGPR = storage.gpr();
+    JSValueRegs scratchRegs = scratch.regs();
+    GPRReg scratchGPR = scratchRegs.payloadGPR();
+    GPRReg scratch2GPR = scratch2.gpr();
 
-    constexpr bool shouldConvertLargeSizeToArrayStorage = false;
-    compileAllocateNewArrayWithSize(node, resultGPR, sizeGPR, node->indexingType(), shouldConvertLargeSizeToArrayStorage);
+    IndexingType indexingMode = node->indexingMode();
+    ASSERT(!hasAnyArrayStorage(indexingMode));
+    ASSERT(!isCopyOnWrite(indexingMode));
+    unsigned butterflyLength = node->child1()->asInt32();
+    ASSERT(butterflyLength < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+
+    constexpr bool hasIndexingHeader = true;
+    size_t allocationSize = Butterfly::totalSize(0, 0, hasIndexingHeader, butterflyLength * sizeof(JSValue));
+
+    JumpList slowCases;
+    emitAllocate(storageGPR, JITAllocator::constant(vm().auxiliarySpace().allocatorForNonInline(allocationSize, AllocatorForMode::EnsureAllocator)), scratchGPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationAllocateUnitializedAuxiliaryBase, storageGPR, TrustedImmPtr(&vm()), TrustedImmPtr(allocationSize)));
+
+    GPRReg sizeGPR = scratch2GPR;
+
+    move(Imm32(butterflyLength), sizeGPR);
+
+    // FIXME: do post increment store pair.
+    addPtr(TrustedImm32(sizeof(IndexingHeader)), storageGPR);
+    static_assert(Butterfly::offsetOfPublicLength() + static_cast<ptrdiff_t>(sizeof(uint32_t)) == Butterfly::offsetOfVectorLength());
+    storePair32(sizeGPR, sizeGPR, storageGPR, TrustedImm32(Butterfly::offsetOfPublicLength()));
+
+    if (hasDouble(indexingMode))
+        moveTrustedValue(jsNaN(), scratchRegs);
+    else
+        moveTrustedValue(JSValue(), scratchRegs);
+
+    emitInitializeButterfly(storageGPR, sizeGPR, scratchRegs, sizeGPR);
+    storageResult(storageGPR, node);
 }
 
-void SpeculativeJIT::compileNewArrayWithConstantSize(Node* node)
+void SpeculativeJIT::compileNewArrayWithButterfly(Node* node)
 {
-    GPRTemporary size(this);
+    ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(node));
+
+    IndexingType indexingMode = node->indexingMode();
+    ASSERT(!hasAnyArrayStorage(node->indexingMode()));
+    ASSERT(!isCopyOnWrite(indexingMode));
+    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+    RegisteredStructure structure = m_graph.registerStructure(globalObject->arrayStructureForIndexingTypeDuringAllocation(node->indexingMode()));
+
+    ASSERT(node->child1()->isInt32Constant());
+    StorageOperand storage(this, node->child2());
     GPRTemporary result(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
 
-    GPRReg sizeGPR = size.gpr();
+    GPRReg storageGPR = storage.gpr();
     GPRReg resultGPR = result.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
 
-    compileNewArrayWithConstantSizeImpl(node, sizeGPR, resultGPR);
-    cellResult(result.gpr(), node);
+    JumpList slowCases;
+
+    emitAllocateJSObject<JSArray>(resultGPR, TrustedImmPtr(structure), storageGPR, scratch1GPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationNewArrayWithSize, result.gpr(), LinkableConstant::globalObject(*this, node), structure, TrustedImm32(node->child1()->asInt32()), storageGPR));
+
+    DFG_ASSERT(m_graph, node, indexingMode & IsArray, indexingMode);
+    cellResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileNewArrayWithSpecies(Node* node)
@@ -16215,17 +16220,13 @@ void SpeculativeJIT::compileAllocateNewArrayWithSize(Node* node, GPRReg resultGP
 
 #if USE(JSVALUE64)
     JSValueRegs emptyValueRegs(scratchGPR);
-    if (hasDouble(structure->indexingType()))
-        move(TrustedImm64(std::bit_cast<int64_t>(PNaN)), emptyValueRegs.gpr());
-    else
-        move(TrustedImm64(JSValue::encode(JSValue())), emptyValueRegs.gpr());
 #else
     JSValueRegs emptyValueRegs(scratchGPR, scratch2GPR);
-    if (hasDouble(structure->indexingType()))
-        moveValue(JSValue(JSValue::EncodeAsDouble, PNaN), emptyValueRegs);
-    else
-        moveValue(JSValue(), emptyValueRegs);
 #endif
+    if (hasDouble(structure->indexingType()))
+        moveTrustedValue(jsNaN(), emptyValueRegs);
+    else
+        moveTrustedValue(JSValue(), emptyValueRegs);
     emitInitializeButterfly(storageGPR, sizeGPR, emptyValueRegs, resultGPR);
 
     emitAllocateJSObject<JSArray>(resultGPR, TrustedImmPtr(structure), storageGPR, scratchGPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1712,7 +1712,6 @@ public:
     void compileSetRegExpObjectLastIndex(Node*);
     void compileLazyJSConstant(Node*);
     void compileMaterializeNewObject(Node*);
-    void compileMaterializeNewArrayWithConstantSize(Node*);
     void compileRecordRegExpCachedResult(Node*);
     void compileToObjectOrCallObjectConstructor(Node*);
     void compileResolveScope(Node*);
@@ -1758,9 +1757,9 @@ public:
     void compileSetArgumentCountIncludingThis(Node*);
     void compileStrCat(Node*);
     void compileNewArrayBuffer(Node*);
+    void compileNewButterflyWithSize(Node*);
     void compileNewArrayWithSize(Node*);
-    void compileNewArrayWithConstantSizeImpl(Node*, GPRReg, GPRReg);
-    void compileNewArrayWithConstantSize(Node*);
+    void compileNewArrayWithButterfly(Node*);
     void compileNewArrayWithSpecies(Node*);
     void compileNewArrayWithSizeAndStructure(Node*);
     void compileNewTypedArray(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3191,8 +3191,13 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case NewArrayWithConstantSize: {
-        compileNewArrayWithConstantSize(node);
+    case NewButterflyWithSize: {
+        compileNewButterflyWithSize(node);
+        break;
+    }
+
+    case NewArrayWithButterfly: {
+        compileNewArrayWithButterfly(node);
         break;
     }
 
@@ -4306,10 +4311,6 @@ void SpeculativeJIT::compile(Node* node)
         compileMaterializeNewObject(node);
         break;
 
-    case MaterializeNewArrayWithConstantSize:
-        compileMaterializeNewArrayWithConstantSize(node);
-        break;
-
     case PutDynamicVar: {
         compilePutDynamicVar(node);
         break;
@@ -4399,7 +4400,8 @@ void SpeculativeJIT::compile(Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -4411,6 +4413,7 @@ void SpeculativeJIT::compile(Node* node)
     case CheckStructureImmediate:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
+    case MaterializeNewArrayWithButterfly:
     case PutStack:
     case KillStack:
     case GetStack:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4553,8 +4553,13 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case NewArrayWithConstantSize: {
-        compileNewArrayWithConstantSize(node);
+    case NewButterflyWithSize: {
+        compileNewButterflyWithSize(node);
+        break;
+    }
+
+    case NewArrayWithButterfly: {
+        compileNewArrayWithButterfly(node);
         break;
     }
 
@@ -6004,10 +6009,6 @@ void SpeculativeJIT::compile(Node* node)
         compileMaterializeNewObject(node);
         break;
 
-    case MaterializeNewArrayWithConstantSize:
-        compileMaterializeNewArrayWithConstantSize(node);
-        break;
-
     case CallDOM:
         compileCallDOM(node);
         break;
@@ -6577,7 +6578,8 @@ void SpeculativeJIT::compile(Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -6590,6 +6592,7 @@ void SpeculativeJIT::compile(Node* node)
     case GetVectorLength:
     case PutHint:
     case CheckStructureImmediate:
+    case MaterializeNewArrayWithButterfly:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -381,7 +381,8 @@ private:
             case NewAsyncGenerator:
             case NewArray:
             case NewArrayWithSize:
-            case NewArrayWithConstantSize:
+            case NewArrayWithButterfly:
+            case NewButterflyWithSize:
             case NewArrayWithSizeAndStructure:
             case NewArrayBuffer:
             case NewInternalFieldObject:
@@ -394,7 +395,7 @@ private:
             case NewSet:
             case NewSymbol:
             case MaterializeNewObject:
-            case MaterializeNewArrayWithConstantSize:
+            case MaterializeNewArrayWithButterfly:
             case MaterializeCreateActivation:
             case MakeRope:
             case MakeAtomString:

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGNodeFlags.h"
-#include "SpeculatedType.h"
+#include "IndexingType.h"
 #include <wtf/PrintStream.h>
 
 namespace JSC { namespace DFG {

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -251,7 +251,8 @@ inline CapabilityLevel canCompile(Node* node)
     case MakeRope:
     case MakeAtomString:
     case NewArrayWithSize:
-    case NewArrayWithConstantSize:
+    case NewArrayWithButterfly:
+    case NewButterflyWithSize:
     case NewArrayWithSpecies:
     case NewArrayWithSizeAndStructure:
     case TryGetById:
@@ -344,7 +345,8 @@ inline CapabilityLevel canCompile(Node* node)
     case EnumeratorPutByVal:
     case BottomValue:
     case PhantomNewObject:
-    case PhantomNewArrayWithConstantSize:
+    case PhantomNewArrayWithButterfly:
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:
@@ -355,7 +357,7 @@ inline CapabilityLevel canCompile(Node* node)
     case PutHint:
     case CheckStructureImmediate:
     case MaterializeNewObject:
-    case MaterializeNewArrayWithConstantSize:
+    case MaterializeNewArrayWithButterfly:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PhantomDirectArguments:

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,17 +36,16 @@ using namespace JSC::DFG;
 
 ExitTimeObjectMaterialization::ExitTimeObjectMaterialization(Node* node, CodeOrigin codeOrigin)
     : m_type(node->op())
-    , m_indexingType(node->op() == DFG::PhantomNewArrayWithConstantSize ? node->indexingType() : NoIndexingShape)
-    , m_size(node->op() == DFG::PhantomNewArrayWithConstantSize ? node->newArraySize() : 0)
+    , m_indexingType(node->hasIndexingType() ? node->indexingType() : NoIndexingShape)
     , m_origin(codeOrigin)
-{
-}
+{ }
 
 ExitTimeObjectMaterialization::~ExitTimeObjectMaterialization() = default;
 
 void ExitTimeObjectMaterialization::add(
     PromotedLocationDescriptor location, const ExitValue& value)
 {
+    // FIXME: We should probably do some validation here that any values stored a Butterfly are correct for the indexing type.
     m_properties.append(ExitPropertyValue(location, value));
 }
 

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.h
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.h
@@ -48,7 +48,6 @@ public:
 
     DFG::NodeType type() const { return m_type; }
     IndexingType indexingType() const { return m_indexingType; }
-    size_t size() const { return m_size; }
     CodeOrigin origin() const { return m_origin; }
     
     ExitValue get(DFG::PromotedLocationDescriptor) const;
@@ -63,7 +62,6 @@ public:
 private:
     DFG::NodeType m_type;
     IndexingType m_indexingType;
-    size_t m_size;
     CodeOrigin m_origin;
     Vector<ExitPropertyValue> m_properties;
 };

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1261,8 +1261,11 @@ private:
         case NewArrayWithSize:
             compileNewArrayWithSize();
             break;
-        case NewArrayWithConstantSize:
-            compileNewArrayWithConstantSize();
+        case NewArrayWithButterfly:
+            compileNewArrayWithButterfly();
+            break;
+        case NewButterflyWithSize:
+            compileNewButterflyWithSize();
             break;
         case NewArrayWithSpecies:
             compileNewArrayWithSpecies();
@@ -1747,8 +1750,8 @@ private:
         case MaterializeNewObject:
             compileMaterializeNewObject();
             break;
-        case MaterializeNewArrayWithConstantSize:
-            compileMaterializeNewArrayWithConstantSize();
+        case MaterializeNewArrayWithButterfly:
+            compileMaterializeNewArrayWithButterfly();
             break;
         case MaterializeCreateActivation:
             compileMaterializeCreateActivation();
@@ -1892,12 +1895,17 @@ private:
             break;
         }
 
+        case PhantomNewArrayWithButterfly: {
+            // It would be very bad to get here in this state and could lead to horrible GC bugs. See ObjectAllocationSinking::handleNode for details.
+            RELEASE_ASSERT(m_node->child2()->op() == PhantomNewButterflyWithSize);
+            [[fallthrough]];
+        }
         case PhantomLocal:
         case MovHint:
         case ZombieHint:
         case ExitOK:
         case PhantomNewObject:
-        case PhantomNewArrayWithConstantSize:
+        case PhantomNewButterflyWithSize:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -10215,23 +10223,29 @@ IGNORE_CLANG_WARNINGS_END
         setJSValue(vmCall(Int64, operationNewArrayWithSize, weakPointer(globalObject), structureValue, publicLength, m_out.intPtrZero));
     }
 
-    LValue compileNewArrayWithConstantSizeImpl()
+    void compileNewButterflyWithSize()
     {
-        LValue publicLength = m_out.constInt32(m_node->newArraySize());
-
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-
         ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(m_node));
-        ASSERT(!hasAnyArrayStorage(m_node->indexingType()));
-        IndexingType indexingType = m_node->indexingType();
-        LValue result = allocateJSArray(
-            publicLength, publicLength, weakPointer(globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType)), m_out.constInt32(indexingType)).array;
-        return result;
+        ASSERT(!isCopyOnWrite(m_node->indexingMode()));
+
+        LValue publicLength = lowInt32(m_node->child1());
+        LValue indexingType = m_out.constInt32(m_node->indexingType());
+
+        LValue butterfly = allocateButterfly(indexingType, m_out.int32Zero, publicLength, publicLength);
+
+        setStorage(butterfly);
+        // No mutator fence is needed. Butterflies are only scanned when the GC discovers them in an object not on the stack.
     }
 
-    void compileNewArrayWithConstantSize()
+    void compileNewArrayWithButterfly()
     {
-        setJSValue(compileNewArrayWithConstantSizeImpl());
+        ASSERT(m_graph.isWatchingHavingABadTimeWatchpoint(m_node));
+        ASSERT(!hasAnyArrayStorage(m_node->indexingType()));
+
+        LValue publicLength = lowInt32(m_node->child1());
+        LValue butterfly = lowStorage(m_node->child2());
+        LValue array = allocateJSArray(m_node->indexingType(), publicLength, butterfly);
+        setJSValue(array);
         mutatorFence();
     }
 
@@ -17253,21 +17267,21 @@ IGNORE_CLANG_WARNINGS_END
             });
     }
 
-    void compileMaterializeNewArrayWithConstantSize()
+    void compileMaterializeNewArrayWithButterfly()
     {
-        // Step 1: Speculate appropriately on all of the children.
         for (unsigned i = 0; i < m_node->numChildren(); ++i)
-            speculate(m_graph.varArgChild(m_node, i));
+            RELEASE_ASSERT(!m_interpreter.needsTypeCheck(m_graph.varArgChild(m_node, i)));
 
-        // Step 2: Create a new array with constant size.
-        LValue result = compileNewArrayWithConstantSizeImpl();
-
-        // Step 3: Get the buttferfly storage and fill the slots.
-        LValue butterfly = m_out.loadPtr(result, m_heaps.JSObject_butterfly);
         IndexingType indexingType = m_node->indexingType();
+        LValue publicLength = lowInt32(m_graph.varArgChild(m_node, 0));
+        // FIXME: we should sort the properties by index then we can shouldInitializeElements = false here but when we do the properties below.
+        LValue butterfly = lowStorage(m_graph.varArgChild(m_node, 1));
+
         ObjectMaterializationData& data = m_node->objectMaterializationData();
+
         for (unsigned i = 0; i < data.m_properties.size(); ++i) {
-            Edge edge = m_graph.varArgChild(m_node, i);
+            // Add two to account for `size` and `butterfly`
+            Edge edge = m_graph.varArgChild(m_node, i + 2);
             unsigned index = data.m_properties[i].info();
             switch (m_node->indexingType()) {
             case ALL_DOUBLE_INDEXING_TYPES:
@@ -17285,7 +17299,8 @@ IGNORE_CLANG_WARNINGS_END
             }
         }
 
-        setJSValue(result);
+        LValue array = allocateJSArray(indexingType, publicLength, butterfly);
+        setJSValue(array);
         mutatorFence();
     }
 
@@ -20702,6 +20717,106 @@ IGNORE_CLANG_WARNINGS_END
         LValue butterfly;
     };
 
+    // FIXME: Reduced version of the JSArray allocation below. We should consolidate them.
+    LValue allocateButterfly(LValue indexingType, LValue preCapacity, LValue publicLength, LValue vectorLength, bool shouldInitializeElements = true)
+    {
+        LBasicBlock slowBlock = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        if (preCapacity->hasInt32() && vectorLength->hasInt32()) {
+            unsigned vectorLengthConst = static_cast<unsigned>(vectorLength->asInt32());
+            if (vectorLengthConst <= MAX_STORAGE_VECTOR_LENGTH) {
+                vectorLengthConst = Butterfly::optimalContiguousVectorLength(
+                    preCapacity->asInt32(), vectorLengthConst);
+                vectorLength = m_out.constInt32(vectorLengthConst);
+            }
+        } else {
+            // We don't compute the optimal vector length for new Array(blah) where blah is not
+            // statically known, since the compute effort of doing it here is probably not worth it.
+        }
+
+        static_assert(MarkedSpace::largeCutoff < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH * sizeof(JSValue), "This assumes any butterfly allocation that would be force to change indexing type would hit the slow path anyway.");
+        static_assert(1 << 3 == sizeof(JSValue));
+
+        LValue payloadSizeInBytes =
+            m_out.shl(
+                m_out.zeroExt(
+                    m_out.add(vectorLength, preCapacity),
+                    pointerType()),
+                m_out.constIntPtr(3));
+
+        LValue butterflySize = m_out.add(
+            payloadSizeInBytes, m_out.constIntPtr(sizeof(IndexingHeader)));
+
+        LValue allocator = allocatorForSize(vm().auxiliarySpace(), butterflySize, slowBlock);
+        LValue base = allocateHeapCell(allocator, slowBlock);
+        ValueFromBlock fastBase = m_out.anchor(base);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowBlock);
+        VM& vm = this->vm();
+        LValue slowButterflyBase = lazySlowPath(
+            [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
+                return createLazyCallGenerator(vm,
+                    operationAllocateUnitializedAuxiliaryBase, locations[0].directGPR(), CCallHelpers::TrustedImmPtr(&vm),
+                    locations[1].directGPR());
+            },
+            payloadSizeInBytes);
+        ValueFromBlock slowBase = m_out.anchor(slowButterflyBase);
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation);
+        LValue butterflyBase = m_out.phi(pointerType(), fastBase, slowBase);
+        LValue butterfly = m_out.add(
+            butterflyBase,
+            m_out.add(
+                m_out.shl(m_out.zeroExt(preCapacity, pointerType()), m_out.constIntPtr(3)),
+                m_out.constIntPtr(sizeof(IndexingHeader))));
+
+
+        m_out.store32(publicLength, butterfly, m_heaps.Butterfly_publicLength);
+        m_out.store32(vectorLength, butterfly, m_heaps.Butterfly_vectorLength);
+
+        initializeArrayElements(
+            indexingType,
+            shouldInitializeElements ? m_out.int32Zero : publicLength, vectorLength,
+            butterfly);
+
+        return butterfly;
+    }
+
+    LValue allocateJSArray(IndexingType indexingType, LValue publicLength, LValue butterfly)
+    {
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        VM& vm = this->vm();
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        RegisteredStructure structure = m_graph.registerStructure(globalObject->arrayStructureForIndexingTypeDuringAllocation(
+            indexingType));
+
+        LValue structureValue = weakStructure(structure);
+        LValue array = allocateObject<JSArray>(structureValue, butterfly, slowCase);
+        ValueFromBlock fastArray = m_out.anchor(array);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowCase);
+        LValue slowResult = lazySlowPath(
+            [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
+                return createLazyCallGenerator(vm,
+                    operationNewArrayWithSize, locations[0].directGPR(), CCallHelpers::TrustedImmPtr(globalObject),
+                    locations[1].directGPR(), locations[2].directGPR(), locations[3].directGPR());
+            },
+            structureValue, publicLength, butterfly);
+        ValueFromBlock slowArray = m_out.anchor(slowResult);
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation);
+        return m_out.phi(pointerType(), fastArray, slowArray);
+    }
+
+    // FIXME: We don't need to handle large array sizes because anything that big has to be precise allocated anyway.
+    // FIXME: We should try replacing this with the two methods above.
     ArrayValues allocateJSArray(LValue publicLength, LValue vectorLength, LValue structure, LValue indexingType, bool shouldInitializeElements = true, bool shouldLargeArraySizeCreateArrayStorage = true)
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -73,33 +73,28 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
     DeferGCForAWhile deferGC(vm);
 
     switch (materialization->type()) {
-    case PhantomNewArrayWithConstantSize: {
+    case PhantomNewArrayWithButterfly: {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        // This might be unnecessary because operationMaterializeObjectInOSR does DeferGCForAWhile but its better to be safe.
         JSArray* array = jsCast<JSArray*>(JSValue::decode(*encodedValue));
         for (unsigned i = materialization->properties().size(); i--;) {
             const ExitPropertyValue& property = materialization->properties()[i];
+            if (property.location().kind() != ArrayIndexedPropertyPLoc)
+                continue;
+
             JSValue value = JSValue::decode(values[i]);
             unsigned index = property.location().info();
-            Butterfly* butterfly = array->butterfly();
 
-            switch (materialization->indexingType()) {
-            case ALL_DOUBLE_INDEXING_TYPES: {
-                ASSERT(value.isNumber());
-                double valueAsDouble = value.asNumber();
-                butterfly->contiguousDouble().at(array, index) = valueAsDouble;
-                break;
-            }
-            case ALL_INT32_INDEXING_TYPES:
-            case ALL_CONTIGUOUS_INDEXING_TYPES: {
-                butterfly->contiguous().at(array, index).set(vm, array, value);
-                break;
-            }
-            default:
-                RELEASE_ASSERT_NOT_REACHED();
-                break;
-            }
+            array->putDirectIndex(globalObject, index, value);
+            scope.assertNoExceptionExceptTermination();
         }
+
+        // This might be unnecessary because operationMaterializeObjectInOSR does DeferGCForAWhile but its better to be safe.
+        if (hasContiguous(materialization->indexingType()))
+            vm.writeBarrier(array);
         break;
     }
+
 
     case PhantomNewObject: {
         JSFinalObject* object = jsCast<JSFinalObject*>(JSValue::decode(*encodedValue));
@@ -126,6 +121,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
         break;
     }
 
+    case PhantomNewButterflyWithSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -218,7 +214,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
 }
 
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSGlobalObject* globalObject, ExitTimeObjectMaterialization* materialization, EncodedJSValue* values))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (JSGlobalObject* globalObject, ExitTimeObjectMaterialization* materialization, EncodedJSValue* values))
 {
     using namespace DFG;
     VM& vm = globalObject->vm();
@@ -233,17 +229,78 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSG
     DeferGCForAWhile deferGC(vm);
 
     switch (materialization->type()) {
-    case PhantomNewArrayWithConstantSize: {
+    case PhantomNewButterflyWithSize: {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        size_t size = materialization->size();
-        Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(materialization->indexingType());
+        size_t size = UINT64_MAX;
+        for (unsigned i = 0; i < materialization->properties().size(); ++i) {
+            const ExitPropertyValue& property = materialization->properties()[i];
+            if (property.location() != PromotedLocationDescriptor(ArrayButterflyPublicLengthPLoc))
+                continue;
 
-        JSArray* result = JSArray::tryCreate(vm, structure, size);
+
+            RELEASE_ASSERT(JSValue::decode(values[i]).isInt32());
+            size = JSValue::decode(values[i]).asInt32();
+            break;
+        }
+        RELEASE_ASSERT(size < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+
+        unsigned preCapacity = 0;
+        unsigned propertyCapacity = 0;
+        IndexingHeader header;
+        header.setPublicLength(size);
+        header.setVectorLength(size);
+        Butterfly* result = Butterfly::tryCreate(vm, globalObject, preCapacity, propertyCapacity, true, header, size * sizeof(JSValue));
         if (!result) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             OPERATION_RETURN(scope, nullptr);
         }
+
+        return std::bit_cast<HeapCell*>(result);
+    }
+
+    case PhantomNewArrayWithButterfly: {
+        Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(materialization->indexingType());
+
+        Butterfly* butterfly = nullptr;
+        for (unsigned i = 0; i < materialization->properties().size(); ++i) {
+            const ExitPropertyValue& property = materialization->properties()[i];
+            if (property.location().kind() == ArrayButterflyPLoc) {
+                butterfly = std::bit_cast<Butterfly*>(values[i]);
+                break;
+            }
+        }
+        RELEASE_ASSERT(butterfly);
+
+        JSArray* result =  JSArray::createWithButterfly(vm, nullptr, structure, butterfly);
+
+        // The real values will be put subsequently by
+        // operationPopulateNewObjectInOSR. We can't fill them in
+        // now, because they may not be available yet (typically
+        // because we have a cyclic dependency graph).
+
+        // We put a dummy value here in order to avoid super-subtle
+        // GC-and-OSR-exit crashes in case we have a bug and some
+        // field is, for any reason, not filled later.
+        // We use a random-ish number instead of a sensible value like
+        // undefined to make possible bugs easier to track.
+        for (unsigned i = 0; i < materialization->properties().size(); ++i) {
+            const ExitPropertyValue& property = materialization->properties()[i];
+            if (property.location().kind() != ArrayIndexedPropertyPLoc) {
+                ASSERT(property.location().kind() == ArrayButterflyPLoc);
+                continue;
+            }
+
+            unsigned index = property.location().info();
+
+            int sentinel = 0xD3137E; // delete
+            ASSERT(jsNumber(sentinel).isInt32());
+            if (hasDouble(materialization->indexingType()))
+                butterfly->contiguousDouble().atUnsafe(index) = static_cast<double>(sentinel);
+            else
+                butterfly->contiguous().atUnsafe(index).setStartingValue(jsNumber(sentinel));
+        }
+
         return result;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLOperations.h
+++ b/Source/JavaScriptCore/ftl/FTLOperations.h
@@ -38,7 +38,7 @@ namespace FTL {
 
 class LazySlowPath;
 
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSGlobalObject*, ExitTimeObjectMaterialization*, EncodedJSValue*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (JSGlobalObject*, ExitTimeObjectMaterialization*, EncodedJSValue*));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalObject*, ExitTimeObjectMaterialization*, EncodedJSValue*, EncodedJSValue*));
 

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -210,19 +210,6 @@ inline unsigned arrayIndexFromIndexingType(IndexingType indexingType)
     return (indexingType & IndexingShapeMask) >> IndexingShapeShift;
 }
 
-inline bool isNewArrayWithConstantSizeIndexingType(IndexingType indexingType)
-{
-    switch (indexingType) {
-    case ALL_DOUBLE_INDEXING_TYPES:
-    case ALL_INT32_INDEXING_TYPES:
-    case ALL_CONTIGUOUS_INDEXING_TYPES: {
-        return true;
-    }
-    default:
-        return false;
-    }
-}
-
 inline IndexingType indexingTypeForValue(JSValue value)
 {
     if (value.isInt32())
@@ -237,7 +224,8 @@ inline IndexingType indexingTypeForValue(JSValue value)
 // Return an indexing type that can handle all of the elements of both indexing types.
 IndexingType leastUpperBoundOfIndexingTypes(IndexingType, IndexingType);
 
-IndexingType leastUpperBoundOfIndexingTypeAndType(IndexingType, SpeculatedType);
+bool isProvenValidTypeForIndexingShapeStorage(IndexingType, SpeculatedType);
+IndexingType leastUpperBoundOfIndexingTypeAndTypeForSpeculation(IndexingType, SpeculatedType);
 IndexingType leastUpperBoundOfIndexingTypeAndValue(IndexingType, JSValue);
 
 void dumpIndexingType(PrintStream&, IndexingType);


### PR DESCRIPTION
#### c3b478c1983f5de5b1b216aa888ca5b47c738ac3
<pre>
Array allocation sinking should split allocations into two, an Array allocation and a Butterfly allocation
<a href="https://rdar.apple.com/159207754">rdar://159207754</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298606">https://bugs.webkit.org/show_bug.cgi?id=298606</a>

Reviewed by Yusuke Suzuki.

This patch minorly rearchitects how we do Array allocation sinking in DFG. Previously we tried to model Arrays
in ObjectAllocationSinking as two allocations one where the actual Array was allocated and a &quot;Butterfly&quot;
at each `GetButterfly`. This meant that there was now a reverse data dependency between the GetButterfly and
the Array allocation Nodes. This was a little unintuitive but also meant that any control flow that would
merge two `GetButterfly`s would escape the Array.

This PR simplifies things by more directly representing the heap in ObjectAllocationSinking. There are now
two nodes that get sunk when sinking an Array: NewButterflyWithSize and NewArrayWithButterfly. All the
indexed properties and the Butterfly&apos;s location are stored on the NewArrayWithButterfly&apos;s Allocation.
The NewButterflyWithSize only contains the Array&apos;s length. If we ever wanted to extend Array allocation sinking
to support out of bounds stores we&apos;d have to teach `handleNode` how to deal with writes to multiple allocations.

Originally I had all the indexed properties and the length are stored on the LocalHeap of NewButterflyWithSize and
NewArrayWithButterfly&apos;s LocalHeap only contains the butterfly. But I realized that we crash while trying to materialize
a phantom array that contains itself or another newly materialized object that&apos;s in a cycle. This is because we have to
materialize the pointer as a PutByVal. We can&apos;t emit this PutByVal without the Array since we need to write barrier after
the store.

Overall, this change is perf neutral or maybe a slight progression on JetStream 3.

Canonical link: <a href="https://commits.webkit.org/300129@main">https://commits.webkit.org/300129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4da3b01494a35b5899a62a5ca9372969534686af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121381 "2 style errors") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41078 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73464 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdc08f74-42f4-4aa0-8166-93372fcbcfce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92201 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61348 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b4d96af-ade7-4e9e-b742-a8103fa78311) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72876 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ded78d2-1f7e-484e-b334-c6de5516e039) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71402 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113511 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130655 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119901 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100799 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100704 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/25537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46111 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45005 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19254 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53880 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150063 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47639 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38180 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50985 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->