### PR TITLE
Address safer cpp warnings in Timer.h

### DIFF
--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -276,6 +276,11 @@ public:
     }
 
     bool hasOneRef() const { return refCount() == 1; }
+
+    // Ideally this would have been private but AbstractRefCounted subclasses need to be able to access this function
+    // to provide its result to ThreadSafeWeakHashSet.
+    size_t weakRefCount() const { return !isStrongOnly(m_bits.loadRelaxed()) ? controlBlock().weakRefCount() : 0; }
+
 protected:
     ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr() = default;
     ThreadSafeWeakPtrControlBlock& controlBlock() const
@@ -309,10 +314,6 @@ protected:
         delete controlBlock;
         return *std::bit_cast<ThreadSafeWeakPtrControlBlock*>(m_bits.loadRelaxed());
     }
-
-    // Ideally this would have been private but AbstractRefCounted subclasses need to be able to access this function
-    // to provide its result to ThreadSafeWeakHashSet.
-    size_t weakRefCount() const { return !isStrongOnly(m_bits.loadRelaxed()) ? controlBlock().weakRefCount() : 0; }
 
 private:
     static bool isStrongOnly(uintptr_t bits) { return bits & strongOnlyFlag; }

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -116,6 +116,32 @@ static auto HasRefPtrMemberFunctionsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_
 template<class T>
 struct HasRefPtrMemberFunctions : decltype(detail::HasRefPtrMemberFunctionsTest<T>(SFINAE_OVERLOAD)) { };
 
+// HasWeakPtrFunctions implementation
+namespace detail {
+
+template<class T>
+static auto HasWeakPtrFunctionsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->weakImpl(), static_cast<std::remove_cv_t<T>*>(nullptr)->weakCount())>;
+template<class>
+static auto HasWeakPtrFunctionsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
+
+}
+
+template<class T>
+struct HasWeakPtrFunctions : decltype(detail::HasWeakPtrFunctionsTest<T>(SFINAE_OVERLOAD)) { };
+
+// HasThreadSafeWeakPtrFunctions implementation
+namespace detail {
+
+template<class T>
+static auto HasThreadSafeWeakPtrFunctionsTest(SFINAE_OVERLOAD_PREFERRED) -> SFINAE1True<decltype(static_cast<std::remove_cv_t<T>*>(nullptr)->weakRefCount())>;
+template<class>
+static auto HasThreadSafeWeakPtrFunctionsTest(SFINAE_OVERLOAD_DEFAULT) -> std::false_type;
+
+}
+
+template<class T>
+struct HasThreadSafeWeakPtrFunctions : decltype(detail::HasThreadSafeWeakPtrFunctionsTest<T>(SFINAE_OVERLOAD)) { };
+
 // HasCheckedPtrMemberFunctions implementation
 namespace detail {
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -44,6 +44,8 @@ template<typename> class ExceptionOr;
 class WebKitMediaKeySession final : public RefCounted<WebKitMediaKeySession>, public EventTarget, public ActiveDOMObject, private LegacyCDMSessionClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebKitMediaKeySession);
 public:
+    USING_CAN_MAKE_WEAKPTR(EventTarget);
+
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebCore/Modules/geolocation/GeoNotifier.h
+++ b/Source/WebCore/Modules/geolocation/GeoNotifier.h
@@ -31,8 +31,7 @@
 #include <WebCore/PositionOptions.h>
 #include <WebCore/Timer.h>
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -42,7 +41,7 @@ class GeolocationPositionError;
 class PositionCallback;
 class PositionErrorCallback;
 
-class GeoNotifier : public RefCounted<GeoNotifier> {
+class GeoNotifier : public RefCountedAndCanMakeWeakPtr<GeoNotifier> {
 public:
     static Ref<GeoNotifier> create(Geolocation& geolocation, Ref<PositionCallback>&& positionCallback, RefPtr<PositionErrorCallback>&& positionErrorCallback, PositionOptions&& options)
     {

--- a/Source/WebCore/Modules/geolocation/GeolocationClient.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationClient.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <optional>
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -35,7 +35,7 @@ class Geolocation;
 class GeolocationPositionData;
 class Page;
 
-class GeolocationClient : public AbstractRefCounted {
+class GeolocationClient : public AbstractRefCountedAndCanMakeWeakPtr<GeolocationClient> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(GeolocationClient);
 public:
     virtual void geolocationDestroyed() = 0;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -73,7 +73,7 @@ class RTCSessionDescription;
 struct LibWebRTCMediaEndpointTransceiverState;
 
 class LibWebRTCMediaEndpoint final
-    : public ThreadSafeRefCounted<LibWebRTCMediaEndpoint, WTF::DestructionThread::Main>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<LibWebRTCMediaEndpoint, WTF::DestructionThread::Main>
     , private webrtc::PeerConnectionObserver
     , private webrtc::RTCStatsCollectorCallback
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -49,7 +49,6 @@ page/cocoa/ResourceUsageOverlayCocoa.mm
 page/csp/ContentSecurityPolicy.cpp
 page/writing-tools/WritingToolsController.mm
 platform/ScrollableArea.cpp
-platform/Timer.h
 platform/cocoa/NetworkExtensionContentFilter.mm
 platform/encryptedmedia/CDMProxy.cpp
 platform/encryptedmedia/clearkey/CDMClearKey.cpp

--- a/Source/WebCore/accessibility/AXGeometryManager.h
+++ b/Source/WebCore/accessibility/AXGeometryManager.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class AXObjectCache;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXGeometryManager);
-class AXGeometryManager final : public ThreadSafeRefCounted<AXGeometryManager> {
+class AXGeometryManager final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AXGeometryManager> {
     WTF_MAKE_NONCOPYABLE(AXGeometryManager);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXGeometryManager, AXGeometryManager);
 public:

--- a/Source/WebCore/bindings/js/GarbageCollectionController.h
+++ b/Source/WebCore/bindings/js/GarbageCollectionController.h
@@ -37,10 +37,11 @@ class VM;
 
 namespace WebCore {
 
-class GarbageCollectionController {
+class GarbageCollectionController final : public CanMakeCheckedPtr<GarbageCollectionController> {
     WTF_MAKE_TZONE_ALLOCATED(GarbageCollectionController);
     WTF_MAKE_NONCOPYABLE(GarbageCollectionController);
     friend class WTF::NeverDestroyed<GarbageCollectionController>;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GarbageCollectionController);
 public:
     WEBCORE_EXPORT static GarbageCollectionController& singleton();
     WEBCORE_EXPORT static void dumpHeapForVM(JSC::VM&);

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -29,6 +29,7 @@
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/Document.h>
 #include <WebCore/Timer.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
@@ -37,7 +38,7 @@ namespace WebCore {
 
 class CachedFont;
 
-class DocumentFontLoader {
+class DocumentFontLoader : public CanMakeWeakPtr<DocumentFontLoader> {
     WTF_MAKE_TZONE_ALLOCATED(DocumentFontLoader);
 public:
     DocumentFontLoader(Document&);

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -23,9 +23,10 @@
 
 #pragma once
 
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class SegmentedString;
 class ScriptableDocumentParser;
 class WeakPtrImplWithEventTargetData;
 
-class DocumentParser : public RefCounted<DocumentParser> {
+class DocumentParser : public RefCountedAndCanMakeWeakPtr<DocumentParser> {
 public:
     virtual ~DocumentParser();
 

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -33,6 +33,7 @@
 
 #include "BaseCheckableInputType.h"
 #include "SwitchTrigger.h"
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ class LayoutPoint;
 enum class WasSetByJavaScript : bool;
 enum class SwitchAnimationType : bool { VisuallyOn, Held };
 
-class CheckboxInputType final : public BaseCheckableInputType {
+class CheckboxInputType final : public BaseCheckableInputType, public CanMakeWeakPtr<CheckboxInputType> {
     WTF_MAKE_TZONE_ALLOCATED(CheckboxInputType);
 public:
     static Ref<CheckboxInputType> create(HTMLInputElement& element)

--- a/Source/WebCore/html/parser/HTMLParserScheduler.h
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.h
@@ -28,7 +28,7 @@
 #include "NestingLevelIncrementer.h"
 #include "Timer.h"
 #include <wtf/CheckedPtr.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -63,7 +63,7 @@ public:
     bool didSeeScript { false };
 };
 
-class HTMLParserScheduler final : public RefCounted<HTMLParserScheduler> {
+class HTMLParserScheduler final : public RefCountedAndCanMakeWeakPtr<HTMLParserScheduler> {
     WTF_MAKE_TZONE_ALLOCATED(HTMLParserScheduler);
     WTF_MAKE_NONCOPYABLE(HTMLParserScheduler);
 public:

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -37,6 +37,7 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/TextTrack.h>
 #include <WebCore/Timer.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -44,7 +45,7 @@ class HTMLDivElement;
 class VTTCueBox;
 class VTTScanner;
 
-class WEBCORE_EXPORT VTTRegion final : public RefCounted<VTTRegion>, public ContextDestructionObserver {
+class WEBCORE_EXPORT VTTRegion final : public RefCountedAndCanMakeWeakPtr<VTTRegion>, public ContextDestructionObserver {
 public:
     static Ref<VTTRegion> create(ScriptExecutionContext& context)
     {

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -33,6 +33,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LoaderMalloc.h>
 #include <WebCore/Timer.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakRef.h>
@@ -50,7 +51,7 @@ enum class NewLoadInProgress : bool { No, Yes };
 enum class ScheduleLocationChangeResult : uint8_t { Stopped, Completed, Started };
 enum class ScheduleHistoryNavigationResult : bool { Completed, Aborted };
 
-class NavigationScheduler final {
+class NavigationScheduler final : public CanMakeWeakPtr<NavigationScheduler> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(NavigationScheduler, Loader);
 public:
     explicit NavigationScheduler(Frame&);

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -28,6 +28,7 @@
 #include <WebCore/SecurityOriginHash.h>
 #include <WebCore/Timer.h>
 #include <pal/SessionID.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
@@ -61,8 +62,11 @@ struct ClientOrigin;
 // -------|-----+++++++++++++++|
 // -------|-----+++++++++++++++|+++++
 
-class MemoryCache {
-    WTF_MAKE_NONCOPYABLE(MemoryCache); WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(MemoryCache, Loader);
+class MemoryCache final : public CanMakeCheckedPtr<MemoryCache> {
+    WTF_MAKE_NONCOPYABLE(MemoryCache);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(MemoryCache, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MemoryCache);
+
     friend NeverDestroyed<MemoryCache>;
     friend class Internals;
 public:

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/Timer.h>
 #include <wtf/PriorityQueue.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
@@ -47,7 +48,7 @@ class Page;
 class Timer;
 class WeakPtrImplWithEventTargetData;
 
-class ImageAnalysisQueue final : public RefCounted<ImageAnalysisQueue> {
+class ImageAnalysisQueue final : public RefCountedAndCanMakeWeakPtr<ImageAnalysisQueue> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageAnalysisQueue, WEBCORE_EXPORT);
 public:
     static Ref<ImageAnalysisQueue> create(Page&);

--- a/Source/WebCore/page/PerformanceMonitor.h
+++ b/Source/WebCore/page/PerformanceMonitor.h
@@ -28,13 +28,14 @@
 #include "ActivityState.h"
 #include "Timer.h"
 #include <wtf/CPUTime.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class Page;
 
-class PerformanceMonitor {
+class PerformanceMonitor : public CanMakeWeakPtr<PerformanceMonitor> {
     WTF_MAKE_TZONE_ALLOCATED(PerformanceMonitor);
 public:
     explicit PerformanceMonitor(Page&);

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -45,7 +45,7 @@
 #include <WebCore/UserInterfaceDirectionPolicy.h>
 #include <WebCore/WritingMode.h>
 #include <unicode/uscript.h>
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
@@ -60,7 +60,7 @@ namespace WebCore {
 
 class Page;
 
-class SettingsBase : public AbstractRefCounted {
+class SettingsBase : public AbstractRefCountedAndCanMakeWeakPtr<SettingsBase> {
     WTF_MAKE_TZONE_ALLOCATED(SettingsBase);
     WTF_MAKE_NONCOPYABLE(SettingsBase);
 public:

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -46,7 +46,7 @@ enum class RenderingUpdateStep : uint32_t;
 
 struct GapRects;
 
-class ServicesOverlayController : private DataDetectorHighlightClient, private PageOverlayClient {
+class ServicesOverlayController : public DataDetectorHighlightClient, private PageOverlayClient {
     WTF_MAKE_TZONE_ALLOCATED(ServicesOverlayController);
 public:
     explicit ServicesOverlayController(Page&);

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.h
@@ -28,6 +28,7 @@
 #include "FloatSize.h"
 #include "ScrollTypes.h"
 #include "Timer.h"
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -47,7 +48,7 @@ class PlatformWheelEvent;
 class ScrollableArea;
 class WeakPtrImplWithEventTargetData;
 
-class ScrollLatchingController {
+class ScrollLatchingController : public CanMakeWeakPtr<ScrollLatchingController> {
     WTF_MAKE_TZONE_ALLOCATED(ScrollLatchingController);
 public:
     explicit ScrollLatchingController(Page&);

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -42,8 +42,10 @@ namespace WebCore {
 
 class GamepadProviderClient;
 
-class HIDGamepadProvider : public GamepadProvider {
+class HIDGamepadProvider final : public GamepadProvider, public CanMakeCheckedPtr<HIDGamepadProvider> {
     WTF_MAKE_NONCOPYABLE(HIDGamepadProvider);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HIDGamepadProvider);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HIDGamepadProvider);
     friend class NeverDestroyed<HIDGamepadProvider>;
 public:
     WEBCORE_EXPORT static HIDGamepadProvider& singleton();

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
@@ -42,6 +42,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HIDGamepadProvider);
+
 static const Seconds connectionDelayInterval { 500_ms };
 static const Seconds hidInputNotificationDelay { 1_ms };
 

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.h
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.h
@@ -28,6 +28,7 @@
 #include "DecodingOptions.h"
 #include "ImageTypes.h"
 #include "Timer.h"
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
@@ -36,7 +37,7 @@ namespace WebCore {
 class BitmapImageSource;
 class ImageFrame;
 
-class ImageFrameAnimator {
+class ImageFrameAnimator : public CanMakeWeakPtr<ImageFrameAnimator> {
     WTF_MAKE_TZONE_ALLOCATED(ImageFrameAnimator);
 public:
     explicit ImageFrameAnimator(BitmapImageSource&);

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -41,7 +41,7 @@
 namespace WebCore {
 
 class RealtimeOutgoingVideoSource
-    : public ThreadSafeRefCounted<RealtimeOutgoingVideoSource, WTF::DestructionThread::Main>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeOutgoingVideoSource, WTF::DestructionThread::Main>
     , public webrtc::VideoTrackSourceInterface
     , private MediaStreamTrackPrivateObserver
     , private RealtimeMediaSource::VideoFrameObserver

--- a/Source/WebCore/platform/mock/TimerEventBasedMock.h
+++ b/Source/WebCore/platform/mock/TimerEventBasedMock.h
@@ -30,7 +30,7 @@
 
 #include "Timer.h"
 #include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 
@@ -55,7 +55,7 @@ protected:
     Vector<RefPtr<TimerEvent> > m_timerEvents;
 };
 
-class TimerEvent : public RefCounted<TimerEvent> {
+class TimerEvent : public RefCountedAndCanMakeWeakPtr<TimerEvent> {
 public:
     TimerEvent(TimerEventBasedMock* mock, Ref<MockNotifier>&& notifier)
         : m_mock(mock)

--- a/Source/WebCore/platform/network/DNSResolveQueue.cpp
+++ b/Source/WebCore/platform/network/DNSResolveQueue.cpp
@@ -36,9 +36,13 @@
 #endif
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DNSResolveQueue);
 
 // When resolve queue is empty, we fire async resolution requests immediately (which is important if the prefetch is triggered by hovering).
 // But during page parsing, we should coalesce identical requests to avoid stressing out the DNS resolver.

--- a/Source/WebCore/platform/network/DNSResolveQueue.h
+++ b/Source/WebCore/platform/network/DNSResolveQueue.h
@@ -31,13 +31,16 @@
 #include <atomic>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
 
-class DNSResolveQueue {
-    friend NeverDestroyed<DNSResolveQueue>;
+class DNSResolveQueue : public CanMakeCheckedPtr<DNSResolveQueue> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DNSResolveQueue);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DNSResolveQueue);
 
+    friend NeverDestroyed<DNSResolveQueue>;
 public:
     virtual ~DNSResolveQueue() = default;
 

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -47,6 +47,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DNSResolveQueueCFNet);
+
 DNSResolveQueueCFNet::DNSResolveQueueCFNet() = default;
 
 DNSResolveQueueCFNet::~DNSResolveQueueCFNet() = default;

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.h
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.h
@@ -30,6 +30,8 @@
 namespace WebCore {
 
 class DNSResolveQueueCFNet final : public DNSResolveQueue {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DNSResolveQueueCFNet);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DNSResolveQueueCFNet);
 public:
     DNSResolveQueueCFNet();
     ~DNSResolveQueueCFNet();

--- a/Source/WebCore/platform/network/curl/DNSResolveQueueCurl.cpp
+++ b/Source/WebCore/platform/network/curl/DNSResolveQueueCurl.cpp
@@ -29,8 +29,12 @@
 #if USE(CURL)
 
 #include "NotImplemented.h"
+#include <wtf/IsoMallocInlines.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DNSResolveQueueCurl);
 
 void DNSResolveQueueCurl::updateIsUsingProxy()
 {

--- a/Source/WebCore/platform/network/curl/DNSResolveQueueCurl.h
+++ b/Source/WebCore/platform/network/curl/DNSResolveQueueCurl.h
@@ -30,6 +30,8 @@
 namespace WebCore {
 
 class DNSResolveQueueCurl final : public DNSResolveQueue {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DNSResolveQueueCurl);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DNSResolveQueueCurl);
 public:
     DNSResolveQueueCurl() = default;
     void resolve(const String& hostname, uint64_t identifier, DNSCompletionHandler&&) final;

--- a/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.cpp
+++ b/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.cpp
@@ -31,11 +31,16 @@
 
 #include <gio/gio.h>
 #include <wtf/Function.h>
+#include <wtf/IsoMallocInlines.h>
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DNSResolveQueueGLib);
 
 // Initially true to ensure prefetch stays disabled until we have proxy settings.
 static bool isUsingHttpProxy = true;

--- a/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.h
+++ b/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.h
@@ -36,6 +36,8 @@
 namespace WebCore {
 
 class DNSResolveQueueGLib final : public DNSResolveQueue {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DNSResolveQueueGLib);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DNSResolveQueueGLib);
 public:
     DNSResolveQueueGLib() = default;
 

--- a/Source/WebCore/storage/StorageArea.h
+++ b/Source/WebCore/storage/StorageArea.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -39,7 +39,7 @@ enum class StorageType : uint8_t;
 
 class SecurityOriginData;
 
-class StorageArea : public RefCounted<StorageArea> {
+class StorageArea : public RefCountedAndCanMakeWeakPtr<StorageArea> {
 public:
     virtual ~StorageArea() = default;
 

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -28,6 +28,7 @@
 #include "MatchResult.h"
 #include "RenderStyle.h"
 #include "Timer.h"
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
@@ -37,7 +38,7 @@ namespace Style {
 
 class Resolver;
 
-class MatchedDeclarationsCache {
+class MatchedDeclarationsCache : public CanMakeWeakPtr<MatchedDeclarationsCache> {
     WTF_MAKE_TZONE_ALLOCATED(MatchedDeclarationsCache);
 public:
     explicit MatchedDeclarationsCache(const Resolver&);

--- a/Source/WebCore/svg/animation/SMILTimeContainer.h
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.h
@@ -30,7 +30,7 @@
 #include "SMILTime.h"
 #include "Timer.h"
 #include <wtf/HashMap.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -42,7 +42,7 @@ class SVGSVGElement;
 class WeakPtrImplWithEventTargetData;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SMILTimeContainer);
-class SMILTimeContainer final : public RefCounted<SMILTimeContainer>  {
+class SMILTimeContainer final : public RefCountedAndCanMakeWeakPtr<SMILTimeContainer>  {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SMILTimeContainer, SMILTimeContainer);
 public:
     static Ref<SMILTimeContainer> create(SVGSVGElement& owner) { return adoptRef(*new SMILTimeContainer(owner)); }

--- a/Source/WebCore/workers/WorkerAnimationController.h
+++ b/Source/WebCore/workers/WorkerAnimationController.h
@@ -41,7 +41,7 @@ class RequestAnimationFrameCallback;
 class WeakPtrImplWithEventTargetData;
 class WorkerGlobalScope;
 
-class WorkerAnimationController final : public ThreadSafeRefCounted<WorkerAnimationController>, public ActiveDOMObject {
+class WorkerAnimationController final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WorkerAnimationController>, public ActiveDOMObject {
 public:
     static Ref<WorkerAnimationController> create(WorkerGlobalScope&);
     ~WorkerAnimationController();
@@ -50,8 +50,8 @@ public:
     void cancelAnimationFrame(int);
 
     // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCounted::ref(); }
-    void deref() const final { ThreadSafeRefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
     WorkerAnimationController(WorkerGlobalScope&);

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/Timer.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
@@ -34,7 +35,7 @@ namespace WebKit {
 
 class Download;
 
-class DownloadMonitor {
+class DownloadMonitor : public CanMakeWeakPtr<DownloadMonitor> {
     WTF_MAKE_TZONE_ALLOCATED(DownloadMonitor);
     WTF_MAKE_NONCOPYABLE(DownloadMonitor);
 public:

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -50,6 +50,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/LazyUniqueRef.h>
 #include <wtf/Ref.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
@@ -349,7 +350,7 @@ protected:
 
     HashSet<Ref<NetworkResourceLoader>> m_keptAliveLoads;
 
-    class CachedNetworkResourceLoader : public RefCounted<CachedNetworkResourceLoader> {
+    class CachedNetworkResourceLoader : public RefCountedAndCanMakeWeakPtr<CachedNetworkResourceLoader> {
         WTF_MAKE_TZONE_ALLOCATED(CachedNetworkResourceLoader);
     public:
         static Ref<CachedNetworkResourceLoader> create(Ref<NetworkResourceLoader>&&);

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebMemorySampler);
+
 static const char separator = '\t';
 
 static void appendSpaces(StringBuilder& string, int count)

--- a/Source/WebKit/Shared/WebMemorySampler.h
+++ b/Source/WebKit/Shared/WebMemorySampler.h
@@ -53,6 +53,7 @@
 
 #include "SandboxExtension.h"
 #include <WebCore/Timer.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/Noncopyable.h>
@@ -69,8 +70,10 @@ struct WebMemoryStatistics {
     Vector<size_t> values;
 };
     
-class WebMemorySampler {
+class WebMemorySampler final : public CanMakeCheckedPtr<WebMemorySampler> {
     WTF_MAKE_NONCOPYABLE(WebMemorySampler);
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebMemorySampler);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebMemorySampler);
 public:
     static WebMemorySampler* singleton();
     void start(const double interval = 0);

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -38,6 +38,7 @@
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/Timer.h>
 #include <span>
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -68,7 +69,9 @@ namespace WebPushD {
 
 using EncodedMessage = Vector<uint8_t>;
 
-class WebPushDaemon {
+class WebPushDaemon final : public CanMakeCheckedPtr<WebPushDaemon> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebPushDaemon);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPushDaemon);
     friend class WTF::NeverDestroyed<WebPushDaemon>;
 public:
     static WebPushDaemon& singleton();

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -110,6 +110,8 @@ using WebCore::SecurityOriginData;
 
 namespace WebPushD {
 
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebPushDaemon);
+
 static unsigned s_protocolVersion = protocolVersionValue;
 
 static constexpr Seconds s_incomingPushTransactionTimeout { 10_s };

--- a/Source/WebKitLegacy/Storage/StorageAreaSync.h
+++ b/Source/WebKitLegacy/Storage/StorageAreaSync.h
@@ -40,7 +40,7 @@ namespace WebKit {
 
 class StorageAreaImpl;
 
-class StorageAreaSync : public ThreadSafeRefCounted<StorageAreaSync, WTF::DestructionThread::Main> {
+class StorageAreaSync : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<StorageAreaSync, WTF::DestructionThread::Main> {
 public:
     static Ref<StorageAreaSync> create(RefPtr<WebCore::StorageSyncManager>&&, Ref<StorageAreaImpl>&&, const String& databaseIdentifier);
     ~StorageAreaSync();

--- a/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
@@ -34,14 +34,14 @@
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 
 // This class triggers asynchronous loads independent of the networking context staying alive (i.e., auditing pingbacks).
 // The object just needs to live long enough to ensure the message was actually sent.
 // As soon as any callback is received from the ResourceHandle, this class will cancel the load and delete itself.
 
-class PingHandle final : public RefCounted<PingHandle>, private WebCore::ResourceHandleClient {
+class PingHandle final : public RefCountedAndCanMakeWeakPtr<PingHandle>, private WebCore::ResourceHandleClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PingHandle);
     WTF_MAKE_NONCOPYABLE(PingHandle);
 public:


### PR DESCRIPTION
#### a488ebde500e0506d470538e23bc3bd3bda20c0f
<pre>
Address safer cpp warnings in Timer.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=298848">https://bugs.webkit.org/show_bug.cgi?id=298848</a>

Reviewed by Ryosuke Niwa.

The Timer constructor used to capture a raw pointer to the object it will
call the &quot;timeout&quot; function on, which caused safer cpp warnings. To address
the issue, we now capture a WeakPtr / ThreadSafeWeakPtr / CheckedPtr as
appropriate, depending on what the object supports.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount const):
* Source/WTF/wtf/TypeTraits.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/geolocation/GeoNotifier.h:
* Source/WebCore/Modules/geolocation/GeolocationClient.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/accessibility/AXGeometryManager.h:
* Source/WebCore/bindings/js/GarbageCollectionController.h:
(WebCore::GarbageCollectionController::ref const): Deleted.
(WebCore::GarbageCollectionController::deref const): Deleted.
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/DocumentParser.h:
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/parser/HTMLParserScheduler.h:
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/loader/cache/MemoryCache.h:
(WebCore::MemoryCache::TypeStatistic::TypeStatistic): Deleted.
(WebCore::MemoryCache::ref const): Deleted.
(WebCore::MemoryCache::deref const): Deleted.
(WebCore::MemoryCache::disabled const): Deleted.
(WebCore::MemoryCache::size const): Deleted.
(WebCore::MemoryCache::setDeadDecodedDataDeletionInterval): Deleted.
(WebCore::MemoryCache::deadDecodedDataDeletionInterval const): Deleted.
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/PerformanceMonitor.h:
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/scrolling/ScrollLatchingController.h:
* Source/WebCore/platform/Timer.h:
(WebCore::Timer::Timer):
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
(WebCore::HIDGamepadProvider::ref const): Deleted.
(WebCore::HIDGamepadProvider::deref const): Deleted.
(WebCore::HIDGamepadProvider::ignoreGameControllerFrameworkDevices): Deleted.
(WebCore::HIDGamepadProvider::numberOfConnectedGamepads const): Deleted.
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm:
* Source/WebCore/platform/graphics/ImageFrameAnimator.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebCore/platform/mock/TimerEventBasedMock.h:
* Source/WebCore/platform/network/DNSResolveQueue.cpp:
* Source/WebCore/platform/network/DNSResolveQueue.h:
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.h:
* Source/WebCore/platform/network/curl/DNSResolveQueueCurl.cpp:
* Source/WebCore/platform/network/curl/DNSResolveQueueCurl.h:
* Source/WebCore/platform/network/glib/DNSResolveQueueGLib.cpp:
* Source/WebCore/platform/network/glib/DNSResolveQueueGLib.h:
* Source/WebCore/storage/StorageArea.h:
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/svg/animation/SMILTimeContainer.h:
* Source/WebCore/workers/WorkerAnimationController.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/Shared/WebMemorySampler.cpp:
* Source/WebKit/Shared/WebMemorySampler.h:
(WebKit::WebMemorySampler::ref const): Deleted.
(WebKit::WebMemorySampler::deref const): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
(WebPushD::WebPushDaemon::ref const): Deleted.
(WebPushD::WebPushDaemon::deref const): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.mm:
* Source/WebKitLegacy/Storage/StorageAreaSync.h:
* Source/WebKitLegacy/WebCoreSupport/PingHandle.h:

Canonical link: <a href="https://commits.webkit.org/299985@main">https://commits.webkit.org/299985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7b2481e1bc9bddd5608cbac9d7f352e8a20b485

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72969 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b8deb74-9dc2-4a86-8f77-4ed8d0b49f90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91819 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61069 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3afa9d9-3af5-4268-b223-547bdff0b844) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72515 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abea8db3-541b-4eff-9070-dd1af2c8da84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26474 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70895 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113019 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130161 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119409 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100437 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100340 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44505 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47676 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53381 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149547 "Build was cancelled. Recent messages:Failed to print configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47147 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149547 "Build was cancelled. Recent messages:Failed to print configuration") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48831 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->