### PR TITLE
WebDriver classic set permission does not use the correct subframe URL

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -926,9 +926,8 @@
             "spec": "https://www.w3.org/TR/permissions/#webdriver-command-set-permission",
             "parameters": [
                 { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the targeted browsing context." },
-                { "name": "state", "$ref": "PermissionState", "description": "The new state to be applied to the permission." },
-                { "name": "topFrameDomain", "type": "string", "description": "Origin whose storage is being accessed." },
-                { "name": "subFrameDomain", "type": "string", "description": "Origin of the subframe that should be granted non-partitioned storage access to the top frame's origin." }
+                { "name": "frameHandle", "$ref": "FrameHandle", "description": "The handle for the frame to set storage access permission for." },
+                { "name": "state", "$ref": "PermissionState", "description": "The new state to be applied to the permission." }
             ],
             "async": true
         },

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -272,7 +272,7 @@ public:
     void loadWebExtension(const Inspector::Protocol::Automation::WebExtensionResourceOptions, const String& resource, Inspector::CommandCallback<String>&&) override;
     void unloadWebExtension(const String& identifier, Inspector::CommandCallback<void>&&) override;
 #endif
-    void setStorageAccessPermissionState(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::Protocol::Automation::PermissionState, const String& topFrameOrigin, const String& subFrameOrigin, Inspector::CommandCallback<void>&&) override;
+    void setStorageAccessPermissionState(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Inspector::Protocol::Automation::PermissionState, Inspector::CommandCallback<void>&&) override;
     void setStorageAccessPolicy(const Inspector::Protocol::Automation::BrowsingContextHandle&, bool blocked, Inspector::CommandCallback<void>&&) override;
 
 #if ENABLE(WEBDRIVER_BIDI)


### PR DESCRIPTION
#### e4458cdbefa223c4a487678320b4f29b30b56952
<pre>
WebDriver classic set permission does not use the correct subframe URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=298841">https://bugs.webkit.org/show_bug.cgi?id=298841</a>
<a href="https://rdar.apple.com/160579069">rdar://160579069</a>

Reviewed by BJ Burg.

This function was being given a subframe URL that was always the top document URL. Instead, pass a frame
handle and get its URL from the WebFrameProxy.

* Source/WebKit/UIProcess/Automation/Automation.json:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::setStorageAccessPermissionState):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:

Canonical link: <a href="https://commits.webkit.org/299972@main">https://commits.webkit.org/299972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/185d1d9581dfbcdaa0fc454a0edbd0f9200d4cdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72933 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f70822b1-dd26-4013-8093-597a75a9f6d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49128 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91791 "1 flakes 57 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61037 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3dcc0e6a-5d8e-4e8e-8c19-1ba91a9ef280) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72487 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0433c6d1-340b-434c-a82e-3ba7ffe75f16) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31962 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70859 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130125 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100407 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100310 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23749 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44461 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19186 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53345 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47111 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->