### PR TITLE
Address Safer CPP warnings in ThreadGlobalData

### DIFF
--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -114,6 +114,17 @@ public:
     class ClientData : public ThreadSafeRefCounted<ClientData> {
     public:
         virtual ~ClientData() = default;
+
+        enum class Type : uint8_t {
+            WebCoreThreadGlobalData
+        };
+        Type type() const { return Type::WebCoreThreadGlobalData; }
+
+    protected:
+        explicit ClientData(Type type)
+        {
+            ASSERT_UNUSED(type, type == Type::WebCoreThreadGlobalData);
+        }
     };
 
     WTF_EXPORT_PRIVATE ~Thread();

--- a/Source/WebCore/PAL/pal/ThreadGlobalData.cpp
+++ b/Source/WebCore/PAL/pal/ThreadGlobalData.cpp
@@ -38,8 +38,9 @@ namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadGlobalData);
 
-ThreadGlobalData::ThreadGlobalData()
-    : m_cachedConverterICU(makeUniqueRef<ICUConverterWrapper>())
+ThreadGlobalData::ThreadGlobalData(Type type)
+    : WTF::Thread::ClientData(type)
+    , m_cachedConverterICU(makeUniqueRef<ICUConverterWrapper>())
 {
 }
 

--- a/Source/WebCore/PAL/pal/ThreadGlobalData.h
+++ b/Source/WebCore/PAL/pal/ThreadGlobalData.h
@@ -44,7 +44,7 @@ public:
     ICUConverterWrapper& cachedConverterICU() { return m_cachedConverterICU; }
 
 protected:
-    PAL_EXPORT ThreadGlobalData();
+    PAL_EXPORT explicit ThreadGlobalData(Type);
 
 private:
     PAL_EXPORT friend ThreadGlobalData& threadGlobalDataSingleton();

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -88,7 +88,6 @@ page/scrolling/ScrollingStateScrollingNode.cpp
 platform/PODRedBlackTree.h
 platform/PlatformStrategies.h
 platform/Scrollbar.h
-platform/ThreadGlobalData.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
 platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -87,8 +87,6 @@ loader/cache/CachedResourceClientWalker.h
 mathml/MathMLRowElement.cpp
 page/NavigatorLoginStatus.cpp
 page/mac/EventHandlerMac.mm
-platform/ThreadGlobalData.cpp
-platform/ThreadGlobalData.h
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
 platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -466,7 +466,6 @@ platform/ScrollView.cpp
 platform/Scrollbar.cpp
 platform/ScrollbarsController.cpp
 platform/ScrollingEffectsController.cpp
-platform/ThreadGlobalData.cpp
 platform/Widget.cpp
 platform/audio/PlatformMediaSession.cpp
 platform/audio/PlatformMediaSessionInterface.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -333,8 +333,6 @@ platform/ScrollAnimator.cpp
 platform/ScrollView.cpp
 platform/ScrollableArea.cpp
 platform/ScrollbarsController.cpp
-platform/ThreadGlobalData.cpp
-platform/ThreadGlobalData.h
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/graphics/ComplexTextController.cpp
 platform/graphics/DisplayRefreshMonitorManager.cpp

--- a/Source/WebCore/platform/ThreadGlobalData.h
+++ b/Source/WebCore/platform/ThreadGlobalData.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSGlobalObject.h>
 #include <pal/ThreadGlobalData.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -33,7 +34,6 @@
 
 namespace JSC {
 class CallFrame;
-class JSGlobalObject;
 }
 
 namespace WebCore {
@@ -139,6 +139,14 @@ WEBCORE_EXPORT ThreadGlobalData& threadGlobalDataSlow();
 WEBCORE_EXPORT ThreadGlobalData& threadGlobalDataSlow() PURE_FUNCTION;
 #endif
 
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ThreadGlobalData)
+    static bool isType(const WTF::Thread::ClientData& data) { return data.type() == PAL::ThreadGlobalData::Type::WebCoreThreadGlobalData; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+namespace WebCore {
+
 #if USE(WEB_THREAD)
 inline ThreadGlobalData& threadGlobalDataSingleton()
 #else
@@ -147,14 +155,14 @@ inline PURE_FUNCTION ThreadGlobalData& threadGlobalDataSingleton()
 {
 #if HAVE(FAST_TLS)
     if (auto* thread = Thread::currentMayBeNull(); thread) [[likely]] {
-        if (auto* clientData = thread->m_clientData.get(); clientData) [[likely]]
-            return *static_cast<ThreadGlobalData*>(clientData);
+        // No need to ref the clientData as we're simply returning it right away.
+        SUPPRESS_UNCOUNTED_LOCAL if (auto* clientData = thread->m_clientData.get(); clientData) [[likely]]
+            return downcast<ThreadGlobalData>(*clientData);
     }
 #else
-    auto& thread = Thread::currentSingleton();
-    auto* clientData = thread.m_clientData.get();
-    if (clientData) [[likely]]
-        return *static_cast<ThreadGlobalData*>(clientData);
+    // No need to ref the clientData as we're simply returning it right away.
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* clientData = Thread::currentSingleton().m_clientData.get()) [[likely]]
+        return downcast<ThreadGlobalData>(*clientData);
 #endif
     return threadGlobalDataSlow();
 }


### PR DESCRIPTION
#### bb2966dbc5b4eaea9e11bea43e7d850a64c007de
<pre>
Address Safer CPP warnings in ThreadGlobalData
<a href="https://bugs.webkit.org/show_bug.cgi?id=298857">https://bugs.webkit.org/show_bug.cgi?id=298857</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/Threading.h:
* Source/WebCore/PAL/pal/ThreadGlobalData.cpp:
(PAL::ThreadGlobalData::ThreadGlobalData):
* Source/WebCore/PAL/pal/ThreadGlobalData.h:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::ThreadGlobalData::ThreadGlobalData):
(WebCore::ThreadGlobalData::destroy):
(WebCore::threadGlobalDataSlow):
* Source/WebCore/platform/ThreadGlobalData.h:
(isType):
(WebCore::threadGlobalDataSingleton):

Canonical link: <a href="https://commits.webkit.org/299986@main">https://commits.webkit.org/299986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c928692722817c16d40a82837ded2742a163f5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72974 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f925c712-833a-4ba5-b111-215957e5e0db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61074 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e919ad55-99ec-4421-9534-34c83dbc1d6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72518 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6dfa55f6-b3e1-4509-bc7b-4ea99c054a94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70900 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130166 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119414 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100440 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100343 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47681 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53386 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/149552 "Build was cancelled. Recent messages:Failed to print configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47152 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/149552 "Build was cancelled. Recent messages:Failed to print configuration") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50496 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48836 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->