### PR TITLE
Make VM::setHasTerminationRequest() thread-safe.

### DIFF
--- a/Source/JavaScriptCore/runtime/StackManager.cpp
+++ b/Source/JavaScriptCore/runtime/StackManager.cpp
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-void StackManager::requestStop()
+CONCURRENT_SAFE void StackManager::requestStop()
 {
     Locker lock { m_mirrorLock };
     m_trapAwareSoftStackLimit.storeRelaxed(stopRequestMarker());
@@ -38,7 +38,7 @@ void StackManager::requestStop()
         mirror.m_trapAwareSoftStackLimit.storeRelaxed(stopRequestMarker());
 }
 
-void StackManager::cancelStop()
+CONCURRENT_SAFE void StackManager::cancelStop()
 {
     if (Options::forceTrapAwareStackChecks()) [[unlikely]]
         return;

--- a/Source/JavaScriptCore/runtime/StackManager.h
+++ b/Source/JavaScriptCore/runtime/StackManager.h
@@ -61,8 +61,8 @@ public:
     void unregisterMirror(Mirror&);
 
     bool hasStopRequest() { return trapAwareSoftStackLimit() == stopRequestMarker(); }
-    void requestStop();
-    void cancelStop();
+    CONCURRENT_SAFE void requestStop();
+    CONCURRENT_SAFE void cancelStop();
 
     void* softStackLimit() const { return m_softStackLimit; }
     void* trapAwareSoftStackLimit() const { return m_trapAwareSoftStackLimit.loadRelaxed(); }

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -377,7 +377,7 @@ void VMTraps::willDestroyVM()
 #endif
 }
 
-void VMTraps::cancelThreadStopIfNeeded()
+CONCURRENT_SAFE void VMTraps::cancelThreadStopIfNeeded()
 {
     Locker locker { *m_trapSignalingLock };
 
@@ -398,7 +398,7 @@ void VMTraps::cancelThreadStopIfNeeded()
     m_threadStopRequested = false;
 }
 
-void VMTraps::requestThreadStopIfNeeded(VMTraps::Event event)
+CONCURRENT_SAFE void VMTraps::requestThreadStopIfNeeded(VMTraps::Event event)
 {
     Locker locker { *m_trapSignalingLock };
     ASSERT(!m_isShuttingDown);

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -223,6 +223,13 @@
 #define WTF_EXTERN_C_END
 #endif
 
+/* CONCURRENT_SAFE */
+
+/* This is only used to annotate some functions as documentation that they are safe to call from any threads without additional
+ * synchronization. It also documents that these functions should not be altered in a way that breaks its concurrency promise.
+ * There isn't currently any compiler constructs that corresponds to this. */
+#define CONCURRENT_SAFE
+
 /* FALLTHROUGH */
 
 #if !defined(FALLTHROUGH) && !defined(__cplusplus)

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ *  Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -106,6 +106,11 @@ using SegmentedVectorMalloc = FastMalloc;
 using HashTableMalloc = FastMalloc;
 #endif
 
+enum class ConcurrencyTag : uint8_t {
+    None,
+    Atomic
+};
+
 template<typename> struct DefaultRefDerefTraits;
 
 template<typename> class Awaitable;
@@ -127,7 +132,7 @@ template<typename, typename, typename> class ObjectIdentifierGeneric;
 template<typename T, typename RawValue = uint64_t> using ObjectIdentifier = ObjectIdentifierGeneric<T, ObjectIdentifierMainThreadAccessTraits<RawValue>, RawValue>;
 template<typename T, typename RawValue = uint64_t> using AtomicObjectIdentifier = ObjectIdentifierGeneric<T, ObjectIdentifierThreadSafeAccessTraits<RawValue>, RawValue>;
 template<typename> class Observer;
-template<typename> class OptionSet;
+template<typename, ConcurrencyTag = ConcurrencyTag::None> class OptionSet;
 template<typename> class Packed;
 template<typename T, size_t = alignof(T)> class PackedAlignedPtr;
 template<typename> struct RawPtrTraits;
@@ -159,7 +164,7 @@ using SaVector = Vector<T, 0, CrashOnOverflow, 16, SequesteredArenaMalloc>;
 
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<AtomString>;
-template<typename T> struct DefaultHash<OptionSet<T>>;
+template<typename T, ConcurrencyTag C> struct DefaultHash<OptionSet<T, C>>;
 template<> struct DefaultHash<String>;
 template<> struct DefaultHash<StringImpl*>;
 template<> struct DefaultHash<URL>;
@@ -216,6 +221,7 @@ using WTF::Awaitable;
 using WTF::BinarySemaphore;
 using WTF::CString;
 using WTF::CompletionHandler;
+using WTF::ConcurrencyTag;
 using WTF::ConcurrentWorkQueue;
 using WTF::Deque;
 using WTF::EnumeratedArray;

--- a/Source/WTF/wtf/OptionSetHash.h
+++ b/Source/WTF/wtf/OptionSetHash.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,13 +31,14 @@
 
 namespace WTF {
 
-template<typename T> struct DefaultHash<OptionSet<T>> {
-    static unsigned hash(OptionSet<T> key)
+template<typename T, ConcurrencyTag concurrency>
+struct DefaultHash<OptionSet<T, concurrency>> {
+    static unsigned hash(OptionSet<T, concurrency> key)
     {
-        return IntHash<typename OptionSet<T>::StorageType>::hash(key.toRaw());
+        return IntHash<typename OptionSet<T, concurrency>::StorageType>::hash(key.toRaw());
     }
 
-    static bool equal(OptionSet<T> a, OptionSet<T> b)
+    static bool equal(OptionSet<T, concurrency> a, OptionSet<T, concurrency> b)
     {
         return a == b;
     }
@@ -44,22 +46,23 @@ template<typename T> struct DefaultHash<OptionSet<T>> {
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 
-template<typename T> struct HashTraits<OptionSet<T>> : GenericHashTraits<OptionSet<T>> {
-    using StorageTraits = UnsignedWithZeroKeyHashTraits<typename OptionSet<T>::StorageType>;
+template<typename T, ConcurrencyTag concurrency>
+struct HashTraits<OptionSet<T, concurrency>> : GenericHashTraits<OptionSet<T, concurrency>> {
+    using StorageTraits = UnsignedWithZeroKeyHashTraits<typename OptionSet<T, concurrency>::StorageType>;
 
-    static OptionSet<T> emptyValue()
+    static OptionSet<T, concurrency> emptyValue()
     {
-        return OptionSet<T>::fromRaw(StorageTraits::emptyValue());
+        return OptionSet<T, concurrency>::fromRaw(StorageTraits::emptyValue());
     }
 
-    static void constructDeletedValue(OptionSet<T>& slot)
+    static void constructDeletedValue(OptionSet<T, concurrency>& slot)
     {
-        typename OptionSet<T>::StorageType storage;
+        typename OptionSet<T, concurrency>::StorageType storage;
         StorageTraits::constructDeletedValue(storage);
-        slot = OptionSet<T>::fromRaw(storage);
+        slot = OptionSet<T, concurrency>::fromRaw(storage);
     }
 
-    static bool isDeletedValue(OptionSet<T> value)
+    static bool isDeletedValue(OptionSet<T, concurrency> value)
     {
         return StorageTraits::isDeletedValue(value.toRaw());
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,456 +42,596 @@ enum class ExampleFlags : uint64_t {
 
 TEST(WTF_OptionSet, EmptySet)
 {
-    OptionSet<ExampleFlags> set;
-    EXPECT_TRUE(set.isEmpty());
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
-    EXPECT_FALSE(set.contains(ExampleFlags::D));
-    EXPECT_FALSE(set.contains(ExampleFlags::E));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set;
+        EXPECT_TRUE(set.isEmpty());
+        EXPECT_FALSE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+        EXPECT_FALSE(set.contains(ExampleFlags::D));
+        EXPECT_FALSE(set.contains(ExampleFlags::E));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, ContainsOneFlag)
 {
-    OptionSet<ExampleFlags> set = ExampleFlags::A;
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
-    EXPECT_FALSE(set.contains(ExampleFlags::D));
-    EXPECT_FALSE(set.contains(ExampleFlags::E));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set = ExampleFlags::A;
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+        EXPECT_FALSE(set.contains(ExampleFlags::D));
+        EXPECT_FALSE(set.contains(ExampleFlags::E));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, Equal)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B };
-    
-    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B }));
-    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::B, ExampleFlags::A }));
-    EXPECT_FALSE(set == ExampleFlags::B);
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::B };
+        EXPECT_TRUE((set == OptionSetType { ExampleFlags::A, ExampleFlags::B }));
+        EXPECT_TRUE((set == OptionSetType { ExampleFlags::B, ExampleFlags::A }));
+        EXPECT_FALSE(set == ExampleFlags::B);
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, NotEqual)
 {
-    OptionSet<ExampleFlags> set = ExampleFlags::A;
-    
-    EXPECT_TRUE(set != ExampleFlags::B);
-    EXPECT_FALSE(set != ExampleFlags::A);
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set = ExampleFlags::A;
+        EXPECT_TRUE(set != ExampleFlags::B);
+        EXPECT_FALSE(set != ExampleFlags::A);
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, Or)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };
-    OptionSet<ExampleFlags> set2 { ExampleFlags::C, ExampleFlags::D };
-
-    EXPECT_TRUE(((set | ExampleFlags::A) == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
-    EXPECT_TRUE(((set | ExampleFlags::D) == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
-    EXPECT_TRUE(((set | set2) == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };
+        OptionSetType set2 { ExampleFlags::C, ExampleFlags::D };
+        EXPECT_TRUE(((set | ExampleFlags::A) == OptionSetType { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+        EXPECT_TRUE(((set | ExampleFlags::D) == OptionSetType { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
+        EXPECT_TRUE(((set | set2) == OptionSetType { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, OrAssignment)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };
 
-    set |= { };
-    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+        set |= { };
+        EXPECT_TRUE((set == OptionSetType { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
 
-    set |= { ExampleFlags::A };
-    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+        set |= { ExampleFlags::A };
+        EXPECT_TRUE((set == OptionSetType { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
 
-    set |= { ExampleFlags::C, ExampleFlags::D };
-    EXPECT_TRUE((set == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
+        set |= { ExampleFlags::C, ExampleFlags::D };
+        EXPECT_TRUE((set == OptionSetType { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C, ExampleFlags::D }));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, Minus)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C };
 
-    EXPECT_TRUE(((set - ExampleFlags::A) == OptionSet<ExampleFlags> { ExampleFlags::B, ExampleFlags::C }));
-    EXPECT_TRUE(((set - ExampleFlags::D) == OptionSet<ExampleFlags> { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
-    EXPECT_TRUE((set - set).isEmpty());
+        EXPECT_TRUE(((set - ExampleFlags::A) == OptionSetType { ExampleFlags::B, ExampleFlags::C }));
+        EXPECT_TRUE(((set - ExampleFlags::D) == OptionSetType { ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+        EXPECT_TRUE((set - set).isEmpty());
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, AddAndRemove)
 {
-    OptionSet<ExampleFlags> set;
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set;
 
-    set.add(ExampleFlags::A);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+        set.add(ExampleFlags::A);
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
 
-    set.add({ ExampleFlags::B, ExampleFlags::C });
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
+        set.add({ ExampleFlags::B, ExampleFlags::C });
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_TRUE(set.contains(ExampleFlags::B));
+        EXPECT_TRUE(set.contains(ExampleFlags::C));
 
-    set.remove(ExampleFlags::B);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
+        set.remove(ExampleFlags::B);
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_TRUE(set.contains(ExampleFlags::C));
 
-    set.remove({ ExampleFlags::A, ExampleFlags::C });
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+        set.remove({ ExampleFlags::A, ExampleFlags::C });
+        EXPECT_FALSE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, Set)
 {
-    OptionSet<ExampleFlags> set;
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set;
 
-    set.set(ExampleFlags::A, true);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+        set.set(ExampleFlags::A, true);
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
 
-    set.set({ ExampleFlags::B, ExampleFlags::C }, true);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
+        set.set({ ExampleFlags::B, ExampleFlags::C }, true);
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_TRUE(set.contains(ExampleFlags::B));
+        EXPECT_TRUE(set.contains(ExampleFlags::C));
 
-    set.set(ExampleFlags::B, false);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
+        set.set(ExampleFlags::B, false);
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_TRUE(set.contains(ExampleFlags::C));
 
-    set.set({ ExampleFlags::A, ExampleFlags::C }, false);
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+        set.set({ ExampleFlags::A, ExampleFlags::C }, false);
+        EXPECT_FALSE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, ContainsTwoFlags)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B };
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
-    EXPECT_FALSE(set.contains(ExampleFlags::D));
-    EXPECT_FALSE(set.contains(ExampleFlags::E));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::B };
+
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_TRUE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+        EXPECT_FALSE(set.contains(ExampleFlags::D));
+        EXPECT_FALSE(set.contains(ExampleFlags::E));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, ContainsTwoFlags2)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::D };
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::D));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
-    EXPECT_FALSE(set.contains(ExampleFlags::E));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::D };
+
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_TRUE(set.contains(ExampleFlags::D));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+        EXPECT_FALSE(set.contains(ExampleFlags::E));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, ContainsTwoFlags3)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::D, ExampleFlags::E };
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::D));
-    EXPECT_TRUE(set.contains(ExampleFlags::E));
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::D, ExampleFlags::E };
+
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::D));
+        EXPECT_TRUE(set.contains(ExampleFlags::E));
+        EXPECT_FALSE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, EmptyOptionSetToRawValueToOptionSet)
 {
-    OptionSet<ExampleFlags> set;
-    EXPECT_TRUE(set.isEmpty());
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set;
+        EXPECT_TRUE(set.isEmpty());
+        EXPECT_FALSE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
 
-    auto set2 = OptionSet<ExampleFlags>::fromRaw(set.toRaw());
-    EXPECT_TRUE(set2.isEmpty());
-    EXPECT_FALSE(set2.contains(ExampleFlags::A));
-    EXPECT_FALSE(set2.contains(ExampleFlags::B));
-    EXPECT_FALSE(set2.contains(ExampleFlags::C));
+        auto set2 = OptionSetType::fromRaw(set.toRaw());
+        EXPECT_TRUE(set2.isEmpty());
+        EXPECT_FALSE(set2.contains(ExampleFlags::A));
+        EXPECT_FALSE(set2.contains(ExampleFlags::B));
+        EXPECT_FALSE(set2.contains(ExampleFlags::C));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, OptionSetThatContainsOneFlagToRawValueToOptionSet)
 {
-    OptionSet<ExampleFlags> set = ExampleFlags::A;
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
-    EXPECT_FALSE(set.contains(ExampleFlags::D));
-    EXPECT_FALSE(set.contains(ExampleFlags::E));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set = ExampleFlags::A;
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+        EXPECT_FALSE(set.contains(ExampleFlags::D));
+        EXPECT_FALSE(set.contains(ExampleFlags::E));
 
-    auto set2 = OptionSet<ExampleFlags>::fromRaw(set.toRaw());
-    EXPECT_FALSE(set2.isEmpty());
-    EXPECT_TRUE(set2.contains(ExampleFlags::A));
-    EXPECT_FALSE(set2.contains(ExampleFlags::B));
-    EXPECT_FALSE(set2.contains(ExampleFlags::C));
-    EXPECT_FALSE(set2.contains(ExampleFlags::D));
-    EXPECT_FALSE(set2.contains(ExampleFlags::E));
+        auto set2 = OptionSetType::fromRaw(set.toRaw());
+        EXPECT_FALSE(set2.isEmpty());
+        EXPECT_TRUE(set2.contains(ExampleFlags::A));
+        EXPECT_FALSE(set2.contains(ExampleFlags::B));
+        EXPECT_FALSE(set2.contains(ExampleFlags::C));
+        EXPECT_FALSE(set2.contains(ExampleFlags::D));
+        EXPECT_FALSE(set2.contains(ExampleFlags::E));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, OptionSetThatContainsOneFlagToRawValueToOptionSet2)
 {
-    OptionSet<ExampleFlags> set = ExampleFlags::E;
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::E));
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
-    EXPECT_FALSE(set.contains(ExampleFlags::D));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set = ExampleFlags::E;
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::E));
+        EXPECT_FALSE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
+        EXPECT_FALSE(set.contains(ExampleFlags::D));
 
-    auto set2 = OptionSet<ExampleFlags>::fromRaw(set.toRaw());
-    EXPECT_FALSE(set2.isEmpty());
-    EXPECT_TRUE(set2.contains(ExampleFlags::E));
-    EXPECT_FALSE(set2.contains(ExampleFlags::A));
-    EXPECT_FALSE(set2.contains(ExampleFlags::B));
-    EXPECT_FALSE(set2.contains(ExampleFlags::C));
-    EXPECT_FALSE(set2.contains(ExampleFlags::D));
+        auto set2 = OptionSetType::fromRaw(set.toRaw());
+        EXPECT_FALSE(set2.isEmpty());
+        EXPECT_TRUE(set2.contains(ExampleFlags::E));
+        EXPECT_FALSE(set2.contains(ExampleFlags::A));
+        EXPECT_FALSE(set2.contains(ExampleFlags::B));
+        EXPECT_FALSE(set2.contains(ExampleFlags::C));
+        EXPECT_FALSE(set2.contains(ExampleFlags::D));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, OptionSetThatContainsTwoFlagsToRawValueToOptionSet)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::C };
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::C };
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::A));
+        EXPECT_TRUE(set.contains(ExampleFlags::C));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
 
-    auto set2 = OptionSet<ExampleFlags>::fromRaw(set.toRaw());
-    EXPECT_FALSE(set2.isEmpty());
-    EXPECT_TRUE(set2.contains(ExampleFlags::A));
-    EXPECT_TRUE(set2.contains(ExampleFlags::C));
-    EXPECT_FALSE(set2.contains(ExampleFlags::B));
+        auto set2 = OptionSetType::fromRaw(set.toRaw());
+        EXPECT_FALSE(set2.isEmpty());
+        EXPECT_TRUE(set2.contains(ExampleFlags::A));
+        EXPECT_TRUE(set2.contains(ExampleFlags::C));
+        EXPECT_FALSE(set2.contains(ExampleFlags::B));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, OptionSetThatContainsTwoFlagsToRawValueToOptionSet2)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::D, ExampleFlags::E };
-    EXPECT_FALSE(set.isEmpty());
-    EXPECT_TRUE(set.contains(ExampleFlags::D));
-    EXPECT_TRUE(set.contains(ExampleFlags::E));
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::D, ExampleFlags::E };
+        EXPECT_FALSE(set.isEmpty());
+        EXPECT_TRUE(set.contains(ExampleFlags::D));
+        EXPECT_TRUE(set.contains(ExampleFlags::E));
+        EXPECT_FALSE(set.contains(ExampleFlags::A));
+        EXPECT_FALSE(set.contains(ExampleFlags::B));
+        EXPECT_FALSE(set.contains(ExampleFlags::C));
 
-    auto set2 = OptionSet<ExampleFlags>::fromRaw(set.toRaw());
-    EXPECT_FALSE(set2.isEmpty());
-    EXPECT_TRUE(set2.contains(ExampleFlags::D));
-    EXPECT_TRUE(set2.contains(ExampleFlags::E));
-    EXPECT_FALSE(set2.contains(ExampleFlags::A));
-    EXPECT_FALSE(set2.contains(ExampleFlags::B));
-    EXPECT_FALSE(set2.contains(ExampleFlags::C));
+        auto set2 = OptionSetType::fromRaw(set.toRaw());
+        EXPECT_FALSE(set2.isEmpty());
+        EXPECT_TRUE(set2.contains(ExampleFlags::D));
+        EXPECT_TRUE(set2.contains(ExampleFlags::E));
+        EXPECT_FALSE(set2.contains(ExampleFlags::A));
+        EXPECT_FALSE(set2.contains(ExampleFlags::B));
+        EXPECT_FALSE(set2.contains(ExampleFlags::C));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, TwoIteratorsIntoSameOptionSet)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::C, ExampleFlags::B };
-    OptionSet<ExampleFlags>::iterator it1 = set.begin();
-    OptionSet<ExampleFlags>::iterator it2 = it1;
-    ++it1;
-    EXPECT_STRONG_ENUM_EQ(ExampleFlags::C, *it1);
-    EXPECT_STRONG_ENUM_EQ(ExampleFlags::B, *it2);
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::C, ExampleFlags::B };
+        typename OptionSetType::iterator it1 = set.begin();
+        typename OptionSetType::iterator it2 = it1;
+        ++it1;
+        EXPECT_STRONG_ENUM_EQ(ExampleFlags::C, *it1);
+        EXPECT_STRONG_ENUM_EQ(ExampleFlags::B, *it2);
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, IterateOverOptionSetThatContainsTwoFlags)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::C };
-    OptionSet<ExampleFlags>::iterator it = set.begin();
-    OptionSet<ExampleFlags>::iterator end = set.end();
-    EXPECT_TRUE(it != end);
-    EXPECT_STRONG_ENUM_EQ(ExampleFlags::A, *it);
-    ++it;
-    EXPECT_STRONG_ENUM_EQ(ExampleFlags::C, *it);
-    ++it;
-    EXPECT_TRUE(it == end);
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::C };
+        typename OptionSetType::iterator it = set.begin();
+        typename OptionSetType::iterator end = set.end();
+        EXPECT_TRUE(it != end);
+        EXPECT_STRONG_ENUM_EQ(ExampleFlags::A, *it);
+        ++it;
+        EXPECT_STRONG_ENUM_EQ(ExampleFlags::C, *it);
+        ++it;
+        EXPECT_TRUE(it == end);
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, IterateOverOptionSetThatContainsFlags2)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::D, ExampleFlags::E };
-    OptionSet<ExampleFlags>::iterator it = set.begin();
-    OptionSet<ExampleFlags>::iterator end = set.end();
-    EXPECT_TRUE(it != end);
-    EXPECT_STRONG_ENUM_EQ(ExampleFlags::D, *it);
-    ++it;
-    EXPECT_STRONG_ENUM_EQ(ExampleFlags::E, *it);
-    ++it;
-    EXPECT_TRUE(it == end);
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::D, ExampleFlags::E };
+        typename OptionSetType::iterator it = set.begin();
+        typename OptionSetType::iterator end = set.end();
+        EXPECT_TRUE(it != end);
+        EXPECT_STRONG_ENUM_EQ(ExampleFlags::D, *it);
+        ++it;
+        EXPECT_STRONG_ENUM_EQ(ExampleFlags::E, *it);
+        ++it;
+        EXPECT_TRUE(it == end);
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, NextItemAfterLargestIn32BitFlagSet)
 {
-    enum class ThirtyTwoBitFlags : uint32_t {
-        A = 1UL << 31,
+    auto test = [] <ConcurrencyTag concurrency> () {
+        enum class ThirtyTwoBitFlags : uint32_t {
+            A = 1UL << 31,
+        };
+        using OptionSetType = OptionSet<ThirtyTwoBitFlags, concurrency>;
+        OptionSetType set { ThirtyTwoBitFlags::A };
+        typename OptionSetType::iterator it = set.begin();
+        typename OptionSetType::iterator end = set.end();
+        EXPECT_TRUE(it != end);
+        ++it;
+        EXPECT_TRUE(it == end);
     };
-    OptionSet<ThirtyTwoBitFlags> set { ThirtyTwoBitFlags::A };
-    OptionSet<ThirtyTwoBitFlags>::iterator it = set.begin();
-    OptionSet<ThirtyTwoBitFlags>::iterator end = set.end();
-    EXPECT_TRUE(it != end);
-    ++it;
-    EXPECT_TRUE(it == end);
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, NextItemAfterLargestIn64BitFlagSet)
 {
-    enum class SixtyFourBitFlags : uint64_t {
-        A = 1ULL << 63,
+    auto test = [] <ConcurrencyTag concurrency> () {
+        enum class SixtyFourBitFlags : uint64_t {
+            A = 1ULL << 63,
+        };
+        using OptionSetType = OptionSet<SixtyFourBitFlags, concurrency>;
+        OptionSetType set { SixtyFourBitFlags::A };
+        typename OptionSetType::iterator it = set.begin();
+        typename OptionSetType::iterator end = set.end();
+        EXPECT_TRUE(it != end);
+        ++it;
+        EXPECT_TRUE(it == end);
     };
-    OptionSet<SixtyFourBitFlags> set { SixtyFourBitFlags::A };
-    OptionSet<SixtyFourBitFlags>::iterator it = set.begin();
-    OptionSet<SixtyFourBitFlags>::iterator end = set.end();
-    EXPECT_TRUE(it != end);
-    ++it;
-    EXPECT_TRUE(it == end);
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, IterationOrderTheSameRegardlessOfInsertionOrder)
 {
-    OptionSet<ExampleFlags> set1 = ExampleFlags::C;
-    set1.add(ExampleFlags::A);
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set1 = ExampleFlags::C;
+        set1.add(ExampleFlags::A);
 
-    OptionSet<ExampleFlags> set2 = ExampleFlags::A;
-    set2.add(ExampleFlags::C);
+        OptionSetType set2 = ExampleFlags::A;
+        set2.add(ExampleFlags::C);
 
-    OptionSet<ExampleFlags>::iterator it1 = set1.begin();
-    OptionSet<ExampleFlags>::iterator it2 = set2.begin();
+        typename OptionSetType::iterator it1 = set1.begin();
+        typename OptionSetType::iterator it2 = set2.begin();
 
-    EXPECT_TRUE(*it1 == *it2);
-    ++it1;
-    ++it2;
-    EXPECT_TRUE(*it1 == *it2);
+        EXPECT_TRUE(*it1 == *it2);
+        ++it1;
+        ++it2;
+        EXPECT_TRUE(*it1 == *it2);
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, OperatorAnd)
 {
-    OptionSet<ExampleFlags> a { ExampleFlags::A };
-    OptionSet<ExampleFlags> ac { ExampleFlags::A, ExampleFlags::C };
-    OptionSet<ExampleFlags> bc { ExampleFlags::B, ExampleFlags::C };
-    {
-        auto set = a & ac;
-        EXPECT_TRUE(!!set);
-        EXPECT_FALSE(set.isEmpty());
-        EXPECT_TRUE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_FALSE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = a & bc;
-        EXPECT_FALSE(!!set);
-        EXPECT_TRUE(set.isEmpty());
-        EXPECT_FALSE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_FALSE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = ac & bc;
-        EXPECT_TRUE(!!set);
-        EXPECT_FALSE(set.isEmpty());
-        EXPECT_FALSE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_TRUE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = ExampleFlags::A & bc;
-        EXPECT_FALSE(!!set);
-        EXPECT_TRUE(set.isEmpty());
-        EXPECT_FALSE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_FALSE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = ExampleFlags::A & ac;
-        EXPECT_TRUE(!!set);
-        EXPECT_FALSE(set.isEmpty());
-        EXPECT_TRUE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_FALSE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = bc & ExampleFlags::A;
-        EXPECT_FALSE(!!set);
-        EXPECT_TRUE(set.isEmpty());
-        EXPECT_FALSE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_FALSE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = ac & ExampleFlags::A;
-        EXPECT_TRUE(!!set);
-        EXPECT_FALSE(set.isEmpty());
-        EXPECT_TRUE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_FALSE(set.contains(ExampleFlags::C));
-    }
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType a { ExampleFlags::A };
+        OptionSetType ac { ExampleFlags::A, ExampleFlags::C };
+        OptionSetType bc { ExampleFlags::B, ExampleFlags::C };
+        {
+            auto set = a & ac;
+            EXPECT_TRUE(!!set);
+            EXPECT_FALSE(set.isEmpty());
+            EXPECT_TRUE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_FALSE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = a & bc;
+            EXPECT_FALSE(!!set);
+            EXPECT_TRUE(set.isEmpty());
+            EXPECT_FALSE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_FALSE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = ac & bc;
+            EXPECT_TRUE(!!set);
+            EXPECT_FALSE(set.isEmpty());
+            EXPECT_FALSE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_TRUE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = ExampleFlags::A & bc;
+            EXPECT_FALSE(!!set);
+            EXPECT_TRUE(set.isEmpty());
+            EXPECT_FALSE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_FALSE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = ExampleFlags::A & ac;
+            EXPECT_TRUE(!!set);
+            EXPECT_FALSE(set.isEmpty());
+            EXPECT_TRUE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_FALSE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = bc & ExampleFlags::A;
+            EXPECT_FALSE(!!set);
+            EXPECT_TRUE(set.isEmpty());
+            EXPECT_FALSE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_FALSE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = ac & ExampleFlags::A;
+            EXPECT_TRUE(!!set);
+            EXPECT_FALSE(set.isEmpty());
+            EXPECT_TRUE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_FALSE(set.contains(ExampleFlags::C));
+        }
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, OperatorXor)
 {
-    OptionSet<ExampleFlags> a { ExampleFlags::A };
-    OptionSet<ExampleFlags> ac { ExampleFlags::A, ExampleFlags::C };
-    OptionSet<ExampleFlags> bc { ExampleFlags::B, ExampleFlags::C };
-    {
-        auto set = a ^ ac;
-        EXPECT_FALSE(set.contains(ExampleFlags::A));
-        EXPECT_FALSE(set.contains(ExampleFlags::B));
-        EXPECT_TRUE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = a ^ bc;
-        EXPECT_TRUE(set.contains(ExampleFlags::A));
-        EXPECT_TRUE(set.contains(ExampleFlags::B));
-        EXPECT_TRUE(set.contains(ExampleFlags::C));
-    }
-    {
-        auto set = ac ^ bc;
-        EXPECT_TRUE(set.contains(ExampleFlags::A));
-        EXPECT_TRUE(set.contains(ExampleFlags::B));
-        EXPECT_FALSE(set.contains(ExampleFlags::C));
-    }
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType a { ExampleFlags::A };
+        OptionSetType ac { ExampleFlags::A, ExampleFlags::C };
+        OptionSetType bc { ExampleFlags::B, ExampleFlags::C };
+        {
+            auto set = a ^ ac;
+            EXPECT_FALSE(set.contains(ExampleFlags::A));
+            EXPECT_FALSE(set.contains(ExampleFlags::B));
+            EXPECT_TRUE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = a ^ bc;
+            EXPECT_TRUE(set.contains(ExampleFlags::A));
+            EXPECT_TRUE(set.contains(ExampleFlags::B));
+            EXPECT_TRUE(set.contains(ExampleFlags::C));
+        }
+        {
+            auto set = ac ^ bc;
+            EXPECT_TRUE(set.contains(ExampleFlags::A));
+            EXPECT_TRUE(set.contains(ExampleFlags::B));
+            EXPECT_FALSE(set.contains(ExampleFlags::C));
+        }
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, ContainsAny)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B };
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::B };
 
-    EXPECT_TRUE(set.containsAny({ ExampleFlags::A }));
-    EXPECT_TRUE(set.containsAny({ ExampleFlags::B }));
-    EXPECT_FALSE(set.containsAny({ ExampleFlags::C }));
-    EXPECT_FALSE(set.containsAny({ ExampleFlags::C, ExampleFlags::D }));
-    EXPECT_TRUE(set.containsAny({ ExampleFlags::A, ExampleFlags::B }));
-    EXPECT_TRUE(set.containsAny({ ExampleFlags::B, ExampleFlags::C }));
-    EXPECT_TRUE(set.containsAny({ ExampleFlags::A, ExampleFlags::C }));
-    EXPECT_TRUE(set.containsAny({ ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+        EXPECT_TRUE(set.containsAny({ ExampleFlags::A }));
+        EXPECT_TRUE(set.containsAny({ ExampleFlags::B }));
+        EXPECT_FALSE(set.containsAny({ ExampleFlags::C }));
+        EXPECT_FALSE(set.containsAny({ ExampleFlags::C, ExampleFlags::D }));
+        EXPECT_TRUE(set.containsAny({ ExampleFlags::A, ExampleFlags::B }));
+        EXPECT_TRUE(set.containsAny({ ExampleFlags::B, ExampleFlags::C }));
+        EXPECT_TRUE(set.containsAny({ ExampleFlags::A, ExampleFlags::C }));
+        EXPECT_TRUE(set.containsAny({ ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, ContainsAll)
 {
-    OptionSet<ExampleFlags> set { ExampleFlags::A, ExampleFlags::B };
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        OptionSetType set { ExampleFlags::A, ExampleFlags::B };
 
-    EXPECT_TRUE(set.containsAll({ ExampleFlags::A }));
-    EXPECT_TRUE(set.containsAll({ ExampleFlags::B }));
-    EXPECT_FALSE(set.containsAll({ ExampleFlags::C }));
-    EXPECT_FALSE(set.containsAll({ ExampleFlags::C, ExampleFlags::D }));
-    EXPECT_TRUE(set.containsAll({ ExampleFlags::A, ExampleFlags::B }));
-    EXPECT_FALSE(set.containsAll({ ExampleFlags::B, ExampleFlags::C }));
-    EXPECT_FALSE(set.containsAll({ ExampleFlags::A, ExampleFlags::C }));
-    EXPECT_FALSE(set.containsAll({ ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+        EXPECT_TRUE(set.containsAll({ ExampleFlags::A }));
+        EXPECT_TRUE(set.containsAll({ ExampleFlags::B }));
+        EXPECT_FALSE(set.containsAll({ ExampleFlags::C }));
+        EXPECT_FALSE(set.containsAll({ ExampleFlags::C, ExampleFlags::D }));
+        EXPECT_TRUE(set.containsAll({ ExampleFlags::A, ExampleFlags::B }));
+        EXPECT_FALSE(set.containsAll({ ExampleFlags::B, ExampleFlags::C }));
+        EXPECT_FALSE(set.containsAll({ ExampleFlags::A, ExampleFlags::C }));
+        EXPECT_FALSE(set.containsAll({ ExampleFlags::A, ExampleFlags::B, ExampleFlags::C }));
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 TEST(WTF_OptionSet, HashSet)
 {
-    HashSet<OptionSet<ExampleFlags>> hashSet;
-    EXPECT_TRUE(hashSet.add(OptionSet<ExampleFlags>()).isNewEntry);
-    EXPECT_TRUE(hashSet.add({ ExampleFlags::A }).isNewEntry);
-    EXPECT_TRUE(hashSet.add({ ExampleFlags::A, ExampleFlags::B }).isNewEntry);
-    EXPECT_FALSE(hashSet.add(OptionSet<ExampleFlags>()).isNewEntry);
-    EXPECT_FALSE(hashSet.add({ ExampleFlags::A }).isNewEntry);
-    EXPECT_FALSE(hashSet.add({ ExampleFlags::A, ExampleFlags::B }).isNewEntry);
-    EXPECT_TRUE(hashSet.remove(OptionSet<ExampleFlags>()));
-    EXPECT_TRUE(hashSet.remove({ ExampleFlags::A }));
-    EXPECT_TRUE(hashSet.remove({ ExampleFlags::A, ExampleFlags::B }));
-    EXPECT_TRUE(hashSet.add(OptionSet<ExampleFlags>()).isNewEntry);
-    EXPECT_TRUE(hashSet.add({ ExampleFlags::A }).isNewEntry);
-    EXPECT_TRUE(hashSet.add({ ExampleFlags::A, ExampleFlags::B }).isNewEntry);
+    auto test = [] <ConcurrencyTag concurrency> () {
+        using OptionSetType = OptionSet<ExampleFlags, concurrency>;
+        HashSet<OptionSetType> hashSet;
+        EXPECT_TRUE(hashSet.add(OptionSetType()).isNewEntry);
+        EXPECT_TRUE(hashSet.add({ ExampleFlags::A }).isNewEntry);
+        EXPECT_TRUE(hashSet.add({ ExampleFlags::A, ExampleFlags::B }).isNewEntry);
+        EXPECT_FALSE(hashSet.add(OptionSetType()).isNewEntry);
+        EXPECT_FALSE(hashSet.add({ ExampleFlags::A }).isNewEntry);
+        EXPECT_FALSE(hashSet.add({ ExampleFlags::A, ExampleFlags::B }).isNewEntry);
+        EXPECT_TRUE(hashSet.remove(OptionSetType()));
+        EXPECT_TRUE(hashSet.remove({ ExampleFlags::A }));
+        EXPECT_TRUE(hashSet.remove({ ExampleFlags::A, ExampleFlags::B }));
+        EXPECT_TRUE(hashSet.add(OptionSetType()).isNewEntry);
+        EXPECT_TRUE(hashSet.add({ ExampleFlags::A }).isNewEntry);
+        EXPECT_TRUE(hashSet.add({ ExampleFlags::A, ExampleFlags::B }).isNewEntry);
+    };
+    test.operator()<ConcurrencyTag::None>();
+    test.operator()<ConcurrencyTag::Atomic>();
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 9ea05fa06f20960616a47235f58d08bb1fbdea55
<pre>
Make VM::setHasTerminationRequest() thread-safe.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298798">https://bugs.webkit.org/show_bug.cgi?id=298798</a>
<a href="https://rdar.apple.com/160494627">rdar://160494627</a>

Reviewed by Yijia Huang.

VM::setHasTerminationRequest() should be thread-safe but is not because it sets a bit on the
VM::m_entryScopeServices OptionSet, and the bit set operation is not atomic..

For the record, this is how the concurrent access works:
1. VM::m_entryScopeServices is normally set by the mutator thread running that VM.
2. However, the Worker.terminate() API can be used by the main thread to terminate worker threads.
    Worker.terminate() calls ...
        WorkerMessagingProxy::terminateWorkerGlobalScope(), which calls ...
            WorkerOrWorkletThread::stop(), which calls ...
                WorkerOrWorkletScriptController::scheduleExecutionTermination(), which calls ...
                    VM::notifyNeedTermination(), which calls ...
                        VM::setHasTerminationRequest(), which calls ...
                            VM::requestEntryScopeService(), and ...

VM::requestEntryScopeService() does bitwise OR of the EntryScopeService::ResetTerminationRequest bit
into the worker thread&apos;s VM::m_entryScopeServices.  This is not thread safe because it may collide with
the worker thread writing values into its VM::m_entryScopeServices.

We can fix this by moving the EntryScopeService::ResetTerminationRequest bit into a separate byte that
is safe to write to concurrently.  However, will go one step further and make a concurrent-safe
OptionSet and use that for storing the EntryScopeService::ResetTerminationRequest bit.  This way, we
can add more concurrent bits if needed.

In practice, the bug never manifests because it is extremely rare for VM::m_entryScopeServices to ever
be written to, and the impact is benign.  Regardless, we are fixing this.

Changes:
1. #define a CONCURRENT_SAFE macro in Compiler.h, and use it to annotate functions that we intend to
   be safe to call concurrently from other threads.  Currently, CONCURRENT_SAFE is just a documentation
   mechanism, and does not correspond to any compiler artifact.  In the future, if desired, we can
   add a verifier pass that ensures that CONCURRENT_SAFE functions can only call other CONCURRENT_SAFE
   functions, and such a verifier would have caught the bug in this commit.

2. Move EntryScopeService::ResetTerminationRequest into a separate enum class ConcurrentEntryScopeService.
   While EntryScopeService bits continue to be stored in VM::m_entryScopeServices,
   ConcurrentEntryScopeService bits will now be stored in a new VM::m_concurrentEntryScopeServices.

   Both VM::m_entryScopeServices and VM::m_concurrentEntryScopeServices are backed by storage in
   VM::m_entryScopeServicesRawBits.  This allows us to do a single null check on
   VM::m_entryScopeServicesRawBits to quickly determine if we have any &quot;services&quot; that we need to
   service (concurrent or otherwise).

3. Enhance WTF::OptionSet to be able to accept a ConcurrencyTag template parameter.  By default,
   if not explicitly specified, ConcurrencyTag::None will be used.  This results in OptionSet
   behaving exactly as it is today.

   However, we can now use OptionSet with ConcurrencyTag::Atomic, which will switch its operations
   to operate on the its m_storage in an atomic way.  This is done for add() and remove() where we
   add / remove bits to / from it m_storage word.

   We also enhance hasExactlyOneBitSet() and toSingleValue() so that they are not subject to TOCTOU
   issues which may cause their result to be internally inconsistent.  These functions need to read
   m_storage more than once.  So, the ConcurrencyTag::Atomic version needs to make a copy of
   m_storage and operate on that single copy that is not subject to concurrent edits.

   VM::m_concurrentEntryScopeServices is implemented using the ConcurrencyTag::Atomic variant of
   OptionSet.

TestWebKitAPI OptionSet tests has been updated to test the ConcurrencyTag::Atomic variant as well.
The VM entryScopeServices mechanism is covered by existing tests e.g. JSC&apos;s testapi.

* Source/JavaScriptCore/runtime/StackManager.cpp:
(JSC::StackManager::requestStop):
(JSC::StackManager::cancelStop):
* Source/JavaScriptCore/runtime/StackManager.h:
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::clearHasTerminationRequest):
(JSC::VM::setHasTerminationRequest):
(JSC::VM::hasAnyEntryScopeServiceRequest):
(JSC::VM::requestEntryScopeService):
(JSC::VM::entryScopeServices):
(JSC::VM::concurrentEntryScopeServices):
(JSC::VM::hasEntryScopeServiceRequest):
(JSC::VM::clearEntryScopeService):
(JSC::VM::notifyNeedDebuggerBreak):
(JSC::VM::notifyNeedShellTimeoutCheck):
(JSC::VM::notifyNeedTermination):
(JSC::VM::notifyNeedWatchdogCheck):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::cancelThreadStopIfNeeded):
(JSC::VMTraps::requestThreadStopIfNeeded):
* Source/JavaScriptCore/runtime/VMTraps.h:
(JSC::VMTraps::clearTrap):
(JSC::VMTraps::fireTrap):
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::add):
(WTF::OptionSet::remove):
(WTF::OptionSet::hasExactlyOneBitSet const):
(WTF::OptionSet::toSingleValue const):
(WTF::isValidOptionSet):
(WTF::ConstexprOptionSet::ConstexprOptionSet):
(WTF::ConstexprOptionSet::operator* const):
* Source/WTF/wtf/OptionSetHash.h:
(WTF::DefaultHash&lt;OptionSet&lt;T&gt;&gt;::hash): Deleted.
(WTF::DefaultHash&lt;OptionSet&lt;T&gt;&gt;::equal): Deleted.
(WTF::HashTraits&lt;OptionSet&lt;T&gt;&gt;::emptyValue): Deleted.
(WTF::HashTraits&lt;OptionSet&lt;T&gt;&gt;::constructDeletedValue): Deleted.
(WTF::HashTraits&lt;OptionSet&lt;T&gt;&gt;::isDeletedValue): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp:
(TestWebKitAPI::TEST(WTF_OptionSet, EmptySet)):
(TestWebKitAPI::TEST(WTF_OptionSet, ContainsOneFlag)):
(TestWebKitAPI::TEST(WTF_OptionSet, Equal)):
(TestWebKitAPI::TEST(WTF_OptionSet, NotEqual)):
(TestWebKitAPI::TEST(WTF_OptionSet, Or)):
(TestWebKitAPI::TEST(WTF_OptionSet, OrAssignment)):
(TestWebKitAPI::TEST(WTF_OptionSet, Minus)):
(TestWebKitAPI::TEST(WTF_OptionSet, AddAndRemove)):
(TestWebKitAPI::TEST(WTF_OptionSet, Set)):
(TestWebKitAPI::TEST(WTF_OptionSet, ContainsTwoFlags)):
(TestWebKitAPI::TEST(WTF_OptionSet, ContainsTwoFlags2)):
(TestWebKitAPI::TEST(WTF_OptionSet, ContainsTwoFlags3)):
(TestWebKitAPI::TEST(WTF_OptionSet, EmptyOptionSetToRawValueToOptionSet)):
(TestWebKitAPI::TEST(WTF_OptionSet, OptionSetThatContainsOneFlagToRawValueToOptionSet)):
(TestWebKitAPI::TEST(WTF_OptionSet, OptionSetThatContainsOneFlagToRawValueToOptionSet2)):
(TestWebKitAPI::TEST(WTF_OptionSet, OptionSetThatContainsTwoFlagsToRawValueToOptionSet)):
(TestWebKitAPI::TEST(WTF_OptionSet, OptionSetThatContainsTwoFlagsToRawValueToOptionSet2)):
(TestWebKitAPI::TEST(WTF_OptionSet, TwoIteratorsIntoSameOptionSet)):
(TestWebKitAPI::TEST(WTF_OptionSet, IterateOverOptionSetThatContainsTwoFlags)):
(TestWebKitAPI::TEST(WTF_OptionSet, IterateOverOptionSetThatContainsFlags2)):
(TestWebKitAPI::TEST(WTF_OptionSet, NextItemAfterLargestIn32BitFlagSet)):
(TestWebKitAPI::TEST(WTF_OptionSet, NextItemAfterLargestIn64BitFlagSet)):
(TestWebKitAPI::TEST(WTF_OptionSet, IterationOrderTheSameRegardlessOfInsertionOrder)):
(TestWebKitAPI::TEST(WTF_OptionSet, OperatorAnd)):
(TestWebKitAPI::TEST(WTF_OptionSet, OperatorXor)):
(TestWebKitAPI::TEST(WTF_OptionSet, ContainsAny)):
(TestWebKitAPI::TEST(WTF_OptionSet, ContainsAll)):
(TestWebKitAPI::TEST(WTF_OptionSet, HashSet)):

Canonical link: <a href="https://commits.webkit.org/300049@main">https://commits.webkit.org/300049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f96e2e6e63349ede5da181339b1f5777c94bae53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120769 "28 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72845 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62094eb1-4cdb-45a2-aba5-1ef711445c75) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91738 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60984 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43c123ae-c429-4d54-bbbb-f2046f70fdb3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/452a0cf1-fb00-4ed0-9c79-8b6a41661050) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70769 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112895 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130033 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119285 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36213 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100352 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100240 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44358 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19221 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47552 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53257 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149106 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47021 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149106 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->