### PR TITLE
[build.webkit.org] Upload test-minibrowser-bundle logs to S3

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -30,7 +30,7 @@ def parser():
     parser = argparse.ArgumentParser(description='filter test output')
     parser.add_argument(
         'filter_type',
-        choices=['jsc', 'layout', 'scan-build', 'webdriver'],
+        choices=['jsc', 'layout', 'scan-build', 'webdriver', 'minibrowser'],
         help='Choose which test logs to filter'
     )
     parser.add_argument(
@@ -83,6 +83,7 @@ def filter_scan_build(log_file_name):
                 print_all_lines = True
                 print(line, end='')
 
+
 def filter_webdriver_tests(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
     with open(log_file, 'w') as f:
@@ -94,6 +95,7 @@ def filter_webdriver_tests(log_file_name):
             if 'tests ran as expected' in line:
                 print_all_lines = True
                 print(line, end='')
+
 
 def filter_test262(log_file_name):
     log_file = os.path.abspath(f'{log_file_name}')
@@ -107,6 +109,20 @@ def filter_test262(log_file_name):
                 print_all_lines = True
                 print(line, end='')
 
+
+def filter_minibrowser_tests(log_file_name):
+    log_file = os.path.abspath(f'{log_file_name}')
+    with open(log_file, 'w') as f:
+        print_all_lines = False
+        for line in sys.stdin:
+            f.write(line)
+            if print_all_lines:
+                print(line, end='')
+            if 'Bundle passed tests on all this' in line:
+                print_all_lines = True
+                print(line, end='')
+
+
 def main():
     args = parser()
     if args.filter_type == 'jsc':
@@ -119,6 +135,8 @@ def main():
         filter_webdriver_tests(args.output)
     elif args.filter_type == 'test262':
         filter_test262(args.output)
+    elif args.filter_type == 'minibrowser':
+        filter_minibrowser_tests(args.output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### 15f11425955200eb7dbd02c3c594d61a40c39e9c
<pre>
[build.webkit.org] Upload test-minibrowser-bundle logs to S3
<a href="https://bugs.webkit.org/show_bug.cgi?id=298781">https://bugs.webkit.org/show_bug.cgi?id=298781</a>
<a href="https://rdar.apple.com/160475835">rdar://160475835</a>

Reviewed by Aakash Jain.

Pipe output of test-minibrowser-bundle into filter-test-logs.
We only want to print the test results at the end.

* Tools/CISupport/build-webkit-org/steps.py:
(TestMiniBrowserBundle):
(TestMiniBrowserBundle.run):
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/Scripts/filter-test-logs:
(parser):
(filter_webdriver_tests):
(filter_minibrowser_tests):
(main):

Canonical link: <a href="https://commits.webkit.org/299906@main">https://commits.webkit.org/299906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c730f4fe55123fc16fb641e1d7bbffd30099967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72736 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45df140f-e312-46f4-8285-bc753a3324ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48932 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91645 "Failed to checkout and rebase branch from PR 50665") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ef79965-0bbe-4a52-8ade-acbf59ae8528) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/32781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd6be121-dc48-4bbc-9b66-846c50384830) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/31808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70658 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129922 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/120081 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104338 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/100105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45549 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47444 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46913 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/50259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/48599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->