### PR TITLE
[GStreamer][MediaStream] Minor refactorings and improvements

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
@@ -47,7 +47,8 @@ public:
     void setSinkAudioCallback(SinkAudioDataCallback&&);
 
 private:
-    std::pair<unsigned long, SinkAudioDataCallback> m_sinkAudioDataCallback;
+    void handleSample(GRefPtr<GstSample>&&);
+    std::pair<GStreamerCapturer::SinkSignalsHolder, SinkAudioDataCallback> m_sinkAudioDataCallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -247,11 +247,11 @@ void GStreamerCapturer::setupPipeline()
     registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(pipeline());
 
-    GRefPtr<GstElement> source = createSource();
-    GRefPtr<GstElement> converter = createConverter();
+    auto source = createSource();
+    auto converter = createConverter();
 
-    m_valve = makeElement("valve"_s);
-    m_capsfilter = makeElement("capsfilter"_s);
+    m_valve = gst_element_factory_make("valve", nullptr);
+    m_capsfilter = gst_element_factory_make("capsfilter", nullptr);
     auto queue = gst_element_factory_make("queue", nullptr);
     if (!m_sink)
         m_sink = makeElement("appsink"_s);
@@ -262,12 +262,12 @@ void GStreamerCapturer::setupPipeline()
     g_object_set(m_sink.get(), "enable-last-sample", FALSE, nullptr);
     g_object_set(m_capsfilter.get(), "caps", m_caps.get(), nullptr);
 
-    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), source.get(), m_capsfilter.get(), m_valve.get(), queue, m_sink.get(), nullptr);
-    auto tail = source.get();
+    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), source, m_capsfilter.get(), m_valve.get(), queue, m_sink.get(), nullptr);
+    auto tail = source;
     if (converter) {
-        gst_bin_add(GST_BIN_CAST(m_pipeline.get()), converter.get());
-        gst_element_link(source.get(), converter.get());
-        tail = converter.get();
+        gst_bin_add(GST_BIN_CAST(m_pipeline.get()), converter);
+        gst_element_link(source, converter);
+        tail = converter;
     }
     gst_element_link_many(tail, m_capsfilter.get(), m_valve.get(), queue, m_sink.get(), nullptr);
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -91,6 +91,11 @@ public:
 
     void stopDevice(bool disconnectSignals);
 
+    struct SinkSignalsHolder {
+        unsigned long prerollSignalId;
+        unsigned long newSampleSignalId;
+    };
+
 protected:
     GRefPtr<GstElement> m_sink;
     GRefPtr<GstElement> m_src;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -229,10 +229,13 @@ void GStreamerVideoCaptureSource::startProducingData()
 
     m_capturer->setFrameRate(frameRate());
     m_capturer->reconfigure();
-    m_capturer->setSinkVideoFrameCallback([this](auto&& videoFrame) {
-        if (!isProducingData() || muted())
+    m_capturer->setSinkVideoFrameCallback([weakThis = ThreadSafeWeakPtr(*this)](auto&& videoFrame) {
+        auto self = weakThis.get();
+        if (!self)
             return;
-        dispatchVideoFrameToObservers(WTFMove(videoFrame), { });
+        if (!self->isProducingData() || self->muted())
+            return;
+        self->dispatchVideoFrameToObservers(videoFrame, { });
     });
 
     m_capturer->start();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -48,6 +48,7 @@ public:
     void setSinkVideoFrameCallback(SinkVideoFrameCallback&&);
 
 private:
+    void handleSample(GRefPtr<GstSample>&&);
     bool setSize(const IntSize&);
     const IntSize& size() const { return m_size; }
 
@@ -57,7 +58,8 @@ private:
     bool isCapturingDisplay() const;
 
     GRefPtr<GstElement> m_videoSrcMIMETypeFilter;
-    std::pair<unsigned long, SinkVideoFrameCallback> m_sinkVideoFrameCallback;
+
+    std::pair<GStreamerCapturer::SinkSignalsHolder, SinkVideoFrameCallback> m_sinkVideoFrameCallback;
     IntSize m_size;
 };
 


### PR DESCRIPTION
#### 719b9aec51d327be818706d41b0f8647bf927f39
<pre>
[GStreamer][MediaStream] Minor refactorings and improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=298836">https://bugs.webkit.org/show_bug.cgi?id=298836</a>

Reviewed by Xabier Rodriguez-Calvar.

Most notably the audio/video capturers now relay the preroll samples to their observers.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::GStreamerAudioCapturer::handleSample):
(WebCore::GStreamerAudioCapturer::setSinkAudioCallback):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::setupPipeline):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::startProducingData):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::handleSample):
(WebCore::GStreamerVideoCapturer::setSinkVideoFrameCallback):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:

Canonical link: <a href="https://commits.webkit.org/300019@main">https://commits.webkit.org/300019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/962a977d2a1dfd8cddeb99ca5c9fe26d6f5ad93d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91771 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61019 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70825 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130091 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100390 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25469 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45674 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23720 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44420 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47606 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53311 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->