### PR TITLE
Extra boundary events may fire when pointer capture released

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_sequence_at_implicit_release_on_click_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_sequence_at_implicit_release_on_click_mouse-expected.txt
@@ -6,5 +6,5 @@ Click or tap on Black.
 Click or tap on Green.
 
 PASS mouse Boundary events are emitted after lostpointercapture
-FAIL No extra events are emitted assert_equals: expected "" but got "pointerover, pointerenter, pointerout, pointerleave"
+PASS No extra events are emitted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_sequence_at_implicit_release_on_click_pen-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_sequence_at_implicit_release_on_click_pen-expected.txt
@@ -6,5 +6,5 @@ Click or tap on Black.
 Click or tap on Green.
 
 PASS pen Boundary events are emitted after lostpointercapture
-FAIL No extra events are emitted assert_equals: expected "" but got "pointerover, pointerenter, pointerout, pointerleave"
+PASS No extra events are emitted
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2876,8 +2876,12 @@ void EventHandler::pointerCaptureElementDidChange(Element* element)
     if (element && m_clickNode)
         m_clickCaptureElement = element;
 
-    // Now that we have a new capture element, we need to dispatch boundary mouse events.
-    updateMouseEventTargetNode(eventNames().gotpointercaptureEvent, element, m_lastPlatformMouseEvent, FireMouseOverOut::Yes);
+    // Since `updateMouseEventTargetNode` will dispatch boundary events, call it only when
+    // pointer capture is received. When capture is released, the PointerCaptureController
+    // already handles the appropriate boundary events (pointerout and pointerleave from
+    // the captured element).
+    if (element)
+        updateMouseEventTargetNode(eventNames().gotpointercaptureEvent, element, m_lastPlatformMouseEvent, FireMouseOverOut::Yes);
 }
 
 MouseEventWithHitTestResults EventHandler::prepareMouseEvent(const HitTestRequest& request, const PlatformMouseEvent& mouseEvent)


### PR DESCRIPTION
#### 3c69d0dd8ba0f144f14946792a8209d67712c0e8
<pre>
Extra boundary events may fire when pointer capture released
<a href="https://bugs.webkit.org/show_bug.cgi?id=274642">https://bugs.webkit.org/show_bug.cgi?id=274642</a>
<a href="https://rdar.apple.com/128669549">rdar://128669549</a>

Reviewed by Abrar Rahman Protyasha.

Since `EventHandler::updateMouseEventTargetNode` will dispatch boundary events, call it
in `EventHandler::pointerCaptureElementDidChange` only when pointer capture is received,
not released. When capture is released, the PointerCaptureController already handles the
appropriate boundary events.

This behavior is tested by
`imported/w3c/web-platform-tests/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html`.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_sequence_at_implicit_release_on_click_mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_sequence_at_implicit_release_on_click_pen-expected.txt:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::pointerCaptureElementDidChange):

Canonical link: <a href="https://commits.webkit.org/299977@main">https://commits.webkit.org/299977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2f58a3757f4c465197b4d41088cfc4475610c11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127254 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72922 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a5e77da-7cd6-4fc7-8236-74bb0963e8fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91783 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61033 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bf3c8ab-7979-4899-a384-82f7e66ed2ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72479 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/332cb157-ad45-4f59-9a50-7081585c8e56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26431 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70848 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130114 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100403 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100306 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44449 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47100 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->