### PR TITLE
Address Safer cpp warnings in MediaSample.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -2,7 +2,6 @@ PAL/pal/graphics/cocoa/WebAVContentKeyGrouping.h
 accessibility/cocoa/AXCoreObjectCocoa.mm
 bridge/objc/WebScriptObject.h
 page/EventHandler.h
-platform/MediaSample.h
 platform/cocoa/WebAVPlayerLayer.h
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
 platform/graphics/ca/cocoa/WebVideoContainerLayer.h

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -68,8 +68,7 @@ static std::pair<GstAudioFormat, GstAudioLayout> convertAudioSampleFormatToGStre
 
 Ref<PlatformRawAudioData> PlatformRawAudioData::create(Ref<MediaSample>&& sample)
 {
-    ASSERT(sample->platformSample().type == PlatformSample::GStreamerSampleType);
-    return PlatformRawAudioDataGStreamer::create(GRefPtr { sample->platformSample().sample.gstSample });
+    return PlatformRawAudioDataGStreamer::create(GRefPtr { sample->platformSample().gstSample() });
 }
 
 RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_t> sourceData, AudioSampleFormat format, float sampleRate, int64_t timestamp, size_t numberOfFrames, size_t numberOfChannels)

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -184,7 +184,7 @@ void AudioVideoRendererAVFObjC::enqueueSample(TrackIdentifier trackId, Ref<Media
 
     switch (*type) {
     case TrackType::Video: {
-        RetainPtr cmSampleBuffer = sample->platformSample().sample.cmSampleBuffer;
+        RetainPtr cmSampleBuffer = sample->platformSample().cmSampleBuffer();
         RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(cmSampleBuffer.get());
         ASSERT(formatDescription);
         if (!formatDescription) {
@@ -216,7 +216,7 @@ void AudioVideoRendererAVFObjC::enqueueSample(TrackIdentifier trackId, Ref<Media
     }
     case TrackType::Audio:
         if (RetainPtr audioRenderer = audioRendererFor(trackId)) {
-            RetainPtr cmSampleBuffer = sample->platformSample().sample.cmSampleBuffer;
+            RetainPtr cmSampleBuffer = sample->platformSample().cmSampleBuffer();
             [audioRenderer enqueueSampleBuffer:cmSampleBuffer.get()];
             if (!allRenderersHaveAvailableSamples() && !sample->isNonDisplaying())
                 setHasAvailableAudioSample(trackId, true);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1796,7 +1796,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::attachContentKeyToSample(const 
         return;
 
     NSError *error = nil;
-    if (!AVSampleBufferAttachContentKey(sample.platformSample().sample.cmSampleBuffer, contentKey, &error))
+    if (!AVSampleBufferAttachContentKey(sample.platformSample().cmSampleBuffer(), contentKey, &error))
         ERROR_LOG(LOGIDENTIFIER, "Failed to attach content key with error: %{public}@", error);
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -400,7 +400,7 @@ void CDMSessionAVContentKeySession::attachContentKeyToSample(const MediaSampleAV
     ASSERT(contentKey);
 
     NSError *error = nil;
-    if (!AVSampleBufferAttachContentKey(sample.platformSample().sample.cmSampleBuffer, contentKey, &error))
+    if (!AVSampleBufferAttachContentKey(sample.platformSample().cmSampleBuffer(), contentKey, &error))
         ERROR_LOG(LOGIDENTIFIER, "Failed to attach content key with error: %{public}@", error);
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -54,7 +54,7 @@ public:
 
     SampleFlags flags() const override;
     PlatformSample platformSample() const override;
-    PlatformSample::Type platformSampleType() const override { return PlatformSample::CMSampleBufferType; }
+    Type type() const override { return Type::CMSampleBuffer; }
     void offsetTimestampsBy(const MediaTime&) override;
     void setTimestamps(const MediaTime&, const MediaTime&) override;
     WEBCORE_EXPORT bool isDivisable() const override;
@@ -113,5 +113,5 @@ struct LogArgument<WebCore::MediaSampleAVFObjC> {
 } // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaSampleAVFObjC)
-static bool isType(const WebCore::MediaSample& sample) { return sample.platformSampleType() == WebCore::PlatformSample::CMSampleBufferType; }
+static bool isType(const WebCore::MediaSample& sample) { return sample.type() == WebCore::MediaSample::Type::CMSampleBuffer; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -152,8 +152,7 @@ size_t MediaSampleAVFObjC::sizeInBytes() const
 
 PlatformSample MediaSampleAVFObjC::platformSample() const
 {
-    PlatformSample sample = { PlatformSample::CMSampleBufferType, { .cmSampleBuffer = m_sample.get() } };
-    return sample;
+    return PlatformSample { m_sample };
 }
 
 static bool isCMSampleBufferAttachmentRandomAccess(CFDictionaryRef attachmentDict)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -255,7 +255,7 @@ bool SourceBufferPrivateAVFObjC::isMediaSampleAllowed(const MediaSample& sample)
 
         if (RefPtr textTrack = downcast<InbandTextTrackPrivateAVF>(result->second)) {
             PlatformSample platformSample = sample.platformSample();
-            textTrack->processVTTSample(platformSample.sample.cmSampleBuffer, sample.presentationTime());
+            textTrack->processVTTSample(platformSample.cmSampleBuffer(), sample.presentationTime());
         }
 
         return false;
@@ -987,7 +987,7 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSampleAVFObjC>&& sample,
 
     PlatformSample platformSample = sample->platformSample();
 
-    CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.sample.cmSampleBuffer);
+    CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.cmSampleBuffer());
     ASSERT(formatDescription);
     if (!formatDescription) {
         ERROR_LOG(logSiteIdentifier, "Received sample with a null formatDescription. Bailing.");
@@ -1037,7 +1037,7 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSampleAVFObjC>&& sample,
         attachContentKeyToSampleIfNeeded(sample);
 
         if (auto renderer = audioRendererForTrackID(trackID)) {
-            [renderer enqueueSampleBuffer:platformSample.sample.cmSampleBuffer];
+            [renderer enqueueSampleBuffer:platformSample.cmSampleBuffer()];
             if (RefPtr player = this->player(); player && !sample->isNonDisplaying())
                 player->setHasAvailableAudioSample(renderer.get(), true);
         }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -906,7 +906,7 @@ void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID tr
 
     PlatformSample platformSample = sample->platformSample();
 
-    CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.sample.cmSampleBuffer);
+    CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.cmSampleBuffer());
     ASSERT(formatDescription);
     if (!formatDescription) {
         ERROR_LOG(logSiteIdentifier, "Received sample with a null formatDescription. Bailing.");

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -479,9 +479,9 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
 
             Vector<Ref<VideoDecoder::DecodePromise>> promises;
             for (Ref sample : MediaSampleAVFObjC::create(cmSamples.get(), 0)->divide()) {
-                auto cmSample = sample->platformSample().sample.cmSampleBuffer;
-                MediaTime presentationTimestamp = PAL::toMediaTime(PAL::CMSampleBufferGetPresentationTimeStamp(cmSample));
-                CMBlockBufferRef rawBuffer = PAL::CMSampleBufferGetDataBuffer(cmSample);
+                RetainPtr cmSample = sample->platformSample().cmSampleBuffer();
+                MediaTime presentationTimestamp = PAL::toMediaTime(PAL::CMSampleBufferGetPresentationTimeStamp(cmSample.get()));
+                CMBlockBufferRef rawBuffer = PAL::CMSampleBufferGetDataBuffer(cmSample.get());
                 ASSERT(rawBuffer);
                 RetainPtr buffer = rawBuffer;
                 // Make sure block buffer is contiguous.

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -124,8 +124,7 @@ void MediaSampleGStreamer::offsetTimestampsBy(const MediaTime& timestampOffset)
 
 PlatformSample MediaSampleGStreamer::platformSample() const
 {
-    PlatformSample sample = { PlatformSample::GStreamerSampleType, { .gstSample = m_sample.get() } };
-    return sample;
+    return PlatformSample { m_sample.get() };
 }
 
 Ref<MediaSample> MediaSampleGStreamer::createNonDisplayingCopy() const

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -51,7 +51,7 @@ public:
     Ref<MediaSample> createNonDisplayingCopy() const override;
     SampleFlags flags() const override { return m_flags; }
     PlatformSample platformSample() const override;
-    PlatformSample::Type platformSampleType() const override { return PlatformSample::GStreamerSampleType; }
+    Type type() const override { return Type::GStreamerSample; }
     void dump(PrintStream&) const override;
 
     const GRefPtr<GstSample>& sample() const { return m_sample; }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -182,7 +182,7 @@ void SourceBufferPrivateGStreamer::enqueueSample(Ref<MediaSample>&& sample, Trac
 {
     ASSERT(isMainThread());
 
-    GRefPtr<GstSample> gstSample = sample->platformSample().sample.gstSample;
+    GRefPtr<GstSample> gstSample = sample->platformSample().gstSample();
     ASSERT(gstSample);
 
 #ifndef GST_DISABLE_GST_DEBUG

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -62,7 +62,7 @@ private:
     size_t sizeInBytes() const override { return sizeof(m_box); }
     SampleFlags flags() const override;
     PlatformSample platformSample() const override;
-    PlatformSample::Type platformSampleType() const override { return PlatformSample::MockSampleBoxType; }
+    Type type() const override { return Type::MockSampleBox; }
     FloatSize presentationSize() const override { return FloatSize(); }
     void dump(PrintStream&) const override;
     void offsetTimestampsBy(const MediaTime& offset) override { m_box.offsetTimestampsBy(offset); }
@@ -87,8 +87,7 @@ MediaSample::SampleFlags MockMediaSample::flags() const
 
 PlatformSample MockMediaSample::platformSample() const
 {
-    PlatformSample sample = { PlatformSample::MockSampleBoxType, { &m_box } };
-    return sample;
+    return PlatformSample { &m_box };
 }
 
 void MockMediaSample::dump(PrintStream& out) const
@@ -234,11 +233,10 @@ void MockSourceBufferPrivate::enqueueSample(Ref<MediaSample>&& sample, TrackID)
     if (!mediaSource)
         return;
 
-    PlatformSample platformSample = sample->platformSample();
-    if (platformSample.type != PlatformSample::MockSampleBoxType)
+    if (sample->type() != MediaSample::Type::MockSampleBox)
         return;
 
-    auto* box = platformSample.sample.mockSampleBox;
+    auto* box = sample->platformSample().mockSampleBox();
     if (!box)
         return;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp
@@ -54,8 +54,8 @@ public:
         return create(m_presentationTime, m_decodeTime, m_duration, static_cast<SampleFlags>(m_flags | IsNonDisplaying));
     }
     SampleFlags flags() const final { return m_flags; }
-    PlatformSample platformSample() const final { return { PlatformSample::None, { nullptr } }; }
-    PlatformSample::Type platformSampleType() const final { return PlatformSample::None; }
+    PlatformSample platformSample() const final { return PlatformSample { static_cast<const MockSampleBox*>(nullptr) }; }
+    Type type() const final { return Type::None; }
 
     void dump(PrintStream&) const final { }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -68,8 +68,8 @@ public:
         return create(m_presentationTime, m_decodeTime, m_duration, static_cast<SampleFlags>(m_flags | IsNonDisplaying));
     }
     SampleFlags flags() const final { return m_flags; }
-    PlatformSample platformSample() const final { return { PlatformSample::None, { nullptr } }; }
-    PlatformSample::Type platformSampleType() const final { return PlatformSample::None; }
+    PlatformSample platformSample() const final { return PlatformSample { static_cast<const MockSampleBox*>(nullptr) }; }
+    Type type() const final { return Type::None; }
 
     void dump(PrintStream&) const final { }
 


### PR DESCRIPTION
#### fed4bee644309eddf0373ffdd5e9a9a5927cf68d
<pre>
Address Safer cpp warnings in MediaSample.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=298853">https://bugs.webkit.org/show_bug.cgi?id=298853</a>

Reviewed by Darin Adler.

* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/platform/MediaSample.h:
(WebCore::PlatformSample::PlatformSample):
(WebCore::PlatformSample::mockSampleBox const):
(WebCore::PlatformSample::cmSampleBuffer const):
(WebCore::PlatformSample::gstSample const):
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
(WebCore::PlatformRawAudioData::create):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::enqueueSample):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::attachContentKeyToSample):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::attachContentKeyToSample):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::platformSample const):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::isMediaSampleAllowed const):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::changeRenderer):
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):
(WebCore::VideoMediaSampleRenderer::shouldDecodeSample):
(WebCore::VideoMediaSampleRenderer::decodedFrameAvailable):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer):
(WebCore::VideoMediaSampleRenderer::assignResourceOwner):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSampleInternal):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp:
(WebCore::MediaSampleGStreamer::platformSample const):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::enqueueSample):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockMediaSample::platformSample const):
(WebCore::MockSourceBufferPrivate::enqueueSample):
* Tools/TestWebKitAPI/Tests/WebCore/MediaReorderQueue.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:

Canonical link: <a href="https://commits.webkit.org/300001@main">https://commits.webkit.org/300001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a007b6e5c13799c0c44d79e5d00068fc392a3e07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121016 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73096 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f7e34a1-a964-42f3-bbca-b90f07ef6d60) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91913 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5f076bd-3ca9-47be-9583-dcf553e43a59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72600 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52c2474f-75bf-45e6-9307-84d529ee4d36) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26589 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71023 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130288 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100523 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104653 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100425 "Found 1 new API test failure: TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23887 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53514 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47272 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48956 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->