### PR TITLE
[GTK] Fix crash in WebPageProxy::currentStateOfModifierKeys

### DIFF
--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -125,17 +125,24 @@ void WebPageProxy::accentColorDidChange()
 
 OptionSet<WebCore::PlatformEvent::Modifier> WebPageProxy::currentStateOfModifierKeys()
 {
+    OptionSet<WebCore::PlatformEvent::Modifier> modifiers;
+
 #if USE(GTK4)
     auto* device = gdk_seat_get_keyboard(gdk_display_get_default_seat(gtk_widget_get_display(viewWidget())));
+    if (!device)
+        return modifiers;
+
     auto gdkModifiers = gdk_device_get_modifier_state(device);
     bool capsLockActive = gdk_device_get_caps_lock_state(device);
 #else
     auto* keymap = gdk_keymap_get_for_display(gtk_widget_get_display(viewWidget()));
+    if (!keymap)
+        return modifiers;
+
     auto gdkModifiers = gdk_keymap_get_modifier_state(keymap);
     bool capsLockActive = gdk_keymap_get_caps_lock_state(keymap);
 #endif
 
-    OptionSet<WebCore::PlatformEvent::Modifier> modifiers;
     if (gdkModifiers & GDK_SHIFT_MASK)
         modifiers.add(WebCore::PlatformEvent::Modifier::ShiftKey);
     if (gdkModifiers & GDK_CONTROL_MASK)
@@ -146,6 +153,7 @@ OptionSet<WebCore::PlatformEvent::Modifier> WebPageProxy::currentStateOfModifier
         modifiers.add(WebCore::PlatformEvent::Modifier::MetaKey);
     if (capsLockActive)
         modifiers.add(WebCore::PlatformEvent::Modifier::CapsLockKey);
+
     return modifiers;
 }
 


### PR DESCRIPTION
#### f5fc32976a5f00d750bc4ecf20d4d34ecddb9680
<pre>
[GTK] Fix crash in WebPageProxy::currentStateOfModifierKeys

<a href="https://bugs.webkit.org/show_bug.cgi?id=298849">https://bugs.webkit.org/show_bug.cgi?id=298849</a>

Reviewed by Carlos Garcia Campos.

Thread 1 &quot;browser&quot; received signal SIGSEGV, Segmentation fault.
0x0000007fb38155fc in gdk_device_get_modifier_state () from target:/usr/lib64/libgtk-4.so.1
(gdb) bt
0  0x0000007fb38155fc in gdk_device_get_modifier_state () from target:/usr/lib64/libgtk-4.so.1
1  0x0000007fb04eb868 in ?? () from target:/usr/lib64/libwebkitgtk-6.0.so.4

(browser:4396): Gdk-CRITICAL **: 11:27:32.870: gdk_seat_get_keyboard: assertion &apos;GDK_IS_SEAT (seat)&apos; failed

See: <a href="https://gitlab.gnome.org/GNOME/gtk/-/blob/4.20.1/gdk/gdkdevice.c#L1335">https://gitlab.gnome.org/GNOME/gtk/-/blob/4.20.1/gdk/gdkdevice.c#L1335</a>,
which doesn&apos;t catch a nullptr device.

Signed-off-by: Thomas Devoogdt &lt;thomas@devoogdt.com&gt;
Canonical link: <a href="https://commits.webkit.org/299947@main">https://commits.webkit.org/299947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba14fe1bf89f4bbd4ce560de56cb80c26844dd18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91800 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61046 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31977 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70871 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100416 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100319 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45715 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23762 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44477 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19171 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47652 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53357 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->