### PR TITLE
Fix extra unsafety in TestPDFDocument

### DIFF
--- a/Tools/TestWebKitAPI/TestPDFDocument.swift
+++ b/Tools/TestWebKitAPI/TestPDFDocument.swift
@@ -92,6 +92,30 @@ typealias CocoaColor = NSColor
         let boundsRect = bounds
         let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)
 
+        #if swift(>=6.2)
+        // FIXME: document safety invariants here.
+        #if HAVE_CGCONTEXT_INIT_WITH_BITMAP_INFO_AND_NULLABLE_COLORSPACE
+        let context = unsafe CGContext(
+            data: nil,
+            width: Int(boundsRect.size.width),
+            height: Int(boundsRect.size.height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo(alpha: .premultipliedLast, byteOrder: .order32Big)
+        )
+        #else
+        let context = unsafe CGContext(
+            data: nil,
+            width: Int(boundsRect.size.width),
+            height: Int(boundsRect.size.height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace!,
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue).union(.byteOrder32Big).rawValue
+        )
+        #endif
+        #else
         #if HAVE_CGCONTEXT_INIT_WITH_BITMAP_INFO_AND_NULLABLE_COLORSPACE
         let context = CGContext(
             data: nil,
@@ -112,6 +136,7 @@ typealias CocoaColor = NSColor
             space: colorSpace!,
             bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue).union(.byteOrder32Big).rawValue
         )
+        #endif
         #endif
 
         guard let context, let cgPage = page.pageRef else {


### PR DESCRIPTION
#### 9b5ae1d49b1c9970e9778ed2676dcadace4af623
<pre>
Fix extra unsafety in TestPDFDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=298795">https://bugs.webkit.org/show_bug.cgi?id=298795</a>
<a href="https://rdar.apple.com/160491512">rdar://160491512</a>

Reviewed by Jonathan Bedard.

This adds the &apos;unsafe&apos; keyword to allow these unsafe calls.

Canonical link: <a href="https://commits.webkit.org/299912@main">https://commits.webkit.org/299912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4f337d087e1ec325ea335b35cfadf58ba1edbe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72748 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05c54aac-e69a-4d43-bfe4-f9f71ce77b09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48944 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60911 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d29c40b4-5880-4012-9527-42d9d33914e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72203 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5b3ed7d-22f5-4fba-adc8-ff9b3a9001be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70671 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129934 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47594 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100113 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45564 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44254 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47456 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46925 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->