### PR TITLE
Do not store LazyNeverDestroyed objects as member variables

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -423,14 +423,14 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(CSSPropertyID propertyID)
     return adoptRef(*new CSSPrimitiveValue(propertyID));
 }
 
-static CSSPrimitiveValue* valueFromPool(std::span<LazyNeverDestroyed<CSSPrimitiveValue>> pool, double value)
+static CSSPrimitiveValue* valueFromPool(std::span<AlignedStorage<CSSPrimitiveValue>> pool, double value)
 {
     // Casting to a signed integer first since casting a negative floating point value to an unsigned
     // integer is undefined behavior.
     unsigned poolIndex = static_cast<unsigned>(static_cast<int>(value));
     double roundTripValue = poolIndex;
     if (equalSpans(asByteSpan(value), asByteSpan(roundTripValue)) && poolIndex < pool.size())
-        return &pool[poolIndex].get();
+        return pool[poolIndex].get();
     return nullptr;
 }
 

--- a/Source/WebCore/css/CSSValuePool.cpp
+++ b/Source/WebCore/css/CSSValuePool.cpp
@@ -37,20 +37,18 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValuePool);
 LazyNeverDestroyed<StaticCSSValuePool> staticCSSValuePool;
 
 StaticCSSValuePool::StaticCSSValuePool()
+    : m_implicitInitialValue(CSSValue::StaticCSSValue, CSSPrimitiveValue::ImplicitInitialValue)
+    , m_transparentColor(CSSValue::StaticCSSValue, WebCore::Color::transparentBlack)
+    , m_whiteColor(CSSValue::StaticCSSValue, WebCore::Color::white)
+    , m_blackColor(CSSValue::StaticCSSValue, WebCore::Color::black)
 {
-    m_implicitInitialValue.construct(CSSValue::StaticCSSValue, CSSPrimitiveValue::ImplicitInitialValue);
-    
-    m_transparentColor.construct(CSSValue::StaticCSSValue, WebCore::Color::transparentBlack);
-    m_whiteColor.construct(CSSValue::StaticCSSValue, WebCore::Color::white);
-    m_blackColor.construct(CSSValue::StaticCSSValue, WebCore::Color::black);
-
     for (auto keyword : allCSSValueKeywords())
-        m_identifierValues[enumToUnderlyingType(keyword)].construct(CSSValue::StaticCSSValue, keyword);
+        new (m_identifierValues[enumToUnderlyingType(keyword)].get()) CSSPrimitiveValue { CSSValue::StaticCSSValue, keyword };
 
     for (unsigned i = 0; i <= maximumCacheableIntegerValue; ++i) {
-        m_pixelValues[i].construct(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_PX);
-        m_percentageValues[i].construct(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_PERCENTAGE);
-        m_numberValues[i].construct(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_NUMBER);
+        new (m_pixelValues[i].get()) CSSPrimitiveValue(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_PX);
+        new (m_percentageValues[i].get()) CSSPrimitiveValue(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_PERCENTAGE);
+        new (m_numberValues[i].get()) CSSPrimitiveValue(CSSValue::StaticCSSValue, i, CSSUnitType::CSS_NUMBER);
     }
 }
 
@@ -76,12 +74,12 @@ Ref<CSSColorValue> CSSValuePool::createColorValue(const WebCore::Color& color)
 {
     // These are the empty and deleted values of the hash table.
     if (color == WebCore::Color::transparentBlack)
-        return staticCSSValuePool->m_transparentColor.get();
+        return staticCSSValuePool->m_transparentColor;
     if (color == WebCore::Color::white)
-        return staticCSSValuePool->m_whiteColor.get();
+        return staticCSSValuePool->m_whiteColor;
     // Just because it is common.
     if (color == WebCore::Color::black)
-        return staticCSSValuePool->m_blackColor.get();
+        return staticCSSValuePool->m_blackColor;
 
     // Remove one entry at random if the cache grows too large.
     // FIXME: Use TinyLRUCache instead?

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -48,18 +48,18 @@ public:
 private:
     StaticCSSValuePool();
 
-    LazyNeverDestroyed<CSSPrimitiveValue> m_implicitInitialValue;
+    CSSPrimitiveValue m_implicitInitialValue;
 
-    LazyNeverDestroyed<CSSColorValue> m_transparentColor;
-    LazyNeverDestroyed<CSSColorValue> m_whiteColor;
-    LazyNeverDestroyed<CSSColorValue> m_blackColor;
+    CSSColorValue m_transparentColor;
+    CSSColorValue m_whiteColor;
+    CSSColorValue m_blackColor;
 
     static constexpr int maximumCacheableIntegerValue = 255;
 
-    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_pixelValues;
-    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_percentageValues;
-    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_numberValues;
-    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, numCSSValueKeywords> m_identifierValues;
+    std::array<AlignedStorage<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_pixelValues;
+    std::array<AlignedStorage<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_percentageValues;
+    std::array<AlignedStorage<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_numberValues;
+    std::array<AlignedStorage<CSSPrimitiveValue>, numCSSValueKeywords> m_identifierValues;
 };
 
 WEBCORE_EXPORT extern LazyNeverDestroyed<StaticCSSValuePool> staticCSSValuePool;
@@ -85,13 +85,13 @@ private:
 
 inline CSSPrimitiveValue& CSSPrimitiveValue::implicitInitialValue()
 {
-    return staticCSSValuePool->m_implicitInitialValue.get();
+    return staticCSSValuePool->m_implicitInitialValue;
 }
 
 inline Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(CSSValueID identifier)
 {
     RELEASE_ASSERT(identifier < numCSSValueKeywords);
-    return staticCSSValuePool->m_identifierValues[identifier].get();
+    return *staticCSSValuePool->m_identifierValues[identifier];
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### d97070b32b34fea5771d017193cf3180efdd82b8
<pre>
Do not store LazyNeverDestroyed objects as member variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=298814">https://bugs.webkit.org/show_bug.cgi?id=298814</a>

Reviewed by Darin Adler.

Stop using LazyNeverDestroyed for member variables in StaticCSSValuePool.

This triggers undefined behavior in ASSERT_ENABLED builds, since the
&apos;m_isConstructed&apos; member of LazyNeverDestroyed&lt;T&gt; is not initialized
in that case. GCC 14 correctly warned about this, breaking the build
on e.g. Ubuntu 25.04, where GCC 14 is default.

The straightforward solution was to directly use AlignedStorage&lt;T&gt;
as type for the pool member variables instead of LazyNeverDestroyed&lt;T&gt;,
preserving the current performance characteristics (no dynamic
allocations, etc.). The &quot;canonical&quot; solution of using e.g.
Vector&lt;RefPtr&lt;CSSPrimitiveValue&gt;&gt; would re-introduce the memory
problems which were previously migitiated by introducing
std::array&lt;LazyNeverDestroyed&lt;...&gt;, capacity&gt; -- thus it is not
applicable here.

Covered by existing tests.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::valueFromPool):
* Source/WebCore/css/CSSValuePool.cpp:
(WebCore::StaticCSSValuePool::StaticCSSValuePool):
(WebCore::CSSValuePool::createColorValue):
* Source/WebCore/css/CSSValuePool.h:
(WebCore::CSSPrimitiveValue::implicitInitialValue):
(WebCore::CSSPrimitiveValue::create):

Canonical link: <a href="https://commits.webkit.org/299936@main">https://commits.webkit.org/299936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02e4fc198d3c50cc56459fb724f114db58b4d790

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91750 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60998 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72437 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26378 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130059 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100368 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100268 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25424 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44381 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53279 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->