### PR TITLE
[WebGPU] https://playcanvas.vercel.app/#/graphics/reflection-box flickers on ToT

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_298796-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_298796-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: validation error
+CONSOLE MESSAGE: GPUComputePassEncoder.setBindGroup: dynamicBuffer(0): dynamicOffset(256) + buffer->bindingSize(4) > buffer->bufferSize(4)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_298796.html
+++ b/LayoutTests/fast/webgpu/regression/repro_298796.html
@@ -1,0 +1,56 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let storageBuffer = device.createBuffer({size: 260, usage: GPUBufferUsage.STORAGE});
+    let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.MAP_READ});
+    let code = `
+@group(0) @binding(0) var<storage, read_write> oob: u32;
+
+@compute @workgroup_size(1)
+fn c() {
+  oob = 11223344;
+}
+`;
+    let bindGroupLayout = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage', hasDynamicOffset: true}},
+      ],
+    });
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout, entries: [
+        {binding: 0, resource: {buffer: storageBuffer, size: 4, offset: 256}},
+      ],
+    });
+    let module = device.createShaderModule({code});
+    let pipeline = device.createComputePipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]}),
+      compute: {module},
+    });
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    computePassEncoder.setPipeline(pipeline);
+    computePassEncoder.setPipeline(pipeline);
+    computePassEncoder.setBindGroup(0, bindGroup0, [256]);
+    computePassEncoder.dispatchWorkgroups(1);
+    computePassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer.mapAsync(GPUMapMode.READ);
+    let outputU32 = new Uint32Array(outputBuffer.getMappedRange());
+    log(outputU32);
+    outputBuffer.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1083,8 +1083,10 @@ bool RenderPassEncoder::splitRenderPass()
         [m_renderCommandEncoder setStencilReferenceValue:*m_stencilReferenceValue];
     if (m_scissorRect)
         [m_renderCommandEncoder setScissorRect:*m_scissorRect];
-    if (RefPtr pipeline = m_pipeline)
+    if (RefPtr pipeline = m_pipeline) {
+        m_pipeline = nullptr;
         setPipeline(*pipeline);
+    }
     m_existingVertexBuffers.fill(ExistingBufferKey { });
     m_existingFragmentBuffers.fill(ExistingBufferKey { });
     m_bindGroupDynamicOffsetsChanged.fill(true);
@@ -1533,12 +1535,13 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
         return;
     }
 
+    if (m_pipeline.get() == &pipeline)
+        return;
+
     m_primitiveType = pipeline.primitiveType();
-    if (m_pipeline.get() != &pipeline) {
-        m_pipeline = pipeline;
-        m_bindGroupDynamicOffsetsChanged.fill(true);
-        m_maxDynamicOffsetAtIndex.fill(0);
-    }
+    m_pipeline = pipeline;
+    m_bindGroupDynamicOffsetsChanged.fill(true);
+    m_maxDynamicOffsetAtIndex.fill(0);
 
     m_vertexDynamicOffsets.fill(0, pipeline.pipelineLayout().sizeOfVertexDynamicOffsets());
     m_fragmentDynamicOffsets.fill(0, pipeline.pipelineLayout().sizeOfFragmentDynamicOffsets() + RenderBundleEncoder::startIndexForFragmentDynamicOffsets);


### PR DESCRIPTION
#### c1cb814aba2955ac1fe32995c6fe5591716ff2be
<pre>
[WebGPU] <a href="https://playcanvas.vercel.app/#/graphics/reflection-box">https://playcanvas.vercel.app/#/graphics/reflection-box</a> flickers on ToT
<a href="https://bugs.webkit.org/show_bug.cgi?id=298796">https://bugs.webkit.org/show_bug.cgi?id=298796</a>
<a href="https://rdar.apple.com/160493568">rdar://160493568</a>

Reviewed by Tadeu Zagallo.

setPipeline partially cleared dynamic offsets which led to artifacts.

Test: fast/webgpu/regression/repro_298796.html
* LayoutTests/fast/webgpu/regression/repro_298796-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_298796.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::splitRenderPass):
(WebGPU::RenderPassEncoder::setPipeline):

Canonical link: <a href="https://commits.webkit.org/300011@main">https://commits.webkit.org/300011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1695a5bc984d6ea0fcce6416091117bedc92593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72816 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6144dee8-49d0-4059-992c-69d11a4fc02f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91709 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60956 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6d0d8c5-84b3-4604-8be6-ad83e59773b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72257 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/953946e8-d695-4b4d-8cec-34204e140c88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26334 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70740 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130002 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100322 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25463 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44322 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53229 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46993 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50339 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->