### PR TITLE
[Smart Lists] Add support for parsing Smart List marker formats

### DIFF
--- a/Source/WTF/wtf/unicode/CharacterNames.h
+++ b/Source/WTF/wtf/unicode/CharacterNames.h
@@ -67,6 +67,7 @@ constexpr char16_t doublePrimeQuotationMark = 0x301E;
 constexpr char16_t emSpace = 0x2003;
 constexpr char32_t emojiCat = 0x1F408;
 constexpr char16_t emojiVariationSelector = 0xFE0F; // Technical name is "VARIATION SELECTOR-16"
+constexpr char16_t emDash = 0x2014;
 constexpr char16_t enDash = 0x2013;
 constexpr char16_t ethiopicPrefaceColon = 0x1366;
 constexpr char16_t ethiopicWordspace = 0x1361;
@@ -218,6 +219,7 @@ using WTF::Unicode::doublePrimeQuotationMark;
 using WTF::Unicode::emSpace;
 using WTF::Unicode::emojiCat;
 using WTF::Unicode::emojiVariationSelector;
+using WTF::Unicode::emDash;
 using WTF::Unicode::enDash;
 using WTF::Unicode::ethiopicPrefaceColon;
 using WTF::Unicode::ethiopicWordspace;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1990,18 +1990,40 @@ void Editor::toggleAutomaticSpellingCorrection()
         client()->toggleAutomaticSpellingCorrection();
 }
 
-bool Editor::isSmartListsEnabled()
-{
-    return client() && client()->isSmartListsEnabled();
-}
-
 void Editor::toggleSmartLists()
 {
+    Ref document = this->document();
+    RefPtr page = document->page();
+    if (!page || !page->isEditable())
+        return;
+
+    if (!document->settings().smartListsEnabled())
+        return;
+
     if (client())
         client()->toggleSmartLists();
 }
 
+#endif // USE(AUTOMATIC_TEXT_REPLACEMENT)
+
+#if PLATFORM(COCOA)
+bool Editor::isSmartListsEnabled()
+{
+    Ref document = this->document();
+    RefPtr page = document->page();
+    if (!page || !page->isEditable())
+        return false;
+
+    if (!document->settings().smartListsEnabled())
+        return false;
+
+#if PLATFORM(MAC)
+    return client() && client()->isSmartListsEnabled();
+#else
+    return true;
 #endif
+}
+#endif // PLATFORM(COCOA)
 
 bool Editor::shouldEndEditing(const SimpleRange& range)
 {

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -573,8 +573,11 @@ public:
     WEBCORE_EXPORT bool isAutomaticSpellingCorrectionEnabled();
     WEBCORE_EXPORT void toggleAutomaticSpellingCorrection();
     WEBCORE_EXPORT bool canEnableAutomaticSpellingCorrection() const;
-    WEBCORE_EXPORT bool isSmartListsEnabled();
     WEBCORE_EXPORT void toggleSmartLists();
+#endif
+
+#if PLATFORM(COCOA)
+    WEBCORE_EXPORT bool isSmartListsEnabled();
 #endif
 
     RefPtr<DocumentFragment> webContentFromPasteboard(Pasteboard&, const SimpleRange& context, bool allowPlainText, bool& chosePlainText);

--- a/Source/WebCore/editing/InsertTextCommand.h
+++ b/Source/WebCore/editing/InsertTextCommand.h
@@ -75,6 +75,8 @@ private:
     bool performOverwrite(const String&, bool selectInsertedText);
     void setEndingSelectionWithoutValidation(const Position& startPosition, const Position& endPosition);
 
+    bool applySmartListsIfNeeded();
+
     friend class TypingCommand;
 
     String m_text;

--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextListParser.h"
+
+#include <WebCore/CSSValueKeywords.h>
+#include <WebCore/FontAttributes.h>
+#include <span>
+#include <wtf/ASCIICType.h>
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/ParsingUtilities.h>
+#include <wtf/text/StringParsingBuffer.h>
+#include <wtf/unicode/CharacterNames.h>
+
+namespace WebCore {
+
+// MARK: Helpers
+
+template<typename Character>
+constexpr int consumeNumber(StringParsingBuffer<Character>& input)
+{
+    // Parse the digits until there is no more input left or a non-ASCII digit character has been encountered.
+    Checked<int> value;
+    do {
+        auto c = input.consume();
+        int digitValue = c - '0';
+        value = (value * 10) + digitValue;
+    } while (!input.atEnd() && WTF::isASCIIDigit(*input));
+
+    ASSERT(value.value() > 0);
+    return value.value();
+}
+
+template<typename Character>
+void skipToEnd(StringParsingBuffer<Character>& input)
+{
+    input.advanceBy(input.lengthRemaining());
+}
+
+// MARK: Primary consumers
+
+template<typename Character>
+std::optional<TextList> tryConsumeUnorderedDiscTextList(StringParsingBuffer<Character>& input)
+{
+    if (WTF::skipExactly(input, '*') ||  WTF::skipCharactersExactly(input, WTF::spanReinterpretCast<const Character>(WTF::span(WTF::Unicode::bullet)))) {
+        if (input.atEnd())
+            return { { { CSS::Keyword::Disc { } }, 0, false } };
+
+        skipToEnd(input);
+    }
+
+    return std::nullopt;
+}
+
+template<typename Character>
+std::optional<TextList> tryConsumeUnorderedDashTextList(StringParsingBuffer<Character>& input)
+{
+    static constexpr std::array marker { WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace };
+
+    if (WTF::skipExactly(input, WTF::Unicode::hyphenMinus)) {
+        if (input.atEnd())
+            return { { Style::ListStyleType { AtomString { std::span { marker } } }, 0, false } };
+
+        skipToEnd(input);
+    }
+
+    return std::nullopt;
+}
+
+template<typename Character>
+std::optional<TextList> tryConsumeOrderedDecimalTextList(StringParsingBuffer<Character>& input)
+{
+    // This algorithm is similar to the one in StringToIntegerConversion.h, but is stricter and simpler; specifically:
+    //
+    //   - only base 10 is allowed
+    //   - whitespace is not allowed anywhere
+    //   - the "-" and "+" signs are not allowed (which consequently restricts the output to non-negative values)
+    //   - prefixed "0"s are not allowed (which consequently restricts the output to non-zero values)
+    //   - "trailing junk" is only allowed if it is either "." or ")"
+
+    // Must start with an ASCII digit that is not 0.
+    if (input.atEnd() || !WTF::isASCIIDigit(*input) || *input == '0')
+        return std::nullopt;
+
+    auto start = consumeNumber(input);
+
+    // The format is valid iff there is a "." or a ")" immediately after the digits, and nothing afterwards.
+    if (WTF::skipExactly(input, '.') || WTF::skipExactly(input, ')')) {
+        if (input.atEnd())
+            return { { { CSS::Keyword::Decimal { } }, start, true } };
+
+        skipToEnd(input);
+    }
+
+    skipToEnd(input);
+    return std::nullopt;
+}
+
+template<typename Character>
+inline std::optional<TextList> consumeTextList(StringParsingBuffer<Character>& input)
+{
+    if (auto result = tryConsumeUnorderedDiscTextList(input))
+        return result;
+
+    if (auto result = tryConsumeUnorderedDashTextList(input))
+        return result;
+
+    if (auto result = tryConsumeOrderedDecimalTextList(input))
+        return result;
+
+    return std::nullopt;
+}
+
+// MARK: Entry point
+
+std::optional<TextList> parseTextList(StringView input)
+{
+    // The input is parsed to a TextList using these rules:
+    //
+    //  <U+002A | U+2022>EOF                        |= <U+2022>          (unordered, disc)
+    //  <U+2010>EOF                                 |= <U+2014  >        (unordered, dash)
+    //  <ordinal><U+002E | U+0029>EOF , ordinal > 0 |= <ordinal><U+002E> (ordered, start=ordinal)
+    //  otherwise                                   |= invalid
+
+    return WTF::readCharactersForParsing(input, [](auto buffer) -> std::optional<TextList> {
+        return consumeTextList(buffer);
+    });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/editing/TextListParser.h
+++ b/Source/WebCore/editing/TextListParser.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/text/StringView.h>
+
+namespace WebCore {
+
+struct TextList;
+
+std::optional<TextList> parseTextList(StringView);
+
+} // namespace WebCore

--- a/Source/WebCore/style/values/lists/StyleListStyleType.cpp
+++ b/Source/WebCore/style/values/lists/StyleListStyleType.cpp
@@ -29,6 +29,8 @@
 
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleValueTypes.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 namespace Style {
@@ -86,6 +88,11 @@ bool ListStyleType::isCircle() const
     return m_type == Type::CounterStyle && m_identifier == nameString(CSSValueCircle);
 }
 
+bool ListStyleType::isDecimal() const
+{
+    return m_type == Type::CounterStyle && m_identifier == nameString(CSSValueDecimal);
+}
+
 bool ListStyleType::isDisc() const
 {
     return m_type == Type::CounterStyle && m_identifier == nameString(CSSValueDisc);
@@ -113,6 +120,15 @@ auto CSSValueConversion<ListStyleType>::operator()(BuilderState& state, const CS
         return CounterStyle { { AtomString { primitiveValue->stringValue() } } };
 
     return AtomString { primitiveValue->stringValue() };
+}
+
+auto CSSValueCreation<ListStyleType>::operator()(CSSValuePool& pool, const RenderStyle& style, const ListStyleType& value) -> Ref<CSSValue>
+{
+    return WTF::switchOn(value,
+        [&](const CSS::Keyword::None& none) { return Style::createCSSValue(pool, style, none); }, // none
+        [&](const CounterStyle& counterStyle) { return Style::createCSSValue(pool, style, counterStyle.identifier); }, // custom-ident
+        [&](const AtomString& identifier) { return Style::createCSSValue(pool, style, identifier); } // string
+    );
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/lists/StyleListStyleType.h
+++ b/Source/WebCore/style/values/lists/StyleListStyleType.h
@@ -30,6 +30,7 @@
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/Variant.h>
 #include <wtf/text/AtomString.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -61,6 +62,11 @@ struct ListStyleType {
     {
     }
 
+    ListStyleType(CSS::Keyword::Decimal keyword)
+        : ListStyleType { CounterStyle { { nameString(keyword.value) } } }
+    {
+    }
+
     ListStyleType(CSS::Keyword::Disc keyword)
         : ListStyleType { CounterStyle { { nameString(keyword.value) } } }
     {
@@ -79,6 +85,7 @@ struct ListStyleType {
 
     bool isCircle() const;
     bool isDisc() const;
+    bool isDecimal() const;
     bool isSquare() const;
 
     std::optional<CounterStyle> tryCounterStyle() const
@@ -135,6 +142,8 @@ private:
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<ListStyleType> { auto operator()(BuilderState&, const CSSValue&) -> ListStyleType; };
+
+template<> struct CSSValueCreation<ListStyleType> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const ListStyleType&); };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -97,7 +97,7 @@ struct WKAppPrivacyReportTestingData {
 - (void)_didDismissContactPicker;
 - (void)_dismissContactPickerWithContacts:(NSArray *)contacts;
 
-- (void)_getRenderTreeAsStringWithCompletionHandler:(void(^)(NSString *, NSError *))callback WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_getRenderTreeAsStringWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSString * NS_NULLABLE_RESULT, NSError * _Nullable error))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic, setter=_setScrollingUpdatesDisabledForTesting:) BOOL _scrollingUpdatesDisabledForTesting;
 @property (nonatomic, readonly) NSString *_scrollingTreeAsText;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1309,9 +1309,6 @@ public:
     bool isSmartInsertDeleteEnabled();
     void setSmartInsertDeleteEnabled(bool);
 
-    bool isSmartListsEnabled();
-    void setSmartListsEnabled(bool);
-
     bool isWebTransportEnabled() const;
 
     bool isSelectTrailingWhitespaceEnabled() const;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -67,6 +67,9 @@
 		07C02FD22D6D6FBC0004ED97 /* rtl-sideways-scrolling.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07C02FD12D6D6FBC0004ED97 /* rtl-sideways-scrolling.html */; };
 		07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBufferTest.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
+		07DEB43E2E7900B100066C32 /* SmartListsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DEB43D2E7900B100066C32 /* SmartListsSupport.swift */; };
+		07DEB4492E7A030F00066C32 /* WebPage+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DEB4482E7A030F00066C32 /* WebPage+Extras.swift */; };
+		07DEB44A2E7A079400066C32 /* Foundation+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04492CF139BF00B453A6 /* Foundation+Extras.swift */; };
 		07DF05182E0531AD00007A1B /* WebPageNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DF05172E0531AD00007A1B /* WebPageNavigationTests.swift */; };
 		07E499911F9E56DF002F1EF3 /* GetUserMediaReprompt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E499901F9E56A1002F1EF3 /* GetUserMediaReprompt.mm */; };
 		07FAA74D2CE95E3200128360 /* WebPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74C2CE95E3200128360 /* WebPageTests.swift */; };
@@ -2435,6 +2438,9 @@
 		07CD32F52065B5420064A4BE /* AVFoundationPreference.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationPreference.mm; sourceTree = "<group>"; };
 		07CD32F72065B72A0064A4BE /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
 		07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetUserMediaNavigation.mm; sourceTree = "<group>"; };
+		07DEB43D2E7900B100066C32 /* SmartListsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartListsSupport.swift; sourceTree = "<group>"; };
+		07DEB4462E7906F800066C32 /* SmartListsSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SmartListsSupport.h; sourceTree = "<group>"; };
+		07DEB4482E7A030F00066C32 /* WebPage+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Extras.swift"; sourceTree = "<group>"; };
 		07DF05172E0531AD00007A1B /* WebPageNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageNavigationTests.swift; sourceTree = "<group>"; };
 		07E1F6A01FFC3A080096C7EC /* GetDisplayMedia.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetDisplayMedia.mm; sourceTree = "<group>"; };
 		07E1F6A11FFC44F90096C7EC /* getDisplayMedia.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = getDisplayMedia.html; path = ../WebKit/getDisplayMedia.html; sourceTree = "<group>"; };
@@ -4612,6 +4618,7 @@
 				7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */,
 				1C15498F2926F944001B9E5B /* WebExtensionUtilities.h */,
 				1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */,
+				07DEB4482E7A030F00066C32 /* WebPage+Extras.swift */,
 				FA8650312C7D01CA00117287 /* WebTransportServer.h */,
 				FA8650322C7D01CA00117287 /* WebTransportServer.mm */,
 				A14FC5841B89739100D107EB /* WKWebViewConfigurationExtras.h */,
@@ -4950,6 +4957,8 @@
 				5C29FE9128EE5F3D00D4FB00 /* SiteIsolation.mm */,
 				5C24A002294A75DD00463E2B /* SkipDecidePolicyForResponsePlugIn.mm */,
 				073310AD2E6E4E800048CF1E /* SmartLists.mm */,
+				07DEB4462E7906F800066C32 /* SmartListsSupport.h */,
+				07DEB43D2E7900B100066C32 /* SmartListsSupport.swift */,
 				2DFF7B6C1DA487AF00814614 /* SnapshotStore.mm */,
 				5774AA6721FBBF7800AF2A1B /* SOAuthorizationTests.mm */,
 				CD5F16612DBC652000CE85D9 /* SpatialAudioExperience.mm */,
@@ -7727,6 +7736,7 @@
 				95C52729275F35E100DA7E40 /* FontShadowTests.cpp in Sources */,
 				1CF59AE321E68932006E37EC /* ForceLightAppearanceInBundle.mm in Sources */,
 				7CCE7EF51A411AE600447C4C /* ForceRepaint.cpp in Sources */,
+				07DEB44A2E7A079400066C32 /* Foundation+Extras.swift in Sources */,
 				7CCE7EC01A411A7E00447C4C /* FragmentNavigation.mm in Sources */,
 				7CCE7EF61A411AE600447C4C /* FrameMIMETypeHTML.cpp in Sources */,
 				7CCE7EF71A411AE600447C4C /* FrameMIMETypePNG.cpp in Sources */,
@@ -7920,6 +7930,7 @@
 				7CCE7ECD1A411A7E00447C4C /* SimplifyMarkup.mm in Sources */,
 				C149D550242E98DF003EBB12 /* SleepDisabler.mm in Sources */,
 				073310B52E6E4EFC0048CF1E /* SmartLists.mm in Sources */,
+				07DEB43E2E7900B100066C32 /* SmartListsSupport.swift in Sources */,
 				0F4FFA9E1ED3AA8500F7111F /* SnapshotViaRenderInContext.mm in Sources */,
 				510A91F824D3622100BFD89C /* SonyDualShock3.mm in Sources */,
 				51EB126424CA6B66000CB030 /* SonyDualShock4.mm in Sources */,
@@ -8050,6 +8061,7 @@
 				7B7D096A2519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm in Sources */,
 				31E9BDA1247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm in Sources */,
 				7CCE7EAB1A411A2400447C4C /* WebKitAgnosticTest.mm in Sources */,
+				07DEB4492E7A030F00066C32 /* WebPage+Extras.swift in Sources */,
 				448110C2253F40300097FC33 /* WebPreferencesTest.mm in Sources */,
 				411223C726035FBF00B0A0B6 /* WebRTC.mm in Sources */,
 				536770341CC8022800D425B1 /* WebScriptObjectDescription.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/Foundation+Extras.swift
@@ -21,9 +21,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
-
 import Foundation
+
+#if compiler(>=6.2)
 
 extension RangeReplaceableCollection {
     init<Failure>(
@@ -47,4 +47,4 @@ extension AsyncSequence {
     }
 }
 
-#endif // ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+#endif // compiler(>=6.2)

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/TestWebKitAPIBundle-Bridging-Header.h
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/TestWebKitAPIBundle-Bridging-Header.h
@@ -24,4 +24,5 @@
  */
 
 #import "../../TestPDFDocument.h"
+#import "../WebKitCocoa/SmartListsSupport.h"
 #import <pal/spi/cg/CoreGraphicsSPI.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <wtf/Platform.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_UI_ACTOR
+@interface SmartListsTestResult : NSObject
+
+@property (nonatomic, readonly, nullable) NSString *expectedRenderTree;
+@property (nonatomic, readonly, nullable) NSString *actualRenderTree;
+
+@property (nonatomic, readonly, nullable) NSString *expectedHTML;
+@property (nonatomic, readonly, nullable) NSString *actualHTML;
+
+@end
+
+NS_SWIFT_UI_ACTOR
+@interface SmartListsTestSelectionConfiguration : NSObject
+
++ (SmartListsTestSelectionConfiguration *)caretSelectionWithPath:(NSString *)path offset:(NSInteger)offset;
+
+@end
+
+NS_SWIFT_UI_ACTOR
+@interface SmartListsTestConfiguration : NSObject
+
+- (instancetype)initWithExpectedHTML:(NSString *)expectedHTML expectedSelection:(SmartListsTestSelectionConfiguration *)expectedSelection input:(NSString *)input;
+
+@end
+
+NS_SWIFT_UI_ACTOR
+@interface SmartListsSupport : NSObject
+
++ (void)processConfiguration:(SmartListsTestConfiguration *)configuration completionHandler:(NS_SWIFT_UI_ACTOR void(^)(SmartListsTestResult * NS_NULLABLE_RESULT, NSError * _Nullable))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift
@@ -1,0 +1,146 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+import Foundation
+@_spi(Testing) import WebKit
+
+@objc
+@implementation
+extension SmartListsTestSelectionConfiguration {
+    fileprivate let path: String
+    fileprivate let offset: Int
+
+    private init(path: String, offset: Int) {
+        self.path = path
+        self.offset = offset
+    }
+
+    @objc(caretSelectionWithPath:offset:)
+    open class func caretSelection(withPath path: String, offset: Int) -> SmartListsTestSelectionConfiguration {
+        SmartListsTestSelectionConfiguration(path: path, offset: offset)
+    }
+}
+
+@objc
+@implementation
+extension SmartListsTestConfiguration {
+    fileprivate let expectedHTML: String
+    fileprivate let expectedSelection: SmartListsTestSelectionConfiguration
+    fileprivate let input: String
+
+    init(expectedHTML: String, expectedSelection: SmartListsTestSelectionConfiguration, input: String) {
+        self.expectedHTML = expectedHTML
+        self.expectedSelection = expectedSelection
+        self.input = input
+    }
+}
+
+@objc
+@implementation
+extension SmartListsTestResult {
+    open let expectedRenderTree: String?
+    open let actualRenderTree: String?
+    open let expectedHTML: String?
+    open let actualHTML: String?
+
+    fileprivate init(expectedRenderTree: String?, actualRenderTree: String?, expectedHTML: String?, actualHTML: String?) {
+        self.expectedRenderTree = expectedRenderTree
+        self.actualRenderTree = actualRenderTree
+        self.expectedHTML = expectedHTML
+        self.actualHTML = actualHTML
+    }
+}
+
+@objc
+@implementation
+extension SmartListsSupport {
+    @objc(processConfiguration:completionHandler:)
+    open class func processConfiguration(_ configuration: SmartListsTestConfiguration) async throws -> SmartListsTestResult {
+        let page = WebPage()
+
+        page.setWebFeature("SmartListsEnabled", enabled: true)
+        page.isEditable = true
+        page.smartListsEnabled = true
+
+        try await page.load(html: "<body></body>").wait()
+
+        try await page.callJavaScript("document.body.focus()")
+
+        for character in configuration.input {
+            await page.insertText("\(character)")
+        }
+
+        guard let actualHTML = try await page.callJavaScript("return document.body.outerHTML") as? String else {
+            fatalError()
+        }
+
+        let actualTree = try await page.renderTree()
+
+        let encoding = """
+            <head>
+              <meta charset="UTF-8">
+            </head>
+            """
+
+        let collapsedExpectedHTML = configuration.expectedHTML
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .joined()
+
+        let expectedHTMLWithEncoding = encoding + collapsedExpectedHTML
+
+        try await page.load(html: expectedHTMLWithEncoding).wait()
+
+        let setSelectionScript = """
+            const elementToPositionCaretAfter = document.evaluate(xPath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+
+            const range = document.createRange();
+            range.setStart(elementToPositionCaretAfter, offset);
+            range.setEnd(elementToPositionCaretAfter, offset);
+
+            let selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            """
+
+        try await page.callJavaScript(
+            setSelectionScript,
+            arguments: [
+                "xPath": configuration.expectedSelection.path,
+                "offset": configuration.expectedSelection.offset,
+            ]
+        )
+
+        let expectedTree = try await page.renderTree()
+
+        return .init(
+            expectedRenderTree: expectedTree,
+            actualRenderTree: actualTree,
+            expectedHTML: configuration.expectedHTML,
+            actualHTML: actualHTML
+        )
+    }
+}
+
+#endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/WebPage+Extras.swift
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+import Foundation
+@_spi(Testing) @_spi(CrossImportOverlay) import WebKit
+import WebKit_Private.WKPreferencesPrivate
+import WebKit_Private.WKWebViewPrivateForTesting
+
+extension WebPage {
+    func waitForNextPresentationUpdate() async {
+        await withCheckedContinuation { continuation in
+            backingWebView._do(afterNextPresentationUpdate: {
+                continuation.resume()
+            })
+        }
+    }
+
+    func setWebFeature(_ key: String, enabled: Bool) {
+        guard let feature = WKPreferences._features().first(where: { $0.key == key }) else {
+            fatalError()
+        }
+
+        backingWebView.configuration.preferences._setEnabled(enabled, for: feature)
+    }
+
+    func renderTree() async throws -> String {
+        try await backingWebView._getRenderTreeAsString()
+    }
+
+    func insertText(_ text: String) async {
+        backingWebView.insertText(text)
+        await waitForNextPresentationUpdate()
+    }
+}
+
+#endif // ENABLE_SWIFTUI


### PR DESCRIPTION
#### a03e91423aaffbc1ec753eccb1c7f973e6798177
<pre>
[Smart Lists] Add support for parsing Smart List marker formats
<a href="https://bugs.webkit.org/show_bug.cgi?id=298831">https://bugs.webkit.org/show_bug.cgi?id=298831</a>
<a href="https://rdar.apple.com/160544109">rdar://160544109</a>

Reviewed by Abrar Rahman Protyasha.

Add initial implementation support for Smart Lists, in particular the parser. From a high-level
perspective, this adds the following flow:

1. When an InsertTextCommand occurs, the command is intercepted by the Smart List logic if the
text is a space character (along with other conditions described in inline comments).

2. When this happens, the space character is not inputted. Instead, a TextList value is parsed
from the beginning of the current line up to the current position, which describes the list type,
start value, and style type.

3. The corresponding list element is then created and inserted, and the selection becomes inside of its list element child.

4. The appropriate style and attributes are set on the list element.

This is a simple implementation mainly to exercise the String -&gt; TextList parser (described below and in comments) and facilitate testing.

* Source/WTF/wtf/unicode/CharacterNames.h:

Add em-dash, used for dashed list markers.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::isSmartListsEnabled):
(WebCore::Editor::toggleSmartLists):

Add additionally guards to exit early if smart lists are unavailable by the system.

* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::setListStyleTypeProperty):

Apply the ListStyleType value as an inline property on the specified element by converting the ListStyleType to a Ref&lt;CSSValue&gt;.

(WebCore::InsertTextCommand::applySmartListsIfNeeded):

If the criteria is met, discard the current command and subtitute an InsertListCommand in its place, using the parsed TextList. Then, apply the relevant attributes and styles, and delete the selection to remove the marker token characters.

(WebCore::InsertTextCommand::doApply):

Skip the rest of the application of this command if a Smart List was applied.

* Source/WebCore/editing/InsertTextCommand.h:

Add deeclaration of private helper method.

* Source/WebCore/editing/TextListParser.cpp: Added.
(WebCore::consumeNumber):
(WebCore::tryConsumeUnorderedDiscTextList):
(WebCore::tryConsumeUnorderedDashTextList):
(WebCore::tryConsumeOrderedDecimalTextList):
(WebCore::consumeTextList):
(WebCore::parseTextList):
* Source/WebCore/editing/TextListParser.h: Added.

Implement a rudimentary parser that converts a String to a TextList. The algorithm is described inline.

* Source/WebCore/style/values/lists/StyleListStyleType.cpp:
(WebCore::Style::ListStyleType::isDecimal const):

Add an accessor function to determine if the counter style type is Decimal, like some other of the existing functions.

(WebCore::Style::CSSValueCreation&lt;ListStyleType&gt;::operator):

It is currently possible to convert a CSSValue to a ListStyleType, however the opposite was not possible.
This adds support for that using the standard CSSValueCreation pattern for better composition, by creating a CSSValue depending on the value of the list style type.

* Source/WebCore/style/values/lists/StyleListStyleType.h:
(WebCore::Style::ListStyleType::ListStyleType):

Add a convenience constructor for the decimal style, like some other of the constructors.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
(webViewWithMarkup):
(insertText):
(InputInstruction::InputInstruction):
(keyDataForKeyInstruction):
(runTest):
(TEST(SmartLists, InsertingSpaceAndTextAfterBulletPointGeneratesListWithText)):
(TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)):
(TEST(SmartLists, InsertingSpaceAfterBulletPointGeneratesEmptyList)):
(TEST(SmartLists, InsertingSpaceAfterBulletPointInMiddleOfSentenceDoesNotGenerateList)):
(TEST(SmartLists, InsertingSpaceAfterPeriodAtStartOfSentenceDoesNotGenerateList)):
(TEST(SmartLists, InsertingSpaceAfterNumberGeneratesOrderedList)):
(TEST(SmartLists, InsertingSpaceAfterMultipleDigitNumberGeneratesOrderedList)):
(TEST(SmartLists, InsertingSpaceAfterInvalidNumberDoesNotGenerateOrderedList)):
(TEST(SmartLists, InsertingListMergesWithPreviousListIfPossible)):

Tests. Lots of tests!

Canonical link: <a href="https://commits.webkit.org/300101@main">https://commits.webkit.org/300101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791b08c5a1161f8696a340a7a1ad1e3731befdba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121345 "23 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73426 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f2a702a-b076-4683-b4b4-b7de25b5883a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92173 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd9d80ae-f67a-40bb-9f8c-5b1aec7b212c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33334 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72850 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/675771a9-98b4-4660-b3e8-0596e3dc2b41) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71364 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113475 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130619 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119865 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100770 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100675 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24150 "Passed tests") | [💥 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44967 "An unexpected error occured. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48131 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53844 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150027 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47603 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38154 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->