### PR TITLE
[JSC] Do not take CalleeGroup lock for tiering up

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -129,30 +129,10 @@ void BBQPlan::work()
         if (context.pcToCodeOriginMap)
             NativeCalleeRegistry::singleton().addPCToCodeOriginMap(callee.ptr(), WTFMove(context.pcToCodeOriginMap));
 
-        // We want to make sure we publish our callee at the same time as we link our callsites. This enables us to ensure we
-        // always call the fastest code. Any function linked after us will see our new code and the new callsites, which they
-        // will update. It's also ok if they publish their code before we reset the instruction caches because after we release
-        // the lock our code is ready to be published too.
-        Locker locker { m_calleeGroup->m_lock };
-
-        m_calleeGroup->setBBQCallee(locker, m_functionIndex, callee.copyRef());
-        ASSERT(m_calleeGroup->replacement(locker, callee->index()) == callee.ptr());
-        m_calleeGroup->reportCallees(locker, callee.ptr(), function->outgoingJITDirectCallees);
-
-        for (auto& call : callee->wasmToWasmCallsites()) {
-            CodePtr<WasmEntryPtrTag> entrypoint;
-            if (call.functionIndexSpace < m_moduleInformation->importFunctionCount())
-                entrypoint = m_calleeGroup->m_wasmToWasmExitStubs[call.functionIndexSpace].code();
-            else {
-                Ref calleeCallee = m_calleeGroup->wasmEntrypointCalleeFromFunctionIndexSpace(locker, call.functionIndexSpace);
-                entrypoint = calleeCallee->entrypoint().retagged<WasmEntryPtrTag>();
-            }
-
-            MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
+        {
+            Locker locker { m_calleeGroup->m_lock };
+            m_calleeGroup->installOptimizedCallee(locker, m_moduleInformation, m_functionIndex, callee.copyRef(), function->outgoingJITDirectCallees);
         }
-
-        m_calleeGroup->updateCallsitesToCallUs(locker, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex);
-        WTF::storeStoreFence();
         {
             Locker locker { m_profiledCallee->tierUpCounter().m_lock };
             m_profiledCallee->tierUpCounter().setCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -117,15 +117,13 @@ static inline RefPtr<Wasm::JITCallee> jitCompileAndSetHeuristics(Wasm::IPIntCall
         case OSRFor::Prologue: {
             if (Options::useWasmIPInt()) [[likely]]
                 return nullptr;
-            Locker locker { calleeGroup.m_lock };
-            return calleeGroup.replacement(locker, callee.index());
+            return calleeGroup.tryGetReplacementConcurrently(callee.functionIndex());
         }
         case OSRFor::Epilogue: {
             return nullptr;
         }
         case OSRFor::Loop: {
-            Locker locker { calleeGroup.m_lock };
-            return calleeGroup.tryGetBBQCalleeForLoopOSR(locker, instance->vm(), callee.functionIndex());
+            return calleeGroup.tryGetBBQCalleeForLoopOSRConcurrently(instance->vm(), callee.functionIndex());
         }
         }
         RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 999f58f9729e3aa231845beb8e3f287efc60db99
<pre>
[JSC] Do not take CalleeGroup lock for tiering up
<a href="https://bugs.webkit.org/show_bug.cgi?id=298802">https://bugs.webkit.org/show_bug.cgi?id=298802</a>
<a href="https://rdar.apple.com/160499361">rdar://160499361</a>

Reviewed by Yijia Huang.

We are taking a lock to get a callee from CalleeGroup. This is weird
since the compiler can just publish it and we can read it concurrently.
The reason why we are doing so is,

1. Let&apos;s say, a new BBQCallee (OMGCallee) is compiled.
2. The new callee is linking its direct calls to the other callees. This
   includes call to itself! Thus, we need to register itself into
   CalleeGroup to allow looking up itself for recursion. However, this
   means that now CalleeGroup is having half-baked callee.
3. After (2), the callee is initialized now. But still instruction cache
   is not flushed, so we cannot use it yet.
4. We collect calls to this callee, and then flush the instruction cache.
   After that, this callee is usable.
5. Then we start liking the other callees&apos; calls to this newly compiled
   callee. So random code starts using this newly installed callee.
6. Now, the installation is done.

The problem is coming from (2). Because we install half-baked Callee
into CalleeGroup, if we read it concurrently and start using it, then we
will hit a crash since direct calls are not linked correctly yet.

Since only the problem of (2) is just installing itself to the
CalleeGroup in a half-baked state, let&apos;s have staging phase instead.

This patch adds m_currentlyInstallingOptimizedCallees and
m_currentlyInstallingOptimizedCalleesIndex. When linking direct calls,
we read this information and use this half-baked callee. However, when
reading CalleeGroup concurrently for tiering up, we ignore this staging
callee. This allows the main thread to peek compiled Callee concurrently
without taking CalleeGroup::m_lock, which has significant lock
contension.

We also introduce m_bbqCalleeLock to protect m_bbqCallee
ThreadSafeWeakOrStringPtr access since this pointer itself is not
thread-safe, we should protect it from concurrent access. But this lock
is per Callee, so it is not having lock contension. We take this lock
only when we need to access to ThreadSafeWeakOrStringPtr.

* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::tryGetReplacementConcurrently const):
(JSC::Wasm::CalleeGroup::tryGetBBQCalleeForLoopOSRConcurrently):
(JSC::Wasm::CalleeGroup::releaseBBQCallee):
(JSC::Wasm::CalleeGroup::tryGetOMGCalleeConcurrently):
(JSC::Wasm::CalleeGroup::startInstallingCallee):
(JSC::Wasm::CalleeGroup::finalizeInstallingCallee):
(JSC::Wasm::CalleeGroup::installOptimizedCallee):
(JSC::Wasm::CalleeGroup::updateCallsitesToCallUs):
(JSC::Wasm::CalleeGroup::calleeIsReferenced const):
(JSC::Wasm::CalleeGroup::ensureOptimizedCalleesSlow):
(JSC::Wasm::CalleeGroup::tryGetBBQCalleeForLoopOSR): Deleted.
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/299970@main">https://commits.webkit.org/299970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/599a4df11be63cfa4c417670b811a47af749367c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72889 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf055c3e-62fe-4aef-aece-c3ece96f5e9f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91761 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61008 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d87721f-1a36-483b-bd87-476b53ec8e56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72459 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09629bb5-8251-481d-87f1-0ae5fb3914a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26398 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70814 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112939 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130081 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119329 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100379 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100282 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44404 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19185 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53301 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149580 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47067 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149580 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48751 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->