### PR TITLE
Bucket input selectors by type

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -249,6 +249,11 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
         collectMatchingRulesForList(matchRequest.ruleSet.focusPseudoClassRules(), matchRequest);
     if (&element == element.document().documentElement())
         collectMatchingRulesForList(matchRequest.ruleSet.rootElementRules(), matchRequest);
+    if (element.hasLocalName(HTMLNames::inputTag->localName())) {
+        auto typeAttr = element.getAttribute(HTMLNames::typeAttr);
+        if (!typeAttr.isNull())
+            collectMatchingRulesForList(matchRequest.ruleSet.inputElementRules(typeAttr.convertToASCIILowercase()), matchRequest);
+    }
     collectMatchingRulesForList(matchRequest.ruleSet.tagRules(element.localName(), isHTML), matchRequest);
     collectMatchingRulesForList(matchRequest.ruleSet.universalRules(), matchRequest);
 }

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -111,6 +111,7 @@ public:
     const RuleDataVector& partPseudoElementRules() const { return m_partPseudoElementRules; }
     const RuleDataVector* focusPseudoClassRules() const { return &m_focusPseudoClassRules; }
     const RuleDataVector* rootElementRules() const { return &m_rootElementRules; }
+    const RuleDataVector* inputElementRules(const AtomString& type) const { return m_inputElementRules.get(type); }
     const RuleDataVector* universalRules() const { return &m_universalRules; }
 
     const Vector<StyleRulePage*>& pageRules() const { return m_pageRules; }
@@ -215,6 +216,7 @@ private:
     RuleDataVector m_partPseudoElementRules;
     RuleDataVector m_focusPseudoClassRules;
     RuleDataVector m_rootElementRules;
+    AtomRuleMap m_inputElementRules;
     RuleDataVector m_universalRules;
     Vector<StyleRulePage*> m_pageRules;
     RefPtr<StyleRuleViewTransition> m_viewTransitionRule;


### PR DESCRIPTION
#### f16aa87e2a341abc15a4982955923f6faef7854e
<pre>
Bucket input selectors by type
<a href="https://bugs.webkit.org/show_bug.cgi?id=298812">https://bugs.webkit.org/show_bug.cgi?id=298812</a>
<a href="https://rdar.apple.com/160418254">rdar://160418254</a>

Reviewed by NOBODY (OOPS!).

Put style rules for input elements into separate buckets by type.

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::ascii const):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::RuleSet::traverseRuleDatas):
(WebCore::Style::RuleSet::shrinkToFit):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::inputElementRules const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f16aa87e2a341abc15a4982955923f6faef7854e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122447 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42155 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32840 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74546 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124323 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42873 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50748 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61824 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125399 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/42873 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/32840 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73724 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/42873 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/32840 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72532 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/42873 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/32840 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131775 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49388 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/50748 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101616 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49762 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/32840 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101485 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/32840 "Hash f16aa87e for PR 50699 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46155 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49246 "Hash f16aa87e for PR 50699 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54992 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48713 "Hash f16aa87e for PR 50699 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52063 "Hash f16aa87e for PR 50699 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50395 "Hash f16aa87e for PR 50699 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->