### PR TITLE
[SVG2] Add `fetchPriority` property support for `SVGScriptElement`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/scripted/attr-script-fetchpriority-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/scripted/attr-script-fetchpriority-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL fetchpriority attribute on SVG <script> elements should reflect valid IDL values assert_equals: high fetchPriority is a valid IDL value on the script element expected (string) "high" but got (undefined) undefined
-FAIL default fetchpriority attribute on SVG <script> elements should be 'auto' assert_equals: expected (string) "auto" but got (undefined) undefined
+PASS fetchpriority attribute on SVG <script> elements should reflect valid IDL values
+PASS default fetchpriority attribute on SVG <script> elements should be 'auto'
 

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -25,7 +25,9 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "Event.h"
+#include "JSRequestPriority.h"
 #include "NodeInlines.h"
+#include "RequestPriority.h"
 #include "ScriptElement.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -117,6 +119,16 @@ void SVGScriptElement::dispatchErrorEvent()
 {
     setErrorOccurred(true);
     ScriptElement::dispatchErrorEvent();
+}
+
+String SVGScriptElement::fetchPriorityForBindings() const
+{
+    return convertEnumerationToString(fetchPriority());
+}
+
+RequestPriority SVGScriptElement::fetchPriority() const
+{
+    return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(SVGNames::fetchpriorityAttr)).value_or(RequestPriority::Auto);
 }
 
 }

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+enum class RequestPriority : uint8_t;
+
 class SVGScriptElement final : public SVGElement, public SVGURIReference, public ScriptElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGScriptElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGScriptElement);
@@ -40,6 +42,8 @@ public:
     using SVGElement::deref;
 
     bool async() const;
+    String fetchPriorityForBindings() const;
+    RequestPriority fetchPriority() const final;
 
 private:
     SVGScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);

--- a/Source/WebCore/svg/SVGScriptElement.idl
+++ b/Source/WebCore/svg/SVGScriptElement.idl
@@ -30,6 +30,7 @@
 ] interface SVGScriptElement : SVGElement {
     [Reflect] attribute DOMString type;
     [ReflectSetter] attribute boolean async;
+    [ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
 };
 
 SVGScriptElement includes SVGURIReference;

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -47,6 +47,7 @@ edgeMode
 elevation
 end
 exponent
+fetchpriority
 fill
 fill-opacity
 fill-rule


### PR DESCRIPTION
#### d3a9775b9f75036e08499daaee8c6efdd855d8d3
<pre>
[SVG2] Add `fetchPriority` property support for `SVGScriptElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298804">https://bugs.webkit.org/show_bug.cgi?id=298804</a>
<a href="https://rdar.apple.com/160503822">rdar://160503822</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox.

This patch aims to add `fetchPriority` to to &apos;SVGScriptElement&apos; interface.
Basically, we are extending `fetchPriority` from HTML counter-part to SVG.

* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::fetchPriorityForBindings const):
(WebCore::SVGScriptElement::fetchPriority const):
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGScriptElement.idl:
* Source/WebCore/svg/svgattrs.in:
* LayoutTests/imported/w3c/web-platform-tests/svg/scripted/attr-script-fetchpriority-expected.txt: Progression
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3a9775b9f75036e08499daaee8c6efdd855d8d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72796 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce41be93-751e-4032-ab19-ca813c2972be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91691 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60938 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c584d1b-091b-4c1b-b811-e6c1d6990621) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72239 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c6ae331-a50f-4da2-b281-27a8b76f81d0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26315 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70720 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129982 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100305 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100144 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44302 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47504 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53209 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46973 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48659 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->