### PR TITLE
[GStreamer] Fix various mediastream and pad probe buffer leaks reported by the GStreamer leak tracer

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -2065,4 +2065,14 @@ GstBuffer* gst_buffer_new_memdup(gconstpointer data, gsize size)
 }
 #endif
 
+#if !GST_CHECK_VERSION(1, 27, 0)
+void gst_pad_probe_info_set_buffer(GstPadProbeInfo* info, GstBuffer* buffer)
+{
+    g_return_if_fail(info->type & GST_PAD_PROBE_TYPE_BUFFER);
+
+    gst_clear_mini_object(&info->data);
+    info->data = buffer;
+}
+#endif
+
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -471,4 +471,8 @@ private:
 GstBuffer* gst_buffer_new_memdup(gconstpointer data, gsize size);
 #endif
 
+#if !GST_CHECK_VERSION(1, 27, 0)
+void gst_pad_probe_info_set_buffer(GstPadProbeInfo*, GstBuffer*);
+#endif
+
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -62,7 +62,7 @@ public:
 
     void addDevice(GRefPtr<GstDevice>&&);
 
-    void teardown();
+    virtual void teardown();
 
 protected:
     Vector<CaptureDevice> m_devices;
@@ -111,6 +111,12 @@ public:
     void deref() const final { }
 
     static VideoCaptureFactory& videoFactory();
+
+    void teardown() final
+    {
+        GStreamerCaptureDeviceManager::teardown();
+        m_pipewireCaptureDeviceManager = nullptr;
+    }
 
 private:
     GStreamerVideoCaptureDeviceManager();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -67,7 +67,7 @@ GStreamerCapturer::GStreamerCapturer(const PipeWireCaptureDevice& device)
 
 GStreamerCapturer::~GStreamerCapturer()
 {
-    tearDown();
+    tearDown(true);
 }
 
 void GStreamerCapturer::tearDown(bool disconnectSignals)
@@ -90,7 +90,9 @@ void GStreamerCapturer::tearDown(bool disconnectSignals)
     m_valve = nullptr;
     m_src = nullptr;
     m_capsfilter = nullptr;
+    m_sink = nullptr;
     m_pipeline = nullptr;
+    m_caps = nullptr;
 }
 
 GStreamerCapturerObserver::~GStreamerCapturerObserver()
@@ -212,7 +214,7 @@ GstElement* GStreamerCapturer::createSource()
             auto [rotation, isMirrored] = webkitGstBufferGetVideoRotation(buffer);
 
             auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), metadata, rotation, isMirrored);
-            GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer.leakRef();
+            gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
             return GST_PAD_PROBE_OK;
         }, nullptr, nullptr);
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -57,7 +57,7 @@ public:
     GStreamerCapturer(const PipeWireCaptureDevice&);
     virtual ~GStreamerCapturer();
 
-    void tearDown(bool disconnectSignals = true);
+    virtual void tearDown(bool disconnectSignals);
 
     void setDevice(std::optional<GStreamerCaptureDevice>&&);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -319,7 +319,7 @@ void GStreamerIncomingTrackProcessor::installRtpBufferPadProbe(const GRefPtr<Gst
         }
 
         auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), videoFrameTimeMetadata);
-        GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer.leakRef();
+        gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
         return GST_PAD_PROBE_OK;
     }, gst_caps_new_empty_simple("timestamp/x-ntp"), reinterpret_cast<GDestroyNotify>(gst_caps_unref));
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -39,6 +39,7 @@ public:
     GStreamerVideoCapturer(const PipeWireCaptureDevice&);
     ~GStreamerVideoCapturer() = default;
 
+    void tearDown(bool disconnectSignals) final;
     void setupPipeline() final;
     GstElement* createConverter() final;
     const char* name() final { return "Video"; }


### PR DESCRIPTION
#### 77738c8819ec805909deb441764c0a4a72309809
<pre>
[GStreamer] Fix various mediastream and pad probe buffer leaks reported by the GStreamer leak tracer
<a href="https://bugs.webkit.org/show_bug.cgi?id=298834">https://bugs.webkit.org/show_bug.cgi?id=298834</a>

Reviewed by Xabier Rodriguez-Calvar.

The most important leaks were in the buffer pad probes that modify buffers, the previous ones were
not un-reffed. The other leaks were about the pipewire device manager and several other GStreamer
objects not cleared before gst_deinit() was called.

Driving-by in the video capturer modify existing caps instead of doing copies.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(gst_pad_probe_info_set_buffer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(videoFrameMetadataGetInfo):
(webkitGstTraceProcessingTimeForElement):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::~GStreamerCapturer):
(WebCore::GStreamerCapturer::tearDown):
(WebCore::GStreamerCapturer::createSource):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::installRtpBufferPadProbe):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::tearDown):
(WebCore::GStreamerVideoCapturer::setSize):
(WebCore::GStreamerVideoCapturer::setFrameRate):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:

Canonical link: <a href="https://commits.webkit.org/299959@main">https://commits.webkit.org/299959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c54da52c24cb322d7021d8836f15cb7098553e78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120903 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91826 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26479 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130171 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100444 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100347 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25436 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45740 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44515 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53391 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->