### PR TITLE
Address more Safer CPP warnings in platform/

### DIFF
--- a/Source/JavaScriptCore/API/tests/Regress141275.mm
+++ b/Source/JavaScriptCore/API/tests/Regress141275.mm
@@ -29,6 +29,7 @@
 #import <Foundation/Foundation.h>
 #import <objc/objc.h>
 #import <objc/runtime.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if JSC_OBJC_API_ENABLED
 
@@ -355,7 +356,7 @@ void runRegress141275()
 
         void (^showErrorIfNeeded)(NSError* error) = ^(NSError* error) {
             if (error) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(mainDispatchQueueSingleton(), ^{
                     NSLog(@"Error: %@", error);
                 });
             }
@@ -371,7 +372,7 @@ void runRegress141275()
             };
         } completion:^(NSError* error) {
             if (error) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(mainDispatchQueueSingleton(), ^{
                     NSLog(@"Error: %@", error);
                 });
             }

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -39,6 +39,7 @@
 #import <wtf/Assertions.h>
 #import <wtf/MainThread.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/WTFString.h>
@@ -115,7 +116,7 @@ RemoteInspector& RemoteInspector::singleton()
             if ([NSThread isMainThread])
                 shared->initialize();
             else {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(mainDispatchQueueSingleton(), ^{
                     shared->initialize();
                 });
             }

--- a/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
@@ -35,6 +35,7 @@
 #if PLATFORM(COCOA)
 #include <notify.h>
 #include <unistd.h>
+#include <wtf/darwin/DispatchExtras.h>
 #endif
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -109,7 +110,7 @@ void WasmOpcodeCounter::registerDispatch()
         dataLogF("<WASM.OP.STAT><%d> Use `notifyutil -v -p %s` to dump statistics.\n", pid, key);
 
         int token;
-        notify_register_dispatch(key, &token, dispatch_get_main_queue(), ^(int) {
+        notify_register_dispatch(key, &token, mainDispatchQueueSingleton(), ^(int) {
             WasmOpcodeCounter::singleton().dump();
         });
     });

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ARDAppClient.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ARDAppClient.m
@@ -199,7 +199,7 @@ static int const kKbpsMultiplier = 1000;
               [strongSelf.peerConnection
                   statisticsWithCompletionHandler:^(
                       RTC_OBJC_TYPE(RTCStatisticsReport) * stats) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
+                    dispatch_async(mainDispatchQueueSingleton(), ^{
                       ARDAppClient *strongerSelf = weakSelf;
                       [strongerSelf.delegate appClient:strongerSelf
                                            didGetStats:stats];
@@ -413,7 +413,7 @@ static int const kKbpsMultiplier = 1000;
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
     didChangeIceConnectionState:(RTCIceConnectionState)newState {
   RTCLog(@"ICE state changed: %ld", (long)newState);
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     [self.delegate appClient:self didChangeConnectionState:newState];
   });
 }
@@ -430,7 +430,7 @@ static int const kKbpsMultiplier = 1000;
 
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
     didGenerateIceCandidate:(RTC_OBJC_TYPE(RTCIceCandidate) *)candidate {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     ARDICECandidateMessage *message =
         [[ARDICECandidateMessage alloc] initWithCandidate:candidate];
     [self sendSignalingMessage:message];
@@ -453,7 +453,7 @@ static int const kKbpsMultiplier = 1000;
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
     didRemoveIceCandidates:
         (NSArray<RTC_OBJC_TYPE(RTCIceCandidate) *> *)candidates {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     ARDICECandidateRemovalMessage *message =
         [[ARDICECandidateRemovalMessage alloc]
             initWithRemovedCandidates:candidates];
@@ -480,7 +480,7 @@ static int const kKbpsMultiplier = 1000;
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
     didCreateSessionDescription:(RTC_OBJC_TYPE(RTCSessionDescription) *)sdp
                           error:(NSError *)error {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     if (error) {
       RTCLogError(@"Failed to create session description. Error: %@", error);
       [self disconnect];
@@ -511,7 +511,7 @@ static int const kKbpsMultiplier = 1000;
 
 - (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
     didSetSessionDescriptionWithError:(NSError *)error {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     if (error) {
       RTCLogError(@"Failed to set session description. Error: %@", error);
       [self disconnect];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ios/ARDVideoCallView.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ios/ARDVideoCallView.m
@@ -184,7 +184,7 @@ static CGFloat const kStatusBarHeight = 20;
   sender.enabled = false;
   [_delegate videoCallView:self
       shouldSwitchCameraWithCompletion:^(NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^(void) {
+        dispatch_async(mainDispatchQueueSingleton(), ^(void) {
           sender.enabled = true;
         });
       }];
@@ -197,7 +197,7 @@ static CGFloat const kStatusBarHeight = 20;
       shouldChangeRouteWithCompletion:^(void) {
         ARDVideoCallView *strongSelf = weakSelf;
         if (strongSelf) {
-          dispatch_async(dispatch_get_main_queue(), ^(void) {
+          dispatch_async(mainDispatchQueueSingleton(), ^(void) {
             sender.enabled = true;
           });
         }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ios/ARDVideoCallViewController.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ios/ARDVideoCallViewController.m
@@ -97,7 +97,7 @@
     didChangeConnectionState:(RTCIceConnectionState)state {
   RTCLog(@"ICE state changed: %ld", (long)state);
   __weak ARDVideoCallViewController *weakSelf = self;
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     ARDVideoCallViewController *strongSelf = weakSelf;
     strongSelf.videoCallView.statusLabel.text =
         [strongSelf statusTextForState:state];
@@ -136,7 +136,7 @@
         (RTC_OBJC_TYPE(RTCVideoTrack) *)remoteVideoTrack {
   self.remoteVideoTrack = remoteVideoTrack;
   __weak ARDVideoCallViewController *weakSelf = self;
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     ARDVideoCallViewController *strongSelf = weakSelf;
     strongSelf.videoCallView.statusLabel.hidden = YES;
   });

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/mac/APPRTCViewController.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/mac/APPRTCViewController.m
@@ -65,7 +65,7 @@ static NSUInteger const kBottomViewHeight = 200;
 @synthesize logView = _logView;
 
 - (void)displayLogMessage:(NSString*)message {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     self.logView.string =
         [NSString stringWithFormat:@"%@%@\n", self.logView.string, message];
     NSRange range = NSMakeRange(self.logView.string.length, 0);
@@ -388,7 +388,7 @@ static NSUInteger const kBottomViewHeight = 200;
 }
 
 - (void)showAlertWithMessage:(NSString*)message {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     NSAlert* alert = [[NSAlert alloc] init];
     [alert setMessageText:message];
     [alert runModal];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/third_party/SocketRocket/SRWebSocket.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/third_party/SocketRocket/SRWebSocket.m
@@ -331,7 +331,7 @@ static __strong NSData *CRLFCRLF;
     // Going to set a specific on the queue so we can validate we're on the work queue
     dispatch_queue_set_specific(_workQueue, (__bridge void *)self, maybe_bridge(_workQueue), NULL);
     
-    _delegateDispatchQueue = dispatch_get_main_queue();
+    _delegateDispatchQueue = mainDispatchQueueSingleton();
     sr_dispatch_retain(_delegateDispatchQueue);
     
     _readBuffer = [[NSMutableData alloc] init];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/capturer/RTCCameraVideoCapturer.m
@@ -159,7 +159,7 @@ const int64_t kNanosecondsPerSecond = 1000000000;
                       RTCLogInfo("startCaptureWithDevice %@ @ %ld fps", format, (long)fps);
 
 #if TARGET_OS_IPHONE
-                      dispatch_async(dispatch_get_main_queue(), ^{
+                      dispatch_async(mainDispatchQueueSingleton(), ^{
                         if (!self->_generatingOrientationNotifications) {
                           [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
                           self->_generatingOrientationNotifications = YES;
@@ -206,7 +206,7 @@ const int64_t kNanosecondsPerSecond = 1000000000;
                       [self.captureSession stopRunning];
 
 #if TARGET_OS_IPHONE
-                      dispatch_async(dispatch_get_main_queue(), ^{
+                      dispatch_async(mainDispatchQueueSingleton(), ^{
                         if (self->_generatingOrientationNotifications) {
                           [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
                           self->_generatingOrientationNotifications = NO;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/metal/RTCMTLNSVideoView.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/metal/RTCMTLNSVideoView.m
@@ -106,7 +106,7 @@
 
 - (void)setSize:(CGSize)size {
   _metalView.drawableSize = size;
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     [self.delegate videoView:self didChangeVideoSize:size];
   });
   [_metalView draw];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/metal/RTCMTLVideoView.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/metal/RTCMTLVideoView.m
@@ -240,7 +240,7 @@
 
 - (void)setSize:(CGSize)size {
   __weak RTCMTLVideoView *weakSelf = self;
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     RTCMTLVideoView *strongSelf = weakSelf;
 
     strongSelf.videoFrameSize = size;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/opengl/RTCEAGLVideoView.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/opengl/RTCEAGLVideoView.m
@@ -228,7 +228,7 @@
 // These methods may be called on non-main thread.
 - (void)setSize:(CGSize)size {
   __weak RTCEAGLVideoView *weakSelf = self;
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     RTCEAGLVideoView *strongSelf = weakSelf;
     [strongSelf.delegate videoView:strongSelf didChangeVideoSize:size];
   });

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/opengl/RTCNSGLVideoView.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/opengl/RTCNSGLVideoView.m
@@ -109,7 +109,7 @@ static CVReturn OnDisplayLinkFired(CVDisplayLinkRef displayLink,
 
 // These methods may be called on non-main thread.
 - (void)setSize:(CGSize)size {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     [self.delegate videoView:self didChangeVideoSize:size];
   });
 }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/helpers/RTCDispatcher.m
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/helpers/RTCDispatcher.m
@@ -49,7 +49,7 @@ static dispatch_queue_t kCaptureSessionQueue = nil;
 + (dispatch_queue_t)dispatchQueueForType:(RTCDispatcherQueueType)dispatchType {
   switch (dispatchType) {
     case RTCDispatcherTypeMain:
-      return dispatch_get_main_queue();
+      return mainDispatchQueueSingleton();
     case RTCDispatcherTypeCaptureSession:
       return kCaptureSessionQueue;
     case RTCDispatcherTypeAudioSession:

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/native/src/audio/audio_device_ios.mm
@@ -645,7 +645,7 @@ void AudioDeviceIOS::HandlePlayoutGlitchDetected() {
   RTCLog(@"Number of detected playout glitches: %lld", num_detected_playout_glitches_);
 
   int64_t glitch_count = num_detected_playout_glitches_;
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(mainDispatchQueueSingleton(), ^{
     RTCAudioSession* session = [RTCAudioSession sharedInstance];
     [session notifyDidDetectPlayoutGlitch:glitch_count];
   });

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		4448265228D18CA600D916F9 /* NotificationCenterCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916F9 /* NotificationCenterCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4606FEE62B1E901800D704F1 /* WeakRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		461229722ACF6B3100BB1CCC /* FastCharacterComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46335BED2E778B1300860373 /* DispatchExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46335BEC2E778B1300860373 /* DispatchExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		465005D82CD2840A00950C5F /* MallocSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 465005D72CD2840A00950C5F /* MallocSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1287,6 +1288,7 @@
 		4606FEE62B1E901800D704F1 /* WeakRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakRef.h; sourceTree = "<group>"; };
 		461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FastCharacterComparison.h; sourceTree = "<group>"; };
 		46209A27266D543A007F8F4A /* CancellableTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CancellableTask.h; sourceTree = "<group>"; };
+		46335BEC2E778B1300860373 /* DispatchExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DispatchExtras.h; sourceTree = "<group>"; };
 		463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleThreadIntegralWrapper.h; sourceTree = "<group>"; };
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
 		465005D72CD2840A00950C5F /* MallocSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MallocSpan.h; sourceTree = "<group>"; };
@@ -2133,6 +2135,7 @@
 		37C7CC281EA40A54007BD956 /* darwin */ = {
 			isa = PBXGroup;
 			children = (
+				46335BEC2E778B1300860373 /* DispatchExtras.h */,
 				6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */,
 				6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */,
 				53FC70CE23FB950C005B1990 /* OSLogPrintStream.h */,
@@ -3473,6 +3476,7 @@
 				DD3DC90627A4BF8E007E5B61 /* DeferrableRefCounted.h in Headers */,
 				DD3DC94B27A4BF8E007E5B61 /* Deque.h in Headers */,
 				E361DB68289115D000B2A2B8 /* digit_comparison.h in Headers */,
+				46335BED2E778B1300860373 /* DispatchExtras.h in Headers */,
 				DDF306E727C08654006A526F /* DispatchSPI.h in Headers */,
 				FFE39CB32B1D7472004972B0 /* div.h in Headers */,
 				DDF3079427C086CD006A526F /* diy-fp.h in Headers */,

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -31,6 +31,7 @@
 
 #if OS(DARWIN)
 #include <malloc/malloc.h>
+#include <wtf/darwin/DispatchExtras.h>
 #endif
 
 #if OS(WINDOWS)
@@ -407,7 +408,7 @@ MallocCallTracker& MallocCallTracker::singleton()
 MallocCallTracker::MallocCallTracker()
 {
     int token;
-    notify_register_dispatch("com.apple.WebKit.dumpUntrackedMallocs", &token, dispatch_get_main_queue(), ^(int) {
+    notify_register_dispatch("com.apple.WebKit.dumpUntrackedMallocs", &token, mainDispatchQueueSingleton(), ^(int) {
         MallocCallTracker::singleton().dumpStats();
     });
 }

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -35,6 +35,10 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RAMSize.h>
 
+#if PLATFORM(COCOA)
+#include <wtf/darwin/DispatchExtras.h>
+#endif
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE bool MemoryPressureHandler::ReliefLogger::s_loggingEnabled = false;
@@ -75,7 +79,7 @@ MemoryPressureHandler::MemoryPressureHandler()
 #endif
 {
 #if PLATFORM(COCOA)
-    setDispatchQueue(dispatch_get_main_queue());
+    setDispatchQueue(mainDispatchQueueSingleton());
 #endif
 }
 

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/cocoa/SpanCocoa.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 namespace WTF {
 
@@ -114,7 +115,7 @@ inline RetainPtr<dispatch_data_t> makeDispatchData(Vector<T>&& vector)
 {
     auto buffer = vector.releaseBuffer();
     auto span = buffer.span();
-    return adoptNS(dispatch_data_create(span.data(), span.size_bytes(), dispatch_get_main_queue(), makeBlockPtr([buffer = WTFMove(buffer)] { }).get()));
+    return adoptNS(dispatch_data_create(span.data(), span.size_bytes(), mainDispatchQueueSingleton(), makeBlockPtr([buffer = WTFMove(buffer)] { }).get()));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -28,6 +28,7 @@
 
 #include <wtf/BlockPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 namespace WTF {
 
@@ -97,7 +98,7 @@ void WorkQueueBase::platformInvalidate()
 }
 
 WorkQueue::WorkQueue(MainTag)
-    : WorkQueueBase(dispatch_get_main_queue())
+    : WorkQueueBase(mainDispatchQueueSingleton())
 {
 }
 

--- a/Source/WTF/wtf/darwin/DispatchExtras.h
+++ b/Source/WTF/wtf/darwin/DispatchExtras.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
+#pragma once
 
-#import <WebKit/WKWebProcessPlugIn.h>
-#import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
-#import <wtf/RetainPtr.h>
-#import <wtf/darwin/DispatchExtras.h>
+#include <dispatch/dispatch.h>
 
-@interface BundleRetainPagePlugIn : NSObject <WKWebProcessPlugIn>
-@end
+namespace WTF {
 
-@implementation BundleRetainPagePlugIn
-
-- (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
+inline dispatch_queue_main_t mainDispatchQueueSingleton()
 {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), mainDispatchQueueSingleton(), [retainedPage = retainPtr(browserContextController)] { });
-
-    // Instantiate a _WKRemoteObjectRegistry to test that its existence does not conflict with the existence
-    // of the _WKRemoteObjectRegistry from the other WebPage that will be in this process.
-    [browserContextController _remoteObjectRegistry];
+    return dispatch_get_main_queue(); // NOLINT
 }
 
-@end
+} // namespace WTF
+
+using WTF::mainDispatchQueueSingleton;

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm
@@ -115,7 +115,7 @@ Ref<SceneKitModelLoader> loadSceneKitModel(Model& modelSource, SceneKitModelLoad
         NSURLErrorFailingURLErrorKey: modelSource.url().createNSURL().get()
     }]);
 
-    dispatch_async(dispatch_get_main_queue(), [weakClient = WeakPtr { client }, loader] {
+    dispatch_async(mainDispatchQueueSingleton(), [weakClient = WeakPtr { client }, loader] {
         auto strongClient = weakClient.get();
         if (!strongClient)
             return;

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
@@ -116,7 +116,7 @@ Ref<SceneKitModelLoader> loadSceneKitModelUsingUSDLoader(Model& modelSource, Sce
 {
     auto loader = SceneKitModelLoaderUSD::create();
     
-    dispatch_async(dispatch_get_main_queue(), [weakClient = WeakPtr { client }, loader, modelSource = Ref { modelSource }] () mutable {
+    dispatch_async(mainDispatchQueueSingleton(), [weakClient = WeakPtr { client }, loader, modelSource = Ref { modelSource }] () mutable {
         // If the client has gone away, there is no reason to do any work.
         auto strongClient = weakClient.get();
         if (!strongClient)

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
@@ -155,7 +155,7 @@ void SceneKitModelPlayer::setIsMuted(bool, CompletionHandler<void(bool success)>
 
 void SceneKitModelPlayer::didFinishLoading(SceneKitModelLoader& loader, Ref<SceneKitModel> model)
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
     ASSERT_UNUSED(loader, &loader == m_loader.get());
 
     m_loader = nullptr;
@@ -169,7 +169,7 @@ void SceneKitModelPlayer::didFinishLoading(SceneKitModelLoader& loader, Ref<Scen
 
 void SceneKitModelPlayer::didFailLoading(SceneKitModelLoader& loader, const ResourceError& error)
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
     ASSERT_UNUSED(loader, &loader == m_loader.get());
 
     m_loader = nullptr;

--- a/Source/WebCore/PAL/pal/Logging.cpp
+++ b/Source/WebCore/PAL/pal/Logging.cpp
@@ -31,6 +31,7 @@
 #if PLATFORM(COCOA)
 #include <notify.h>
 #include <wtf/BlockPtr.h>
+#include <wtf/darwin/DispatchExtras.h>
 #endif
 
 namespace PAL {
@@ -39,7 +40,7 @@ void registerNotifyCallback(ASCIILiteral notifyID, Function<void()>&& callback)
 {
 #if PLATFORM(COCOA)
     int token;
-    notify_register_dispatch(notifyID.characters(), &token, dispatch_get_main_queue(), makeBlockPtr([callback = WTFMove(callback)](int) {
+    notify_register_dispatch(notifyID.characters(), &token, mainDispatchQueueSingleton(), makeBlockPtr([callback = WTFMove(callback)](int) {
         callback();
     }).get());
 #else

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -658,7 +658,6 @@ platform/Widget.cpp
 platform/animation/AcceleratedEffectValues.cpp
 platform/animation/Animation.cpp
 platform/animation/AnimationList.cpp
-platform/audio/PlatformMediaSessionManager.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -48,7 +48,6 @@ page/ShareDataReader.cpp
 page/cocoa/ResourceUsageOverlayCocoa.mm
 page/csp/ContentSecurityPolicy.cpp
 page/writing-tools/WritingToolsController.mm
-platform/RemoteCommandListener.cpp
 platform/ScrollableArea.cpp
 platform/Timer.h
 platform/cocoa/NetworkExtensionContentFilter.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,6 +1,4 @@
 Modules/WebGPU/GPUQueue.cpp
-Modules/model-element/scenekit/SceneKitModelLoader.mm
-Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
 Modules/model-element/scenekit/SceneKitModelPlayer.mm
 Modules/notifications/NotificationDataCocoa.mm
 Modules/speech/cocoa/WebSpeechRecognizerTask.mm
@@ -45,9 +43,7 @@ editing/mac/TextAlternativeWithRange.mm
 editing/mac/TextUndoInsertionMarkupMac.mm
 inspector/agents/page/PageTimelineAgent.cpp
 inspector/mac/PageDebuggerMac.mm
-loader/cocoa/DiskCacheMonitorCocoa.mm
 loader/cocoa/PrivateClickMeasurementCocoa.mm
-page/cocoa/MemoryReleaseCocoa.mm
 page/cocoa/PageCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
 page/mac/EventHandlerMac.mm
@@ -58,10 +54,7 @@ page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/AudioSampleBufferConverter.mm
-platform/audio/cocoa/AudioSessionCocoa.mm
-platform/audio/cocoa/MediaSessionManagerCocoa.mm
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
-platform/audio/mac/AudioSessionMac.mm
 platform/audio/mac/SharedRoutingArbitrator.mm
 platform/cf/KeyedDecoderCF.cpp
 platform/cf/KeyedEncoderCF.cpp
@@ -76,7 +69,6 @@ platform/cocoa/NetworkExtensionContentFilter.mm
 platform/cocoa/ParentalControlsContentFilter.mm
 platform/cocoa/PlatformPasteboardCocoa.mm
 platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
-platform/cocoa/PowerSourceNotifier.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SystemBattery.mm
 platform/cocoa/TextRecognitionResultCocoa.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -21,7 +21,6 @@ page/mac/EventHandlerMac.mm
 page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
-platform/VideoFrame.mm
 platform/audio/cocoa/AudioEncoderCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp

--- a/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
+++ b/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
@@ -32,6 +32,7 @@
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/MainThread.h>
 #import <wtf/RefPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if USE(WEB_THREAD)
 #import "WebCoreThreadRun.h"
@@ -81,7 +82,7 @@ DiskCacheMonitor::DiskCacheMonitor(const ResourceRequest& request, PAL::SessionI
     auto cancelMonitorBlockToRun = cancelMonitorBlock;
 #endif
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * diskCacheMonitorTimeout), dispatch_get_main_queue(), cancelMonitorBlockToRun);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * diskCacheMonitorTimeout), mainDispatchQueueSingleton(), cancelMonitorBlockToRun);
 
     // Set up the disk caching callback to create the ShareableResource and send it to the WebProcess.
     auto block = ^(CFCachedURLResponseRef cachedResponse) {
@@ -110,7 +111,7 @@ DiskCacheMonitor::DiskCacheMonitor(const ResourceRequest& request, PAL::SessionI
 #else
     auto blockToRun = block;
 #endif
-    _CFCachedURLResponseSetBecameFileBackedCallBackBlock(cachedResponse, blockToRun, dispatch_get_main_queue());
+    _CFCachedURLResponseSetBecameFileBackedCallBackBlock(cachedResponse, blockToRun, mainDispatchQueueSingleton());
 }
 
 void DiskCacheMonitor::resourceBecameFileBacked(SharedBuffer& fileBackedBuffer)

--- a/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
@@ -35,6 +35,7 @@
 #import "LocaleCocoa.h"
 #import <notify.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "LegacyTileCache.h"
@@ -105,10 +106,10 @@ void registerMemoryReleaseNotifyCallbacks()
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         int dummy;
-        notify_register_dispatch("com.apple.WebKit.fullGC", &dummy, dispatch_get_main_queue(), ^(int) {
+        notify_register_dispatch("com.apple.WebKit.fullGC", &dummy, mainDispatchQueueSingleton(), ^(int) {
             GarbageCollectionController::singleton().garbageCollectNow();
         });
-        notify_register_dispatch("com.apple.WebKit.deleteAllCode", &dummy, dispatch_get_main_queue(), ^(int) {
+        notify_register_dispatch("com.apple.WebKit.deleteAllCode", &dummy, mainDispatchQueueSingleton(), ^(int) {
             GarbageCollectionController::singleton().deleteAllCode(JSC::PreventCollectionAndDeleteAllCode);
             GarbageCollectionController::singleton().garbageCollectNow();
         });

--- a/Source/WebCore/platform/RemoteCommandListener.cpp
+++ b/Source/WebCore/platform/RemoteCommandListener.cpp
@@ -81,7 +81,7 @@ RemoteCommandListener::~RemoteCommandListener() = default;
 void RemoteCommandListener::scheduleSupportedCommandsUpdate()
 {
     if (!m_updateCommandsTask.isPending()) {
-        m_updateCommandsTask.scheduleTask([this] ()  {
+        m_updateCommandsTask.scheduleTask([this, protectedThis = Ref { *this }] ()  {
             updateSupportedCommands();
         });
     }

--- a/Source/WebCore/platform/VideoFrame.mm
+++ b/Source/WebCore/platform/VideoFrame.mm
@@ -43,10 +43,10 @@ RefPtr<VideoFrameCV> VideoFrame::asVideoFrameCV()
     if (auto* videoFrameCV = dynamicDowncast<VideoFrameCV>(*this))
         return videoFrameCV;
 
-    auto buffer = pixelBuffer();
+    RetainPtr buffer = pixelBuffer();
     if (!buffer)
         return nullptr;
-    return VideoFrameCV::create(presentationTime(), isMirrored(), rotation(), buffer);
+    return VideoFrameCV::create(presentationTime(), isMirrored(), rotation(), buffer.get());
 }
 #endif // USE(AVFOUNDATION)
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -116,10 +116,10 @@ WeakPtr<PlatformMediaSessionInterface> PlatformMediaSessionManager::bestEligible
     if (eligibleAudioVideoSessions.isEmpty()) {
         if (eligibleWebAudioSessions.isEmpty())
             return nullptr;
-        return WeakPtr { eligibleWebAudioSessions[0].get() }->selectBestMediaSession(eligibleWebAudioSessions, purpose);
+        return RefPtr { eligibleWebAudioSessions[0].get() }->selectBestMediaSession(eligibleWebAudioSessions, purpose);
     }
 
-    return WeakPtr { eligibleAudioVideoSessions[0].get() }->selectBestMediaSession(eligibleAudioVideoSessions, purpose);
+    return RefPtr { eligibleAudioVideoSessions[0].get() }->selectBestMediaSession(eligibleAudioVideoSessions, purpose);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
@@ -52,14 +52,15 @@ void AudioSessionCocoa::setEligibleForSmartRoutingInternal(bool eligible)
     if (!AudioSession::shouldManageAudioSessionCategory())
         return;
 
-    static bool supportsEligibleForBT = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setEligibleForBTSmartRoutingConsideration:error:)]
-        && [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(eligibleForBTSmartRoutingConsideration)];
+    // FIXME: This is a safer cpp false positive (160259918).
+    SUPPRESS_UNRETAINED_ARG static bool supportsEligibleForBT = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setEligibleForBTSmartRoutingConsideration:error:)] && [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(eligibleForBTSmartRoutingConsideration)];
     if (!supportsEligibleForBT)
         return;
 
     RELEASE_LOG(Media, "AudioSession::setEligibleForSmartRouting() %s", eligible ? "true" : "false");
 
-    AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
+    // FIXME: This is a safer cpp false positive (160259918).
+    SUPPRESS_UNRETAINED_ARG AVAudioSession *session = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
     if (session.eligibleForBTSmartRoutingConsideration == eligible)
         return;
 
@@ -95,8 +96,10 @@ void AudioSessionCocoa::setEligibleForSmartRouting(bool isEligible, ForceUpdate 
 bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
 {
 #if HAVE(AVAUDIOSESSION)
-    static bool supportsSharedInstance = [PAL::getAVAudioSessionClassSingleton() respondsToSelector:@selector(sharedInstance)];
-    static bool supportsSetActive = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setActive:withOptions:error:)];
+    // FIXME: This is a safer cpp false positive (160259918).
+    SUPPRESS_UNRETAINED_ARG static bool supportsSharedInstance = [PAL::getAVAudioSessionClassSingleton() respondsToSelector:@selector(sharedInstance)];
+    // FIXME: This is a safer cpp false positive (160259918).
+    SUPPRESS_UNRETAINED_ARG static bool supportsSetActive = [PAL::getAVAudioSessionClassSingleton() instancesRespondToSelector:@selector(setActive:withOptions:error:)];
 
     if (!supportsSharedInstance)
         return true;
@@ -113,8 +116,10 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
         setEligibleForSmartRouting(true);
         m_workQueue->dispatchSync([&success] {
             NSError *error = nil;
-            if (supportsSetActive)
-                [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:YES withOptions:0 error:&error];
+            if (supportsSetActive) {
+                // FIXME: This is a safer cpp false positive (160259918).
+                SUPPRESS_UNRETAINED_ARG [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:YES withOptions:0 error:&error];
+            }
             if (error)
                 RELEASE_LOG_ERROR(Media, "failed to activate audio session, error: %@", error.localizedDescription);
             success = !error;
@@ -124,8 +129,10 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
 
     m_workQueue->dispatch([] {
         NSError *error = nil;
-        if (supportsSetActive)
-            [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:NO withOptions:0 error:&error];
+        if (supportsSetActive) {
+            // FIXME: This is a safer cpp false positive (160259918).
+            SUPPRESS_UNRETAINED_ARG [[PAL::getAVAudioSessionClassSingleton() sharedInstance] setActive:NO withOptions:0 error:&error];
+        }
         if (error)
             RELEASE_LOG_ERROR(Media, "failed to deactivate audio session, error: %@", error.localizedDescription);
     });

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -49,6 +49,7 @@
 #import <wtf/MathExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #import "MediaRemoteSoftLink.h"
 #include <pal/cocoa/AVFoundationSoftLink.h>
@@ -361,7 +362,7 @@ void MediaSessionManagerCocoa::clearNowPlayingInfo()
 
     MRMediaRemoteSetCanBeNowPlayingApplication(false);
     MRMediaRemoteSetNowPlayingInfo(nullptr);
-    MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), kMRPlaybackStateStopped, dispatch_get_main_queue(), ^(MRMediaRemoteError error) {
+    MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), kMRPlaybackStateStopped, mainDispatchQueueSingleton(), ^(MRMediaRemoteError error) {
 #if LOG_DISABLED
         UNUSED_PARAM(error);
 #else
@@ -428,7 +429,7 @@ void MediaSessionManagerCocoa::setNowPlayingInfo(bool setAsNowPlayingApplication
         MRMediaRemoteSetParentApplication(MRMediaRemoteGetLocalOrigin(), nowPlayingInfo.metadata.sourceApplicationIdentifier.createCFString().get());
 
     MRPlaybackState playbackState = (nowPlayingInfo.isPlaying) ? kMRPlaybackStatePlaying : kMRPlaybackStatePaused;
-    MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), playbackState, dispatch_get_main_queue(), ^(MRMediaRemoteError error) {
+    MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), playbackState, mainDispatchQueueSingleton(), ^(MRMediaRemoteError error) {
 #if LOG_DISABLED
         UNUSED_PARAM(error);
 #else

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <wtf/StdLibExtras.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 enum {
     kAudioHardwarePropertyProcessIsRunning = 'prun'
@@ -128,14 +129,14 @@ AudioHardwareListenerMac::AudioHardwareListenerMac(Client& client)
             weakThis->propertyChanged(unsafeMakeSpan(properties, count));
     });
 
-    AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &processIsRunningPropertyDescriptor(), dispatch_get_main_queue(), m_block);
-    AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &outputDevicePropertyDescriptor(), dispatch_get_main_queue(), m_block);
+    AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &processIsRunningPropertyDescriptor(), mainDispatchQueueSingleton(), m_block);
+    AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &outputDevicePropertyDescriptor(), mainDispatchQueueSingleton(), m_block);
 }
 
 AudioHardwareListenerMac::~AudioHardwareListenerMac()
 {
-    AudioObjectRemovePropertyListenerBlock(kAudioObjectSystemObject, &processIsRunningPropertyDescriptor(), dispatch_get_main_queue(), m_block);
-    AudioObjectRemovePropertyListenerBlock(kAudioObjectSystemObject, &outputDevicePropertyDescriptor(), dispatch_get_main_queue(), m_block);
+    AudioObjectRemovePropertyListenerBlock(kAudioObjectSystemObject, &processIsRunningPropertyDescriptor(), mainDispatchQueueSingleton(), m_block);
+    AudioObjectRemovePropertyListenerBlock(kAudioObjectSystemObject, &outputDevicePropertyDescriptor(), mainDispatchQueueSingleton(), m_block);
     Block_release(m_block);
 }
 

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -37,6 +37,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/UniqueArray.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/WTFString.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -95,11 +96,11 @@ AudioSessionMac::~AudioSessionMac() = default;
 void AudioSessionMac::removePropertyListenersForDefaultDevice() const
 {
     if (hasBufferSizeObserver()) {
-        AudioObjectRemovePropertyListenerBlock(defaultDevice(), &bufferSizeAddress(), dispatch_get_main_queue(), m_handleBufferSizeChangeBlock.get());
+        AudioObjectRemovePropertyListenerBlock(defaultDevice(), &bufferSizeAddress(), mainDispatchQueueSingleton(), m_handleBufferSizeChangeBlock.get());
         m_handleBufferSizeChangeBlock = nullptr;
     }
     if (hasSampleRateObserver()) {
-        AudioObjectRemovePropertyListenerBlock(defaultDevice(), &nominalSampleRateAddress(), dispatch_get_main_queue(), m_handleSampleRateChangeBlock.get());
+        AudioObjectRemovePropertyListenerBlock(defaultDevice(), &nominalSampleRateAddress(), mainDispatchQueueSingleton(), m_handleSampleRateChangeBlock.get());
         m_handleSampleRateChangeBlock = nullptr;
     }
     if (hasMuteChangeObserver())
@@ -149,7 +150,7 @@ void AudioSessionMac::addDefaultDeviceObserverIfNeeded() const
         if (auto session = weakSession.get())
             session->handleDefaultDeviceChange();
     });
-    AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &defaultOutputDeviceAddress(), dispatch_get_main_queue(), m_handleDefaultDeviceChangeBlock.get());
+    AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &defaultOutputDeviceAddress(), mainDispatchQueueSingleton(), m_handleDefaultDeviceChangeBlock.get());
 }
 
 const AudioObjectPropertyAddress& AudioSessionMac::nominalSampleRateAddress()
@@ -171,7 +172,7 @@ void AudioSessionMac::addSampleRateObserverIfNeeded() const
         if (RefPtr session = weakSession.get())
             session->handleSampleRateChange();
     });
-    AudioObjectAddPropertyListenerBlock(defaultDevice(), &nominalSampleRateAddress(), dispatch_get_main_queue(), m_handleSampleRateChangeBlock.get());
+    AudioObjectAddPropertyListenerBlock(defaultDevice(), &nominalSampleRateAddress(), mainDispatchQueueSingleton(), m_handleSampleRateChangeBlock.get());
 }
 
 void AudioSessionMac::handleSampleRateChange() const
@@ -205,7 +206,7 @@ void AudioSessionMac::addBufferSizeObserverIfNeeded() const
         if (RefPtr session = weakSession.get())
             session->handleBufferSizeChange();
     });
-    AudioObjectAddPropertyListenerBlock(defaultDevice(), &bufferSizeAddress(), dispatch_get_main_queue(), m_handleBufferSizeChangeBlock.get());
+    AudioObjectAddPropertyListenerBlock(defaultDevice(), &bufferSizeAddress(), mainDispatchQueueSingleton(), m_handleBufferSizeChangeBlock.get());
 }
 
 void AudioSessionMac::handleBufferSizeChange() const
@@ -542,7 +543,7 @@ void AudioSessionMac::addMuteChangeObserverIfNeeded() const
         if (RefPtr session = weakSession.get())
             session->handleMutedStateChange();
     });
-    AudioObjectAddPropertyListenerBlock(defaultDevice(), &muteAddress(), dispatch_get_main_queue(), m_handleMutedStateChangeBlock.get());
+    AudioObjectAddPropertyListenerBlock(defaultDevice(), &muteAddress(), mainDispatchQueueSingleton(), m_handleMutedStateChangeBlock.get());
 }
 
 void AudioSessionMac::removeMuteChangeObserverIfNeeded() const
@@ -550,7 +551,7 @@ void AudioSessionMac::removeMuteChangeObserverIfNeeded() const
     if (!hasMuteChangeObserver())
         return;
 
-    AudioObjectRemovePropertyListenerBlock(defaultDevice(), &muteAddress(), dispatch_get_main_queue(), m_handleMutedStateChangeBlock.get());
+    AudioObjectRemovePropertyListenerBlock(defaultDevice(), &muteAddress(), mainDispatchQueueSingleton(), m_handleMutedStateChangeBlock.get());
     m_handleMutedStateChangeBlock = nullptr;
 }
 

--- a/Source/WebCore/platform/cocoa/PowerSourceNotifier.mm
+++ b/Source/WebCore/platform/cocoa/PowerSourceNotifier.mm
@@ -31,6 +31,7 @@
 #import <pal/spi/cocoa/IOPSLibSPI.h>
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ PowerSourceNotifier::PowerSourceNotifier(PowerSourceNotifierCallback&& callback)
     : m_callback(WTFMove(callback))
 {
     int token = 0;
-    auto status = notify_register_dispatch(kIOPSNotifyPowerSource, &token, dispatch_get_main_queue(), [weakThis = WeakPtr { *this }] (int) {
+    auto status = notify_register_dispatch(kIOPSNotifyPowerSource, &token, mainDispatchQueueSingleton(), [weakThis = WeakPtr { *this }] (int) {
         if (weakThis)
             weakThis->notifyPowerSourceChanged();
     });

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -50,6 +50,7 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakPtr.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #pragma mark - Soft Linking
 #import "CoreVideoSoftLink.h"
@@ -276,8 +277,7 @@ void AudioVideoRendererAVFObjC::requestMediaDataWhenReady(TrackIdentifier trackI
                         DEBUG_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "Not ready to request audio data, ignoring");
                 }
             });
-            // False positive webkit.org/b/298037
-            SUPPRESS_UNRETAINED_ARG [audioRenderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:handler.get()];
+            [audioRenderer requestMediaDataWhenReadyOnQueue:mainDispatchQueueSingleton() usingBlock:handler.get()];
         }
         break;
     default:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -52,6 +52,7 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/StringHash.h>
 
@@ -274,7 +275,7 @@ AVContentKeySession* CDMInstanceFairPlayStreamingAVFObjC::contentKeySession()
     if (!m_delegate)
         lazyInitialize(m_delegate, adoptNS([[WebCoreFPSContentKeySessionDelegate alloc] initWithParent:*this]));
 
-    [m_session setDelegate:m_delegate.get() queue:dispatch_get_main_queue()];
+    [m_session setDelegate:m_delegate.get() queue:mainDispatchQueueSingleton()];
     return m_session.get();
 }
 
@@ -1751,7 +1752,7 @@ bool CDMInstanceSessionFairPlayStreamingAVFObjC::ensureSessionOrGroup(KeyGroupin
     if (!m_session)
         return false;
 
-    [m_session setDelegate:m_delegate.get() queue:dispatch_get_main_queue()];
+    [m_session setDelegate:m_delegate.get() queue:mainDispatchQueueSingleton()];
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -44,6 +44,7 @@
 #import <wtf/MonotonicTime.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -496,7 +497,7 @@ void LocalSampleBufferDisplayLayer::requestNotificationWhenReadyForVideoData()
 
     ThreadSafeWeakPtr weakThis { *this };
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [m_sampleBufferDisplayLayer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+    [m_sampleBufferDisplayLayer requestMediaDataWhenReadyOnQueue:mainDispatchQueueSingleton() usingBlock:^{
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -67,6 +67,7 @@
 #import <wtf/WeakPtr.h>
 #import <wtf/WorkQueue.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/CString.h>
 
 #pragma mark - Soft Linking
@@ -619,7 +620,7 @@ void SourceBufferPrivateAVFObjC::trackDidChangeEnabled(AudioTrackPrivate& track,
 #endif
 
             ThreadSafeWeakPtr weakThis { *this };
-            [renderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+            [renderer requestMediaDataWhenReadyOnQueue:mainDispatchQueueSingleton() usingBlock:^{
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->didBecomeReadyForMoreSamples(trackID);
             }];
@@ -1156,7 +1157,7 @@ void SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples(TrackID tra
         }
     } else if (auto renderer = audioRendererForTrackID(trackID)) {
         ThreadSafeWeakPtr weakThis { *this };
-        [renderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+        [renderer requestMediaDataWhenReadyOnQueue:mainDispatchQueueSingleton() usingBlock:^{
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->didBecomeReadyForMoreSamples(trackID);
         }];

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -43,6 +43,7 @@
 #import <wtf/MonotonicTime.h>
 #import <wtf/NativePromise.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(VISION)
 #import "FormatDescriptionUtilities.h"
@@ -911,7 +912,7 @@ void VideoMediaSampleRenderer::resetReadyForMoreMediaData()
     }
 
     ThreadSafeWeakPtr weakThis { *this };
-    [renderer() requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+    [renderer() requestMediaDataWhenReadyOnQueue:mainDispatchQueueSingleton() usingBlock:^{
         assertIsMainThread();
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -45,6 +45,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if HAVE(PIP_CONTROLLER)
 #import <AVKit/AVPictureInPictureController.h>
@@ -559,7 +560,7 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
 
     [self removeObserver];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [self startPictureInPicture];
     });
 }
@@ -593,7 +594,7 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
         return;
 
     if ([self isPictureInPicturePossible]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             [self startPictureInPicture];
         });
         return;

--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
@@ -43,6 +43,7 @@
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #import <pal/ios/UIKitSoftLink.h>
 
@@ -867,7 +868,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
-    dispatch_group_notify(fileLoadingGroup.get(), dispatch_get_main_queue(), itemLoadCompletion);
+    dispatch_group_notify(fileLoadingGroup.get(), mainDispatchQueueSingleton(), itemLoadCompletion);
 }
 
 - (NSItemProvider *)itemProviderAtIndex:(NSUInteger)index

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -40,6 +40,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
@@ -211,7 +212,7 @@ Vector<CoreAudioCaptureDevice>& CoreAudioCaptureDeviceManager::coreAudioCaptureD
             kAudioObjectPropertyScopeGlobal,
             kAudioObjectPropertyElementMain
         };
-        auto err = AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &address, dispatch_get_main_queue(), listener);
+        auto err = AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &address, mainDispatchQueueSingleton(), listener);
         if (err)
             LOG_ERROR("CoreAudioCaptureDeviceManager::devices(%p) AudioObjectAddPropertyListener for kAudioHardwarePropertyDevices returned error %d (%.4s)", this, (int)err, (char*)&err);
 
@@ -220,7 +221,7 @@ Vector<CoreAudioCaptureDevice>& CoreAudioCaptureDeviceManager::coreAudioCaptureD
             kAudioObjectPropertyScopeGlobal,
             kAudioObjectPropertyElementMain
         };
-        err = AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &address, dispatch_get_main_queue(), listener);
+        err = AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &address, mainDispatchQueueSingleton(), listener);
         if (err)
             LOG_ERROR("CoreAudioCaptureDeviceManager::devices(%p) AudioObjectAddPropertyListener for kAudioHardwarePropertyDefaultInputDevice returned error %d (%.4s)", this, (int)err, (char*)&err);
 
@@ -229,7 +230,7 @@ Vector<CoreAudioCaptureDevice>& CoreAudioCaptureDeviceManager::coreAudioCaptureD
             kAudioObjectPropertyScopeGlobal,
             kAudioObjectPropertyElementMain
         };
-        err = AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &address, dispatch_get_main_queue(), listener);
+        err = AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &address, mainDispatchQueueSingleton(), listener);
         if (err)
             LOG_ERROR("CoreAudioCaptureDeviceManager::devices(%p) AudioObjectAddPropertyListener for kAudioHardwarePropertyDefaultOutputDevice returned error %d (%.4s)", this, (int)err, (char*)&err);
     }

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -41,6 +41,7 @@
 #include <wtf/URL.h>
 #include <wtf/cf/VectorCF.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#include <wtf/darwin/DispatchExtras.h>
 #include <wtf/posix/SocketPOSIX.h>
 #include <wtf/text/StringHash.h>
 
@@ -136,7 +137,7 @@ void DNSResolveQueueCFNet::performDNSLookup(const String& hostname, Ref<Completi
     });
     timeoutTimer->startOneShot(timeoutForDNSResolution);
 
-    nw_resolver_set_update_handler(resolver.get(), dispatch_get_main_queue(), makeBlockPtr([resolver = WTFMove(resolver), completionHandler = WTFMove(completionHandler), timeoutTimer = WTFMove(timeoutTimer)] (nw_resolver_status_t status, nw_array_t resolvedEndpoints) mutable {
+    nw_resolver_set_update_handler(resolver.get(), mainDispatchQueueSingleton(), makeBlockPtr([resolver = WTFMove(resolver), completionHandler = WTFMove(completionHandler), timeoutTimer = WTFMove(timeoutTimer)] (nw_resolver_status_t status, nw_array_t resolvedEndpoints) mutable {
         if (status != nw_resolver_status_complete)
             return;
 

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -43,6 +43,7 @@
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/cf/StringConcatenateCF.h>
@@ -827,7 +828,7 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
             return;
         for (Ref observer : it->value)
             observer->cookiesAdded(host, cookies);
-    }).get() onQueue:dispatch_get_main_queue()];
+    }).get() onQueue:mainDispatchQueueSingleton()];
 
     [nsCookieStorage() _setCookiesRemovedHandler:makeBlockPtr([this, weakThis = WeakPtr { *this }](NSArray<NSHTTPCookie *> *removedCookies, NSString *domainForRemovedCookies, bool removeAllCookies) {
         if (!weakThis)
@@ -850,7 +851,7 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
             return;
         for (Ref observer : it->value)
             observer->cookiesDeleted(host, cookies);
-    }).get() onQueue:dispatch_get_main_queue()];
+    }).get() onQueue:mainDispatchQueueSingleton()];
 }
 
 void NetworkStorageSession::unregisterCookieChangeListenersIfNecessary()

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -44,6 +44,7 @@
 #import "UTIUtilities.h"
 #import <AVFoundation/AVPlayer.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(MAC)
 #import "NSScrollerImpDetails.h"
@@ -284,7 +285,7 @@ bool Internals::emitWebCoreLogs(unsigned logCount, bool useMainThread) const
             RELEASE_LOG_FORWARDABLE(Testing, WEBCORE_TEST_LOG, i);
     });
     if (useMainThread)
-        dispatch_async(dispatch_get_main_queue(), blockPtr.get());
+        dispatch_async(mainDispatchQueueSingleton(), blockPtr.get());
     else
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), blockPtr.get());
     return true;
@@ -297,7 +298,7 @@ bool Internals::emitLogs(const String& logString, unsigned logCount, bool useMai
             RELEASE_LOG(Testing, "%s", logString.utf8().data());
     });
     if (useMainThread)
-        dispatch_async(dispatch_get_main_queue(), blockPtr.get());
+        dispatch_async(mainDispatchQueueSingleton(), blockPtr.get());
     else
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), blockPtr.get());
     return true;

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -33,7 +33,9 @@
 
 #if PLATFORM(COCOA)
 #include <notify.h>
+#include <wtf/darwin/DispatchExtras.h>
 #endif
+
 namespace WGSL {
 
 namespace Metal {
@@ -57,7 +59,7 @@ static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         int dumpMetalCodeToken;
-        notify_register_dispatch("com.apple.WebKit.WebGPU.TogglePrintMetalCode", &dumpMetalCodeToken, dispatch_get_main_queue(), ^(int) {
+        notify_register_dispatch("com.apple.WebKit.WebGPU.TogglePrintMetalCode", &dumpMetalCodeToken, mainDispatchQueueSingleton(), ^(int) {
             dumpMetalCode = !dumpMetalCode;
         });
     });

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -50,6 +50,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #define OBJC_STRINGIFYHELPER(x) @#x
 #define OBJC_STRINGIFY(x) OBJC_STRINGIFYHELPER(x)
@@ -73,7 +74,7 @@ struct GPUFrameCapture {
         static std::once_flag onceFlag;
         std::call_once(onceFlag, [] {
             int captureFrameToken;
-            notify_register_dispatch("com.apple.WebKit.WebGPU.CaptureFrame", &captureFrameToken, dispatch_get_main_queue(), ^(int token) {
+            notify_register_dispatch("com.apple.WebKit.WebGPU.CaptureFrame", &captureFrameToken, mainDispatchQueueSingleton(), ^(int token) {
                 uint64_t state;
                 notify_get_state(token, &state);
                 maxSubmitCallsToCapture = std::max<int>(1, state);
@@ -81,7 +82,7 @@ struct GPUFrameCapture {
             });
 
             int captureFirstFrameToken;
-            notify_register_dispatch("com.apple.WebKit.WebGPU.ToggleCaptureFirstFrame", &captureFirstFrameToken, dispatch_get_main_queue(), ^(int) {
+            notify_register_dispatch("com.apple.WebKit.WebGPU.ToggleCaptureFirstFrame", &captureFirstFrameToken, mainDispatchQueueSingleton(), ^(int) {
                 captureFirstFrame = !captureFirstFrame;
             });
         });
@@ -139,7 +140,7 @@ GPUShaderValidation Device::shaderValidationState() const
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         int captureFirstFrameToken;
-        notify_register_dispatch("com.apple.WebKit.WebGPU.ToggleShaderValidationState", &captureFirstFrameToken, dispatch_get_main_queue(), ^(int) {
+        notify_register_dispatch("com.apple.WebKit.WebGPU.ToggleShaderValidationState", &captureFirstFrameToken, mainDispatchQueueSingleton(), ^(int) {
             shaderValidationState = (shaderValidationState == MTLShaderValidationEnabled ? MTLShaderValidationDefault : MTLShaderValidationEnabled);
         });
     });
@@ -156,7 +157,7 @@ bool Device::enableEncoderTimestamps() const
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         int token;
-        notify_register_dispatch("com.apple.WebKit.WebGPU.EnableEncoderTimestamps", &token, dispatch_get_main_queue(), ^(int) {
+        notify_register_dispatch("com.apple.WebKit.WebGPU.EnableEncoderTimestamps", &token, mainDispatchQueueSingleton(), ^(int) {
             enable = !enable;
             WTFLogAlways("Encoder timestamps are %s", enable ? "ENABLED" : "DISABLED");
         });

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -56,6 +56,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/TextStream.h>
 
 #import "WebKitSwiftSoftLink.h"
@@ -237,7 +238,7 @@ Ref<REModelLoader> RKUSDModelLoadScheduler::scheduleModelLoad(Model& model, cons
 {
     auto loader = RKModelLoaderUSD::create(model, attributionTaskID, entityMemoryLimit, client);
 
-    dispatch_async(dispatch_get_main_queue(), [this, loader] () mutable {
+    dispatch_async(mainDispatchQueueSingleton(), [this, loader] () mutable {
         m_pendingLoads.append(loader);
         loadNextModel();
     });
@@ -247,7 +248,7 @@ Ref<REModelLoader> RKUSDModelLoadScheduler::scheduleModelLoad(Model& model, cons
 
 void RKUSDModelLoadScheduler::loadNextModel()
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
 
     static const size_t maxLimitOnParallelLoads = 3;
     if (m_inProgressLoadsCount >= maxLimitOnParallelLoads)
@@ -264,7 +265,7 @@ void RKUSDModelLoadScheduler::loadNextModel()
 
     m_inProgressLoadsCount++;
     nextLoad->load([this] {
-        dispatch_assert_queue(dispatch_get_main_queue());
+        dispatch_assert_queue(mainDispatchQueueSingleton());
         ASSERT(m_inProgressLoadsCount > 0);
         m_inProgressLoadsCount--;
         loadNextModel();
@@ -336,7 +337,7 @@ ALWAYS_INLINE void ModelProcessModelPlayerProxy::send(T&& message)
 
 void ModelProcessModelPlayerProxy::createLayer()
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
     ASSERT(!m_layer);
 
     m_layer = adoptNS([[WKModelProcessModelLayer alloc] init]);
@@ -582,7 +583,7 @@ static RECALayerService *webDefaultLayerService(void)
 
 void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& loader, Ref<WebCore::REModel> model)
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
     ASSERT(&loader == m_loader.get());
 
     bool canLoadWithRealityKit = [getWKRKEntityClassSingleton() isLoadFromDataAvailable];
@@ -657,7 +658,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 
 void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader, const WebCore::ResourceError& error)
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
     ASSERT(&loader == m_loader.get());
 
     m_loader = nullptr;
@@ -673,7 +674,7 @@ static int defaultEntityMemoryLimit = 100; // MB
 
 void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSize layoutSize)
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
 
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load size=%zu id=%" PRIu64, this, model.data()->size(), m_id.toUInt64());
     sizeDidChange(layoutSize);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -54,6 +54,7 @@
 
 #if PLATFORM(COCOA)
 #include <notify.h>
+#include <wtf/darwin/DispatchExtras.h>
 #endif
 
 namespace WebKit {
@@ -127,7 +128,7 @@ Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref
 #if PLATFORM(COCOA)
         // Triggers with "notifyutil -p com.apple.WebKit.Cache.dump".
         int token;
-        notify_register_dispatch("com.apple.WebKit.Cache.dump", &token, dispatch_get_main_queue(), ^(int) {
+        notify_register_dispatch("com.apple.WebKit.Cache.dump", &token, mainDispatchQueueSingleton(), ^(int) {
             dumpContentsToFile();
         });
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -49,6 +49,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if ENABLE(CONTENT_FILTERING)
 #import <pal/spi/cocoa/NEFilterSourceSPI.h>
@@ -174,7 +175,7 @@ void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<vo
         m_clearCacheDispatchGroup = adoptOSObject(dispatch_group_create());
 
     RetainPtr group = m_clearCacheDispatchGroup.get();
-    dispatch_group_async(group.get(), RetainPtr { dispatch_get_main_queue() }.get(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {
+    dispatch_group_async(group.get(), RetainPtr { mainDispatchQueueSingleton() }.get(), makeBlockPtr([this, protectedThis = Ref { *this }, modifiedSince, completionHandler = WTFMove(completionHandler)] () mutable {
         auto aggregator = CallbackAggregator::create(WTFMove(completionHandler));
         forEachNetworkSession([modifiedSince, &aggregator](NetworkSession& session) {
             if (RefPtr cache = session.cache())

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -35,6 +35,10 @@
 #include <wtf/UUID.h>
 #include <wtf/text/MakeString.h>
 
+#if OS(DARWIN)
+#include <wtf/darwin/DispatchExtras.h>
+#endif
+
 namespace WebKit {
 
 #define MDNS_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkMDNSRegister::" fmt, this, ##__VA_ARGS__)
@@ -138,7 +142,7 @@ void NetworkMDNSRegister::registerMDNSName(WebCore::ScriptExecutionContextIdenti
             MDNS_RELEASE_LOG("registerMDNSName DNSServiceCreateConnection error %d", error);
             return completionHandler(name, WebCore::MDNSRegisterError::DNSSD);
         }
-        error = DNSServiceSetDispatchQueue(service, dispatch_get_main_queue());
+        error = DNSServiceSetDispatchQueue(service, mainDispatchQueueSingleton());
         if (error) {
             MDNS_RELEASE_LOG("registerMDNSName DNSServiceCreateConnection error %d", error);
             return completionHandler(name, WebCore::MDNSRegisterError::DNSSD);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -48,6 +48,7 @@
 #if PLATFORM(COCOA)
 #include <pal/spi/cocoa/NetworkSPI.h>
 #include <wtf/BlockPtr.h>
+#include <wtf/darwin/DispatchExtras.h>
 #endif
 
 namespace WebKit {
@@ -133,7 +134,7 @@ static NetworkRTCSharedMonitor& networkSharedMonitor()
 static RetainPtr<nw_path_monitor> createNWPathMonitor()
 {
     auto nwMonitor = adoptCF(nw_path_monitor_create());
-    nw_path_monitor_set_queue(nwMonitor.get(), dispatch_get_main_queue());
+    nw_path_monitor_set_queue(nwMonitor.get(), mainDispatchQueueSingleton());
     nw_path_monitor_set_update_handler(nwMonitor.get(), makeBlockPtr([](nw_path_t path) {
         networkSharedMonitor().updateNetworksFromPath(path);
     }).get());

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -31,6 +31,7 @@
 #import "WebPushDaemonConnection.h"
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace WebKit {
 
@@ -53,7 +54,7 @@ void Connection::sendWithReply(xpc_object_t message, CompletionHandler<void(xpc_
 
     ASSERT(m_connection.get());
     ASSERT(xpc_get_type(message) == XPC_TYPE_DICTIONARY);
-    xpc_connection_send_message_with_reply(m_connection.get(), message, dispatch_get_main_queue(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    xpc_connection_send_message_with_reply(m_connection.get(), message, mainDispatchQueueSingleton(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
         ASSERT(RunLoop::isMain());
         completionHandler(reply);
     }).get());
@@ -64,7 +65,7 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
 {
     if (m_connection)
         return;
-    m_connection = adoptOSObject(xpc_connection_create_mach_service(m_machServiceName.data(), dispatch_get_main_queue(), 0));
+    m_connection = adoptOSObject(xpc_connection_create_mach_service(m_machServiceName.data(), mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(m_connection.get(), [weakThis = WeakPtr { *this }](xpc_object_t event) {
         if (!weakThis)
             return;

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -39,6 +39,7 @@
 #import <JavaScriptCore/JavaScriptCore.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/FileSystem.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIKit.h>
@@ -443,7 +444,7 @@ void callAfterRandomDelay(Function<void()>&& completionHandler)
 {
     // Random delay between 100 and 500 milliseconds.
     auto delay = Seconds::fromMilliseconds(100) + Seconds::fromMilliseconds((static_cast<double>(arc4random()) / static_cast<double>(UINT32_MAX)) * 400);
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay.nanosecondsAs<int64_t>()), dispatch_get_main_queue(), makeBlockPtr(WTFMove(completionHandler)).get());
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay.nanosecondsAs<int64_t>()), mainDispatchQueueSingleton(), makeBlockPtr(WTFMove(completionHandler)).get());
 }
 
 NSDate *toAPI(const WallTime& time)

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -60,7 +60,6 @@ Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
 Shared/JavaScriptEvaluationResult.mm
 Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 Shared/mac/AuxiliaryProcessMac.mm
-Shared/mac/ScrollingAccelerationCurveMac.mm
 UIProcess/API/C/mac/WKNotificationPrivateMac.mm
 UIProcess/API/C/mac/WKProtectionSpaceNS.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
@@ -143,7 +142,6 @@ UIProcess/Extensions/WebExtensionController.h
 UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
 UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
 UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
-UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
 UIProcess/Inspector/mac/WKInspectorViewController.mm
 UIProcess/Inspector/mac/WKInspectorWKWebView.mm
 UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -215,7 +213,6 @@ WebProcess/WebPage/mac/WebPageMac.mm
 WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
 WebProcess/cocoa/LaunchServicesDatabaseManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
-webpushd/ApplePushServiceConnection.mm
 webpushd/MockPushServiceConnection.mm
 webpushd/PushService.mm
 webpushd/WebPushDaemon.mm

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -53,6 +53,7 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SoftLinking.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
 #if ENABLE(CFPREFS_DIRECT_MODE)
@@ -145,7 +146,7 @@ void AuxiliaryProcess::platformStopRunLoop()
 
 void AuxiliaryProcess::registerWithStateDumper(ASCIILiteral title)
 {
-    os_state_add_handler(dispatch_get_main_queue(), [this, title] (os_state_hints_t hints) {
+    os_state_add_handler(mainDispatchQueueSingleton(), [this, title] (os_state_hints_t hints) {
         @autoreleasepool {
             os_state_data_t os_state = nullptr;
 

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -35,6 +35,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/cocoa/objcSPI.h>
 
 namespace API {
@@ -122,7 +123,7 @@ using WebKit::wrapper;
     if (isMainRunLoop()) \
         _objc_deallocOnMainThreadHelper((__bridge void *)self); \
     else \
-        dispatch_async_f(dispatch_get_main_queue(), (__bridge void *)self, _objc_deallocOnMainThreadHelper); \
+        dispatch_async_f(mainDispatchQueueSingleton(), (__bridge void *)self, _objc_deallocOnMainThreadHelper); \
 } \
 \
 using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -28,6 +28,7 @@
 #import "XPCUtilities.h"
 
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/ASCIILiteral.h>
 
 #if PLATFORM(MAC)
@@ -43,7 +44,7 @@ XPCEndpoint::XPCEndpoint()
     m_connection = adoptOSObject(xpc_connection_create(nullptr, nullptr));
     m_endpoint = adoptOSObject(xpc_endpoint_create(m_connection.get()));
 
-    xpc_connection_set_target_queue(m_connection.get(), dispatch_get_main_queue());
+    xpc_connection_set_target_queue(m_connection.get(), mainDispatchQueueSingleton());
     xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
         xpc_type_t type = xpc_get_type(message);
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
@@ -68,7 +69,7 @@ XPCEndpoint::XPCEndpoint()
 #endif
             }
 #endif // USE(APPLE_INTERNAL_SDK)
-            xpc_connection_set_target_queue(connection.get(), dispatch_get_main_queue());
+            xpc_connection_set_target_queue(connection.get(), mainDispatchQueueSingleton());
             xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t event) {
                 handleEvent(connection.get(), event);
             });

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -41,6 +41,7 @@
 #import <wtf/RunLoop.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/darwin/XPCExtras.h>
 
 // FIXME: Add daemon plist to repository.
@@ -98,7 +99,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         }
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             NSLog(@"XPC activity happening");
             PCM::doDailyActivityInManager();
         });

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -34,6 +34,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/WTFProcess.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/darwin/XPCExtras.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/StringToIntegerConversion.h>
@@ -182,7 +183,7 @@ void setOSTransaction(OSObjectPtr<os_transaction_t>&& transaction)
     // control our lifetime via process assertions instead of leaking this OS transaction.
     static dispatch_once_t flag;
     dispatch_once(&flag, ^{
-        globalSource.get() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, dispatch_get_main_queue()));
+        globalSource.get() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, mainDispatchQueueSingleton()));
         dispatch_source_set_event_handler(globalSource.get().get(), ^{
             exitProcess(0);
         });

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
@@ -37,6 +37,7 @@
 #import "_WKWebExtensionSQLiteRow.h"
 #import <wtf/BlockPtr.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -107,7 +108,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
 
         NSString *errorMessage;
         if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage createIfNecessary:NO]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(errorMessage);
             });
 
@@ -125,7 +126,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
 
         NSString *deleteDatabaseErrorMessage = [strongSelf _deleteDatabaseIfEmpty];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             // Errors from opening the database or deleting keys take precedence over an error deleting the database.
             completionHandler(errorMessage.length ? errorMessage : deleteDatabaseErrorMessage);
         });
@@ -153,7 +154,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
         NSString *errorMessage;
 
         if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(errorMessage);
             });
 
@@ -166,7 +167,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
         for (NSDictionary *script in scripts)
             [strongSelf _insertScript:script inDatabase:strongSelf->_database errorMessage:&errorMessage];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(errorMessage);
         });
     });
@@ -180,7 +181,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
         auto strongSelf = weakSelf.get();
         auto* scripts = [strongSelf _getScriptsWithOutErrorMessage:&errorMessage];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(scripts, errorMessage);
         });
     });

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -40,6 +40,7 @@
 #import <wtf/FileSystem.h>
 #import <wtf/RunLoop.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
 using namespace WebKit;
@@ -94,7 +95,7 @@ using namespace WebKit;
 {
     dispatch_async(_databaseQueue, ^{
         NSString *deleteDatabaseErrorMessage = [self _deleteDatabase];
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(deleteDatabaseErrorMessage);
         });
     });
@@ -356,7 +357,7 @@ using namespace WebKit;
 
         NSString *errorMessage;
         if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(nil, errorMessage);
             });
 
@@ -372,7 +373,7 @@ using namespace WebKit;
             errorMessage = @"Failed to create savepoint.";
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(!errorMessage.length ? savepointIdentifier : nil, errorMessage);
         });
     });
@@ -388,7 +389,7 @@ using namespace WebKit;
 
         NSString *errorMessage;
         if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(errorMessage);
             });
 
@@ -404,7 +405,7 @@ using namespace WebKit;
             errorMessage = @"Failed to release savepoint.";
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(errorMessage);
         });
     });
@@ -420,7 +421,7 @@ using namespace WebKit;
 
         NSString *errorMessage;
         if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(errorMessage);
             });
 
@@ -436,7 +437,7 @@ using namespace WebKit;
             errorMessage = @"Failed to rollback to savepoint.";
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(errorMessage);
         });
     });

--- a/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
+++ b/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
@@ -33,6 +33,7 @@
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/IOKitSPI.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace WebKit {
 
@@ -95,7 +96,7 @@ static ScrollingAccelerationCurve fromIOHIDCurveArrayWithAcceleration(NSArray<NS
 static RetainPtr<IOHIDEventSystemClientRef> createHIDClient()
 {
     auto client = adoptCF(IOHIDEventSystemClientCreateWithType(nil, kIOHIDEventSystemClientTypePassive, nil));
-    IOHIDEventSystemClientSetDispatchQueue(client.get(), dispatch_get_main_queue());
+    IOHIDEventSystemClientSetDispatchQueue(client.get(), mainDispatchQueueSingleton());
     IOHIDEventSystemClientActivate(client.get());
     return client;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -45,6 +45,7 @@
 #import <wtf/Deque.h>
 #import <wtf/MemoryPressureHandler.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKitSPI.h>
@@ -491,7 +492,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
                 timeoutInterval = timeoutOption.doubleValue;
         }
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeoutInterval * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeoutInterval * NSEC_PER_SEC), mainDispatchQueueSingleton(), ^{
             if (finished)
                 return;
             cancel(WKErrorAttributedStringContentLoadTimedOut, nil);
@@ -508,7 +509,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
     if ([NSThread isMainThread])
         runConversion();
     else
-        dispatch_async(dispatch_get_main_queue(), runConversion);
+        dispatch_async(mainDispatchQueueSingleton(), runConversion);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -36,6 +36,7 @@
 #import "WKWebExtensionMatchPatternInternal.h"
 #import "WebExtension.h"
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 NSErrorDomain const WKWebExtensionErrorDomain = @"WKWebExtensionErrorDomain";
 
@@ -52,7 +53,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
     // Use an async dispatch in the meantime to prevent clients from expecting synchronous results.
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         RefPtr<API::Error> error;
         Ref result = WebKit::WebExtension::create(appExtensionBundle, nil, error);
 
@@ -73,7 +74,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
     // Use an async dispatch in the meantime to prevent clients from expecting synchronous results.
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         RefPtr<API::Error> error;
         Ref result = WebKit::WebExtension::create(nil, resourceBaseURL, error);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -247,6 +247,7 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #endif // PLATFORM(IOS_FAMILY)
 
@@ -1608,7 +1609,7 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
             // callSnapshotRect() calls the client callback which may call directly or indirectly addCommitHandler.
             // It is prohibited by CA to add a commit handler while processing a registered commit handler.
             // So postpone calling callSnapshotRect() till CATransaction processes its commit handlers.
-            dispatch_async(dispatch_get_main_queue(), [callSnapshotRect = WTFMove(callSnapshotRect)] {
+            dispatch_async(mainDispatchQueueSingleton(), [callSnapshotRect = WTFMove(callSnapshotRect)] {
                 callSnapshotRect();
             });
         } forPhase:kCATransactionPhasePostCommit];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -71,6 +71,7 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/persistence/PersistentDecoder.h>
 #import <wtf/persistence/PersistentEncoder.h>
 
@@ -1624,7 +1625,7 @@ struct WKWebsiteData {
     if (!webPushAction)
         return NO;
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         WKWebsiteDataStore *dataStore = _WKWebsiteDataStoreBSActionHandler.shared->_webPushActionHandler.get()(webPushAction.get());
         [dataStore _handleWebPushAction:webPushAction.get()];
     });

--- a/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
@@ -34,6 +34,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 
 #import <pal/cocoa/CoreTelephonySoftLink.h>
@@ -79,9 +80,9 @@ bool shouldAllowAutoFillForCellularIdentifiers(const URL& topURL)
     }
 
 #if HAVE(DELAY_INIT_LINKING)
-    static NeverDestroyed cachedClient = adoptNS([[CoreTelephonyClient alloc] initWithQueue:dispatch_get_main_queue()]);
+    static NeverDestroyed cachedClient = adoptNS([[CoreTelephonyClient alloc] initWithQueue:mainDispatchQueueSingleton()]);
 #else
-    static NeverDestroyed cachedClient = adoptNS([PAL::allocCoreTelephonyClientInstance() initWithQueue:dispatch_get_main_queue()]);
+    static NeverDestroyed cachedClient = adoptNS([PAL::allocCoreTelephonyClientInstance() initWithQueue:mainDispatchQueueSingleton()]);
 #endif
     auto client = cachedClient->get();
 

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -32,6 +32,7 @@
 #import <WebCore/NotImplemented.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 #import <pal/cf/CoreMediaSoftLink.h>
@@ -54,7 +55,7 @@
 }
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePlayCommand:(AVDelegatingPlaybackCoordinatorPlayCommand *)playCommand completionHandler:(void (^)(void))completionHandler {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         RefPtr parent = _parent.get();
         if (!parent) {
             completionHandler();
@@ -68,7 +69,7 @@
 }
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePauseCommand:(AVDelegatingPlaybackCoordinatorPauseCommand *)pauseCommand completionHandler:(void (^)(void))completionHandler {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         RefPtr parent = _parent.get();
         if (!parent) {
             completionHandler();
@@ -82,7 +83,7 @@
 }
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssueSeekCommand:(AVDelegatingPlaybackCoordinatorSeekCommand *)seekCommand completionHandler:(void (^)(void))completionHandler {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         RefPtr parent = _parent.get();
         if (!parent) {
             completionHandler();
@@ -96,7 +97,7 @@
 }
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssueBufferingCommand:(AVDelegatingPlaybackCoordinatorBufferingCommand *)bufferingCommand completionHandler:(void (^)(void))completionHandler {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         RefPtr parent = _parent.get();
         if (!parent) {
             completionHandler();
@@ -110,7 +111,7 @@
 }
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePrepareTransitionCommand:(AVDelegatingPlaybackCoordinatorPrepareTransitionCommand *)prepareTransitionCommand {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         RefPtr parent = _parent.get();
         if (!parent)
             return;

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -41,6 +41,7 @@
 #import <wtf/MachSendRight.h>
 #import <wtf/MainThread.h>
 #import <wtf/MonotonicTime.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if ENABLE(ARKIT_INLINE_PREVIEW_IOS)
 #import "APIUIClient.h"
@@ -110,7 +111,7 @@ void ModelElementController::takeModelElementFullscreen(ModelIdentifier modelIde
             return;
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             remoteViewController.modalPresentationStyle = UIModalPresentationOverFullScreen;
             remoteViewController.view.backgroundColor = UIColor.clearColor;
 
@@ -122,7 +123,7 @@ void ModelElementController::takeModelElementFullscreen(ModelIdentifier modelIde
             }];
 
             [preview observeDismissFullscreenWithCompletionHandler:^(CAFenceHandle *dismissFenceHandle, NSDictionary *payload, NSError *dismissError) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(mainDispatchQueueSingleton(), ^{
                     if (dismissError || !dismissFenceHandle) {
                         LOG(ModelElement, "Unable to get fence handle when dismissing fullscreen instance: %@", [dismissError localizedDescription]);
                         [dismissFenceHandle invalidate];

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -52,6 +52,7 @@
 #endif
 #import <wtf/LoggerHelper.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -1057,7 +1058,7 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
         return;
 
     VideoReceiverEndpointMessage endpointMessage(WTFMove(processIdentifier), contextId.object(), WTFMove(playerIdentifier), endpoint, endpointIdentifier);
-    xpc_connection_send_message_with_reply(xpcConnection.get(), endpointMessage.encode().get(), dispatch_get_main_queue(), ^(xpc_object_t reply) {
+    xpc_connection_send_message_with_reply(xpcConnection.get(), endpointMessage.encode().get(), mainDispatchQueueSingleton(), ^(xpc_object_t reply) {
         RefPtr videoPresentationManager = page->videoPresentationManager();
         if (!videoPresentationManager)
             return;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -93,6 +93,7 @@
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
 #import <wtf/spi/cocoa/XTSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
@@ -245,13 +246,6 @@ static dispatch_queue_t globalQueueSingleton()
 {
     return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 }
-
-#if !PLATFORM(IOS_FAMILY)
-static dispatch_queue_t mainQueueSingleton()
-{
-    return dispatch_get_main_queue();
-}
-#endif
 
 #if PLATFORM(MAC)
 static NSApplication* NSAppSingleton()
@@ -917,7 +911,7 @@ void WebProcessPool::registerNotificationObservers()
     m_openDirectoryNotifyTokens.reserveInitialCapacity(std::size(messages));
     for (auto* message : messages) {
         int notifyToken;
-        notify_register_dispatch(message, &notifyToken, mainQueueSingleton(), ^(int token) {
+        notify_register_dispatch(message, &notifyToken, mainDispatchQueueSingleton(), ^(int token) {
             RELEASE_LOG(Notifications, "OpenDirectory invalidated cache");
 #if ENABLE(GPU_PROCESS)
             auto handle = SandboxExtension::createHandleForMachLookup("com.apple.system.opendirectoryd.libinfo"_s, std::nullopt);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -52,6 +52,7 @@
 #import "WebProcessProxy.h"
 #import <WebCore/LocalizedStrings.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPI.h"
@@ -657,7 +658,7 @@ void WebExtensionAction::propertiesDidChange()
 
     m_updatePending = true;
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, updateThrottleDuration.nanosecondsAs<int64_t>()), dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, updateThrottleDuration.nanosecondsAs<int64_t>()), mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
         m_updatePending = false;
 
         RefPtr extensionContext = m_extensionContext.get();
@@ -1061,7 +1062,7 @@ void WebExtensionAction::popupDidFinishDocumentLoad()
         return;
 
     // Delay showing the popup until a minimum size or a timeout is reached.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, popoverShowTimeout.nanosecondsAs<int64_t>()), dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }] {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, popoverShowTimeout.nanosecondsAs<int64_t>()), mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (popupPresented() || !hasPopupWebView() || !presentsPopupWhenReady() || !extensionContext())
             return;
 
@@ -1091,7 +1092,7 @@ void WebExtensionAction::readyToPresentPopup()
     if (RefPtr extensionController = extensionContext()->extensionController())
         extensionController->setShowingActionPopup(true);
 
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
         if (!extensionContext() || !popupPresented())
             return;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -37,6 +37,7 @@
 #import "WebExtensionContext.h"
 #import "WebExtensionMenuItem.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/StringBuilder.h>
 
 #if USE(APPKIT)
@@ -91,7 +92,7 @@ void WebExtensionCommand::dispatchChangedEventSoonIfNeeded()
 
     m_oldShortcut = shortcutString();
 
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
         RefPtr context = extensionContext();
         if (!context)
             return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
@@ -36,6 +36,7 @@
 #import "_WKWebExtensionSQLiteHelpers.h"
 #import "_WKWebExtensionSQLiteRow.h"
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 using namespace WebKit;
 
@@ -92,7 +93,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
 
         NSString *errorMessage;
         if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(errorMessage);
             });
 
@@ -123,7 +124,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
             errorMessage = [NSString stringWithFormat:@"Failed to add %@ rules. Some rules do not have unique IDs (%@).", strongSelf->_storageType, [existingRuleIDs componentsJoinedByString:@", "]];
 
         if (errorMessage.length) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(errorMessage);
             });
 
@@ -136,7 +137,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
                 break;
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(errorMessage);
         });
     });
@@ -157,7 +158,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
 
         NSString *errorMessage;
         if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage createIfNecessary:NO]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(errorMessage);
             });
 
@@ -175,7 +176,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
 
         NSString *deleteDatabaseErrorMessage = [strongSelf _deleteDatabaseIfEmpty];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             // Errors from opening the database or deleting keys take precedence over an error deleting the database.
             completionHandler(errorMessage.length ? errorMessage : deleteDatabaseErrorMessage);
         });
@@ -193,7 +194,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
         NSString *errorMessage;
         NSArray<NSDictionary<NSString *, id> *> *rules = [strongSelf _getRulesWithRuleIDs:ruleIDs errorMessage:&errorMessage];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(rules, errorMessage);
         });
     });

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -31,11 +31,13 @@
 #include "WebExtensionControllerParameters.h"
 #include "WebExtensionControllerProxyMessages.h"
 #include "WebPageProxy.h"
-#if PLATFORM(COCOA)
-#include <wtf/BlockPtr.h>
-#endif
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/BlockPtr.h>
+#include <wtf/darwin/DispatchExtras.h>
+#endif
 
 namespace WebKit {
 
@@ -67,7 +69,7 @@ WebExtensionController::WebExtensionController(Ref<WebExtensionControllerConfigu
     // when the first extension is about to be loaded.
 
 #if PLATFORM(COCOA)
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(freshlyCreatedTimeout.seconds() * NSEC_PER_SEC)), dispatch_get_main_queue(), makeBlockPtr([this, weakThis = WeakPtr { *this }] {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(freshlyCreatedTimeout.seconds() * NSEC_PER_SEC)), mainDispatchQueueSingleton(), makeBlockPtr([this, weakThis = WeakPtr { *this }] {
         if (!weakThis)
             return;
 

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm
@@ -34,6 +34,7 @@
 #import "WebURLSchemeHandlerCocoa.h"
 #import <WebCore/MIMETypeRegistry.h>
 #import <wtf/Assertions.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @implementation WKInspectorResourceURLSchemeHandler {
     RetainPtr<NSMapTable<id <WKURLSchemeTask>, NSOperation *>> _fileLoadOperations;
@@ -65,7 +66,7 @@
 
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
     if (!_cachedBundle) {
         _cachedBundle = [NSBundle bundleWithIdentifier:@"com.apple.WebInspectorUI"];
 
@@ -127,7 +128,7 @@
 
 - (void)webView:(WKWebView *)webView stopURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
-    dispatch_assert_queue(dispatch_get_main_queue());
+    dispatch_assert_queue(mainDispatchQueueSingleton());
     if (NSOperation *operation = [_fileLoadOperations objectForKey:urlSchemeTask]) {
         [operation cancel];
         [_fileLoadOperations removeObjectForKey:urlSchemeTask];

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -57,6 +57,7 @@
 #import <wtf/CompletionHandler.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/Base64.h>
 
 static const NSUInteger windowStyleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable | NSWindowStyleMaskFullSizeContentView;
@@ -157,7 +158,7 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
     // depend on this for enforcing the height constraints, so a small delay isn't terrible. Most
     // of the time the views will already have the correct frames because of autoresizing masks.
 
-    dispatch_after(DISPATCH_TIME_NOW, dispatch_get_main_queue(), ^{
+    dispatch_after(DISPATCH_TIME_NOW, mainDispatchQueueSingleton(), ^{
         if (RefPtr proxy = _inspectorProxy.get())
             proxy->inspectedViewFrameDidChange();
     });
@@ -175,7 +176,7 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
     if (window.inLiveResize)
         return;
 
-    dispatch_after(DISPATCH_TIME_NOW, dispatch_get_main_queue(), ^{
+    dispatch_after(DISPATCH_TIME_NOW, mainDispatchQueueSingleton(), ^{
         if (RefPtr proxy = _inspectorProxy.get())
             proxy->inspectedViewFrameDidChange();
     });

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -48,6 +48,7 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/Threading.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/darwin/XPCExtras.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
 #import <wtf/text/CString.h>
@@ -459,7 +460,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
     }
 
     ref();
-    xpc_connection_send_message_with_reply(m_xpcConnection.get(), bootstrapMessage.get(), dispatch_get_main_queue(), ^(xpc_object_t reply) {
+    xpc_connection_send_message_with_reply(m_xpcConnection.get(), bootstrapMessage.get(), mainDispatchQueueSingleton(), ^(xpc_object_t reply) {
         // Errors are handled in the event handler.
         // It is possible for this block to be called after the error event handler, in which case we're no longer
         // launching and we already took care of cleaning things up.

--- a/Source/WebKit/UIProcess/ios/WKModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKModelView.mm
@@ -42,6 +42,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/UUID.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK(AssetViewer);
@@ -179,7 +180,7 @@ SOFT_LINK_CLASS(AssetViewer, ASVInlinePreview);
             return;
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             [self.layer.context addFence:fenceHandle];
             [_preview setFrameWithinFencedTransaction:bounds];
             [fenceHandle invalidate];

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -39,6 +39,7 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/NotificationCenterCF.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
 
 SOFT_LINK_FRAMEWORK(CoreLocation)
@@ -263,7 +264,7 @@ static RetainPtr<NSMutableDictionary> createChallengeDictionary(NSData *data)
         else
             sites = adoptNS([[NSMutableDictionary alloc] init]);
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             if (!_sites)
                 _sites = sites;
             completionHandler();

--- a/Source/WebKit/UIProcess/mac/ServicesController.mm
+++ b/Source/WebKit/UIProcess/mac/ServicesController.mm
@@ -35,6 +35,7 @@
 #import <pal/spi/mac/NSSharingServiceSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace WebKit {
 
@@ -113,7 +114,7 @@ void ServicesController::refreshExistingServices(bool refreshImmediately)
             m_hasRichContentServices = hasServices;
         });
 
-        dispatch_group_notify(serviceLookupGroup.get(), dispatch_get_main_queue(), makeBlockPtr([this] {
+        dispatch_group_notify(serviceLookupGroup.get(), mainDispatchQueueSingleton(), makeBlockPtr([this] {
             bool availableServicesChanged = (m_lastSentHasImageServices != m_hasImageServices) || (m_lastSentHasSelectionServices != m_hasSelectionServices) || (m_lastSentHasRichContentServices != m_hasRichContentServices);
 
             m_lastSentHasSelectionServices = m_hasSelectionServices;

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -31,6 +31,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/WeakPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface _WKAPSConnectionDelegate : NSObject<APSConnectionDelegate> {
     WeakPtr<WebPushD::ApplePushServiceConnection> _connection;
@@ -70,7 +71,7 @@ namespace WebPushD {
 
 ApplePushServiceConnection::ApplePushServiceConnection(const String& incomingPushServiceName)
 {
-    m_connection = adoptNS([[APSConnection alloc] initWithEnvironmentName:APSEnvironmentProduction namedDelegatePort:incomingPushServiceName.createNSString().get() queue:dispatch_get_main_queue()]);
+    m_connection = adoptNS([[APSConnection alloc] initWithEnvironmentName:APSEnvironmentProduction namedDelegatePort:incomingPushServiceName.createNSString().get() queue:mainDispatchQueueSingleton()]);
     m_delegate = adoptNS([[_WKAPSConnectionDelegate alloc] initWithConnection:this]);
     [m_connection setDelegate:m_delegate.get()];
 }

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -41,6 +41,7 @@
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/MakeString.h>
@@ -107,7 +108,7 @@ static void performAfterFirstUnlock(Function<void()>&& function)
     RELEASE_LOG(Push, "Device is locked. Delaying init until it unlocks for the first time.");
 
     if (notifyToken == NOTIFY_TOKEN_INVALID) {
-        notify_register_dispatch(kMobileKeyBagLockStatusNotifyToken, &notifyToken, dispatch_get_main_queue(), ^(int token) {
+        notify_register_dispatch(kMobileKeyBagLockStatusNotifyToken, &notifyToken, mainDispatchQueueSingleton(), ^(int token) {
             if (!notify_is_valid_token(token) || !hasUnlockedAtLeastOnce())
                 return;
             runFunctions();

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -57,6 +57,7 @@
 #import <wtf/URL.h>
 #import <wtf/WorkQueue.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/darwin/XPCExtras.h>
 #import <wtf/text/MakeString.h>
 
@@ -160,7 +161,7 @@ WebPushDaemon::WebPushDaemon()
 {
 #if PLATFORM(IOS)
     int token;
-    notify_register_dispatch("com.apple.webclip.uninstalled", &token, dispatch_get_main_queue(), ^(int) {
+    notify_register_dispatch("com.apple.webclip.uninstalled", &token, mainDispatchQueueSingleton(), ^(int) {
         updateSubscriptionSetState();
     });
 #endif

--- a/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
@@ -37,6 +37,7 @@
 #import "DumpRenderTreePasteboard.h"
 #import "EventSendingController.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface DumpRenderTreeFilePromiseReceiver : NSFilePromiseReceiver {
     RetainPtr<NSArray<NSString *>> _promisedUTIs;
@@ -125,7 +126,7 @@ static std::pair<NSURL *, NSError *> copyFile(NSURL *sourceURL, NSURL *destinati
             NSURL *destinationURL;
             std::tie(destinationURL, error) = copyFile(sourceURL, destinationDirectory);
             if (destinationURL) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(mainDispatchQueueSingleton(), ^{
                     [_destinationURLs addObject:destinationURL];
                 });
             }

--- a/Tools/DumpRenderTree/mac/FrameLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/FrameLoadDelegate.mm
@@ -53,6 +53,7 @@
 #import <WebKit/WebSecurityOriginPrivate.h>
 #import <WebKit/WebViewPrivate.h>
 #import <wtf/Assertions.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if !PLATFORM(IOS_FAMILY)
 #import "AppleScriptController.h"
@@ -221,7 +222,7 @@ IGNORE_WARNINGS_END
         [sender setDefersCallbacks:YES];
         int64_t deferredWaitTime = 5 * NSEC_PER_MSEC;
         dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-        dispatch_after(when, dispatch_get_main_queue(), ^{
+        dispatch_after(when, mainDispatchQueueSingleton(), ^{
 #if PLATFORM(IOS_FAMILY)
             WebThreadLock();
 #endif

--- a/Tools/DumpRenderTree/mac/TestRunnerMac.mm
+++ b/Tools/DumpRenderTree/mac/TestRunnerMac.mm
@@ -79,6 +79,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/WallTime.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPIForTesting.h"
@@ -1145,7 +1146,7 @@ void TestRunner::simulateWebNotificationClick(JSValueRef jsNotification)
 {
     NSString *notificationID = [[mainFrame webView] _notificationIDForTesting:jsNotification];
     m_hasPendingWebNotificationClick = true;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (!m_hasPendingWebNotificationClick)
             return;
 

--- a/Tools/EditingHistory/EditingHistory/TestRunner.m
+++ b/Tools/EditingHistory/EditingHistory/TestRunner.m
@@ -29,6 +29,7 @@
 #import "TestUtil.h"
 #import "WKWebViewAdditions.h"
 #import <Carbon/Carbon.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static WKUserScript *injectedMessageEventHandlerScript(NSString *listener, NSString *event)
 {
@@ -124,7 +125,7 @@ static WKUserScript *injectedMessageEventHandlerScript(NSString *listener, NSStr
 - (void)expectEvents:(NSDictionary<NSString *, NSNumber *> *)expectedEventCounts afterPerforming:(dispatch_block_t)action
 {
     _pendingEventCounts = [expectedEventCounts mutableCopy];
-    dispatch_async(dispatch_get_main_queue(), action);
+    dispatch_async(mainDispatchQueueSingleton(), action);
     waitUntil(CONDITION_BLOCK(self.isDoneWaitingForPendingEvents));
     _pendingEventCounts = nil;
 }

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3612,6 +3612,10 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_strncmp:
         error(line_number, 'safercpp/strncmp', 4, "strncmp() is unsafe.")
 
+    uses_dispatch_get_main_queue = search(r'dispatch_get_main_queue\(', line)
+    if uses_dispatch_get_main_queue:
+        error(line_number, 'safercpp/dispatch_get_main_queue', 4, "use mainDispatchQueueSingleton() instead of dispatch_get_main_queue().")
+
     uses_printf = search(r'\bprintf\b', line)
     if uses_printf:
         error(line_number, 'safercpp/printf', 4, "printf is unsafe. Use SAFE_PRINTF instead.")
@@ -5007,6 +5011,7 @@ class CppChecker(object):
         'runtime/wtf_never_destroyed',
         'safercpp/atoi',
         'safercpp/checked_getter_for_init',
+        'safercpp/dispatch_get_main_queue',
         'safercpp/memchr',
         'safercpp/memcmp',
         'safercpp/memcpy',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -2365,7 +2365,7 @@ class CppStyleTest(CppStyleTestBase):
         self.assert_lint('for{', 'Missing space before {'
                          '  [whitespace/braces] [5]')
         self.assert_lint('for {', '')
-        self.assert_lint('dispatch_async(dispatch_get_main_queue(), ^{', '')
+        self.assert_lint('dispatch_async(mainDispatchQueueSingleton(), ^{', '')
         self.assert_lint('[outOfBandTracks.get() addObject:@{', '')
         self.assert_lint('EXPECT_DEBUG_DEATH({', '')
         self.assert_lint('LOCAL_LOG(R"({ "url": "%{public}s",)", url.string().utf8().data());', '')

--- a/Tools/TestWebKitAPI/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/NetworkConnection.mm
@@ -32,6 +32,7 @@
 #import <wtf/SHA1.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/StringToIntegerConversion.h>
 
@@ -53,7 +54,7 @@ static RetainPtr<dispatch_data_t> dataFromString(String&& s)
     auto impl = s.releaseImpl();
     ASSERT(impl->is8Bit());
     auto characters = impl->span8();
-    return adoptNS(dispatch_data_create(characters.data(), characters.size(), dispatch_get_main_queue(), ^{
+    return adoptNS(dispatch_data_create(characters.data(), characters.size(), mainDispatchQueueSingleton(), ^{
         (void)impl;
     }));
 }
@@ -228,7 +229,7 @@ Connection ConnectionGroup::createWebTransportConnection(ConnectionType type) co
 
     RetainPtr connection = adoptNS(nw_connection_group_extract_connection(m_data->group.get(), nil, webtransportOptions.get()));
     ASSERT(connection);
-    nw_connection_set_queue(connection.get(), dispatch_get_main_queue());
+    nw_connection_set_queue(connection.get(), mainDispatchQueueSingleton());
     nw_connection_start(connection.get());
     return Connection(connection.get());
 }
@@ -259,7 +260,7 @@ void ConnectionGroup::receiveIncomingConnection(Connection connection)
             return;
         data->connectionHandler(connection);
     });
-    nw_connection_set_queue(connection.m_connection.get(), dispatch_get_main_queue());
+    nw_connection_set_queue(connection.m_connection.get(), mainDispatchQueueSingleton());
     nw_connection_start(connection.m_connection.get());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm
@@ -31,6 +31,7 @@
 #import "PlatformUtilities.h"
 #import "PlatformWebView.h"
 #import <WebKit/WKWebViewPrivate.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -77,7 +78,7 @@ TEST(WebKit, DeferredViewInWindowStateChange)
 
     __block bool done = false;
     WKPageRef page = webView.page();
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         EXPECT_JS_TRUE(page, "document.hidden");
         done = true;
     });

--- a/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm
@@ -40,6 +40,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 
@@ -80,7 +81,7 @@
 - (void)joinWithCompletion:(void(^ _Nonnull)(BOOL))completionHandler
 {
     _lastMethodCalled = @"join";
-    dispatch_async(dispatch_get_main_queue(), ^() {
+    dispatch_async(mainDispatchQueueSingleton(), ^() {
         completionHandler(!_failsCommands);
     });
 }
@@ -93,7 +94,7 @@
 - (void)seekTo:(double)time withCompletion:(void(^ _Nonnull)(BOOL))completionHandler
 {
     _lastMethodCalled = @"seekTo";
-    dispatch_async(dispatch_get_main_queue(), ^() {
+    dispatch_async(mainDispatchQueueSingleton(), ^() {
         completionHandler(!_failsCommands);
     });
 }
@@ -101,7 +102,7 @@
 - (void)playWithCompletion:(void(^ _Nonnull)(BOOL))completionHandler
 {
     _lastMethodCalled = @"play";
-    dispatch_async(dispatch_get_main_queue(), ^() {
+    dispatch_async(mainDispatchQueueSingleton(), ^() {
         completionHandler(!_failsCommands);
     });
 }
@@ -109,7 +110,7 @@
 - (void)pauseWithCompletion:(void(^ _Nonnull)(BOOL))completionHandler
 {
     _lastMethodCalled = @"pause";
-    dispatch_async(dispatch_get_main_queue(), ^() {
+    dispatch_async(mainDispatchQueueSingleton(), ^() {
         completionHandler(!_failsCommands);
     });
 }
@@ -117,7 +118,7 @@
 - (void)setTrack:(NSString*)trackIdentifier withCompletion:(void(^ _Nonnull)(BOOL))completionHandler
 {
     _lastMethodCalled = @"setTrack";
-    dispatch_async(dispatch_get_main_queue(), ^() {
+    dispatch_async(mainDispatchQueueSingleton(), ^() {
         completionHandler(!_failsCommands);
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
@@ -30,6 +30,7 @@
 #import <WebKit/PreferenceObserver.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/StringBuilder.h>
 
 #if WK_HAVE_C_SPI
@@ -184,7 +185,7 @@ TEST_F(AppleLanguagesTest, DISABLED_UpdateAppleLanguages)
     system([NSString stringWithFormat:@"defaults write NSGlobalDomain AppleLanguages '(\"en-US\")'"].UTF8String);
 
     // Implement our own timeout because we would fail to reset the language if we let the test actually time out.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC), mainDispatchQueueSingleton(), ^{
         done = true;
     });
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
@@ -34,8 +34,8 @@
 #import "TestWKWebView.h"
 #import <WebKit/PreferenceObserver.h>
 #import <WebKit/WKWebViewPrivate.h>
-
 #import <wtf/ObjCRuntimeExtras.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static bool receivedPreferenceNotification = false;
 
@@ -70,7 +70,7 @@ static constexpr Seconds preferenceQuerySleepTime = 1_s;
 static void waitForPreferenceSynchronization()
 {
     __block bool didSynchronize = false;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         didSynchronize = true;
     });
     TestWebKitAPI::Util::run(&didSynchronize);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -40,6 +40,7 @@
 #import <WebKit/_WKFrameTreeNode.h>
 #import <WebKit/_WKSessionState.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/WTFString.h>
 
@@ -157,7 +158,7 @@ static size_t navigations;
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         decisionHandler(WKNavigationActionPolicyAllow);
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
@@ -39,6 +39,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKThumbnailView.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static bool didFinishLoad;
 static bool didTakeSnapshot;
@@ -327,7 +328,7 @@ static std::pair<WebCore::Color, WebCore::Color> leftCornerColorsForThumbnailVie
 {
     __block RetainPtr<CGImageRef> snapshot;
     __block bool done = false;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         snapshot = thumbnailView._test_cgImage;
         done = true;
     });

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuMouseEvents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuMouseEvents.mm
@@ -34,6 +34,7 @@
 #import "TestWKWebView.h"
 #import <Carbon/Carbon.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
     
@@ -57,7 +58,7 @@ static void runTest(NSEventModifierFlags flags, NSEventType mouseDownType, NSEve
     __block bool done = false;
     __block BlockPtr<void(NSMenu *)> completionHandlerCopy;
     [uiDelegate setGetContextMenuFromProposedMenu:^(NSMenu *, _WKContextMenuElementInfo *, id <NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandlerCopy = completionHandler;
             done = true;
         });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
@@ -38,6 +38,7 @@
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -139,7 +140,7 @@ TEST(AnimatedResize, AnimatedResizeDoesNotHang)
             [webView setFrame:CGRectMake(0, 0, [webView frame].size.width + 100, 400)];
         }];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             [webView _endAnimatedResize];
         });
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AsyncPolicyForNavigationResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AsyncPolicyForNavigationResponse.mm
@@ -29,6 +29,7 @@
 #import "Test.h"
 #import <WebKit/WKWebView.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static bool shouldAccept = true;
 static bool navigationComplete = false;
@@ -67,7 +68,7 @@ static bool navigationFailed = false;
 {
     int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-    dispatch_after(when, dispatch_get_main_queue(), ^{
+    dispatch_after(when, mainDispatchQueueSingleton(), ^{
         decisionHandler(shouldAccept ? WKNavigationResponsePolicyAllow : WKNavigationResponsePolicyCancel);
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm
@@ -45,6 +45,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/WTFString.h>
 
 static bool receivedNotification;
@@ -215,7 +216,7 @@ TEST(ContentRuleList, DisplayNoneInSrcDocIFrame)
     __block bool isDone = false;
 
     // Make sure the frame loads before checking the computed style.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.05 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.05 * NSEC_PER_SEC), mainDispatchQueueSingleton(), ^{
         NSString *getHeaderDisplay = @"window.getComputedStyle(document.getElementById('subframe').contentDocument.querySelector('h1')).getPropertyValue('display')";
         EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:getHeaderDisplay], "none");
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
@@ -42,6 +42,7 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static bool shouldCancelNavigation;
 static bool shouldDelayDecision;
@@ -65,7 +66,7 @@ static NSString *thirdURL = @"data:text/html,Third";
     if (shouldCancelNavigation) {
         int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
         dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-        dispatch_after(when, dispatch_get_main_queue(), ^{
+        dispatch_after(when, mainDispatchQueueSingleton(), ^{
             decisionHandler(WKNavigationActionPolicyCancel);
             decidedPolicy = true;
         });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -62,6 +62,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/WTFString.h>
 
@@ -932,7 +933,7 @@ TEST(_WKDownload, DownloadMonitorCancel)
 TEST(_WKDownload, DISABLED_DownloadMonitorSurvive)
 {
     __block BOOL timeoutReached = NO;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2.5 * NSEC_PER_SEC), mainDispatchQueueSingleton(), ^{
         [monitorDelegate() stopWaitingForDidFail];
         timeoutReached = YES;
     });
@@ -951,7 +952,7 @@ TEST(_WKDownload, DownloadMonitorReturnToForeground)
 #endif
 {
     __block BOOL timeoutReached = NO;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2.5 * NSEC_PER_SEC), mainDispatchQueueSingleton(), ^{
         [monitorDelegate() stopWaitingForDidFail];
         timeoutReached = YES;
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -49,6 +49,7 @@
 #import <WebKit/_WKInspector.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/MakeString.h>
 
@@ -496,7 +497,7 @@ static void attemptConnectionInProcessWithoutEntitlement()
 {
 #if USE(APPLE_INTERNAL_SDK)
     __block bool done = false;
-    auto connection = adoptNS(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", dispatch_get_main_queue(), 0));
+    auto connection = adoptNS(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t event) {
         EXPECT_EQ(event, XPC_ERROR_CONNECTION_INTERRUPTED);
         done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -38,6 +38,7 @@
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #import <pal/cocoa/VisionKitCoreSoftLink.h>
 
@@ -55,7 +56,7 @@ static void swizzledPresentViewController(UIViewController *, SEL, UIViewControl
 
 static int32_t swizzledProcessRequest(VKCImageAnalyzer *, SEL, id request, void (^)(double progress), void (^completion)(VKImageAnalysis *, NSError *))
 {
-    dispatch_async(dispatch_get_main_queue(), [completion = makeBlockPtr(completion)] {
+    dispatch_async(mainDispatchQueueSingleton(), [completion = makeBlockPtr(completion)] {
         completion(TestWebKitAPI::createImageAnalysisWithSimpleFixedResults().get(), nil);
     });
     return 100;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
@@ -41,6 +41,7 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
@@ -106,7 +107,7 @@ public:
     {
         bool gotNowPlaying = false;
         RetainPtr<MRNowPlayingClientRef> nowPlayingClient;
-        MRMediaRemoteGetNowPlayingClient(dispatch_get_main_queue(), [&] (MRNowPlayingClientRef player, CFErrorRef error) {
+        MRMediaRemoteGetNowPlayingClient(mainDispatchQueueSingleton(), [&] (MRNowPlayingClientRef player, CFErrorRef error) {
             if (!error && player)
                 nowPlayingClient = player;
             gotNowPlaying = true;
@@ -248,7 +249,7 @@ public:
         bool completed = false;
         RetainPtr<NSArray> result;
 
-        MRMediaRemoteGetSupportedCommandsForOrigin(MRMediaRemoteGetLocalOrigin(), dispatch_get_main_queue(), [&] (CFArrayRef commands) {
+        MRMediaRemoteGetSupportedCommandsForOrigin(MRMediaRemoteGetLocalOrigin(), mainDispatchQueueSingleton(), [&] (CFArrayRef commands) {
             result = (__bridge NSArray *)commands;
             completed = true;
         });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm
@@ -34,6 +34,7 @@
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @class ModalAlertsUIDelegate;
 
@@ -155,7 +156,7 @@ static bool didRespondToPrompt = false;
 
 - (void)_webView:(WKWebView *)webView runBeforeUnloadConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL result))completionHandler
 {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), mainDispatchQueueSingleton(), ^{
         completionHandler(shouldRejectClosingViaPrompt ? NO : YES);
         didRespondToPrompt = true;
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
@@ -52,6 +52,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/UUID.h>
 #import <wtf/Vector.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
 TEST(NetworkProcess, Entitlements)
@@ -682,7 +683,7 @@ TEST(_WKDataTask, Cancel)
         task.delegate = delegate.get();
         delegate.get().didReceiveResponse = ^(_WKDataTask *task, NSURLResponse *response, void (^decisionHandler)(_WKDataTaskResponsePolicy)) {
             decisionHandler(_WKDataTaskResponsePolicyAllow);
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 EXPECT_NOT_NULL(task.delegate);
                 [task cancel];
                 EXPECT_NULL(task.delegate);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlaying.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlaying.mm
@@ -37,6 +37,7 @@
 #import <wtf/HashSet.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/WTFString.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK(MediaRemote)
@@ -68,7 +69,7 @@ static RetainPtr<MRNowPlayingClientRef> getNowPlayingClient()
 {
     bool gotNowPlaying = false;
     RetainPtr<MRNowPlayingClientRef> nowPlayingClient;
-    MRMediaRemoteGetNowPlayingClient(dispatch_get_main_queue(), [&] (MRNowPlayingClientRef player, CFErrorRef error) {
+    MRMediaRemoteGetNowPlayingClient(mainDispatchQueueSingleton(), [&] (MRNowPlayingClientRef player, CFErrorRef error) {
         if (!error && player)
             nowPlayingClient = player;
         gotNowPlaying = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm
@@ -42,6 +42,7 @@
 #import <WebKit/WKWindowFeaturesPrivate.h>
 #import <WebKit/_WKFrameTreeNode.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @class OpenAndCloseWindowUIDelegate;
 @class OpenAndCloseWindowUIDelegateAsync;
@@ -125,14 +126,14 @@ TEST(WebKit, OpenAndCloseWindow)
 {
     if (_shouldCallback) {
         if (!_shouldCallbackWithNil) {
-            dispatch_async(dispatch_get_main_queue(), ^ {
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 openedWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
                 [openedWebView setUIDelegate:sharedUIDelegateAsync.get()];
                 self.expectedClosingView = openedWebView.get();
                 completionHandler(openedWebView.get());
             });
         } else {
-            dispatch_async(dispatch_get_main_queue(), ^ {
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 self.expectedClosingView = webView;
                 completionHandler(nil);
             });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
@@ -36,6 +36,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 TEST(WKWebView, PrepareForMoveToWindow)
 {
@@ -123,7 +124,7 @@ TEST(WKWebView, PrepareForMoveToWindowThenViewDeallocBeforeMoving)
         webView = nil;
     }
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [window setFrame:NSMakeRect(0, 0, 10, 10) display:YES];
         isDone = true;
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -66,6 +66,7 @@
 #import <wtf/RunLoop.h>
 #import <wtf/Vector.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
@@ -352,7 +353,7 @@ static RetainPtr<WKWebView> createdWebView;
     auto doAsynchronouslyIfNecessary = [self, strongSelf = retainPtr(self), task = retainPtr(task)](Function<void(id <WKURLSchemeTask>)>&& f, double delay) {
         if (!_shouldRespondAsynchronously)
             return f(task.get());
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC), dispatch_get_main_queue(), makeBlockPtr([self, strongSelf, task, f = WTFMove(f)] {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC), mainDispatchQueueSingleton(), makeBlockPtr([self, strongSelf, task, f = WTFMove(f)] {
             if (_runningTasks.contains(task.get()))
                 f(task.get());
         }).get());
@@ -5721,7 +5722,7 @@ TEST(ProcessSwap, CommittedProcessCrashDuringCrossSiteNavigation)
         decisionHandler(WKNavigationActionPolicyAllow); // Will ask the load to proceed in a new provisional WebProcess since the navigation is cross-site.
 
         // Simulate a crash of the committed WebProcess while the provisional navigation starts in the new provisional WebProcess.
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.2 * NSEC_PER_SEC), mainDispatchQueueSingleton(), ^{
             kill(pid1, 9);
             didKill = true;
         });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm
@@ -47,6 +47,7 @@
 #import <WebKit/_WKDownloadDelegate.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 using namespace TestWebKitAPI;
 
@@ -321,7 +322,7 @@ TEST(QuickLook, AllowResponseAfterLoadingPreview)
     int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
 
-    dispatch_after(when, dispatch_get_main_queue(), ^{
+    dispatch_after(when, mainDispatchQueueSingleton(), ^{
         decisionHandler(_responsePolicy);
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ReparentWebViewTimeout.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ReparentWebViewTimeout.mm
@@ -31,6 +31,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 TEST(WebKit, ReparentWebViewTimeout)
 {
@@ -47,11 +48,11 @@ TEST(WebKit, ReparentWebViewTimeout)
     void (^runTest)(void) = ^{
         __block bool done = false;
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 [webView removeFromSuperview];
 
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(mainDispatchQueueSingleton(), ^{
                     [webView addToTestWindow];
                     [webView waitForNextPresentationUpdate];
                     done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -47,6 +47,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/URL.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
 static bool finishedNavigation = false;
@@ -495,7 +496,7 @@ void waitUntilTwoServersConnected(const unsigned& serversConnected, CompletionHa
         completionHandler();
         return;
     }
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([&serversConnected, completionHandler = WTFMove(completionHandler)] () mutable {
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([&serversConnected, completionHandler = WTFMove(completionHandler)] () mutable {
         waitUntilTwoServersConnected(serversConnected, WTFMove(completionHandler));
     }).get());
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunScriptAfterDocumentLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunScriptAfterDocumentLoad.mm
@@ -32,6 +32,7 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Seconds.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static const char* markup =
     "<head>"
@@ -68,7 +69,7 @@ TEST(RunScriptAfterDocumentLoad, ExecutionOrderOfScriptsInDocument)
         // Delay request responses for the other two scripts for a short duration to ensure that in the absence
         // of the deferred asynchronous scripts configuration flag, we will normally execute the asynchronous script
         // before the other scripts.
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (0.25_s).nanoseconds()), dispatch_get_main_queue(), responseBlock);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (0.25_s).nanoseconds()), mainDispatchQueueSingleton(), responseBlock);
     }];
 
     auto messages = adoptNS([NSMutableArray new]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -44,6 +44,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/StringPrintStream.h>
 #import <wtf/URL.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/WTFString.h>
 
@@ -262,7 +263,7 @@ private:
     }
 
     auto allowSOAuthorizationLoad = self.allowSOAuthorizationLoad;
-    dispatch_async(dispatch_get_main_queue(), ^() {
+    dispatch_async(mainDispatchQueueSingleton(), ^() {
         if (allowSOAuthorizationLoad)
             completionHandler(_WKSOAuthorizationLoadPolicyAllow);
         else

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -70,6 +70,7 @@
 #import <wtf/Vector.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
@@ -179,7 +180,7 @@ static bool navigationFailed = false;
 {
     int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-    dispatch_after(when, dispatch_get_main_queue(), ^{
+    dispatch_after(when, mainDispatchQueueSingleton(), ^{
         decisionHandler(shouldAccept ? WKNavigationResponsePolicyAllow : WKNavigationResponsePolicyCancel);
     });
 }
@@ -4921,7 +4922,7 @@ TEST(ServiceWorker, ServiceWorkerReadableStreamDownloadCancel)
     navigationDownloadDelegate.get().navigationResponseDidBecomeDownload = ^(WKWebView *, WKNavigationResponse *, WKDownload *download) {
         int64_t deferredWaitTime = 500 * NSEC_PER_MSEC;
         dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-        dispatch_after(when, dispatch_get_main_queue(), ^{
+        dispatch_after(when, mainDispatchQueueSingleton(), ^{
             [download cancel:^(NSData*) { }];
         });
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -49,6 +49,7 @@
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebViewPrivateForTestingMac.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if ENABLE(POINTER_LOCK)
 #import <GameController/GameController.h>
@@ -1426,7 +1427,7 @@ static void synthesizeWheelEvents(NSView *view, int x, int y)
     [view scrollWheel:event];
     
     // Wheel events get coalesced sometimes. Make more events until one is not handled.
-    dispatch_async(dispatch_get_main_queue(), ^ {
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         synthesizeWheelEvents(view, x, y);
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -59,6 +59,7 @@
 #import <WebKit/_WKFeature.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
 @interface WKWebView ()
@@ -830,7 +831,7 @@ UNIFIED_PDF_TEST(PrintPDFUsingPrintInteractionController)
 
     [printInteractionController _setupPrintPanel:nil];
     [printInteractionController _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             [printInteractionController _cleanPrintState];
             done = true;
@@ -1007,7 +1008,7 @@ UNIFIED_PDF_TEST(WebViewResizeShouldNotCrash)
     webView = nil;
 
     __block bool finishedDispatch = false;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         finishedDispatch = true;
     });
 
@@ -1203,7 +1204,7 @@ static void checkKeyboardScrollability(TestWKWebView *webView)
         RetainPtr secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@" " charactersIgnoringModifiers:@" " modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
 
         [webView handleKeyEvent:firstWebEvent.get() completion:^(WebEvent *theEvent, BOOL wasHandled) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{
                 [webView handleKeyEvent:secondWebEvent.get() completion:^(WebEvent *theEvent, BOOL wasHandled) {
                     completionHandler();
                 }];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
@@ -34,6 +34,7 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <notify.h>
 #import <wtf/MonotonicTime.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 // This test loads file-with-video.html. Then it calls a JavaScript method to create a source buffer and play the video,
 // waits for WKMediaNetworkingActivity notification to be fired.
@@ -64,7 +65,7 @@ TEST(WebKit, MSEHasMediaStreamingActivity)
     __block bool isMediaStreamingChanged = false;
     __block bool isMediaStreaming = false;
 
-    int status = notify_register_dispatch(WebKitMediaStreamingActivity, &token, dispatch_get_main_queue(), ^(int token) {
+    int status = notify_register_dispatch(WebKitMediaStreamingActivity, &token, mainDispatchQueueSingleton(), ^(int token) {
         uint64_t state = 0;
         notify_get_state(token, &state);
         isMediaStreamingChanged = true;
@@ -108,7 +109,7 @@ TEST(WebKit, ManagedMSEHasMediaStreamingActivity)
     __block bool isMediaStreamingChanged = false;
     __block bool isMediaStreaming = false;
 
-    int status = notify_register_dispatch(WebKitMediaStreamingActivity, &token, dispatch_get_main_queue(), ^(int token) {
+    int status = notify_register_dispatch(WebKitMediaStreamingActivity, &token, mainDispatchQueueSingleton(), ^(int token) {
         uint64_t state = 0;
         notify_get_state(token, &state);
         isMediaStreamingChanged = true;
@@ -152,7 +153,7 @@ TEST(WebKit, ManagedMSEHasMediaStreamingActivityWithPolicy)
     __block bool isMediaStreamingChanged = false;
     __block bool isMediaStreaming = false;
 
-    int status = notify_register_dispatch(WebKitMediaStreamingActivity, &token, dispatch_get_main_queue(), ^(int token) {
+    int status = notify_register_dispatch(WebKitMediaStreamingActivity, &token, mainDispatchQueueSingleton(), ^(int token) {
         uint64_t state = 0;
         notify_get_state(token, &state);
         isMediaStreamingChanged = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
@@ -36,6 +36,7 @@
 #import <WebKit/WKWebpagePreferences.h>
 #import <WebKit/_WKFrameHandle.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 typedef void (^CallCompletionBlock)();
 
@@ -51,7 +52,7 @@ typedef void (^CallCompletionBlock)();
 
 - (void)callBlockAsync:(CallCompletionBlock)callCompletionBlock
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         callCompletionBlock();
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -54,6 +54,7 @@
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/StringToIntegerConversion.h>
@@ -129,7 +130,7 @@
 {
     int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-    dispatch_after(when, dispatch_get_main_queue(), ^{
+    dispatch_after(when, mainDispatchQueueSingleton(), ^{
         decisionHandler(WKNavigationActionPolicyAllow);
     });
 
@@ -139,7 +140,7 @@
 {
     int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-    dispatch_after(when, dispatch_get_main_queue(), ^{
+    dispatch_after(when, mainDispatchQueueSingleton(), ^{
         decisionHandler(WKNavigationResponsePolicyAllow);
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
@@ -29,6 +29,7 @@
 
 #import "WebExtensionUtilities.h"
 #import <WebKit/WKWebExtensionCommand.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -224,7 +225,7 @@ TEST(WKWebExtensionAPICookies, GetAll)
     }];
 
     __block bool done = false;
-    dispatch_group_notify(cookieGroup, dispatch_get_main_queue(), ^{
+    dispatch_group_notify(cookieGroup, mainDispatchQueueSingleton(), ^{
         done = true;
     });
 
@@ -289,7 +290,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognito)
     }];
 
     __block bool done = false;
-    dispatch_group_notify(cookieGroup, dispatch_get_main_queue(), ^{
+    dispatch_group_notify(cookieGroup, mainDispatchQueueSingleton(), ^{
         done = true;
     });
 
@@ -364,7 +365,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognitoWithPrivateAccess)
     }];
 
     __block bool done = false;
-    dispatch_group_notify(cookieGroup, dispatch_get_main_queue(), ^{
+    dispatch_group_notify(cookieGroup, mainDispatchQueueSingleton(), ^{
         done = true;
     });
 
@@ -480,7 +481,7 @@ TEST(WKWebExtensionAPICookies, GetAllWithFilters)
     }];
 
     __block bool done = false;
-    dispatch_group_notify(cookieGroup, dispatch_get_main_queue(), ^{
+    dispatch_group_notify(cookieGroup, mainDispatchQueueSingleton(), ^{
         done = true;
     });
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKWebExtensionContextPrivate.h>
 #import <WebKit/WKWebExtensionControllerDelegate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -169,7 +170,7 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
         EXPECT_EQ(requestedMatchPatterns.count, matchPatterns.count);
         EXPECT_TRUE([requestedMatchPatterns isEqualToSet:matchPatterns]);
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             callback(requestedMatchPatterns, nil);
             requestComplete = true;
         });
@@ -282,7 +283,7 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
 
     // Grant the requested permissions.
     requestDelegate.get().promptForPermissions = ^(id<WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             requestComplete = true;
             callback(requestedPermissions, nil);
         });
@@ -328,7 +329,7 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
 
     // Grant the requested match patterns.
     requestDelegate.get().promptForPermissionMatchPatterns = ^(id<WKWebExtensionTab> tab, NSSet<WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<WKWebExtensionMatchPattern *> *, NSDate *)) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             requestComplete = true;
             callback(requestedMatchPatterns, [NSDate dateWithTimeIntervalSinceNow:10]);
         });
@@ -369,7 +370,7 @@ TEST(WKWebExtensionAPIPermissions, RequestAllURLsMatchPattern)
 
     // Grant the requested match patterns.
     requestDelegate.get().promptForPermissionMatchPatterns = ^(id<WKWebExtensionTab> tab, NSSet<WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<WKWebExtensionMatchPattern *> *, NSDate *)) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             requestComplete = true;
             callback(requestedMatchPatterns, [NSDate dateWithTimeIntervalSinceNow:10]);
         });
@@ -754,7 +755,7 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
 
     // Grant the requested permissions.
     requestDelegate.get().promptForPermissions = ^(id<WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             requestComplete = true;
             callback(requestedPermissions, nil);
         });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -31,6 +31,7 @@
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import "WebExtensionUtilities.h"
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -1396,7 +1397,7 @@ TEST(WKWebExtensionAPIRuntime, SendNativeMessage)
         EXPECT_NS_EQUAL(applicationIdentifier, @"test");
         EXPECT_NS_EQUAL(message, @"Hello");
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{
             replyHandler(@"Received", nil);
         });
     };
@@ -1420,7 +1421,7 @@ TEST(WKWebExtensionAPIRuntime, SendNativeMessageWithInvalidReply)
         EXPECT_NS_EQUAL(applicationIdentifier, @"test");
         EXPECT_NS_EQUAL(message, @"Hello");
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{
             replyHandler(@{ @"bad": NSUUID.UUID }, nil);
         });
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -31,6 +31,7 @@
 #import "TestWKWebView.h"
 #import "WebExtensionUtilities.h"
 #import <JavaScriptCore/MathCommon.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -830,7 +831,7 @@ TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)
             EXPECT_TRUE([requestedURLs containsObject:loopbackURL]);
 
             // Only approve localhost for the first request.
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler([NSSet setWithObject:localhostURL], nil);
             });
 
@@ -841,7 +842,7 @@ TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)
             EXPECT_TRUE([requestedURLs containsObject:loopbackURL]);
 
             // Approve nothing for the second request.
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 completionHandler(NSSet.set, nil);
             });
         }
@@ -913,7 +914,7 @@ TEST(WKWebExtensionAPITabs, QueryWithPermissionBypass)
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionTabs];
 
     manager.get().internalDelegate.promptForPermissionToAccessURLs = ^(id<WKWebExtensionTab>, NSSet<NSURL *> *requestedURLs, void (^completionHandler)(NSSet<NSURL *> *allowedURLs, NSDate *)) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler(NSSet.set, nil);
         });
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm
@@ -32,6 +32,7 @@
 #import <Carbon/Carbon.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WebKitPrivate.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static NSString *GetInputValueJSExpression = @"document.querySelector('input').value";
 static NSString *GetDocumentScrollTopJSExpression = @"document.body.scrollTop";
@@ -117,7 +118,7 @@ static NSString *GetDocumentScrollTopJSExpression = @"document.body.scrollTop";
 - (void)typeString:(NSString *)string inputMessage:(NSString *)inputMessage
 {
     for (uint64_t i = 0; i < string.length; ++i) {
-        dispatch_async(dispatch_get_main_queue(), ^()
+        dispatch_async(mainDispatchQueueSingleton(), ^()
         {
             [self typeCharacter:[string characterAtIndex:i]];
         });
@@ -198,7 +199,7 @@ TEST(WKWebViewCandidateTests, ClickingInTextFieldDoesNotThrashCandidateVisibilit
     [wkWebView typeString:@"test" inputMessage:@"input"];
     [wkWebView expectCandidateListVisibilityUpdates:0 whenPerformingActions:^()
     {
-        dispatch_async(dispatch_get_main_queue(), ^()
+        dispatch_async(mainDispatchQueueSingleton(), ^()
         {
             [wkWebView mouseDownAtPoint:NSMakePoint(100, 300) simulatePressure:YES];
         });
@@ -214,7 +215,7 @@ TEST(WKWebViewCandidateTests, ShouldNotRequestCandidatesInPasswordField)
     [wkWebView waitForMessage:@"loaded"];
     [wkWebView _forceRequestCandidates];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [wkWebView mouseDownAtPoint:NSMakePoint(400, 150) simulatePressure:YES];
     });
     [wkWebView waitForMessage:@"password-focused"];
@@ -233,7 +234,7 @@ TEST(WKWebViewCandidateTests, ShouldRequestCandidatesInTextField)
     [wkWebView waitForMessage:@"loaded"];
     [wkWebView _forceRequestCandidates];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [wkWebView mouseDownAtPoint:NSMakePoint(400, 450) simulatePressure:YES];
     });
     [wkWebView waitForMessage:@"text-focused"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WebKitPrivate.h>
 #import <WebKit/_WKWebViewPrintFormatter.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface UIPrintFormatter ()
 - (NSInteger)_recalcPageCount;
@@ -197,7 +198,7 @@ TEST(WKWebView, PrintToPDFUsingPrintInteractionController)
 
     [printInteractionController _setupPrintPanel:nil];
     [printInteractionController _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             pdfDataLength = [pdfData length];
 
@@ -229,7 +230,7 @@ TEST(WKWebView, PrintToPDFUsingMultiplePrintInteractionControllers)
     __block NSUInteger pdfDataLength = 0;
     [printInteractionController _setupPrintPanel:nil];
     [printInteractionController _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             pdfDataLength = [pdfData length];
 
@@ -249,7 +250,7 @@ TEST(WKWebView, PrintToPDFUsingMultiplePrintInteractionControllers)
     __block NSUInteger pdfDataLength2 = 0;
     [printInteractionController2 _setupPrintPanel:nil];
     [printInteractionController2 _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             pdfDataLength2 = [pdfData length];
 
@@ -283,7 +284,7 @@ TEST(WKWebView, PrintToPDFUsingPrintInteractionControllerAndPrintPageRenderer)
     __block NSUInteger printInteractionControllerPDFDataLength = 0;
     [printInteractionController _setupPrintPanel:nil];
     [printInteractionController _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             printInteractionControllerPDFDataLength = [pdfData length];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -56,6 +56,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
@@ -229,7 +230,7 @@ TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
         if (_allowedAutoplayQuirksForURL)
             [websitePolicies _setAllowedAutoplayQuirks:_allowedAutoplayQuirksForURL(navigationAction.request.URL)];
@@ -1002,7 +1003,7 @@ static void respond(id <WKURLSchemeTask>task, NSString *html = nil)
     [preferences _setCustomHeaderFields:@[headerFields.get()]];
     
     if ([navigationAction.request.URL.path isEqualToString:@"/mainresource"]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             decisionHandler(WKNavigationActionPolicyAllow, preferences);
         });
     } else

--- a/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKWebsiteDataStoreRef.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static bool testFinished;
 
@@ -77,7 +78,7 @@ static RetainPtr<WKWebView> wkView;
 
 - (void)startLoading
 {
-    dispatch_async(dispatch_get_main_queue(), ^ {
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         kill(WKWebsiteDataStoreGetNetworkProcessIdentifier(WKPageGetWebsiteDataStore([wkView _pageRefForTransitionToWKWebView])), SIGKILL);
         [self.client URLProtocol:self didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:nil]];
     });
@@ -85,7 +86,7 @@ static RetainPtr<WKWebView> wkView;
 
 - (void)stopLoading
 {
-    dispatch_async(dispatch_get_main_queue(), ^ {
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         testFinished = true;
     });
 }

--- a/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
@@ -45,6 +45,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface ActionSheetObserver : NSObject<WKUIDelegatePrivate>
 @property (nonatomic) BlockPtr<NSArray *(_WKActivatedElementInfo *, NSArray *)> presentationHandler;
@@ -126,7 +127,7 @@ TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingV
 
     __block bool done = false;
     [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             done = true;
         });
     }];

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -51,8 +51,10 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKitLegacy/WebEvent.h>
 #import <cmath>
-#import <pal/cocoa/CoreTelephonySoftLink.h>
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
+#import <wtf/darwin/DispatchExtras.h>
+
+#import <pal/cocoa/CoreTelephonySoftLink.h>
 
 namespace TestWebKitAPI {
 
@@ -472,7 +474,7 @@ TEST(KeyboardInputTests, HandleKeyEventsWhileSwappingWebProcess)
 
     bool done = false;
     auto keyEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:65 isTabKey:NO]);
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), [keyEvent, webView, &done] {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), mainDispatchQueueSingleton(), [keyEvent, webView, &done] {
         [webView handleKeyEvent:keyEvent.get() completion:[keyEvent, &done](WebEvent *event, BOOL handled) {
             EXPECT_TRUE([event isEqual:keyEvent.get()]);
             EXPECT_FALSE(handled);

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
@@ -33,6 +33,7 @@
 #import "UIKitSPIForTesting.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/Vector.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface ScrollViewDelegate : NSObject<UIScrollViewDelegate> {
     @public Vector<CGPoint> _contentOffsetHistory;
@@ -67,7 +68,7 @@
 {
     int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-    dispatch_after(when, dispatch_get_main_queue(), ^{
+    dispatch_after(when, mainDispatchQueueSingleton(), ^{
         decisionHandler(WKNavigationActionPolicyAllow);
     });
 }
@@ -76,7 +77,7 @@
 {
     int64_t deferredWaitTime = 100 * NSEC_PER_MSEC;
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, deferredWaitTime);
-    dispatch_after(when, dispatch_get_main_queue(), ^{
+    dispatch_after(when, mainDispatchQueueSingleton(), ^{
         decisionHandler(WKNavigationResponsePolicyAllow);
     });
 }
@@ -273,7 +274,7 @@ TEST(ScrollViewInsetTests, ChangeInsetWithoutAutomaticAdjustmentWhileWebProcessI
     [webView removeFromSuperview];
 
     __block bool done = false;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [window addSubview:webView.get()];
         [webView _setObscuredInsets:UIEdgeInsetsMake(updatedTopInset, 0, 0, 0)];
         [[webView scrollView] _setAutomaticContentOffsetAdjustmentEnabled:NO];

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -34,6 +34,7 @@
 #import "UIKitSPIForTesting.h"
 #import "WKTouchEventsGestureRecognizer.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface UIView (WKContentView)
 - (void)_touchEventsRecognized;
@@ -128,7 +129,7 @@ TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)
     }
 
     __block bool done = false;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         done = true;
     });
     TestWebKitAPI::Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -40,6 +40,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKFeature.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 constexpr CGFloat blackColorComponents[4] = { 0, 0, 0, 1 };
 constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
@@ -516,7 +517,7 @@ TEST(WKScrollViewTests, AllowsKeyboardScrolling)
         auto secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@" " charactersIgnoringModifiers:@" " modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
 
         [webView handleKeyEvent:firstWebEvent.get() completion:^(WebEvent *theEvent, BOOL wasHandled) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{
                 [webView handleKeyEvent:secondWebEvent.get() completion:^(WebEvent *theEvent, BOOL wasHandled) {
                     completionHandler();
                 }];

--- a/Tools/TestWebKitAPI/Tests/mac/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FocusWebView.mm
@@ -35,6 +35,7 @@
 #import "WKWebViewConfigurationExtras.h"
 #import <QuartzCore/QuartzCore.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -59,7 +60,7 @@ TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)
     [webView removeFromSuperview];
     [CATransaction flush];
     __block bool doneUnparenting = false;
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         doneUnparenting = true;
     });
     Util::run(&doneUnparenting);

--- a/Tools/TestWebKitAPI/Tests/mac/FragmentNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FragmentNavigation.mm
@@ -27,6 +27,7 @@
 #import "PlatformUtilities.h"
 
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 static bool testFinished;
 
@@ -62,7 +63,7 @@ static bool testFinished;
 
     [listener ignore];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [self _runNextTestWithWebView:webView];
     });
 }

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
@@ -43,6 +43,7 @@
 #import <pal/spi/mac/NSTextInputContextSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface SlowTextInputContext : NSTextInputContext
 @property (nonatomic) BlockPtr<void()> handledInputMethodEventBlock;
@@ -53,7 +54,7 @@
 - (void)handleEventByInputMethod:(NSEvent *)event completionHandler:(void(^)(BOOL handled))completionHandler
 {
     [super handleEventByInputMethod:event completionHandler:^(BOOL handled) {
-        dispatch_async(dispatch_get_main_queue(), ^() {
+        dispatch_async(mainDispatchQueueSingleton(), ^() {
             completionHandler(handled);
             if (_handledInputMethodEventBlock)
                 _handledInputMethodEventBlock();
@@ -64,7 +65,7 @@
 - (void)handleEvent:(NSEvent *)event completionHandler:(void(^)(BOOL handled))completionHandler
 {
     [super handleEvent:event completionHandler:^(BOOL handled) {
-        dispatch_async(dispatch_get_main_queue(), ^() {
+        dispatch_async(mainDispatchQueueSingleton(), ^() {
             completionHandler(handled);
         });
     }];
@@ -133,7 +134,7 @@
         MockTextInputContextAction *lastItem = _actions.lastObject;
         [_actions removeLastObject];
         double delay = lastItem ? lastItem.delay : 10;
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{
             if (lastItem)
                 [self.client setMarkedText:lastItem.markedText selectedRange:lastItem.selectedRange replacementRange:lastItem.replacementRange];
             completionHandler(!!lastItem);

--- a/Tools/TestWebKitAPI/WebTransportServer.mm
+++ b/Tools/TestWebKitAPI/WebTransportServer.mm
@@ -32,6 +32,7 @@
 #import "Utilities.h"
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -85,11 +86,11 @@ WebTransportServer::WebTransportServer(Function<ConnectionTask(ConnectionGroup)>
         nw_connection_group_set_new_connection_handler(incomingConnectionGroup, [connectionGroup] (nw_connection_t incomingConnection) mutable {
             connectionGroup.receiveIncomingConnection(incomingConnection);
         });
-        nw_connection_group_set_queue(incomingConnectionGroup, dispatch_get_main_queue());
+        nw_connection_group_set_queue(incomingConnectionGroup, mainDispatchQueueSingleton());
         nw_connection_group_start(incomingConnectionGroup);
     });
 
-    nw_listener_set_queue(listener.get(), dispatch_get_main_queue());
+    nw_listener_set_queue(listener.get(), mainDispatchQueueSingleton());
 
     __block bool ready = false;
     nw_listener_set_state_changed_handler(listener.get(), ^(nw_listener_state_t state, nw_error_t error) {

--- a/Tools/TestWebKitAPI/cocoa/NSItemProviderAdditions.mm
+++ b/Tools/TestWebKitAPI/cocoa/NSItemProviderAdditions.mm
@@ -28,6 +28,7 @@
 
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @implementation NSItemProvider (NSItemProviderAdditions)
 
@@ -41,7 +42,7 @@
     auto retainedData = retainPtr(data);
     [self registerDataRepresentationForTypeIdentifier:typeIdentifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler: [retainedData, delay] (DataLoadCompletionBlock block) -> NSProgress * {
         if (delay > 0) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), [block = makeBlockPtr(block), retainedData] {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), mainDispatchQueueSingleton(), [block = makeBlockPtr(block), retainedData] {
                 block(retainedData.get(), nil);
             });
         } else

--- a/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
@@ -30,6 +30,7 @@
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebKit/WKURLSchemeTask.h>
 #import <wtf/Assertions.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 // Note: this class is a simplified version of WKResourceURLSchemeHandler for testing purposes.
 
@@ -60,7 +61,7 @@
     }
 
     NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             [_fileLoadOperations removeObjectForKey:urlSchemeTask];
         });
 
@@ -103,7 +104,7 @@
 - (void)webView:(WKWebView *)webView stopURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
     // Ensure that all blocks with pending removals are dispatched before doing a map lookup.
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (NSOperation *operation = [_fileLoadOperations objectForKey:urlSchemeTask]) {
             [operation cancel];
             [_fileLoadOperations removeObjectForKey:urlSchemeTask];

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -39,6 +39,7 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 // Enable this to test all web extension tests with site isolation.
 static constexpr BOOL shouldEnableSiteIsolation = NO;
@@ -279,7 +280,7 @@ static constexpr BOOL shouldEnableSiteIsolation = NO;
 {
     _done = false;
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(interval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(interval * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{
         self->_done = true;
     });
 
@@ -537,7 +538,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setReaderModeActive:(BOOL)showing forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (self->_setReaderModeShowing)
             self->_setReaderModeShowing(showing);
 
@@ -551,7 +552,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)detectWebpageLocaleForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale *, NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (self->_webpageLocale)
             completionHandler(self->_webpageLocale(), nil);
         else
@@ -561,7 +562,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)reloadFromOrigin:(BOOL)fromOrigin forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (self->_reload)
             self->_reload(fromOrigin);
         else if (fromOrigin)
@@ -575,7 +576,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)goBackForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (self->_goBack)
             self->_goBack();
         else
@@ -587,7 +588,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)goForwardForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (self->_goForward)
             self->_goForward();
         else
@@ -604,7 +605,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setParentTab:(id<WKWebExtensionTab>)parentTab forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         self->_parentTab = dynamic_objc_cast<TestWebExtensionTab>(parentTab);
 
         completionHandler(nil);
@@ -618,7 +619,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setPinned:(BOOL)pinned forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         self->_pinned = pinned;
 
         [self->_extensionController didChangeTabProperties:WKWebExtensionTabChangedPropertiesPinned forTab:self];
@@ -634,7 +635,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setMuted:(BOOL)muted forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         self->_muted = muted;
 
         [self->_extensionController didChangeTabProperties:WKWebExtensionTabChangedPropertiesMuted forTab:self];
@@ -645,7 +646,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)duplicateUsingConfiguration:(WKWebExtensionTabConfiguration *)configuration forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(id<WKWebExtensionTab> duplicatedTab, NSError *error))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (self->_duplicate)
             self->_duplicate(configuration, completionHandler);
         else
@@ -655,7 +656,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)activateForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         auto *previousActiveTab = self->_window.activeTab;
         self->_window.activeTab = self;
 
@@ -674,7 +675,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setSelected:(BOOL)selected forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         self->_selected = selected;
 
         if (selected)
@@ -688,7 +689,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)closeForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [self->_window closeTab:self];
 
         completionHandler(nil);
@@ -917,7 +918,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setWindowState:(WKWebExtensionWindowState)state forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *error))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         self->_windowState = state;
 
         if (state == WKWebExtensionWindowStateFullscreen) {
@@ -949,7 +950,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setFrame:(CGRect)frame forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *error))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         self->_frame = frame;
 
         completionHandler(nil);
@@ -966,7 +967,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)closeForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *error))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (self->_didClose)
             self->_didClose();
 

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -43,6 +43,7 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if USE(BROWSERENGINEKIT)
 #import <BrowserEngineKit/BrowserEngineKit.h>
@@ -709,7 +710,7 @@ IGNORE_WARNINGS_END
         [delegate dragInteraction:[_webView dragInteraction] sessionWillBegin:_dragSession.get()];
 
         RetainPtr<WKWebView> retainedWebView = _webView;
-        dispatch_async(dispatch_get_main_queue(), ^() {
+        dispatch_async(mainDispatchQueueSingleton(), ^() {
             [retainedWebView resignFirstResponder];
         });
 
@@ -988,7 +989,7 @@ IGNORE_WARNINGS_END
     if (!self.showCustomActionSheetBlock)
         return NO;
 
-    dispatch_async(dispatch_get_main_queue(), [strongSelf = retainPtr(self)] {
+    dispatch_async(mainDispatchQueueSingleton(), [strongSelf = retainPtr(self)] {
         [[strongSelf->_webView dragInteractionDelegate] dragInteraction:[strongSelf->_webView dragInteraction] sessionWillBegin:strongSelf->_dragSession.get()];
         strongSelf->_phase = DragAndDropPhaseBegan;
         [strongSelf _scheduleAdvanceProgress];

--- a/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm
+++ b/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm
@@ -31,6 +31,7 @@
 #import "DragAndDropSimulator.h"
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @implementation TestFilePromiseReceiver {
     RetainPtr<NSString> _promisedTypeIdentifier;
@@ -121,7 +122,7 @@ static NSURL *copyFile(NSURL *sourceURL, NSURL *destinationDirectory, NSError **
         else
             destination = writeToWebLoc(_promisedFileURL.get(), destinationDirectory, &error);
         if (destination) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(mainDispatchQueueSingleton(), ^{
                 _destinationURL = destination;
             });
         }

--- a/Tools/TestWebKitAPI/mac/VirtualGamepad.mm
+++ b/Tools/TestWebKitAPI/mac/VirtualGamepad.mm
@@ -36,6 +36,7 @@
 #import <HID/HIDManager.h>
 #import <HID/HIDUserDevice.h>
 #import <IOKit/hid/IOHIDDeviceKeys.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -64,7 +65,7 @@ VirtualGamepad::VirtualGamepad(const GamepadMapping& gamepadMapping)
     [m_userDevice activate];
 
     m_device = adoptNS([[HIDDevice alloc] initWithService:m_userDevice.get().service]);
-    [m_device setDispatchQueue:dispatch_get_main_queue()];
+    [m_device setDispatchQueue:mainDispatchQueueSingleton()];
     [m_device open];
     [m_device activate];
 }

--- a/Tools/TestWebKitAPI/mac/WebKitAgnosticTest.mm
+++ b/Tools/TestWebKitAPI/mac/WebKitAgnosticTest.mm
@@ -30,6 +30,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebViewPrivate.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface FrameLoadDelegate : NSObject <WebFrameLoadDelegate> {
     bool* _didFinishLoad;
@@ -148,7 +149,7 @@ void WebKitAgnosticTest::waitForNextPresentationUpdate(WebView *)
 {
     // FIXME: This isn't currently required anywhere. Just dispatch to the next runloop for now.
     __block bool done = false;
-    dispatch_async(dispatch_get_main_queue(), ^() {
+    dispatch_async(mainDispatchQueueSingleton(), ^() {
         done = true;
     });
     Util::run(&done);

--- a/Tools/WebGPUPlayground/CommandLinePlayground/main.c
+++ b/Tools/WebGPUPlayground/CommandLinePlayground/main.c
@@ -26,6 +26,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <WebGPU/WebGPU.h>
 #include <dispatch/dispatch.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 #define UNUSED_PARAM(variable) (void)variable
 
@@ -38,7 +39,7 @@ int main()
         },
         ^(WGPUWorkItem workItem)
         {
-            dispatch_async(dispatch_get_main_queue(), workItem);
+            dispatch_async(mainDispatchQueueSingleton(), workItem);
         },
     };
     WGPUInstanceDescriptor instanceDescriptor = {

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -37,6 +37,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPIForTesting.h"
@@ -304,7 +305,7 @@ IGNORE_WARNINGS_END
     ASSERT(!self.zoomToScaleCompletionHandler);
 
     if (self.scrollView.zoomScale == scale) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(mainDispatchQueueSingleton(), ^{
             completionHandler();
         });
         return;

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -43,6 +43,7 @@
 #import <WebKit/_WKTargetedElementRequest.h>
 #import <WebKit/_WKTextExtraction.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface WKWebView (WKWebViewInternal)
 - (void)paste:(id)sender;
@@ -79,7 +80,7 @@ void UIScriptControllerCocoa::doAsyncTask(JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -98,7 +99,7 @@ void UIScriptControllerCocoa::doAfterPresentationUpdate(JSValueRef callback)
 
 void UIScriptControllerCocoa::completeTaskAsynchronouslyAfterActivityStateUpdate(unsigned callbackID)
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         auto* mainWebView = TestController::singleton().mainWebView();
         ASSERT(mainWebView);
 

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -46,6 +46,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <mach-o/dyld.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface NSMenu ()
 - (id)_menuImpl;
@@ -97,7 +98,7 @@ static void setSwizzledPopUpMenu(NSMenu *menu)
 
     gCurrentPopUpMenu = menu;
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:NSMenuDidBeginTrackingNotification object:nil];
     });
 }
@@ -123,7 +124,7 @@ static void swizzledCancelTracking(NSMenu *menu, SEL)
     if ([menu.delegate respondsToSelector:@selector(menuDidClose:)])
         [menu.delegate menuDidClose:menu];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(mainDispatchQueueSingleton(), ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:NSMenuDidEndTrackingNotification object:nil];
     });
 }


### PR DESCRIPTION
#### ff428d7252b8e23cf2a55e46c44e30e954c5b58d
<pre>
Address more Safer CPP warnings in platform/
<a href="https://bugs.webkit.org/show_bug.cgi?id=298840">https://bugs.webkit.org/show_bug.cgi?id=298840</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/tests/Regress141275.mm:
(runRegress141275):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::singleton):
* Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp:
(JSC::Wasm::WasmOpcodeCounter::registerDispatch):
* Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ARDAppClient.m:
(-[ARDAppClient setShouldGetStats:]):
(-[ARDAppClient peerConnection:didChangeIceConnectionState:]):
(-[ARDAppClient peerConnection:didGenerateIceCandidate:]):
(-[ARDAppClient peerConnection:didRemoveIceCandidates:]):
(-[ARDAppClient peerConnection:didCreateSessionDescription:error:]):
(-[ARDAppClient peerConnection:didSetSessionDescriptionWithError:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ios/ARDVideoCallView.m:
(-[ARDVideoCallView onCameraSwitch:]):
(-[ARDVideoCallView onRouteChange:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ios/ARDVideoCallViewController.m:
(-[ARDVideoCallViewController appClient:didChangeConnectionState:]):
(-[ARDVideoCallViewController appClient:didReceiveRemoteVideoTrack:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/mac/APPRTCViewController.m:
(-[APPRTCMainView displayLogMessage:]):
(-[APPRTCViewController showAlertWithMessage:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/third_party/SocketRocket/SRWebSocket.m:
(-[SRWebSocket _SR_commonInit]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/capturer/RTCCameraVideoCapturer.m:
(-[RTCCameraVideoCapturer startCaptureWithDevice:format:fps:completionHandler:]):
(-[RTCCameraVideoCapturer stopCaptureWithCompletionHandler:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/metal/RTCMTLNSVideoView.m:
(-[RTCMTLNSVideoView setSize:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/metal/RTCMTLVideoView.m:
(-[RTCMTLVideoView setSize:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/opengl/RTCEAGLVideoView.m:
(-[RTCEAGLVideoView setSize:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/renderer/opengl/RTCNSGLVideoView.m:
(-[RTCNSGLVideoView setSize:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/helpers/RTCDispatcher.m:
(+[RTCDispatcher dispatchQueueForType:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/native/src/audio/audio_device_ios.mm:
(webrtc::ios_adm::AudioDeviceIOS::HandlePlayoutGlitchDetected):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::MallocCallTracker::MallocCallTracker):
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::MemoryPressureHandler):
* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::makeDispatchData):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueue::WorkQueue):
* Source/WTF/wtf/darwin/DispatchExtras.h: Copied from Source/WebCore/platform/VideoFrame.mm.
(WTF::mainDispatchQueueSingleton):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm:
(WebCore::loadSceneKitModel):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm:
(WebCore::loadSceneKitModelUsingUSDLoader):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm:
(WebCore::SceneKitModelPlayer::didFinishLoading):
(WebCore::SceneKitModelPlayer::didFailLoading):
* Source/WebCore/PAL/pal/Logging.cpp:
(PAL::registerNotifyCallback):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm:
(WebCore::DiskCacheMonitor::DiskCacheMonitor):
* Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm:
(WebCore::registerMemoryReleaseNotifyCallbacks):
* Source/WebCore/platform/RemoteCommandListener.cpp:
(WebCore::RemoteCommandListener::scheduleSupportedCommandsUpdate):
* Source/WebCore/platform/VideoFrame.mm:
(WebCore::VideoFrame::asVideoFrameCV):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::bestEligibleSessionForRemoteControls):
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::setEligibleForSmartRoutingInternal):
(WebCore::AudioSessionCocoa::tryToSetActiveInternal):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::clearNowPlayingInfo):
(WebCore::MediaSessionManagerCocoa::setNowPlayingInfo):
* Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp:
(WebCore::AudioHardwareListenerMac::AudioHardwareListenerMac):
(WebCore::AudioHardwareListenerMac::~AudioHardwareListenerMac):
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::removePropertyListenersForDefaultDevice const):
(WebCore::AudioSessionMac::addDefaultDeviceObserverIfNeeded const):
(WebCore::AudioSessionMac::addSampleRateObserverIfNeeded const):
(WebCore::AudioSessionMac::addBufferSizeObserverIfNeeded const):
(WebCore::AudioSessionMac::addMuteChangeObserverIfNeeded const):
(WebCore::AudioSessionMac::removeMuteChangeObserverIfNeeded const):
* Source/WebCore/platform/cocoa/PowerSourceNotifier.mm:
(WebCore::PowerSourceNotifier::PowerSourceNotifier):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::requestMediaDataWhenReady):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::contentKeySession):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::ensureSessionOrGroup):
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::requestNotificationWhenReadyForVideoData):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::beginLoadingMetadata):
(WebCore::MediaPlayerPrivateAVFoundationObjC::performTaskAtTime):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::sizeWillChangeAtTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreMediaData):
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(-[WebAVPlayerViewController observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVPlayerViewController MY_NO_RETURN]):
* Source/WebCore/platform/ios/WebItemProviderPasteboard.mm:
(-[WebItemProviderPasteboard doAfterLoadingProvidedContentIntoFileURLs:synchronousTimeout:]):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::CoreAudioCaptureDeviceManager::coreAudioCaptureDevices):
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::DNSResolveQueueCFNet::performDNSLookup):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::registerCookieChangeListenersIfNecessary):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::emitWebCoreLogs const):
(WebCore::Internals::emitLogs const):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::dumpMetalCodeIfNeeded):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::GPUFrameCapture::registerForFrameCapture):
(WebGPU::Device::shaderValidationState const):
(WebGPU::Device::enableEncoderTimestamps const):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::RKUSDModelLoadScheduler::scheduleModelLoad):
(WebKit::RKUSDModelLoadScheduler::loadNextModel):
(WebKit::ModelProcessModelPlayerProxy::createLayer):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::didFailLoading):
(WebKit::ModelProcessModelPlayerProxy::load):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::Cache):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::clearDiskCache):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::NetworkMDNSRegister::registerMDNSName):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::createNWPathMonitor):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::didReceiveServerTrustChallenge):
(WebKit::createParameters):
(WebKit::NetworkTransportSession::initialize):
(WebKit::NetworkTransportSession::setupDatagramConnection):
(WebKit::NetworkTransportSession::setupConnectionHandler):
(WebKit::NetworkTransportSession::createStream):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::Connection::sendWithReply const):
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::callAfterRandomDelay):
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::registerWithStateDumper):
* Source/WebKit/Shared/Cocoa/WKObject.h:
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::startListeningForMachServiceConnections):
(WebKit::encoderToXPCData):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::registerScheduledActivityHandler):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::setOSTransaction):
* Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm:
(-[_WKWebExtensionRegisteredScriptsSQLiteStore deleteScriptsWithIDs:completionHandler:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore addScripts:completionHandler:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore getScriptsWithCompletionHandler:]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore deleteDatabaseWithCompletionHandler:]):
(-[_WKWebExtensionSQLiteStore createSavepointWithCompletionHandler:]):
(-[_WKWebExtensionSQLiteStore commitSavepoint:completionHandler:]):
(-[_WKWebExtensionSQLiteStore rollbackToSavepoint:completionHandler:]):
* Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm:
(WebKit::createHIDClient):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(+[WKWebExtension extensionWithAppExtensionBundle:completionHandler:]):
(+[WKWebExtension extensionWithResourceBaseURL:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView takeSnapshotWithConfiguration:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[_WKWebsiteDataStoreBSActionHandler handleNotificationResponse:]):
* Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm:
(WebKit::shouldAllowAutoFillForCellularIdentifiers):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePlayCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePauseCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssueSeekCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssueBufferingCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePrepareTransitionCommand:]):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::takeModelElementFullscreen):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::mainQueueSingleton): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::sendNativeMessage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::propertiesDidChange):
(WebKit::WebExtensionAction::popupDidFinishDocumentLoad):
(WebKit::WebExtensionAction::readyToPresentPopup):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::dispatchChangedEventSoonIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::recordError):
(WebKit::WebExtensionContext::clearError):
(WebKit::WebExtensionContext::permissionsDidChange):
(WebKit::WebExtensionContext::requestPermissionMatchPatterns):
(WebKit::WebExtensionContext::requestPermissionToAccessURLs):
(WebKit::WebExtensionContext::requestPermissions):
(WebKit::WebExtensionContext::didChangeTabProperties):
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm:
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore addRules:completionHandler:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore deleteRules:completionHandler:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore getRulesWithRuleIDs:completionHandler:]):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::WebExtensionController):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.mm:
(-[WKInspectorResourceURLSchemeHandler webView:startURLSchemeTask:]):
(-[WKInspectorResourceURLSchemeHandler webView:stopURLSchemeTask:]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(-[WKWebInspectorUIProxyObjCAdapter inspectedViewFrameDidChange:]):
(-[WKWebInspectorUIProxyObjCAdapter observeValueForKeyPath:ofObject:change:context:]):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/ios/WKModelView.mm:
(-[WKModelView updateBounds]):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(-[WKWebGeolocationPolicyDecider _loadWithCompletionHandler:]):
* Source/WebKit/UIProcess/mac/ServicesController.mm:
(WebKit::ServicesController::refreshExistingServices):
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
(WebPushD::ApplePushServiceConnection::ApplePushServiceConnection):
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::performAfterFirstUnlock):
* Source/WebKit/webpushd/WebPushDaemon.mm:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::connectToService):
(WebPushTool::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm:
(-[DumpRenderTreeFilePromiseReceiver receivePromisedFilesAtDestination:options:operationQueue:reader:]):
* Tools/DumpRenderTree/mac/FrameLoadDelegate.mm:
(-[FrameLoadDelegate webView:didStartProvisionalLoadForFrame:]):
* Tools/DumpRenderTree/mac/TestRunnerMac.mm:
(TestRunner::simulateWebNotificationClick):
* Tools/EditingHistory/EditingHistory/TestRunner.m:
(-[TestRunner expectEvents:afterPerforming:]):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::dataFromString):
(TestWebKitAPI::ConnectionGroup::createWebTransportConnection const):
(TestWebKitAPI::ConnectionGroup::receiveIncomingConnection):
* Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm:
(TestWebKitAPI::TEST(WebKit, DeferredViewInWindowStateChange)):
* Tools/TestWebKitAPI/Tests/WebKit/MediaSessionCoordinatorTest.mm:
(-[_WKMockMediaSessionCoordinator joinWithCompletion:]):
(-[_WKMockMediaSessionCoordinator seekTo:withCompletion:]):
(-[_WKMockMediaSessionCoordinator playWithCompletion:]):
(-[_WKMockMediaSessionCoordinator pauseWithCompletion:]):
(-[_WKMockMediaSessionCoordinator setTrack:withCompletion:]):
* Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm:
(TEST_F(AppleLanguagesTest, DISABLED_UpdateAppleLanguages)):
* Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm:
(waitForPreferenceSynchronization):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(-[AsyncPolicyDecisionDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm:
(TestWebKitAPI::leftCornerColorsForThumbnailView):
* Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuMouseEvents.mm:
(TestWebKitAPI::runTest):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST(AnimatedResize, AnimatedResizeDoesNotHang)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AsyncPolicyForNavigationResponse.mm:
(-[TestAsyncNavigationDelegate webView:decidePolicyForNavigationResponse:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleRetainPagePlugIn.mm:
(-[BundleRetainPagePlugIn webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm:
(TEST(ContentRuleList, DisplayNoneInSrcDocIFrame)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(-[DecidePolicyForNavigationActionController webView:decidePolicyForNavigationAction:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::TEST(_WKDownload, DISABLED_DownloadMonitorSurvive)):
(TestWebKitAPI::TEST(_WKDownload, DownloadMonitorReturnToForeground)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::attemptConnectionInProcessWithoutEntitlement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
(swizzledProcessRequest):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm:
(TestWebKitAPI::MediaSessionTest::getNowPlayingClient):
(TestWebKitAPI::MediaSessionTest::getSupportedCommands):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm:
(-[SlowBeforeUnloadPromptUIDelegate _webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(TEST(_WKDataTask, Cancel)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlaying.mm:
(getNowPlayingClient):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm:
(-[OpenAndCloseWindowUIDelegateAsync _webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ParserYieldTokenTests.mm:
(waitForDelay):
(TEST(ParserYieldTokenTests, AsyncScriptRunsWhenFetched)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm:
(TEST(WKWebView, PrepareForMoveToWindowThenViewDeallocBeforeMoving)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[PSONScheme webView:startURLSchemeTask:]):
((ProcessSwap, CommittedProcessCrashDuringCrossSiteNavigation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm:
(-[QuickLookAsyncDelegate webView:decidePolicyForNavigationResponse:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ReparentWebViewTimeout.mm:
(TEST(WebKit, ReparentWebViewTimeout)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(waitUntilTwoServersConnected):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RunScriptAfterDocumentLoad.mm:
(TEST(RunScriptAfterDocumentLoad, ExecutionOrderOfScriptsInDocument)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(-[TestSOAuthorizationDelegate _webView:decidePolicyForSOAuthorizationLoadWithCurrentPolicy:forExtension:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[TestSWAsyncNavigationDelegate webView:decidePolicyForNavigationResponse:decisionHandler:]):
((ServiceWorker, ServiceWorkerReadableStreamDownloadCancel)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
(TestWebKitAPI::checkKeyboardScrollability):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm:
(TestWebKitAPI::TEST(WebKit, MSEHasMediaStreamingActivity)):
(TestWebKitAPI::TEST(WebKit, ManagedMSEHasMediaStreamingActivity)):
(TestWebKitAPI::TEST(WebKit, ManagedMSEHasMediaStreamingActivityWithPolicy)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm:
(-[PrintWithSimulatedPageComputationUIDelegate callBlockAsync:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
(-[URLSchemeHandlerAsyncNavigationDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[URLSchemeHandlerAsyncNavigationDelegate webView:decidePolicyForNavigationResponse:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAll)):
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllIncognito)):
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllIncognitoWithPrivateAccess)):
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllWithFilters)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestAllURLsMatchPattern)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendNativeMessage)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendNativeMessageWithInvalidReply)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, QueryWithPermissionBypass)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm:
(-[CandidateTestWebView typeString:inputMessage:]):
(TEST(WKWebViewCandidateTests, ClickingInTextFieldDoesNotThrashCandidateVisibility)):
(TEST(WKWebViewCandidateTests, ShouldNotRequestCandidatesInPasswordField)):
(TEST(WKWebViewCandidateTests, ShouldRequestCandidatesInTextField)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm:
(TEST(WKWebView, PrintToPDFUsingPrintInteractionController)):
(TEST(WKWebView, PrintToPDFUsingMultiplePrintInteractionControllers)):
(TEST(WKWebView, PrintToPDFUsingPrintInteractionControllerAndPrintPageRenderer)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
(TestWebKitAPI::WebPushXPCConnectionMessageSender::sendWithAsyncReplyWithoutUsingIPCConnection const):
(TestWebKitAPI::createAndConfigureConnectionToService):
(TestWebKitAPI::TEST(WebPushD, BasicCommunication)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(-[AsyncAutoplayPoliciesDelegate webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):
(-[CustomHeaderFieldsDelegate webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsTest.mm:
(-[CloseWhileStartingProtocol startLoading]):
(-[CloseWhileStartingProtocol stopLoading]):
* Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm:
(TestWebKitAPI::TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingViewController)):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, HandleKeyEventsWhileSwappingWebProcess)):
* Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm:
(-[AsyncPolicyDelegateForInsetTest webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[AsyncPolicyDelegateForInsetTest webView:decidePolicyForNavigationResponse:decisionHandler:]):
(TestWebKitAPI::TEST(ScrollViewInsetTests, ChangeInsetWithoutAutomaticAdjustmentWhileWebProcessIsUnresponsive)):
* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:
(TestWebKitAPI::TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)):
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, AllowsKeyboardScrolling)):
* Tools/TestWebKitAPI/Tests/mac/FocusWebView.mm:
(TestWebKitAPI::TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)):
* Tools/TestWebKitAPI/Tests/mac/FragmentNavigation.mm:
(-[WebKit1FragmentNavigationTestDelegate webView:decidePolicyForNavigationAction:request:frame:decisionListener:]):
* Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm:
(-[SlowTextInputContext handleEventByInputMethod:completionHandler:]):
(-[SlowTextInputContext handleEvent:completionHandler:]):
(-[MockTextInputContext handleEventByInputMethod:completionHandler:]):
* Tools/TestWebKitAPI/WebTransportServer.mm:
(TestWebKitAPI::WebTransportServer::WebTransportServer):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::HTTPServer::listenerParameters):
(TestWebKitAPI::HTTPServer::HTTPServer):
(TestWebKitAPI::m_protocol):
* Tools/TestWebKitAPI/cocoa/NSItemProviderAdditions.mm:
(-[NSItemProvider registerDataRepresentationForTypeIdentifier:withData:loadingDelay:]):
* Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm:
(-[TestInspectorURLSchemeHandler webView:startURLSchemeTask:]):
(-[TestInspectorURLSchemeHandler webView:stopURLSchemeTask:]):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager runForTimeInterval:]):
(-[TestWebExtensionTab setReaderModeActive:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab detectWebpageLocaleForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab reloadFromOrigin:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab goBackForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab goForwardForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab setParentTab:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab setPinned:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab setMuted:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab duplicateUsingConfiguration:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab activateForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab setSelected:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab closeForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow setWindowState:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow setFrame:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow closeForWebExtensionContext:completionHandler:]):
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[DragAndDropSimulator _advanceProgress]):
(-[DragAndDropSimulator _webView:showCustomSheetForElement:]):
* Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm:
(-[TestFilePromiseReceiver receivePromisedFilesAtDestination:options:operationQueue:reader:]):
* Tools/TestWebKitAPI/mac/VirtualGamepad.mm:
(TestWebKitAPI::VirtualGamepad::VirtualGamepad):
* Tools/TestWebKitAPI/mac/WebKitAgnosticTest.mm:
(TestWebKitAPI::WebKitAgnosticTest::waitForNextPresentationUpdate):
* Tools/WebGPUPlayground/CommandLinePlayground/main.c:
(main):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView zoomToScale:animated:completionHandler:]):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::doAsyncTask):
(WTR::UIScriptControllerCocoa::completeTaskAsynchronouslyAfterActivityStateUpdate):
* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(-[HIDEventGenerator _sendHIDEvent:]):
(-[HIDEventGenerator sendMarkerHIDEventWithCompletionBlock:]):
(-[HIDEventGenerator _waitFor:]):
(-[HIDEventGenerator longPress:completionBlock:]):
(-[HIDEventGenerator eventDispatchThreadEntry:]):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::applyAutocorrection):
(WTR::UIScriptControllerIOS::activateDataListSuggestion):
(WTR::UIScriptControllerIOS::doAfterDoubleTapDelay):
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::setSwizzledPopUpMenu):
(WTR::swizzledCancelTracking):

Canonical link: <a href="https://commits.webkit.org/299983@main">https://commits.webkit.org/299983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/346a447db389f23d793b645d9d16d71b17347bfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120867 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72943 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46202357-540b-4aba-b50a-adbee8ad7c90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91798 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61044 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/063f55be-5f36-40e6-8fd3-592046cc9a4b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72494 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea34b134-b72e-440a-8f62-22d8e4acae13) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120224 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26448 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70869 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/112993 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130135 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119383 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100415 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100318 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25449 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44475 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47650 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53355 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149521 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 50723") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47121 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149521 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 50723") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48805 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->