### PR TITLE
Add a layout test for setting generic font families for SVG images

### DIFF
--- a/LayoutTests/svg/as-image/generic-font-expected.html
+++ b/LayoutTests/svg/as-image/generic-font-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<svg width="100px" height="100px">
+  <text font-size="20" x="0" y="20" fill="green" style="font-family:Ahem">Fail</text>
+  <text font-size="20" x="0" y="40" fill="green" style="font-family:Ahem">Fail</text>
+  <text font-size="20" x="0" y="60" fill="green" style="font-family:Ahem">Fail</text>
+  <text font-size="20" x="0" y="80" fill="green" style="font-family:Ahem">Fail</text>
+  <text font-size="20" x="0" y="100" fill="green" style="font-family:Ahem">Fail</text>
+</svg>

--- a/LayoutTests/svg/as-image/generic-font.html
+++ b/LayoutTests/svg/as-image/generic-font.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script>
+  if (window.internals) {
+      window.internals.settings.setStandardFontFamily("Ahem", "Zyyy");
+      window.internals.settings.setSerifFontFamily("Ahem", "Zyyy");
+      window.internals.settings.setFixedFontFamily("Ahem", "Zyyy");
+      window.internals.settings.setCursiveFontFamily("Ahem", "Zyyy");
+      window.internals.settings.setFantasyFontFamily("Ahem", "Zyyy");
+  }
+</script>
+<img src="resources/generic-font.svg">

--- a/LayoutTests/svg/as-image/resources/generic-font.svg
+++ b/LayoutTests/svg/as-image/resources/generic-font.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100px" height="100px">
+  <text font-size="20" x="0" y="20" fill="green" style="font-family:serif">Fail</text>
+  <text font-size="20" x="0" y="40" fill="green" style="font-family:san-serif">Fail</text>
+  <text font-size="20" x="0" y="60" fill="green" style="font-family:monospace">Fail</text>
+  <text font-size="20" x="0" y="80" fill="green" style="font-family:cursive">Fail</text>
+  <text font-size="20" x="0" y="100" fill="green" style="font-family:fantasy">Fail</text>
+</svg>


### PR DESCRIPTION
#### e92dbe46cdba65b33f31ec4e34db455d1c25055c
<pre>
Add a layout test for setting generic font families for SVG images
<a href="https://bugs.webkit.org/show_bug.cgi?id=20846">https://bugs.webkit.org/show_bug.cgi?id=20846</a>

Reviewed by NOBODY (OOPS!).

&lt;<a href="https://commits.webkit.org/287903@main">https://commits.webkit.org/287903@main</a>&gt; fixed the bug of generic font
family settings not propagating to SVG images, but no tests were
added. It can be tested with
internals.settings.setStandardFontFamily() and Ahem font.

* LayoutTests/svg/as-image/generic-font-expected.html: Added.
* LayoutTests/svg/as-image/generic-font.html: Added.
* LayoutTests/svg/as-image/resources/generic-font.svg: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e92dbe46cdba65b33f31ec4e34db455d1c25055c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72808 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91701 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60946 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123685 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32832 "Found 1 new test failure: svg/as-image/generic-font.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72249 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31861 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26321 "Found 1 new test failure: svg/as-image/generic-font.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70732 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102320 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26502 "Found 1 new test failure: svg/as-image/generic-font.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129994 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47654 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36180 "Found 1 new test failure: svg/as-image/generic-font.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100315 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48022 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104395 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100154 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45604 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23636 "Found 1 new test failure: svg/as-image/generic-font.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47516 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->