### PR TITLE
REGRESSION(299031@main): `RELEASE_ASSERT(a.globalPosition() != b.globalPosition())` is hit under `compareAnimationsByCompositeOrder()` when calling `WebAnimation::commitStyles()`

### DIFF
--- a/LayoutTests/webanimations/commit-style-crash-expected.txt
+++ b/LayoutTests/webanimations/commit-style-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if it does not crash.

--- a/LayoutTests/webanimations/commit-style-crash.html
+++ b/LayoutTests/webanimations/commit-style-crash.html
@@ -1,0 +1,32 @@
+<style>
+
+@keyframes anim1 { }
+
+@keyframes anim2 { }
+
+</style>
+<script>
+
+window.testRunner?.dumpAsText();
+
+const stylesheet = document.styleSheets[0];
+
+stylesheet.insertRule(`polyline { animation: anim1 1s, anim2 1s; }`, stylesheet.rules);
+
+const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+document.documentElement.prepend(svg);
+
+const polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+svg.prepend(polyline);
+
+const mpath = document.createElementNS('http://www.w3.org/2000/svg', 'mpath');
+polyline.append(mpath);
+
+const animation = polyline.getAnimations()[0];
+
+mpath.before(stylesheet.ownerNode);
+
+animation.commitStyles();
+
+</script>
+<p>PASS if it does not crash.</p>

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1798,7 +1798,11 @@ ExceptionOr<void> WebAnimation::commitStyles()
     // would be disregarded.
     auto* unsortedAnimations = styledElement->animations({ });
     ASSERT(unsortedAnimations && !unsortedAnimations->isEmpty());
-    auto sortedAnimations = copyToVector(*unsortedAnimations);
+    auto sortedAnimations = WTF::compactMap(*unsortedAnimations, [](auto& animation) -> RefPtr<WebAnimation> {
+        if (animation->playState() != WebAnimation::PlayState::Idle)
+            return animation.ptr();
+        return nullptr;
+    });
     std::ranges::stable_sort(sortedAnimations, [](auto& lhs, auto& rhs) {
         return compareAnimationsByCompositeOrder(lhs.get(), rhs.get());
     });


### PR DESCRIPTION
#### 2a73cdd7c497a4385a1ee3b4992ca3729c81ace5
<pre>
REGRESSION(299031@main): `RELEASE_ASSERT(a.globalPosition() != b.globalPosition())` is hit under `compareAnimationsByCompositeOrder()` when calling `WebAnimation::commitStyles()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298860">https://bugs.webkit.org/show_bug.cgi?id=298860</a>
<a href="https://rdar.apple.com/160101397">rdar://160101397</a>

Reviewed by Anne van Kesteren.

In 299031@main we changed our implementation for `Animation.commitStyles()` to no longer go through the animation target&apos;s associated
keyframe effect stack and instead use all animations associated with that target in order to include animations that would be marked
as not relevant [0] since the spec behavior changed to include animations that would be right at their finished time.

That change meant that we would potentially iterate over idle animations. In itself, this is not an issue since idle animations would
not have an effect on the animated style. However, it caused an assertion in `compareAnimationsByCompositeOrder()` to fail because in
some cases we would try to sort style-originated animations that did not yet have a global position and would have been canceled by the
time `commitStyles()` was called, as was the case in the newly-created test.

We now filter the list of animations to consider to remove any idle animation.

[0] <a href="https://drafts.csswg.org/web-animations-1/#relevant-animations-section">https://drafts.csswg.org/web-animations-1/#relevant-animations-section</a>

Test: webanimations/commit-style-crash.html
* LayoutTests/webanimations/commit-style-crash-expected.txt: Added.
* LayoutTests/webanimations/commit-style-crash.html: Added.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):

Canonical link: <a href="https://commits.webkit.org/299952@main">https://commits.webkit.org/299952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86609e294e488f838c535811694672fab8c37ac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72966 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91816 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61062 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72512 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70892 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130158 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100433 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100336 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44501 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19174 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53378 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->