### PR TITLE
[css-conditional-5] container-names are tree-scoped

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
@@ -14,8 +14,8 @@ PASS A :host::part rule should match containers in the originating element tree
 PASS Container name set inside a shadow tree should match query using ::part on the outside
 PASS Container name set with a ::part should match query inside the shadow tree
 PASS Container name set inside a shadow tree should match query for a ::slotted() rule inside the tree
-FAIL Container name set inside a shadow tree should match query for host child on the outside assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Container name set inside a shadow tree should match query for host child on the outside
 PASS Container name set on :host from inside a shadow tree matching query inside the shadow tree
 PASS Container name set on :host from inside a shadow tree matching query for ::slotted inside the shadow tree
-FAIL Container name set on :host from inside a shadow tree should match query for slotted from the outside of the shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Container name set on :host from inside a shadow tree should match query for slotted from the outside of the shadow tree
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-name-tree-scoped-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-name-tree-scoped-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Outer scope query should match container-name set by :host rule in shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Outer scope query should match container-name set by :host rule in shadow tree
 FAIL Outer scope query should match container-name set by ::slotted rule in shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 PASS Inner scope query should match container-name set by :host rule in shadow tree
 PASS Inner scope query containing ::slotted should match container-name set by :host rule in shadow tree

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -163,8 +163,7 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requ
         if (scopeOrdinal >= ScopeOrdinal::FirstSlot && scopeOrdinal <= ScopeOrdinal::SlotLimit)
             return assignedSlotForScopeOrdinal(element, scopeOrdinal);
 
-        // Unnamed queries query the composed tree, while named queries do not.
-        if (scopeOrdinal == ScopeOrdinal::Element && element.assignedSlot() && name.isEmpty())
+        if (scopeOrdinal == ScopeOrdinal::Element && element.assignedSlot())
             return element.assignedSlot();
 
         return nullptr;


### PR DESCRIPTION
#### efd4ebe98cab2bbb385ffe1e1e40d3870917727b
<pre>
[css-conditional-5] container-names are tree-scoped
<a href="https://bugs.webkit.org/show_bug.cgi?id=298626">https://bugs.webkit.org/show_bug.cgi?id=298626</a>

Reviewed by Matthieu Dubet.

Removes the check for container name, which enables
all containers to be queried through the flat tree

Per CSSWG spec update here <a href="https://github.com/w3c/csswg-drafts/pull/12720/commits/c1e3a31a0bcb44bf22c3a32d28bcf24ca9b2b2b8">https://github.com/w3c/csswg-drafts/pull/12720/commits/c1e3a31a0bcb44bf22c3a32d28bcf24ca9b2b2b8</a>
and resolution here <a href="https://github.com/w3c/csswg-drafts/issues/12090#issuecomment-3204775586">https://github.com/w3c/csswg-drafts/issues/12090#issuecomment-3204775586</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-name-tree-scoped-expected.txt:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):

Canonical link: <a href="https://commits.webkit.org/300033@main">https://commits.webkit.org/300033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dff7803195b88b9156ac9c1b11ef483ec059158

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73194 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49388 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26668 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71124 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130385 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25476 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23965 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47898 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53611 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47369 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->