### PR TITLE
[JSC] Assert that values are not empty in call and callWithArguments arguments

### DIFF
--- a/Source/JavaScriptCore/interpreter/CachedCall.h
+++ b/Source/JavaScriptCore/interpreter/CachedCall.h
@@ -137,6 +137,18 @@ public:
         VM& vm = m_vm;
         auto scope = DECLARE_THROW_SCOPE(vm);
 
+        ASSERT_WITH_MESSAGE(!thisValue.isEmpty(), "Expected thisValue to be non-empty. Use jsUndefined() if you meant to use undefined.");
+#if ASSERT_ENABLED
+        if constexpr (sizeof...(args) > 0) {
+            size_t argIndex = 0;
+            auto checkArg = [&argIndex](JSValue arg) {
+                ASSERT_WITH_MESSAGE(!arg.isEmpty(), "arguments[%zu] is JSValue(). Use jsUndefined() if you meant to make it undefined.", argIndex);
+                ++argIndex;
+            };
+            (checkArg(args), ...);
+        }
+#endif
+
 #if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
         ASSERT(sizeof...(args) == static_cast<size_t>(m_protoCallFrame.argumentCount()));
         constexpr unsigned argumentCountIncludingThis = 1 + sizeof...(args);


### PR DESCRIPTION
#### 92935b22b9a62f75340d6470a7e47461e0b3c508
<pre>
[JSC] Assert that values are not empty in call and callWithArguments arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=298842">https://bugs.webkit.org/show_bug.cgi?id=298842</a>

Reviewed by Justin Michaud.

Passing empty JSValues to `JSC::call` and `cachedCall-&gt;callWithArguments` sometimes causes crashes.
This patch adds assertions to verify that all arguments are not empty.

* Source/JavaScriptCore/interpreter/CachedCall.h:
(JSC::CachedCall::callWithArguments):
* Source/JavaScriptCore/runtime/CallData.cpp:
(JSC::call):

Canonical link: <a href="https://commits.webkit.org/300003@main">https://commits.webkit.org/300003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4b952e53bfe979c05c35144bb257640288a2d09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91835 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61081 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72529 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26491 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70915 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113039 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130181 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119429 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100472 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100367 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25456 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45759 "Found 60 new test failures: cookies/cookie-store-register-eventlistener-from-file-protocol.html cookies/cookie-store-start-listening-for-change-with-null-url-crash.html http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html ... (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23802 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44525 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53401 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149592 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47167 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37955 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->