### PR TITLE
[SwiftUI] Add more functionality to SwiftBrowser to aid debugging

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -918,6 +918,10 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 - (void)_showWritingTools WK_API_AVAILABLE(macos(15.2));
 
+- (BOOL)_isSmartListsEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_setSmartListsEnabled:(BOOL)flag WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_toggleSmartLists:(id)sender WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
 @end
 
 @interface WKWebView (WKWindowSnapshot)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -393,6 +393,24 @@ final public class WebPage {
         return webView
     }()
 
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public var isEditable: Bool {
+        get { backingWebView._isEditable }
+        set { backingWebView._isEditable = newValue }
+    }
+
+    #if os(macOS)
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public var smartListsEnabled: Bool {
+        get { backingWebView._isSmartListsEnabled() }
+        set { backingWebView._setSmartListsEnabled(newValue) }
+    }
+    #endif
+
     // MARK: Loading functions
     
     @ObservationIgnored

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -513,21 +513,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
     _impl->toggleAutomaticTextReplacement();
 }
 
-- (BOOL)isSmartListsEnabled
-{
-    return _impl->isSmartListsEnabled();
-}
-
-- (void)setSmartListsEnabled:(BOOL)flag
-{
-    _impl->setSmartListsEnabled(flag);
-}
-
-- (void)toggleSmartLists:(id)sender
-{
-    _impl->toggleSmartLists();
-}
-
 - (void)uppercaseWord:(id)sender
 {
     _impl->uppercaseWord();
@@ -2057,6 +2042,21 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(WRITING_TOOLS)
     _impl->showWritingTools();
 #endif
+}
+
+- (BOOL)_isSmartListsEnabled
+{
+    return _impl->isSmartListsEnabled();
+}
+
+- (void)_setSmartListsEnabled:(BOOL)flag
+{
+    _impl->setSmartListsEnabled(flag);
+}
+
+- (void)_toggleSmartLists:(id)sender
+{
+    _impl->toggleSmartLists();
 }
 
 @end // WKWebView (WKPrivateMac)

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -156,6 +156,28 @@ extension View {
     public nonisolated func webViewScrollInputBehavior(_ behavior: ScrollInputBehavior, for input: ScrollInputKind) -> some View {
         environment(\.webViewScrollInputBehaviorContext, .init(behavior: behavior, input: input))
     }
+
+    // FIXME: This is currently a very limited and simple implementation of scroll edge effects.
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public nonisolated func webViewScrollEdgeEffectStyle(_ style: ScrollEdgeEffectStyle?, for edges: Edge.Set) -> some View {
+        self
+            .ignoresSafeArea(edges: edges)
+            .environment(\.webViewScrollEdgeEffectStyleContext, .init(style: style, edges: edges))
+    }
+
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public nonisolated func webViewWebPreference<Value>(
+        _ feature: WebView.WebPreferenceFeature<Value>,
+        value: Value
+    ) -> some View where Value: Sendable, Value: Codable {
+        transformEnvironment(\.webViewWebPreferenceContext) { context in
+            context.set(feature, to: value)
+        }
+    }
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -24,7 +24,7 @@
 #if ENABLE_SWIFTUI
 
 public import SwiftUI
-public import WebKit
+@_spi(CrossImportOverlay) public import WebKit
 
 /// A view that displays some web content.
 ///
@@ -242,6 +242,17 @@ extension WebView {
     public struct ActivatedElementInfo: Hashable, Sendable {
         /// The URL of the link that the user clicked.
         public let linkURL: URL?
+    }
+
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public struct WebPreferenceFeature<Value>: Sendable where Value: Sendable, Value: Codable {
+        public static var allowSmartLists: WebPreferenceFeature<Bool> {
+            .init(rawValue: "SmartListsEnabled")
+        }
+
+        let rawValue: String
     }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -56,6 +56,12 @@ extension EnvironmentValues {
 
     @Entry
     var webViewScrollInputBehaviorContext: ScrollInputBehaviorContext? = nil
+
+    @Entry
+    var webViewScrollEdgeEffectStyleContext: ScrollEdgeEffectStyleContext? = nil
+
+    @Entry
+    var webViewWebPreferenceContext = WebPreferenceContext()
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
@@ -46,4 +46,23 @@ struct ScrollInputBehaviorContext {
     let input: ScrollInputKind
 }
 
+struct ScrollEdgeEffectStyleContext {
+    let style: ScrollEdgeEffectStyle?
+    let edges: Edge.Set
+}
+
+struct WebPreferenceContext {
+    private var features: [String: Any] = [:]
+
+    mutating func set<Value>(_ key: WebView.WebPreferenceFeature<Value>, to value: Value) {
+        features[key.rawValue] = value
+    }
+
+    func get<Value>(_ key: String, as: Value.Type) -> Value? {
+        features[key] as? Value
+    }
+
+    var isEmpty: Bool { features.isEmpty }
+}
+
 #endif

--- a/Tools/SwiftBrowser/Source/Modifiers/WebContextMenu.swift
+++ b/Tools/SwiftBrowser/Source/Modifiers/WebContextMenu.swift
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import SwiftUI
+import WebKit
+
+#if os(macOS)
+private struct WebContextMenu: ViewModifier {
+    @Environment(\.openWindow)
+    private var openWindow
+
+    @Environment(BrowserViewModel.self)
+    private var viewModel
+
+    func body(content: Content) -> some View {
+        content
+            .webViewContextMenu { element in
+                if let url = element.linkURL {
+                    Button("Open Link in New Window") {
+                        let request = URLRequest(url: url)
+                        openWindow(value: CodableURLRequest(request))
+                    }
+                } else {
+                    if let previousItem = viewModel.page.backForwardList.backList.last {
+                        Button("Back") {
+                            viewModel.page.load(previousItem)
+                        }
+                    }
+
+                    if let nextItem = viewModel.page.backForwardList.forwardList.first {
+                        Button("Forward") {
+                            viewModel.page.load(nextItem)
+                        }
+                    }
+
+                    Button("Reload") {
+                        viewModel.page.reload()
+                    }
+                }
+            }
+    }
+}
+#endif // os(macOS)
+
+extension View {
+    func webContextMenu() -> some View {
+        #if os(macOS)
+        modifier(WebContextMenu())
+        #else
+        self
+        #endif
+    }
+}

--- a/Tools/SwiftBrowser/Source/Modifiers/WebToolbarModifier.swift
+++ b/Tools/SwiftBrowser/Source/Modifiers/WebToolbarModifier.swift
@@ -1,0 +1,199 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import SwiftUI
+import WebKit
+
+private struct ToolbarBackForwardMenuView: View {
+    struct LabelConfiguration {
+        let text: String
+        let systemImage: String
+        let key: KeyEquivalent
+    }
+
+    let list: [WebPage.BackForwardList.Item]
+    let label: LabelConfiguration
+    let navigateToItem: (WebPage.BackForwardList.Item) -> Void
+
+    var body: some View {
+        Menu {
+            ForEach(list) { item in
+                Button(item.title ?? item.url.absoluteString) {
+                    navigateToItem(item)
+                }
+            }
+        } label: {
+            Label(label.text, systemImage: label.systemImage)
+                .labelStyle(.iconOnly)
+        } primaryAction: {
+            // Safe because the menu is disabled if `list.isEmpty`
+            // swift-format-ignore: NeverForceUnwrap
+            navigateToItem(list.first!)
+        }
+        .menuIndicator(.hidden)
+        .disabled(list.isEmpty)
+        .keyboardShortcut(label.key)
+    }
+}
+
+private struct MediaCaptureStateButtonView: View {
+    struct LabelConfiguration {
+        let activeSystemImage: String
+        let mutedSystemImage: String
+    }
+
+    let captureState: WKMediaCaptureState
+    let configuration: LabelConfiguration
+    let action: (WKMediaCaptureState) -> Void
+
+    var body: some View {
+        switch captureState {
+        case .none:
+            EmptyView()
+
+        case .active:
+            Button {
+                action(.muted)
+            } label: {
+                Label("Mute", systemImage: configuration.activeSystemImage)
+                    .labelStyle(.iconOnly)
+            }
+
+        case .muted:
+            Button {
+                action(.active)
+            } label: {
+                Label("Unmute", systemImage: configuration.mutedSystemImage)
+                    .labelStyle(.iconOnly)
+            }
+
+        @unknown default:
+            fatalError()
+        }
+    }
+}
+
+private struct WebToolbarModifier: ViewModifier {
+    #if os(iOS)
+    private static let navigationToolbarItemPlacement = ToolbarItemPlacement.bottomBar
+    #else
+    private static let navigationToolbarItemPlacement = ToolbarItemPlacement.navigation
+    #endif
+
+    @Environment(BrowserViewModel.self)
+    private var viewModel
+
+    @Binding
+    var findNavigatorIsPresented: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                ToolbarItemGroup(placement: Self.navigationToolbarItemPlacement) {
+                    ToolbarBackForwardMenuView(
+                        list: viewModel.page.backForwardList.backList.reversed(),
+                        label: .init(text: "Backward", systemImage: "chevron.backward", key: "[")
+                    ) {
+                        viewModel.page.load($0)
+                    }
+
+                    #if os(iOS)
+                    Spacer()
+                    #endif
+
+                    ToolbarBackForwardMenuView(
+                        list: viewModel.page.backForwardList.forwardList,
+                        label: .init(text: "Forward", systemImage: "chevron.forward", key: "]")
+                    ) {
+                        viewModel.page.load($0)
+                    }
+
+                    Spacer()
+
+                    Button {
+                        findNavigatorIsPresented.toggle()
+                    } label: {
+                        Label("Find", systemImage: "magnifyingglass")
+                            .labelStyle(.iconOnly)
+                    }
+                    .keyboardShortcut("f")
+                }
+
+                ToolbarItemGroup(placement: .principal) {
+                    @Bindable
+                    var viewModel = viewModel
+
+                    TextField("URL", text: $viewModel.displayedURL)
+                        .textContentType(.URL)
+                        .onSubmit {
+                            viewModel.navigateToSubmittedURL()
+                        }
+                        .textFieldStyle(.roundedBorder)
+                        .padding(.leading, 4)
+                        .frame(minWidth: 300)
+
+                    if viewModel.page.isLoading {
+                        Button {
+                            viewModel.page.stopLoading()
+                        } label: {
+                            Image(systemName: "xmark")
+                        }
+                        .keyboardShortcut(".")
+                    } else {
+                        Button {
+                            viewModel.page.reload()
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .keyboardShortcut("r")
+                    }
+
+                    MediaCaptureStateButtonView(
+                        captureState: viewModel.page.cameraCaptureState,
+                        configuration: .init(activeSystemImage: "video.fill", mutedSystemImage: "video.slash.fill"),
+                        action: viewModel.setCameraCaptureState(_:)
+                    )
+
+                    MediaCaptureStateButtonView(
+                        captureState: viewModel.page.microphoneCaptureState,
+                        configuration: .init(activeSystemImage: "microphone.fill", mutedSystemImage: "microphone.slash.fill"),
+                        action: viewModel.setMicrophoneCaptureState(_:)
+                    )
+                }
+
+                ToolbarItemGroup {
+                    if viewModel.page.isLoading {
+                        ProgressView(value: viewModel.page.estimatedProgress, total: 1.0)
+                            .progressViewStyle(.circular)
+                            .controlSize(.small)
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+    func webToolbar(findNavigatorIsPresented: Binding<Bool>) -> some View {
+        modifier(WebToolbarModifier(findNavigatorIsPresented: findNavigatorIsPresented))
+    }
+}

--- a/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
@@ -29,4 +29,6 @@ enum AppStorageKeys {
     static let mediaCaptureAuthorization = "mediaCaptureAuthorization2"
     static let scrollBounceBehaviorBasedOnSize = "scrollBounceBehaviorBasedOnSize"
     static let backgroundHidden = "backgroundHidden"
+    static let showColorInTabBar = "showColorInTabBar"
+    static let isEditable = "isEditable"
 }

--- a/Tools/SwiftBrowser/Source/Views/BrowserView.swift
+++ b/Tools/SwiftBrowser/Source/Views/BrowserView.swift
@@ -22,17 +22,34 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 import SwiftUI
+@_spi(Testing) import WebKit
+import _WebKit_SwiftUI
 
 struct BrowserView: View {
-    @Binding var url: URL?
+    @Binding
+    var url: URL?
+
+    let smartListsEnabled: Bool
+
+    @AppStorage(AppStorageKeys.isEditable)
+    private var isEditable = false
 
     let initialRequest: URLRequest
 
-    @State private var viewModel = BrowserViewModel()
+    @State
+    private var viewModel = BrowserViewModel()
 
     var body: some View {
         ContentView(url: $url, initialRequest: initialRequest)
             .environment(viewModel)
+            .onChange(of: isEditable, initial: true) {
+                viewModel.page.isEditable = isEditable
+            }
+            .onChange(of: smartListsEnabled, initial: true) {
+                #if os(macOS)
+                viewModel.page.smartListsEnabled = smartListsEnabled
+                #endif
+            }
     }
 }
 
@@ -46,6 +63,6 @@ struct BrowserView: View {
         return URLRequest(url: url)
     }()
 
-    BrowserView(url: $url, initialRequest: request)
+    BrowserView(url: $url, smartListsEnabled: true, initialRequest: request)
         .environment(viewModel)
 }

--- a/Tools/SwiftBrowser/Source/Views/SettingsView.swift
+++ b/Tools/SwiftBrowser/Source/Views/SettingsView.swift
@@ -25,7 +25,8 @@ import SwiftUI
 import WebKit
 
 private struct PermissionDecisionView: View {
-    @Binding var permissionDecision: WKPermissionDecision
+    @Binding
+    var permissionDecision: WKPermissionDecision
 
     let label: String
 
@@ -41,7 +42,8 @@ private struct PermissionDecisionView: View {
 }
 
 private struct BinaryValuePicker: View {
-    @Binding var value: Bool
+    @Binding
+    var value: Bool
 
     let description: String
 
@@ -59,13 +61,23 @@ private struct BinaryValuePicker: View {
 }
 
 struct GeneralSettingsView: View {
-    @AppStorage(AppStorageKeys.homepage) private var homepage = "https://www.webkit.org"
+    @AppStorage(AppStorageKeys.homepage)
+    private var homepage = "https://www.webkit.org"
 
-    @AppStorage(AppStorageKeys.orientationAndMotionAuthorization) private var orientationAndMotionAuthorization = WKPermissionDecision.prompt
-    @AppStorage(AppStorageKeys.mediaCaptureAuthorization) private var mediaCaptureAuthorization = WKPermissionDecision.prompt
+    @AppStorage(AppStorageKeys.orientationAndMotionAuthorization)
+    private var orientationAndMotionAuthorization = WKPermissionDecision.prompt
 
-    @AppStorage(AppStorageKeys.scrollBounceBehaviorBasedOnSize) private var scrollBounceBehaviorBasedOnSize = false
-    @AppStorage(AppStorageKeys.backgroundHidden) private var backgroundHidden = false
+    @AppStorage(AppStorageKeys.mediaCaptureAuthorization)
+    private var mediaCaptureAuthorization = WKPermissionDecision.prompt
+
+    @AppStorage(AppStorageKeys.scrollBounceBehaviorBasedOnSize)
+    private var scrollBounceBehaviorBasedOnSize = false
+
+    @AppStorage(AppStorageKeys.backgroundHidden)
+    private var backgroundHidden = false
+
+    @AppStorage(AppStorageKeys.showColorInTabBar)
+    private var showColorInTabBar = true
 
     let currentURL: URL?
 
@@ -110,6 +122,11 @@ struct GeneralSettingsView: View {
                     falseLabel: "Automatic",
                     trueLabel: "Always Hide"
                 )
+            }
+
+            Section {
+                Toggle("Show color in tab bar", isOn: $showColorInTabBar)
+                    .padding(.top)
             }
         }
     }

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		07A58C0E2D04DD4700CAB4ED /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07A58C0D2D04DD4700CAB4ED /* WebKit.framework */; };
 		07A58C482D05651C00CAB4ED /* AppStorageKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A58C472D05651C00CAB4ED /* AppStorageKeys.swift */; };
 		07A58C4A2D0567A100CAB4ED /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A58C492D0567A100CAB4ED /* SettingsView.swift */; };
+		07E88A872E774C93005A53CB /* WebToolbarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E88A862E774C93005A53CB /* WebToolbarModifier.swift */; };
+		07E88A892E777C61005A53CB /* WebContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E88A882E777C61005A53CB /* WebContextMenu.swift */; };
 		330FBEE22DEAD07600C266CA /* CommandLine+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FBEE12DEAD05F00C266CA /* CommandLine+Extras.swift */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +61,8 @@
 		07A58C0D2D04DD4700CAB4ED /* WebKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WebKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		07A58C472D05651C00CAB4ED /* AppStorageKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKeys.swift; sourceTree = "<group>"; };
 		07A58C492D0567A100CAB4ED /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		07E88A862E774C93005A53CB /* WebToolbarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebToolbarModifier.swift; sourceTree = "<group>"; };
+		07E88A882E777C61005A53CB /* WebContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContextMenu.swift; sourceTree = "<group>"; };
 		330FBEE12DEAD05F00C266CA /* CommandLine+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommandLine+Extras.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -139,6 +143,7 @@
 			isa = PBXGroup;
 			children = (
 				07259B372D1F978200B45C4E /* Extensions */,
+				07E88A852E774C7E005A53CB /* Modifiers */,
 				07259B2C2D1F303300B45C4E /* ViewModel */,
 				07259B302D1F30DB00B45C4E /* Views */,
 				07A4CE9E2D08C06400764F5E /* Empty.swift */,
@@ -183,6 +188,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		07E88A852E774C7E005A53CB /* Modifiers */ = {
+			isa = PBXGroup;
+			children = (
+				07E88A882E777C61005A53CB /* WebContextMenu.swift */,
+				07E88A862E774C93005A53CB /* WebToolbarModifier.swift */,
+			);
+			path = Modifiers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -222,6 +236,7 @@
 				};
 			};
 			buildConfigurationList = 07A58BCF2D0400B300CAB4ED /* Build configuration list for PBXProject "SwiftBrowser" */;
+			compatibilityVersion = "Xcode 15.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -230,7 +245,6 @@
 			);
 			mainGroup = 07A58BCB2D0400B300CAB4ED;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 63;
 			productRefGroup = 07A58BD52D0400B300CAB4ED /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -268,6 +282,8 @@
 				07A58BEF2D04013100CAB4ED /* SwiftBrowser.swift in Sources */,
 				078F11852D288FAC00B3582D /* URLRequest+Codable.swift in Sources */,
 				07259B392D1F97A500B45C4E /* URLResponse+Extras.swift in Sources */,
+				07E88A892E777C61005A53CB /* WebContextMenu.swift in Sources */,
+				07E88A872E774C93005A53CB /* WebToolbarModifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -36,13 +36,6 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFeature.h>
 
-// FIXME: Come up with a better testing infrastructure that doesn't rely on forward declarations.
-@interface WKWebView (SmartLists)
-- (BOOL)isSmartListsEnabled;
-- (void)setSmartListsEnabled:(BOOL)flag;
-- (void)toggleSmartLists:(id)sender;
-@end
-
 static NSString* const WebSmartListsEnabled = @"WebSmartListsEnabled";
 
 // MARK: Utilities
@@ -109,11 +102,11 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), NO);
     resetUserDefaults();
 
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
-    [webView setSmartListsEnabled:YES];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
     // Case 2: _editable => true, user default => nil, preference => false
@@ -122,11 +115,11 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), NO);
     resetUserDefaults();
 
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
-    [webView setSmartListsEnabled:YES];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
     // Case 3: _editable => false, user default => true, preference => false
@@ -135,11 +128,11 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), NO);
     setUserDefaultsValue(YES);
 
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
-    [webView setSmartListsEnabled:YES];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
     // Case 4: _editable => true, user default => true, preference => false
@@ -148,11 +141,11 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), NO);
     setUserDefaultsValue(YES);
 
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
-    [webView setSmartListsEnabled:YES];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
     // Case 5: _editable => false, user default => nil, preference => true
@@ -161,11 +154,11 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), YES);
     resetUserDefaults();
 
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
-    [webView setSmartListsEnabled:YES];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
     // Case 6: _editable => true, user default => nil, preference => true
@@ -174,15 +167,15 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), YES);
     resetUserDefaults();
 
-    EXPECT_TRUE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
-    [webView setSmartListsEnabled:NO];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:NO];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_FALSE([userDefaultsValue() boolValue]);
 
-    [webView toggleSmartLists:nil];
-    EXPECT_TRUE([webView isSmartListsEnabled]);
+    [webView _toggleSmartLists:nil];
+    EXPECT_TRUE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
     // Case 7: _editable => false, user default => true, preference => true
@@ -191,11 +184,11 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), YES);
     setUserDefaultsValue(YES);
 
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
-    [webView setSmartListsEnabled:YES];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
     // Case 8: _editable => true, user default => true, preference => true
@@ -204,11 +197,11 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     setSmartListsPreference(configuration.get(), YES);
     setUserDefaultsValue(YES);
 
-    EXPECT_TRUE([webView isSmartListsEnabled]);
+    EXPECT_TRUE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
-    [webView setSmartListsEnabled:NO];
-    EXPECT_FALSE([webView isSmartListsEnabled]);
+    [webView _setSmartListsEnabled:NO];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_FALSE([userDefaultsValue() boolValue]);
 }
 


### PR DESCRIPTION
#### 09150f408020a7eebfdd37343b14ed647b45a5ab
<pre>
[SwiftUI] Add more functionality to SwiftBrowser to aid debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=298846">https://bugs.webkit.org/show_bug.cgi?id=298846</a>
<a href="https://rdar.apple.com/160587389">rdar://160587389</a>

Reviewed by Aditya Keerthi.

- Make it possible for SwiftBrowser to toggle the &quot;_editable&quot; property
- Make it possible for SwiftBrowser to toggle Smart Lists enablement
- Adapt SwiftBrowser for Liquid Glass, and make it possible to control the scroll edge effect style
- Make it possible for SwiftBrowser to toggle web preference feature flags
- Refactor SwiftBrowser views for better composition
- Add some icons to menu bar items
- Fix some formatting

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(isEditable):
(smartListsEnabled):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _isSmartListsEnabled]):
(-[WKWebView _setSmartListsEnabled:]):
(-[WKWebView _toggleSmartLists:]):
(-[WKWebView isSmartListsEnabled]): Deleted.
(-[WKWebView setSmartListsEnabled:]): Deleted.
(-[WKWebView toggleSmartLists:]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::firstRectForCharacterRange):
* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
(View.webViewScrollEdgeEffectStyle(_:for:)):
* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:
(WebPreferenceFeature.allowSmartLists):
* Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift:
(EnvironmentValues.webViewScrollEdgeEffectStyleContext):
* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
(WebPreferenceContext.features):
(WebPreferenceContext.isEmpty):
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Tools/SwiftBrowser/Source/Modifiers/WebContextMenu.swift: Added.
(WebContextMenu.body(_:)):
(View.webContextMenu):
* Tools/SwiftBrowser/Source/Modifiers/WebToolbarModifier.swift: Added.
(body):
(LabelConfiguration.body):
(WebToolbarModifier.findNavigatorIsPresented):
(WebToolbarModifier.body(_:)):
(View.webToolbar(_:)):
* Tools/SwiftBrowser/Source/SwiftBrowser.swift:
(SwiftBrowserApp.mostRecentURL):
(SwiftBrowserApp.body):
* Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift:
* Tools/SwiftBrowser/Source/Views/BrowserView.swift:
(BrowserView.url):
(BrowserView.body):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.url):
(ContentView.scrollBounceBehaviorBasedOnSize):
(ContentView.backgroundHidden):
(ContentView.showColorInTabBar):
(ContentView.body):
(body): Deleted.
(LabelConfiguration.body): Deleted.
(PrincipalToolbarGroup.body): Deleted.
* Tools/SwiftBrowser/Source/Views/SettingsView.swift:
(PermissionDecisionView.permissionDecision):
(BinaryValuePicker.value):
(GeneralSettingsView.body):
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
(TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)):

Canonical link: <a href="https://commits.webkit.org/299974@main">https://commits.webkit.org/299974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5397612e1b3a515834029cbecc81ee621bbcf860

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e19f357-f315-4931-9d55-91b65a147b2a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91836 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61101 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df818df1-f818-4891-9565-efd463357edb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72531 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13c14d18-3aee-43f9-aedb-8268cce2bf5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70920 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130186 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100453 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100356 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25442 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44530 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53406 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47172 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50516 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48856 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->