### PR TITLE
Add WKWebpagePreferences SPI to allow JSHandle creation from the page world for a navigation

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -55,8 +55,8 @@ public:
     void setAllowAutofill() { m_allowAutofill = true; }
     bool allowAutofill() const { return m_allowAutofill; }
 
-    bool allowJSHandleCreation() const { return m_allowJSHandleCreation; }
-    void setAllowJSHandleCreation() { m_allowJSHandleCreation = true; }
+    bool allowsJSHandleCreation() const { return m_allowsJSHandleCreation; }
+    void setAllowsJSHandleCreation() { m_allowsJSHandleCreation = true; }
 
     void setAllowNodeSerialization() { m_allowNodeSerialization = true; }
     bool allowNodeSerialization() const { return m_allowNodeSerialization; }
@@ -107,7 +107,7 @@ private:
     bool m_shadowRootIsAlwaysOpen : 1 { false };
     bool m_closedShadowRootIsExposedForExtensions : 1 { false };
     bool m_shouldDisableLegacyOverrideBuiltInsBehavior : 1 { false };
-    bool m_allowJSHandleCreation : 1 { false };
+    bool m_allowsJSHandleCreation : 1 { false };
     bool m_allowNodeSerialization : 1 { false };
     bool m_allowPostLegacySynchronousMessage : 1 { false };
     bool m_isMediaControls : 1 { false };

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -62,7 +62,6 @@ public:
 
     static void destroy(JSC::JSCell*);
 
-public:
     Lock& gcLock() WTF_RETURNS_LOCK(m_gcLock) { return m_gcLock; }
 
     JSDOMStructureMap& structures() WTF_REQUIRES_LOCK(m_gcLock) { return m_structures; }
@@ -110,12 +109,13 @@ public:
     JSC::JSFunction* createCrossOriginFunction(JSC::JSGlobalObject*, JSC::PropertyName, JSC::NativeFunction, unsigned length);
     JSC::GetterSetter* createCrossOriginGetterSetter(JSC::JSGlobalObject*, JSC::PropertyName, JSC::GetValueFunc, JSC::PutValueFunc);
 
-public:
     ~JSDOMGlobalObject();
 
     static constexpr const JSC::ClassInfo* info() { return &s_info; }
 
     inline static JSC::Structure* createStructure(JSC::VM&, JSC::JSValue);
+
+    bool allowsJSHandleCreation() const;
 
 protected:
     JSDOMGlobalObject(JSC::VM&, JSC::Structure*, Ref<DOMWrapperWorld>&&, const JSC::GlobalObjectMethodTable* = nullptr);

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -222,7 +222,7 @@ bool JSDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGl
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
     RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(thisObject->wrapped());
-    if (propertyName == builtinNames(lexicalGlobalObject->vm()).webkitPublicName() && localDOMWindow && localDOMWindow->shouldHaveWebKitNamespaceForWorld(thisObject->world())) {
+    if (propertyName == builtinNames(lexicalGlobalObject->vm()).webkitPublicName() && localDOMWindow && localDOMWindow->shouldHaveWebKitNamespaceForWorld(thisObject->world(), lexicalGlobalObject)) {
         slot.setCacheableCustom(thisObject, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly, jsDOMWindow_webkit);
         return true;
     }

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2194,6 +2194,7 @@ sub NeedsRuntimeCheck
 
     return $context->extendedAttributes->{EnabledByDeprecatedGlobalSetting}
         || $context->extendedAttributes->{EnabledForContext}
+        || $context->extendedAttributes->{EnabledForGlobalObject}
         || $context->extendedAttributes->{EnabledForWorld}
         || $context->extendedAttributes->{EnabledBySetting}
         || $context->extendedAttributes->{EnabledByQuirk}
@@ -4378,6 +4379,14 @@ sub GenerateRuntimeEnableConditionalString
         AddToImplIncludes("DOMWrapperWorld.h");
 
         push(@conjuncts, "worldForDOMObject(*this)." . ToMethodName($context->extendedAttributes->{EnabledForWorld}) . "()");
+    }
+
+    if ($context->extendedAttributes->{EnabledForGlobalObject}) {
+        assert("Must specify value for EnabledForGlobalObject.") if $context->extendedAttributes->{EnabledForGlobalObject} eq "VALUE_IS_MISSING";
+
+        AddToImplIncludes("DOMWrapperWorld.h");
+
+        push(@conjuncts, "jsCast<JSDOMGlobalObject*>(this->globalObject())->" . ToMethodName($context->extendedAttributes->{EnabledForGlobalObject}) . "()");
     }
 
     if ($context->extendedAttributes->{EnabledBySetting}) {

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -191,6 +191,9 @@
         "EnabledForContext": {
             "contextsAllowed": ["attribute", "interface"]
         },
+        "EnabledForGlobalObject": {
+            "contextsAllowed": ["attribute", "operation", "interface"]
+        },
         "EnabledForWorld": {
             "contextsAllowed": ["attribute", "operation", "interface"],
             "values": ["*"],

--- a/Source/WebCore/bindings/scripts/preprocess-idls.pl
+++ b/Source/WebCore/bindings/scripts/preprocess-idls.pl
@@ -513,7 +513,7 @@ sub GenerateConstructorAttributes
     my $code = "    ";
     my @extendedAttributesList;
     foreach my $attributeName (sort keys %{$extendedAttributes}) {
-      next unless ($attributeName eq "Conditional" || $attributeName eq "EnabledByDeprecatedGlobalSetting" || $attributeName eq "EnabledForWorld"
+      next unless ($attributeName eq "Conditional" || $attributeName eq "EnabledByDeprecatedGlobalSetting" || $attributeName eq "EnabledForWorld" || $attributeName eq "EnabledForGlobalObject"
         || $attributeName eq "EnabledBySetting" || $attributeName eq "SecureContext" || $attributeName eq "PrivateIdentifier"
         || $attributeName eq "PublicIdentifier" || $attributeName eq "DisabledByQuirk" || $attributeName eq "EnabledByQuirk"
         || $attributeName eq "EnabledForContext") || $attributeName eq "LegacyFactoryFunctionEnabledBySetting";

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -382,6 +382,9 @@ public:
     void setAllowPrivacyProxy(bool allow) { m_allowPrivacyProxy = allow; }
     bool allowPrivacyProxy() const { return m_allowPrivacyProxy; }
 
+    void setAllowsJSHandleCreationInPageWorld(bool allow) { m_allowsJSHandleCreationInPageWorld = allow; }
+    bool allowsJSHandleCreationInPageWorld() const { return m_allowsJSHandleCreationInPageWorld; }
+
     void setCustomUserAgentAsSiteSpecificQuirks(String&& customUserAgent) { m_customUserAgentAsSiteSpecificQuirks = WTFMove(customUserAgent); }
     const String& customUserAgentAsSiteSpecificQuirks() const { return m_customUserAgentAsSiteSpecificQuirks; }
 
@@ -786,6 +789,7 @@ private:
     bool m_loadStartedDuringSwipeAnimation { false };
     bool m_lastNavigationWasAppInitiated { true };
     bool m_allowPrivacyProxy { true };
+    bool m_allowsJSHandleCreationInPageWorld : 1 { false };
 
     bool m_deferMainResourceDataLoad { true };
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -838,9 +838,12 @@ VisualViewport& LocalDOMWindow::visualViewport()
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
 
-bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world)
+bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world, JSC::JSGlobalObject* globalObject)
 {
-    if (world.allowJSHandleCreation() || world.allowNodeSerialization())
+    if (world.allowNodeSerialization())
+        return true;
+
+    if (jsCast<JSDOMGlobalObject*>(globalObject)->allowsJSHandleCreation())
         return true;
 
     RefPtr frame = this->frame();

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -350,7 +350,7 @@ public:
 #endif
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    bool shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld&);
+    bool shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld&, JSC::JSGlobalObject*);
     WebKitNamespace* webkitNamespace();
 #endif
 

--- a/Source/WebCore/page/WebKitJSHandle.idl
+++ b/Source/WebCore/page/WebKitJSHandle.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledForWorld=allowJSHandleCreation,
+    EnabledForGlobalObject=allowsJSHandleCreation,
     Exposed=Window,
     ExportMacro=WEBCORE_EXPORT
 ] interface WebKitJSHandle {

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -31,7 +31,7 @@
     Exposed=Window
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
-    [EnabledForWorld=allowJSHandleCreation, CallWith=CurrentGlobalObject] WebKitJSHandle jsHandle(object object);
+    [EnabledForGlobalObject=allowsJSHandleCreation, CallWith=CurrentGlobalObject] WebKitJSHandle jsHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
 };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -185,7 +185,6 @@ struct WebPageCreationParameters {
 
     bool useDarkAppearance { false };
     bool useElevatedUserInterfaceLevel { false };
-    bool allowJSHandleInPageContentWorld { false };
     bool allowPostingLegacySynchronousMessages { false };
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -107,7 +107,6 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     bool useDarkAppearance;
     bool useElevatedUserInterfaceLevel;
-    bool allowJSHandleInPageContentWorld;
     bool allowPostingLegacySynchronousMessages;
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -76,6 +76,7 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
 
     documentLoader.setAllowedAutoplayQuirks(quirks);
     documentLoader.setAutoplayPolicy(core(websitePolicies.autoplayPolicy));
+    documentLoader.setAllowsJSHandleCreationInPageWorld(websitePolicies.allowsJSHandleCreationInPageWorld);
 
     switch (websitePolicies.popUpPolicy) {
     case WebsitePopUpPolicy::Default:

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -88,6 +88,7 @@ public:
     bool allowPrivacyProxy { true };
     bool allowSiteSpecificQuirksToOverrideContentMode { false };
     bool allowSharedProcess { true };
+    bool allowsJSHandleCreationInPageWorld { false };
     WebsitePushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy { WebsitePushAndNotificationsEnabledPolicy::UseGlobalPolicy };
     WebsiteInlineMediaPlaybackPolicy inlineMediaPlaybackPolicy { WebsiteInlineMediaPlaybackPolicy::Default };
     WebCore::ResourceRequest alternateRequest;

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -89,6 +89,7 @@ struct WebKit::WebsitePoliciesData {
     bool allowPrivacyProxy;
     bool allowSiteSpecificQuirksToOverrideContentMode;
     bool allowSharedProcess;
+    bool allowsJSHandleCreationInPageWorld;
     WebKit::WebsitePushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy;
     WebKit::WebsiteInlineMediaPlaybackPolicy inlineMediaPlaybackPolicy;
     WebCore::ResourceRequest alternateRequest;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -367,16 +367,6 @@ bool PageConfiguration::lockdownModeEnabled() const
     return lockdownModeEnabledBySystem();
 }
 
-void PageConfiguration::setAllowJSHandleInPageContentWorld(bool allow)
-{
-    m_data.allowJSHandleInPageContentWorld = allow;
-}
-
-bool PageConfiguration::allowJSHandleInPageContentWorld() const
-{
-    return m_data.allowJSHandleInPageContentWorld;
-}
-
 void PageConfiguration::setAllowPostingLegacySynchronousMessages(bool allow)
 {
     m_data.allowPostingLegacySynchronousMessages = allow;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -456,9 +456,6 @@ public:
     void setDelaysWebProcessLaunchUntilFirstLoad(bool);
     bool delaysWebProcessLaunchUntilFirstLoad() const;
 
-    void setAllowJSHandleInPageContentWorld(bool);
-    bool allowJSHandleInPageContentWorld() const;
-
     void setAllowPostingLegacySynchronousMessages(bool);
     bool allowPostingLegacySynchronousMessages() const;
 
@@ -646,7 +643,6 @@ private:
         bool scrollToTextFragmentMarkingEnabled { true };
         bool showsSystemScreenTimeBlockingView { true };
         bool shouldSendConsoleLogsToUIProcessForTesting { false };
-        bool allowJSHandleInPageContentWorld { false };
         bool allowPostingLegacySynchronousMessages { false };
 
 #if PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -158,6 +158,9 @@ public:
     const WebCore::ResourceRequest& alternateRequest() const;
     void setAlternateRequest(WebCore::ResourceRequest&&);
 
+    bool allowsJSHandleCreationInPageWorld() const { return m_data.allowsJSHandleCreationInPageWorld; }
+    void setAllowsJSHandleCreationInPageWorld(bool allows) { m_data.allowsJSHandleCreationInPageWorld = allows; }
+
 private:
     WebKit::WebsitePoliciesData m_data;
     RefPtr<WebKit::WebsiteDataStore> m_websiteDataStore;

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -130,12 +130,12 @@ void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfi
     toProtectedImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
 }
 
-void WKPageConfigurationSetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration, bool allow)
+WKWebsitePoliciesRef WKPageConfigurationGetDefaultWebsitePolicies(WKPageConfigurationRef configuration)
 {
-    toProtectedImpl(configuration)->setAllowJSHandleInPageContentWorld(allow);
+    return toAPI(toProtectedImpl(configuration)->protectedDefaultWebsitePolicies().get());
 }
 
-bool WKPageConfigurationGetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration)
+void WKPageConfigurationSetDefaultWebsitePolicies(WKPageConfigurationRef configuration, WKWebsitePoliciesRef policies)
 {
-    return toProtectedImpl(configuration)->allowJSHandleInPageContentWorld();
+    toProtectedImpl(configuration)->setDefaultWebsitePolicies(toProtectedImpl(policies));
 }

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
@@ -55,6 +55,9 @@ WK_EXPORT void WKPageConfigurationSetRelatedPage(WKPageConfigurationRef configur
 WK_EXPORT WKWebsiteDataStoreRef WKPageConfigurationGetWebsiteDataStore(WKPageConfigurationRef configuration);
 WK_EXPORT void WKPageConfigurationSetWebsiteDataStore(WKPageConfigurationRef configuration, WKWebsiteDataStoreRef websiteDataStore);
 
+WK_EXPORT WKWebsitePoliciesRef WKPageConfigurationGetDefaultWebsitePolicies(WKPageConfigurationRef configuration);
+WK_EXPORT void WKPageConfigurationSetDefaultWebsitePolicies(WKPageConfigurationRef configuration, WKWebsitePoliciesRef policies);
+
 WK_EXPORT void WKPageConfigurationSetInitialCapitalizationEnabled(WKPageConfigurationRef configuration, bool enabled);
 WK_EXPORT void WKPageConfigurationSetBackgroundCPULimit(WKPageConfigurationRef configuration, double cpuLimit); // Terminates process if it uses more than CPU limit over an extended period of time while in the background.
 
@@ -62,9 +65,6 @@ WK_EXPORT void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef con
 WK_EXPORT void WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(WKPageConfigurationRef configuration, bool should);
 
 WK_EXPORT void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);
-
-WK_EXPORT void WKPageConfigurationSetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration, bool allow);
-WK_EXPORT bool WKPageConfigurationGetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
@@ -179,3 +179,13 @@ void WKWebsitePoliciesSetDataStore(WKWebsitePoliciesRef websitePolicies, WKWebsi
 {
     toProtectedImpl(websitePolicies)->setWebsiteDataStore(toProtectedImpl(websiteDataStore));
 }
+
+bool WKWebsitePoliciesGetAllowsJSHandleCreationInPageWorld(WKWebsitePoliciesRef websitePolicies)
+{
+    return toProtectedImpl(websitePolicies)->allowsJSHandleCreationInPageWorld();
+}
+
+void WKWebsitePoliciesSetAllowsJSHandleCreationInPageWorld(WKWebsitePoliciesRef websitePolicies, bool allows)
+{
+    toProtectedImpl(websitePolicies)->setAllowsJSHandleCreationInPageWorld(allows);
+}

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h
@@ -75,6 +75,9 @@ WK_EXPORT void WKWebsitePoliciesSetPopUpPolicy(WKWebsitePoliciesRef, enum WKWebs
 WK_EXPORT WKWebsiteDataStoreRef WKWebsitePoliciesGetDataStore(WKWebsitePoliciesRef);
 WK_EXPORT void WKWebsitePoliciesSetDataStore(WKWebsitePoliciesRef, WKWebsiteDataStoreRef);
 
+WK_EXPORT bool WKWebsitePoliciesGetAllowsJSHandleCreationInPageWorld(WKWebsitePoliciesRef);
+WK_EXPORT void WKWebsitePoliciesSetAllowsJSHandleCreationInPageWorld(WKWebsitePoliciesRef, bool);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -802,4 +802,15 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     return _websitePolicies->alternateRequest().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
 }
 
+
+- (void)_setAllowsJSHandleCreationInPageWorld:(BOOL)allows
+{
+    _websitePolicies->setAllowsJSHandleCreationInPageWorld(allows);
+}
+
+- (BOOL)_allowsJSHandleCreationInPageWorld
+{
+    return _websitePolicies->allowsJSHandleCreationInPageWorld();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -133,4 +133,6 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=_setAlternateRequest:) NSURLRequest *_alternateRequest WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+@property (nonatomic, setter=_setAllowsJSHandleCreationInPageWorld:) BOOL _allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12169,7 +12169,6 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.canUseCredentialStorage = m_canUseCredentialStorage;
 
     parameters.httpsUpgradeEnabled = preferences->upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
-    parameters.allowJSHandleInPageContentWorld = m_configuration->allowJSHandleInPageContentWorld();
     parameters.allowPostingLegacySynchronousMessages = m_configuration->allowPostingLegacySynchronousMessages();
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -123,7 +123,7 @@ void InjectedBundleScriptWorld::setAllowAutofill()
 
 void InjectedBundleScriptWorld::setAllowJSHandleCreation()
 {
-    m_world->setAllowJSHandleCreation();
+    m_world->setAllowsJSHandleCreation();
 }
 
 void InjectedBundleScriptWorld::setAllowNodeSerialization()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1179,8 +1179,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         page->setOpenedByDOM();
     }
 
-    if (parameters.allowJSHandleInPageContentWorld)
-        InjectedBundleScriptWorld::normalWorldSingleton().setAllowJSHandleCreation();
     if (parameters.allowPostingLegacySynchronousMessages)
         InjectedBundleScriptWorld::normalWorldSingleton().setAllowPostingLegacySynchronousMessages();
 }


### PR DESCRIPTION
#### faa2c01e654d1f7d5ebb35438a7df3bfcfb19a34
<pre>
Add WKWebpagePreferences SPI to allow JSHandle creation from the page world for a navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=298832">https://bugs.webkit.org/show_bug.cgi?id=298832</a>
<a href="https://rdar.apple.com/160546140">rdar://160546140</a>

Reviewed by Chris Dumez.

JSHandle creation is typically enabled for a WKContentWorld through _WKContentWorldConfiguration.allowJSHandleCreation.
WebKitTestRunner needed it in the page world, so it was using WKPageConfigurationSetAllowJSHandleInPageContentWorld.
However, we need to explore the possibility of using it for some navigations in the page content world but not for others.
This introduces such a way to do that as part of <a href="https://rdar.apple.com/160471423">rdar://160471423</a>.

To do so, we needed to introduce a new scope for bindings to be available in.  EnabledForWorld is either always on or always
off in a certain world.  EnabledForContext is either enabled for all worlds or no worlds.  For this we need something that
is on when the specific global object says it&apos;s on.  For worlds where it&apos;s on, it&apos;ll be always on.  For global objects
where it&apos;s on, it&apos;ll be on in that normal world.

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::allowsJSHandleCreation const):
(WebCore::DOMWrapperWorld::setAllowsJSHandleCreation):
(WebCore::DOMWrapperWorld::allowJSHandleCreation const): Deleted.
(WebCore::DOMWrapperWorld::setAllowJSHandleCreation): Deleted.
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::allowsJSHandleCreation const):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::getOwnPropertySlot):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(NeedsRuntimeCheck):
(GenerateRuntimeEnableConditionalString):
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/bindings/scripts/preprocess-idls.pl:
(GenerateConstructorAttributes):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::setAllowsJSHandleCreationInPageWorld):
(WebCore::DocumentLoader::allowsJSHandleCreationInPageWorld const):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/WebKitJSHandle.idl:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::setAllowJSHandleInPageContentWorld): Deleted.
(API::PageConfiguration::allowJSHandleInPageContentWorld const): Deleted.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting):
(WKPageConfigurationSetAllowJSHandleInPageContentWorld): Deleted.
(WKPageConfigurationGetAllowJSHandleInPageContentWorld): Deleted.
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h:
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp:
(WKWebsitePoliciesGetAllowsJSHandleCreationInPageWorld):
(WKWebsitePoliciesSetAllowsJSHandleCreationInPageWorld):
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setAllowsJSHandleCreationInPageWorld:]):
(-[WKWebpagePreferences _allowsJSHandleCreationInPageWorld]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::setAllowJSHandleCreation):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_toolbarsAreVisible):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm:
(TestWebKitAPI::TEST(JSHandle, WebpagePreferences)):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::generatePageConfiguration):

Canonical link: <a href="https://commits.webkit.org/300037@main">https://commits.webkit.org/300037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9cbd6d6bfbd07a060b60030c616f1805f5d27c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73071 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57c8561f-b980-48b1-885d-5437ddd2bc58) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91900 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61136 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/829cf3fe-5310-4301-a20a-91a8883c04b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72587 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00e19ac4-2c38-4a01-8819-2fb1216634c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70997 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130263 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100514 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100416 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23863 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44606 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19212 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53489 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47247 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->