### PR TITLE
[Smart Lists] Conversion from HTML to NSAttributedString fails if an unordered list starts with a negative value

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -153,7 +153,7 @@ header: <WebCore/AttributedString.h>
 [CustomHeader] struct WebCore::ParagraphStyleTextList {
     WebCore::AttributedStringTextListID thisID
     String markerFormat;
-    [Validator='startingItemNumber >= 0'] int64_t startingItemNumber;
+    int64_t startingItemNumber;
 }
 
 header: <WebCore/AttributedString.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -460,6 +460,33 @@ TEST(WKWebView, AttributedStringFromList)
     checkListAtIndex(7, @"Four", secondList);
 }
 
+TEST(WKWebView, AttributedStringFromListWithNegativeStartValue)
+{
+    static constexpr auto html = R"""(
+    <body contenteditable dir='auto'>
+        <ol start='-4'>
+            <li>A</li>
+        </ol>
+    </body>
+    )"""_s;
+
+    const DecomposedAttributedText expected { {
+        DecomposedAttributedText::OrderedList { -4, {
+            "\t-4\tA\n"_s,
+        } },
+    } };
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    [webView synchronouslyLoadHTMLString:html.createNSString().get()];
+
+    RetainPtr string = [webView _contentsAsAttributedString];
+    auto actual = decompose(string.get());
+
+    TextStream stream;
+    stream << "expected " << actual << " to equal " << expected;
+    EXPECT_EQ(actual, expected) << stream.release().utf8().data();
+}
+
 TEST(WKWebView, AttributedStringFromListWithCustomListStyleTypes)
 {
     static constexpr auto html = R"""(

--- a/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h
+++ b/Tools/TestWebKitAPI/cocoa/DecomposedAttributedText.h
@@ -106,7 +106,14 @@ struct _DecomposedAttributedTextOrderedList {
 
     _DecomposedAttributedTextOrderedList(int startingItemNumber, DecomposedAttributedText::ListMarker marker, Vector<DecomposedAttributedText::Element>&& children)
         : marker(marker)
-        , startingItemNumber(startingItemNumber), children(children)
+        , startingItemNumber(startingItemNumber)
+        , children(children)
+    {
+    }
+
+    _DecomposedAttributedTextOrderedList(int startingItemNumber, Vector<DecomposedAttributedText::Element>&& children)
+        : startingItemNumber(startingItemNumber)
+        , children(children)
     {
     }
 


### PR DESCRIPTION
#### 076a1fcf6ac3f1c857df25c15366cb6eb070f7fe
<pre>
[Smart Lists] Conversion from HTML to NSAttributedString fails if an unordered list starts with a negative value
<a href="https://bugs.webkit.org/show_bug.cgi?id=298799">https://bugs.webkit.org/show_bug.cgi?id=298799</a>
<a href="https://rdar.apple.com/160497353">rdar://160497353</a>

Reviewed by Aditya Keerthi.

It is valid (albeit not that common) in both HTML and AppKit/UIKit to have an ordered list that starts at a negative value.
Therefore, remove this invalid validator.

* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TestWebKitAPI::TEST(WKWebView, AttributedStringFromListWithNegativeStartValue)):
(TestWebKitAPI::TEST(WKWebView, AttributedStringFromListWithCustomListStyleTypes)): Deleted.
(TestWebKitAPI::AttributedStringWithoutNetworkLoads)): Deleted.
(TestWebKitAPI::AttributedStringWithSourceApplicationBundleID)): Deleted.
(TestWebKitAPI::TextWithWebFontAsAttributedString)): Deleted.
(TestWebKitAPI::AttributedStringAndCDATASection)): Deleted.
(TestWebKitAPI::AttributedStringIncludesUserSelectNoneContent)): Deleted.
(TestWebKitAPI::RequestAllTextRunsWithSubframes)): Deleted.

Canonical link: <a href="https://commits.webkit.org/299922@main">https://commits.webkit.org/299922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4492e903c490f4716e956cc7e0b3838c36e88cda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120700 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72775 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/238e9374-e5c6-4198-a355-13fa255d26ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91675 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60929 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8e8a5c5-ee10-4b2c-9523-ad7e5ee4190d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108199 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72225 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fdc4997-175f-4306-a31f-16cf4b1789ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70698 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47621 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100295 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25416 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23622 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46952 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->