### PR TITLE
[build.webkit.org] Upload  test262 logs to S3

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -45,26 +45,26 @@ def parser():
 def filter_jsc_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
     with open(log_file, 'w') as f:
-        print_line = False
+        print_all_lines = False
         for line in sys.stdin:
             f.write(line)
-            if print_line:
+            if print_all_lines:
                 print(line, end='')
             elif line.startswith('** The following JSC') or line.startswith('Results'):
-                print_line = True
+                print_all_lines = True
                 print(line, end='')
 
 
 def filter_layout_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
     with open(log_file, 'w') as f:
-        print_line = False
+        print_all_lines = False
         for line in sys.stdin:
             f.write(line)
-            if print_line:
+            if print_all_lines:
                 print(line, end='')
             elif line.startswith('=> Results') or 'Exiting early' in line or 'leaks found' in line:
-                print_line = True
+                print_all_lines = True
                 print(line, end='')
 
 
@@ -86,13 +86,25 @@ def filter_scan_build(log_file_name):
 def filter_webdriver_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
     with open(log_file, 'w') as f:
-        print_line = False
+        print_all_lines = False
         for line in sys.stdin:
             f.write(line)
-            if print_line:
+            if print_all_lines:
                 print(line, end='')
             if 'tests ran as expected' in line:
-                print_line = True
+                print_all_lines = True
+                print(line, end='')
+
+def filter_test262(log_file_name):
+    log_file = os.path.abspath(f'{log_file_name}')
+    with open(log_file, 'w') as f:
+        print_all_lines = False
+        for line in sys.stdin:
+            f.write(line)
+            if print_all_lines or line.startswith('! NEW FAIL'):
+                print(line, end='')
+            if 'TESTS SUMMARY---' in line:
+                print_all_lines = True
                 print(line, end='')
 
 def main():
@@ -105,6 +117,8 @@ def main():
         filter_scan_build(args.output)
     elif args.filter_type == 'webdriver':
         filter_webdriver_tests(args.output)
+    elif args.filter_type == 'test262':
+        filter_test262(args.output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### a3ed549ec3005b8b35e0707ad03795ea9f6b3c97
<pre>
[build.webkit.org] Upload  test262 logs to S3
<a href="https://bugs.webkit.org/show_bug.cgi?id=298780">https://bugs.webkit.org/show_bug.cgi?id=298780</a>
<a href="https://rdar.apple.com/160475791">rdar://160475791</a>

Reviewed by Aakash Jain.

Pipe output of test262 into filter-test-logs.
If we see any line with &quot;SUMMARY&quot; (such as for failures or success), we print all lines after that.
We also print all lines with &quot;! NEW FAIL&quot;.

* Tools/CISupport/build-webkit-org/steps.py:
(RunTest262Tests):
(RunTest262Tests.run):
* Tools/CISupport/build-webkit-org/steps_unittest.py: Added unit tests.
* Tools/Scripts/filter-test-logs: Drive-by fix to change the print_lines variable to print_all_lines for clarity.
(filter_jsc_tests):
(filter_layout_tests):
(filter_webdriver_tests):
(filter_test262):
(main):

Canonical link: <a href="https://commits.webkit.org/299905@main">https://commits.webkit.org/299905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af5961147c70b34eee0be0889f2e6c8f6f969204

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127051 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/72734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d419477-2bae-4e5c-b12f-fc3ed859698e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48930 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/72734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed33563f-3962-4656-a2ce-28728af72179) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123611 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/32783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72192 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66b5404e-fe04-475b-b8f4-909b849701a3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26260 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70656 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/120079 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104335 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/100101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45546 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19145 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47442 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46911 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/50257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/48597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->