### PR TITLE
[css-tables] Stop row collapsing from subtracting border spacing twice

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-group-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-group-001-expected.txt
@@ -13,7 +13,7 @@ row 3
 
 PASS row group visibility:collapse doesn't change table width
 FAIL row group visibility:collapse changes table height assert_equals: row group visibility:collapse changes table height expected 116 but got 328
-FAIL the first row should be collapsed assert_equals: the first row should be collapsed expected 0 but got 106
-FAIL the second row should be collapsed assert_equals: the second row should be collapsed expected 0 but got 106
+PASS the first row should be collapsed
+PASS the second row should be collapsed
 PASS the third row stays the same
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -562,7 +562,7 @@ layer at (0,0) size 785x2352
               RenderTableCell {TD} at (68,2) size 66x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 62x17
                   text run at (2,2) width 62: "C13 large"
-            RenderTableRow {TR} at (0,26) size 136x-2
+            RenderTableRow {TR} at (0,26) size 136x0
               RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x17
                   text run at (2,2) width 27: "C21"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -562,7 +562,7 @@ layer at (0,0) size 800x2563
               RenderTableCell {TD} at (67,2) size 67x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x19
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,28) size 136x-2
+            RenderTableRow {TR} at (0,28) size 136x0
               RenderTableCell {TD} at (2,15) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-11) size 27x19
                   text run at (2,2) width 27: "C21"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -562,7 +562,7 @@ layer at (0,0) size 785x2354
               RenderTableCell {TD} at (67,2) size 67x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x18
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,26) size 136x-2
+            RenderTableRow {TR} at (0,26) size 136x0
               RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C21"

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -159,6 +159,8 @@ void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldSty
     // In the collapsed border model, there is no cell spacing.
     m_hSpacing = collapseBorders() ? 0 : Style::evaluate(style().borderHorizontalSpacing());
     m_vSpacing = collapseBorders() ? 0 : Style::evaluate(style().borderVerticalSpacing());
+    ASSERT(m_hSpacing >= 0);
+    ASSERT(m_vSpacing >= 0);
 
     if (!m_tableLayout || style().isFixedTableLayout() != oldFixedTableLayout) {
         // According to the CSS2 spec, you only use fixed table layout if an explicit width is specified on the table. Auto width implies auto table layout.


### PR DESCRIPTION
#### 5a02340881d478e5c443896f50e372edb48ad074
<pre>
[css-tables] Stop row collapsing from subtracting border spacing twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=298828">https://bugs.webkit.org/show_bug.cgi?id=298828</a>
<a href="https://rdar.apple.com/160542118">rdar://160542118</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/a5f185d1c5985029f448f1f90dc633eb43196116">https://chromium.googlesource.com/chromium/src.git/+/a5f185d1c5985029f448f1f90dc633eb43196116</a>

A collapsed row would subtract border-spacing right away, then also
subtract it later when passing heights to %-height children.

Unlike Blink&apos;s approach, I added &apos;rowHasVisibilityCollapse&apos; as lambda,
in future, if we leverage it across other functions, we can change it
into helper function.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::styleDidChange):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::layoutRows):
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-group-001-expected.txt: Progressions

&gt; Rebaselines:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt:

Canonical link: <a href="https://commits.webkit.org/300023@main">https://commits.webkit.org/300023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c1d551af7be601621d88d268eedcdf5c45e106a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73160 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62fd2a9e-56dc-46e2-9078-70a975bc4062) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49354 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/634439be-ad05-4914-94b3-cd392b07349b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124031 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72654 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3c32a19-3f6b-4e43-84fe-d371b4aeadaf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32143 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71089 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102625 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/26818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130351 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36484 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48374 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/104703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100481 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25471 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/45884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44698 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53577 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50682 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49019 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->