### PR TITLE
[AutoFill Debugging] Make `WKTextExtractionLinkItem`'s URL nullable

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
@@ -458,13 +458,13 @@ extension WKTextExtractionEditable {
 extension WKTextExtractionLinkItem {
     let target: String
     @nonobjc
-    private let backingURL: NSURL
+    private let backingURL: NSURL?
 
-    var url: URL { backingURL as URL }
+    var url: URL? { backingURL as URL? }
 
     init(
         target: String,
-        url: URL,
+        url: URL?,
         rectInWebView: CGRect,
         children: [WKTextExtractionItem],
         eventListeners: WKTextExtractionEventListenerTypes,
@@ -473,7 +473,7 @@ extension WKTextExtractionLinkItem {
         nodeIdentifier: String?
     ) {
         self.target = target
-        self.backingURL = url as NSURL
+        self.backingURL = url as NSURL?
         super
             .init(
                 with: rectInWebView,
@@ -490,7 +490,10 @@ extension WKTextExtractionLinkItem {
         var parts = super.textRepresentationParts
 
         parts.insert("link", at: 0)
-        parts.append("url='\(url.absoluteString.escaped)'")
+
+        if let url {
+            parts.append("url='\(url.absoluteString.escaped)'")
+        }
 
         if !target.isEmpty {
             parts.append("target='\(target.escaped)'")

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -130,9 +130,9 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 @end
 
 @interface WKTextExtractionLinkItem : WKTextExtractionItem
-- (instancetype)initWithTarget:(NSString *)target url:(NSURL *)url rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
+- (instancetype)initWithTarget:(NSString *)target url:(nullable NSURL *)url rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *target;
-@property (nonatomic, readonly) NSURL *url;
+@property (nonatomic, readonly, nullable) NSURL *url;
 @end
 
 @interface WKTextExtractionContentEditableItem : WKTextExtractionItem


### PR DESCRIPTION
#### 7b161537db53ecf834a281a6c995aa7bfb826bb2
<pre>
[AutoFill Debugging] Make `WKTextExtractionLinkItem`&apos;s URL nullable
<a href="https://bugs.webkit.org/show_bug.cgi?id=298822">https://bugs.webkit.org/show_bug.cgi?id=298822</a>
<a href="https://rdar.apple.com/160535084">rdar://160535084</a>

Reviewed by Richard Robinson.

Make the `url` property on this object nullable, and exclude it from the text extraction if it&apos;s
`nil`. From code inspection, it should be possible for a non-empty `WTF::URL` to be passed into this
codepath which yields a `nil` `NSURL`. I discovered a single crash report underneath this codepath
while testing, but could not reproduce it on subsequent attempts.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(WKTextExtractionLinkItem.url):
(WKTextExtractionLinkItem.textRepresentationParts):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:

Canonical link: <a href="https://commits.webkit.org/299932@main">https://commits.webkit.org/299932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef61fafbd0dfdc6f098b7f3e49b8f0afde5e4c89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72862 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e42becf2-3ba3-43c6-afdd-34dec2927f7b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49057 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91747 "Found 1 new test failure: fullscreen/fullscreen-zero-height-element-with-non-zero-children.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60992 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de33e04a-2a51-4989-8a3c-b6ae6917df87) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72407 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/baafe122-89f6-4322-949c-d38042c0e15b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31904 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70787 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130054 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47707 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100364 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100257 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/25421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44376 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47569 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53274 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->