### PR TITLE
GPUP: Add separate state setters for pattern with NativeImages and ImageBuffers

### DIFF
--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -71,8 +71,8 @@ public:
     WEBCORE_EXPORT const SourceImage& tileImage() const;
     WEBCORE_EXPORT void setTileImage(SourceImage&&);
 
-    RefPtr<NativeImage> tileNativeImage() const;
-    RefPtr<ImageBuffer> tileImageBuffer() const;
+    WEBCORE_EXPORT RefPtr<NativeImage> tileNativeImage() const;
+    WEBCORE_EXPORT RefPtr<ImageBuffer> tileImageBuffer() const;
 
     const Parameters& parameters() const { return m_parameters; }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -150,11 +150,18 @@ void RemoteGraphicsContext::setFillGradient(Ref<Gradient>&& gradient, const Affi
     context().setFillGradient(WTFMove(gradient), spaceTransform);
 }
 
-void RemoteGraphicsContext::setFillPattern(RenderingResourceIdentifier tileImageIdentifier, const PatternParameters& parameters)
+void RemoteGraphicsContext::setFillPatternNativeImage(RenderingResourceIdentifier identifier, const PatternParameters& parameters)
 {
-    auto tileImage = sourceImage(tileImageIdentifier);
+    RefPtr tileImage = resourceCache().cachedNativeImage(identifier);
     MESSAGE_CHECK(tileImage);
-    context().setFillPattern(Pattern::create(WTFMove(*tileImage), parameters));
+    context().setFillPattern(Pattern::create({ tileImage.releaseNonNull() }, parameters));
+}
+
+void RemoteGraphicsContext::setFillPatternImageBuffer(RenderingResourceIdentifier identifier, const PatternParameters& parameters)
+{
+    RefPtr tileImageBuffer = this->imageBuffer(identifier);
+    MESSAGE_CHECK(tileImageBuffer);
+    context().setFillPattern(Pattern::create({ tileImageBuffer.releaseNonNull() }, parameters));
 }
 
 void RemoteGraphicsContext::setFillRule(WindRule rule)
@@ -184,11 +191,18 @@ void RemoteGraphicsContext::setStrokeGradient(Ref<Gradient>&& gradient, const Af
     context().setStrokeGradient(WTFMove(gradient), spaceTransform);
 }
 
-void RemoteGraphicsContext::setStrokePattern(RenderingResourceIdentifier tileImageIdentifier, const PatternParameters& parameters)
+void RemoteGraphicsContext::setStrokePatternNativeImage(RenderingResourceIdentifier identifier, const PatternParameters& parameters)
 {
-    auto tileImage = sourceImage(tileImageIdentifier);
+    RefPtr tileImage = resourceCache().cachedNativeImage(identifier);
     MESSAGE_CHECK(tileImage);
-    context().setStrokePattern(Pattern::create(WTFMove(*tileImage), parameters));
+    context().setStrokePattern(Pattern::create({ tileImage.releaseNonNull() }, parameters));
+}
+
+void RemoteGraphicsContext::setStrokePatternImageBuffer(RenderingResourceIdentifier identifier, const PatternParameters& parameters)
+{
+    RefPtr tileImageBuffer = imageBuffer(identifier);
+    MESSAGE_CHECK(tileImageBuffer);
+    context().setStrokePattern(Pattern::create({ tileImageBuffer.releaseNonNull() }, parameters));
 }
 
 void RemoteGraphicsContext::setStrokePackedColorAndThickness(PackedColor::RGBA color, float thickness)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -61,13 +61,15 @@ public:
     void setFillColor(const WebCore::Color&);
     void setFillCachedGradient(RemoteGradientIdentifier, const WebCore::AffineTransform&);
     void setFillGradient(Ref<WebCore::Gradient>&&, const WebCore::AffineTransform&);
-    void setFillPattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, const WebCore::PatternParameters&);
+    void setFillPatternNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::PatternParameters&);
+    void setFillPatternImageBuffer(WebCore::RenderingResourceIdentifier bufferIdentifier, const WebCore::PatternParameters&);
     void setFillRule(WebCore::WindRule);
     void setStrokePackedColor(WebCore::PackedColor::RGBA);
     void setStrokeColor(const WebCore::Color&);
     void setStrokeCachedGradient(RemoteGradientIdentifier, const WebCore::AffineTransform&);
     void setStrokeGradient(Ref<WebCore::Gradient>&&, const WebCore::AffineTransform&);
-    void setStrokePattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, const WebCore::PatternParameters&);
+    void setStrokePatternNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::PatternParameters&);
+    void setStrokePatternImageBuffer(WebCore::RenderingResourceIdentifier bufferIdentifier, const WebCore::PatternParameters&);
     void setStrokePackedColorAndThickness(WebCore::PackedColor::RGBA, float);
     void setStrokeThickness(float);
     void setStrokeStyle(WebCore::StrokeStyle);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -39,13 +39,15 @@ messages -> RemoteGraphicsContext Stream {
     SetFillColor(WebCore::Color color) StreamBatched
     SetFillCachedGradient(WebKit::RemoteGradientIdentifier identifier, WebCore::AffineTransform spaceTransform) StreamBatched
     SetFillGradient(Ref<WebCore::Gradient> gradient, WebCore::AffineTransform spaceTransform) StreamBatched
-    SetFillPattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, WebCore::PatternParameters pattern) StreamBatched
+    SetFillPatternNativeImage(WebCore::RenderingResourceIdentifier nativeImageIdentifier, WebCore::PatternParameters pattern) StreamBatched
+    SetFillPatternImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::PatternParameters pattern) StreamBatched
     SetFillRule(enum:bool WebCore::WindRule rule) StreamBatched
     SetStrokePackedColor(WebCore::PackedColor::RGBA color) StreamBatched
     SetStrokeColor(WebCore::Color color) StreamBatched
     SetStrokeCachedGradient(WebKit::RemoteGradientIdentifier identifier, WebCore::AffineTransform spaceTransform) StreamBatched
     SetStrokeGradient(Ref<WebCore::Gradient> gradient, WebCore::AffineTransform spaceTransform) StreamBatched
-    SetStrokePattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, WebCore::PatternParameters pattern) StreamBatched
+    SetStrokePatternNativeImage(WebCore::RenderingResourceIdentifier nativeImageIdentifier, WebCore::PatternParameters pattern) StreamBatched
+    SetStrokePatternImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::PatternParameters pattern) StreamBatched
     SetStrokePackedColorAndThickness(WebCore::PackedColor::RGBA color, float thickness) StreamBatched
     SetStrokeThickness(float thickness) StreamBatched
     SetStrokeStyle(enum:uint8_t WebCore::StrokeStyle style) StreamBatched

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -765,8 +765,13 @@ void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
         if (auto packedColor = fillBrush.packedColor())
             send(Messages::RemoteGraphicsContext::SetFillPackedColor(*packedColor));
         else if (RefPtr pattern = fillBrush.pattern()) {
-            recordResourceUse(pattern->tileImage());
-            send(Messages::RemoteGraphicsContext::SetFillPattern(pattern->tileImage().imageIdentifier(), pattern->parameters()));
+            if (RefPtr image = pattern->tileNativeImage()) {
+                if (recordResourceUse(*image))
+                    send(Messages::RemoteGraphicsContext::SetFillPatternNativeImage(image->renderingResourceIdentifier(), pattern->parameters()));
+            } else if (RefPtr buffer = pattern->tileImageBuffer()) {
+                if (recordResourceUse(*buffer))
+                    send(Messages::RemoteGraphicsContext::SetFillPatternImageBuffer(buffer->renderingResourceIdentifier(), pattern->parameters()));
+            }
         } else if (RefPtr gradient = fillBrush.gradient()) {
             if (auto identifier = recordResourceUse(*gradient))
                 send(Messages::RemoteGraphicsContext::SetFillCachedGradient(*identifier, fillBrush.gradientSpaceTransform()));
@@ -784,8 +789,13 @@ void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
             } else
                 send(Messages::RemoteGraphicsContext::SetStrokePackedColor(*packedColor));
         } else if (RefPtr pattern = strokeBrush.pattern()) {
-            recordResourceUse(pattern->tileImage());
-            send(Messages::RemoteGraphicsContext::SetStrokePattern(pattern->tileImage().imageIdentifier(), pattern->parameters()));
+            if (RefPtr image = pattern->tileNativeImage()) {
+                if (recordResourceUse(*image))
+                    send(Messages::RemoteGraphicsContext::SetStrokePatternNativeImage(image->renderingResourceIdentifier(), pattern->parameters()));
+            } else if (RefPtr buffer = pattern->tileImageBuffer()) {
+                if (recordResourceUse(*buffer))
+                    send(Messages::RemoteGraphicsContext::SetStrokePatternImageBuffer(buffer->renderingResourceIdentifier(), pattern->parameters()));
+            }
         } else if (RefPtr gradient = strokeBrush.gradient()) {
             if (auto identifier = recordResourceUse(*gradient))
                 send(Messages::RemoteGraphicsContext::SetStrokeCachedGradient(*identifier, strokeBrush.gradientSpaceTransform()));


### PR DESCRIPTION
#### 39a1301aaed15fb1767b40c7f8fbb375649525b0
<pre>
GPUP: Add separate state setters for pattern with NativeImages and ImageBuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=298858">https://bugs.webkit.org/show_bug.cgi?id=298858</a>
<a href="https://rdar.apple.com/160599397">rdar://160599397</a>

Reviewed by Simon Fraser.

Sending SourceImage as a message is problematic because it contains
NativeImage or ImageBuffer reference. These references must be resolved
statefully through RemoteRenderingBackend, but IPC decoding cannot do
that. The send of SourceImage cannot really be received as SourceImage.
This is currently worked around by adding RenderingResourceIdentifier
as the third variant in SourceImage. This complicates the implementation
with redundant ASSERT_NOT_REACHED() paths.

Remove few uses of SourceImage in the encode/decode part and use
explicit identifiers. This is working towards being able to identify
NativeImages and ImageBuffers in type-safe manner.

* Source/WebCore/platform/graphics/Pattern.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::setFillPatternNativeImage):
(WebKit::RemoteGraphicsContext::setFillPatternImageBuffer):
(WebKit::RemoteGraphicsContext::setStrokePatternNativeImage):
(WebKit::RemoteGraphicsContext::setStrokePatternImageBuffer):
(WebKit::RemoteGraphicsContext::setFillPattern): Deleted.
(WebKit::RemoteGraphicsContext::setStrokePattern): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary):

Canonical link: <a href="https://commits.webkit.org/300330@main">https://commits.webkit.org/300330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48953a9d24e8576a4aeaa22e8e3f79a997e8b697

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/24b37fb9-bec3-49ef-8779-9d17370eae33) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92412 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61426 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84ff6a5a-b0ff-4874-8ab6-cd1925b38077) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73074 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/661fdbf7-9466-444f-b075-5587da67672f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27049 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130944 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100998 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45185 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54058 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->