### PR TITLE
Address safer CPP warnings in PlatformStrategies.h

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -234,7 +234,7 @@ inline ExpectedType& downcast(CheckedRef<ArgType, ArgPtrTraits>& source)
 }
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
-inline const ExpectedType& downcast(const CheckedRef<ArgType, ArgPtrTraits>& source)
+inline ExpectedType& downcast(const CheckedRef<ArgType, ArgPtrTraits>& source)
 {
     return downcast<ExpectedType>(source.get());
 }

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1709,7 +1709,7 @@ bool MediaSource::enabledForContext(ScriptExecutionContext& context)
     UNUSED_PARAM(context);
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
     if (context.isWorkerGlobalScope())
-        return context.settingsValues().mediaSourceInWorkerEnabled && platformStrategies()->mediaStrategy().hasThreadSafeMediaSourceSupport();
+        return context.settingsValues().mediaSourceInWorkerEnabled && platformStrategies()->mediaStrategy()->hasThreadSafeMediaSourceSupport();
 #endif
 
     ASSERT(context.isDocument());
@@ -1746,7 +1746,7 @@ Ref<MediaSourceHandle> MediaSource::handle()
 
 bool MediaSource::canConstructInDedicatedWorker(ScriptExecutionContext& context)
 {
-    return context.settingsValues().mediaSourceInWorkerEnabled && platformStrategies()->mediaStrategy().hasThreadSafeMediaSourceSupport();
+    return context.settingsValues().mediaSourceInWorkerEnabled && platformStrategies()->mediaStrategy()->hasThreadSafeMediaSourceSupport();
 }
 
 #endif

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -154,7 +154,7 @@ static void createImageBitmap(VideoFrame& videoFrame, CompletionHandler<void(Ref
     }
 
     if (hasPlatformStrategies()) {
-        platformStrategies()->mediaStrategy().nativeImageFromVideoFrame(videoFrame, [videoFrame = Ref { videoFrame }, imageBuffer = imageBuffer.releaseNonNull(), completionHandler = WTFMove(completionHandler)](auto&& nativeImage) mutable {
+        platformStrategies()->mediaStrategy()->nativeImageFromVideoFrame(videoFrame, [videoFrame = Ref { videoFrame }, imageBuffer = imageBuffer.releaseNonNull(), completionHandler = WTFMove(completionHandler)](auto&& nativeImage) mutable {
             if (!nativeImage) {
                 completionHandler(createImageBitmapViaDrawing(WTFMove(imageBuffer), videoFrame));
                 return;

--- a/Source/WebCore/Modules/push-api/PushStrategy.h
+++ b/Source/WebCore/Modules/push-api/PushStrategy.h
@@ -29,12 +29,15 @@
 #include <WebCore/PushPermissionState.h>
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/PushSubscriptionIdentifier.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 template<typename> class ExceptionOr;
 
 class WEBCORE_EXPORT PushStrategy {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PushStrategy);
 public:
     virtual ~PushStrategy() = default;
 
@@ -49,6 +52,12 @@ public:
 
     using GetPushPermissionStateCallback = CompletionHandler<void(ExceptionOr<PushPermissionState>&&)>;
     virtual void windowGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) = 0;
+
+    // CheckedPtr interface.
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -119,7 +119,7 @@ void DefaultAudioDestinationNode::createDestination()
 {
     ALWAYS_LOG(LOGIDENTIFIER, "contextSampleRate = ", sampleRate(), ", hardwareSampleRate = ", AudioDestination::hardwareSampleRate());
     ASSERT(!m_destination);
-    m_destination = platformStrategies()->mediaStrategy().createAudioDestination({ *this, m_inputDeviceId, m_numberOfInputChannels, channelCount(), sampleRate()
+    m_destination = platformStrategies()->mediaStrategy()->createAudioDestination({ *this, m_inputDeviceId, m_numberOfInputChannels, channelCount(), sampleRate()
 #if PLATFORM(IOS_FAMILY)
         , context().sceneIdentifier()
 #endif

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -85,7 +85,6 @@ page/mac/ServicesOverlayController.mm
 page/scrolling/ScrollingStateNode.h
 page/scrolling/ScrollingStateScrollingNode.cpp
 platform/PODRedBlackTree.h
-platform/PlatformStrategies.h
 platform/Scrollbar.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
 platform/graphics/ImageBufferContextSwitcher.h

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -6675,7 +6675,7 @@ void SerializedScriptValue::writeBlobsToDiskForIndexedDB(bool isEphemeral, Compl
     if (isEphemeral)
         return completionHandler({ });
 
-    blobRegistry().writeBlobsToTemporaryFilesForIndexedDB(blobURLs(), [completionHandler = WTFMove(completionHandler), this, protectedThis = Ref { *this }] (auto&& blobFilePaths) mutable {
+    blobRegistry()->writeBlobsToTemporaryFilesForIndexedDB(blobURLs(), [completionHandler = WTFMove(completionHandler), this, protectedThis = Ref { *this }] (auto&& blobFilePaths) mutable {
         ASSERT(isMainThread());
 
         if (blobFilePaths.isEmpty()) {

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -93,12 +93,12 @@ void ThreadableBlobRegistry::registerInternalFileBlobURL(const URL& url, const S
     String effectivePath = !replacementPath.isNull() ? replacementPath : path;
 
     if (isMainThread()) {
-        blobRegistry().registerInternalFileBlobURL(url, BlobDataFileReference::create(effectivePath), path, contentType);
+        blobRegistry()->registerInternalFileBlobURL(url, BlobDataFileReference::create(effectivePath), path, contentType);
         return;
     }
 
     callOnMainThread([url = url.isolatedCopy(), effectivePath = effectivePath.isolatedCopy(), path = path.isolatedCopy(), contentType = contentType.isolatedCopy()] {
-        blobRegistry().registerInternalFileBlobURL(url, BlobDataFileReference::create(effectivePath), path, contentType);
+        blobRegistry()->registerInternalFileBlobURL(url, BlobDataFileReference::create(effectivePath), path, contentType);
     });
 }
 
@@ -106,13 +106,13 @@ void ThreadableBlobRegistry::registerInternalBlobURL(const URL& url, Vector<Blob
 {
     ASSERT(BlobURL::isInternalURL(url));
     if (isMainThread()) {
-        blobRegistry().registerInternalBlobURL(url, WTFMove(blobParts), contentType);
+        blobRegistry()->registerInternalBlobURL(url, WTFMove(blobParts), contentType);
         return;
     }
     for (auto& part : blobParts)
         part.detachFromCurrentThread();
     callOnMainThread([url = url.isolatedCopy(), blobParts = WTFMove(blobParts), contentType = contentType.isolatedCopy()]() mutable {
-        blobRegistry().registerInternalBlobURL(url, WTFMove(blobParts), contentType);
+        blobRegistry()->registerInternalBlobURL(url, WTFMove(blobParts), contentType);
     });
 }
 
@@ -131,7 +131,7 @@ void ThreadableBlobRegistry::registerBlobURL(SecurityOrigin* origin, PolicyConta
 {
     if (isMainThread()) {
         addToOriginMapIfNecessary(url, origin);
-        blobRegistry().registerBlobURL(url, srcURL, policyContainer, topOrigin);
+        blobRegistry()->registerBlobURL(url, srcURL, policyContainer, topOrigin);
         return;
     }
 
@@ -141,7 +141,7 @@ void ThreadableBlobRegistry::registerBlobURL(SecurityOrigin* origin, PolicyConta
 
     callOnMainThread([url = url.isolatedCopy(), srcURL = srcURL.isolatedCopy(), policyContainer = crossThreadCopy(WTFMove(policyContainer)), strongOrigin = WTFMove(strongOrigin), topOrigin = crossThreadCopy(topOrigin)]() mutable {
         addToOriginMapIfNecessary(url, WTFMove(strongOrigin));
-        blobRegistry().registerBlobURL(url, srcURL, policyContainer, topOrigin);
+        blobRegistry()->registerBlobURL(url, srcURL, policyContainer, topOrigin);
     });
 }
 
@@ -154,11 +154,11 @@ void ThreadableBlobRegistry::registerInternalBlobURLOptionallyFileBacked(const U
 {
     ASSERT(BlobURL::isInternalURL(url));
     if (isMainThread()) {
-        blobRegistry().registerInternalBlobURLOptionallyFileBacked(url, srcURL, BlobDataFileReference::create(fileBackedPath), contentType);
+        blobRegistry()->registerInternalBlobURLOptionallyFileBacked(url, srcURL, BlobDataFileReference::create(fileBackedPath), contentType);
         return;
     }
     callOnMainThread([url = url.isolatedCopy(), srcURL = srcURL.isolatedCopy(), fileBackedPath = fileBackedPath.isolatedCopy(), contentType = contentType.isolatedCopy()] {
-        blobRegistry().registerInternalBlobURLOptionallyFileBacked(url, srcURL, BlobDataFileReference::create(fileBackedPath), contentType);
+        blobRegistry()->registerInternalBlobURLOptionallyFileBacked(url, srcURL, BlobDataFileReference::create(fileBackedPath), contentType);
     });
 }
 
@@ -166,23 +166,23 @@ void ThreadableBlobRegistry::registerInternalBlobURLForSlice(const URL& newURL, 
 {
     ASSERT(BlobURL::isInternalURL(newURL));
     if (isMainThread()) {
-        blobRegistry().registerInternalBlobURLForSlice(newURL, srcURL, start, end, contentType);
+        blobRegistry()->registerInternalBlobURLForSlice(newURL, srcURL, start, end, contentType);
         return;
     }
 
     callOnMainThread([newURL = newURL.isolatedCopy(), srcURL = srcURL.isolatedCopy(), start, end, contentType = contentType.isolatedCopy()] {
-        blobRegistry().registerInternalBlobURLForSlice(newURL, srcURL, start, end, contentType);
+        blobRegistry()->registerInternalBlobURLForSlice(newURL, srcURL, start, end, contentType);
     });
 }
 
 String ThreadableBlobRegistry::blobType(const URL& url)
 {
     if (isMainThread())
-        return blobRegistry().blobType(url);
+        return blobRegistry()->blobType(url);
 
     String result;
     callOnMainThreadAndWait([url = url.isolatedCopy(), &result] {
-        result = blobRegistry().blobType(url).isolatedCopy();
+        result = blobRegistry()->blobType(url).isolatedCopy();
     });
     return result;
 
@@ -191,11 +191,11 @@ String ThreadableBlobRegistry::blobType(const URL& url)
 unsigned long long ThreadableBlobRegistry::blobSize(const URL& url)
 {
     if (isMainThread())
-        return blobRegistry().blobSize(url);
+        return blobRegistry()->blobSize(url);
 
     unsigned long long resultSize;
     callOnMainThreadAndWait([url = url.isolatedCopy(), &resultSize] {
-        resultSize = blobRegistry().blobSize(url);
+        resultSize = blobRegistry()->blobSize(url);
     });
     return resultSize;
 }
@@ -204,7 +204,7 @@ void ThreadableBlobRegistry::unregisterBlobURL(const URL& url, const std::option
 {
     ensureOnMainThread([url = url.isolatedCopy(), topOrigin = crossThreadCopy(topOrigin)] {
         unregisterBlobURLOriginIfNecessaryOnMainThread(url);
-        blobRegistry().unregisterBlobURL(url, topOrigin);
+        blobRegistry()->unregisterBlobURL(url, topOrigin);
     });
 }
 
@@ -219,7 +219,7 @@ void ThreadableBlobRegistry::registerBlobURLHandle(const URL& url, const std::op
         if (isBlobURLContainingNullOrigin(url))
             blobURLReferencesMap().add(url.stringWithoutFragmentIdentifier());
 
-        blobRegistry().registerBlobURLHandle(url, topOrigin);
+        blobRegistry()->registerBlobURLHandle(url, topOrigin);
     });
 }
 
@@ -227,7 +227,7 @@ void ThreadableBlobRegistry::unregisterBlobURLHandle(const URL& url, const std::
 {
     ensureOnMainThread([url = url.isolatedCopy(), topOrigin = crossThreadCopy(topOrigin)] {
         unregisterBlobURLOriginIfNecessaryOnMainThread(url);
-        blobRegistry().unregisterBlobURLHandle(url, topOrigin);
+        blobRegistry()->unregisterBlobURLHandle(url, topOrigin);
     });
 }
 

--- a/Source/WebCore/loader/LoaderStrategy.cpp
+++ b/Source/WebCore/loader/LoaderStrategy.cpp
@@ -27,8 +27,11 @@
 #include "LoaderStrategy.h"
 
 #include "NetworkLoadInformation.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(LoaderStrategy);
 
 LoaderStrategy::~LoaderStrategy() = default;
 

--- a/Source/WebCore/loader/LoaderStrategy.h
+++ b/Source/WebCore/loader/LoaderStrategy.h
@@ -32,6 +32,7 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceLoaderOptions.h>
 #include <WebCore/StoredCredentialsPolicy.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -56,7 +57,9 @@ class SubresourceLoader;
 
 struct FetchOptions;
 
-class WEBCORE_EXPORT LoaderStrategy {
+class WEBCORE_EXPORT LoaderStrategy : public CanMakeCheckedPtr<LoaderStrategy> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(LoaderStrategy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LoaderStrategy);
 public:
     virtual void loadResource(LocalFrame&, CachedResource&, ResourceRequest&&, const ResourceLoaderOptions&, CompletionHandler<void(RefPtr<SubresourceLoader>&&)>&&) = 0;
     virtual void loadResourceSynchronously(FrameLoader&, ResourceLoaderIdentifier, const ResourceRequest&, ClientCredentialPolicy, const FetchOptions&, const HTTPHeaderMap&, ResourceError&, ResourceResponse&, Vector<uint8_t>& data) = 0;

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -53,7 +53,7 @@ void DeprecatedGlobalSettings::setAVFoundationEnabled(bool enabled)
         return;
 
     shared().m_AVFoundationEnabled = enabled;
-    platformStrategies()->mediaStrategy().resetMediaEngines();
+    platformStrategies()->mediaStrategy()->resetMediaEngines();
 }
 #endif
 
@@ -66,7 +66,7 @@ void DeprecatedGlobalSettings::setGStreamerEnabled(bool enabled)
     shared().m_GStreamerEnabled = enabled;
 
 #if ENABLE(VIDEO)
-    platformStrategies()->mediaStrategy().resetMediaEngines();
+    platformStrategies()->mediaStrategy()->resetMediaEngines();
 #endif
 }
 #endif

--- a/Source/WebCore/platform/MediaStrategy.cpp
+++ b/Source/WebCore/platform/MediaStrategy.cpp
@@ -27,12 +27,16 @@
 #include "MediaStrategy.h"
 
 #include "MediaPlayer.h"
+#include <wtf/TZoneMallocInlines.h>
+
 #if ENABLE(MEDIA_SOURCE)
 #include "DeprecatedGlobalSettings.h"
 #include "MockMediaPlayerMediaSource.h"
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(MediaStrategy);
 
 MediaStrategy::MediaStrategy() = default;
 

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -31,6 +31,7 @@
 #endif
 #include <WebCore/NativeImage.h>
 #include <WebCore/NowPlayingManager.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 
@@ -44,7 +45,9 @@ class VideoFrame;
 
 struct AudioDestinationCreationOptions;
 
-class WEBCORE_EXPORT MediaStrategy {
+class WEBCORE_EXPORT MediaStrategy : public CanMakeThreadSafeCheckedPtr<MediaStrategy> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaStrategy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaStrategy);
 public:
 #if ENABLE(WEB_AUDIO)
     virtual Ref<AudioDestination> createAudioDestination(const AudioDestinationCreationOptions&) = 0;

--- a/Source/WebCore/platform/Pasteboard.cpp
+++ b/Source/WebCore/platform/Pasteboard.cpp
@@ -64,7 +64,7 @@ Vector<String> Pasteboard::readAllStrings(const String& type)
 std::optional<Vector<PasteboardItemInfo>> Pasteboard::allPasteboardItemInfo() const
 {
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
-    if (auto* strategy = platformStrategies()->pasteboardStrategy())
+    if (CheckedPtr strategy = platformStrategies()->pasteboardStrategy())
         return strategy->allPasteboardItemInfo(name(), m_changeCount, context());
 #endif
     return std::nullopt;
@@ -73,7 +73,7 @@ std::optional<Vector<PasteboardItemInfo>> Pasteboard::allPasteboardItemInfo() co
 std::optional<PasteboardItemInfo> Pasteboard::pasteboardItemInfo(size_t index) const
 {
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
-    if (auto* strategy = platformStrategies()->pasteboardStrategy())
+    if (CheckedPtr strategy = platformStrategies()->pasteboardStrategy())
         return strategy->informationForItemAtIndex(index, name(), m_changeCount, context());
 #else
     UNUSED_PARAM(index);
@@ -83,21 +83,21 @@ std::optional<PasteboardItemInfo> Pasteboard::pasteboardItemInfo(size_t index) c
 
 String Pasteboard::readString(size_t index, const String& type)
 {
-    if (auto* strategy = platformStrategies()->pasteboardStrategy())
+    if (CheckedPtr strategy = platformStrategies()->pasteboardStrategy())
         return strategy->readStringFromPasteboard(index, type, name(), context());
     return { };
 }
 
 RefPtr<WebCore::SharedBuffer> Pasteboard::readBuffer(std::optional<size_t> index, const String& type)
 {
-    if (auto* strategy = platformStrategies()->pasteboardStrategy())
+    if (CheckedPtr strategy = platformStrategies()->pasteboardStrategy())
         return strategy->readBufferFromPasteboard(index, type, name(), context());
     return nullptr;
 }
 
 URL Pasteboard::readURL(size_t index, String& title)
 {
-    if (auto* strategy = platformStrategies()->pasteboardStrategy())
+    if (CheckedPtr strategy = platformStrategies()->pasteboardStrategy())
         return strategy->readURLFromPasteboard(index, name(), title, context());
     return { };
 }

--- a/Source/WebCore/platform/PasteboardStrategy.h
+++ b/Source/WebCore/platform/PasteboardStrategy.h
@@ -26,8 +26,10 @@
 #ifndef PasteboardStrategy_h
 #define PasteboardStrategy_h
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -42,7 +44,9 @@ struct PasteboardItemInfo;
 struct PasteboardURL;
 struct PasteboardWebContent;
 
-class PasteboardStrategy {
+class PasteboardStrategy : public CanMakeCheckedPtr<PasteboardStrategy> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PasteboardStrategy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PasteboardStrategy);
 public:
 #if PLATFORM(IOS_FAMILY)
     virtual void writeToPasteboard(const PasteboardURL&, const String& pasteboardName, const PasteboardContext*) = 0;

--- a/Source/WebCore/platform/PlatformStrategies.cpp
+++ b/Source/WebCore/platform/PlatformStrategies.cpp
@@ -26,9 +26,22 @@
 #include "config.h"
 #include "PlatformStrategies.h"
 
+#include "BlobRegistry.h"
+#include "LoaderStrategy.h"
+#include "MediaStrategy.h"
+#include "PasteboardStrategy.h"
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+#include "PushStrategy.h"
+#endif
+
 namespace WebCore {
 
 static PlatformStrategies* s_platformStrategies;
+
+PlatformStrategies::PlatformStrategies() = default;
+
+PlatformStrategies::~PlatformStrategies() = default;
 
 bool hasPlatformStrategies()
 {
@@ -53,6 +66,44 @@ void setPlatformStrategies(PlatformStrategies* platformStrategies)
     // throw an exception here in release builds.
     ASSERT(platformStrategies == s_platformStrategies);
 }
+
+CheckedPtr<LoaderStrategy> PlatformStrategies::loaderStrategy()
+{
+    if (!m_loaderStrategy)
+        m_loaderStrategy = createLoaderStrategy();
+    return m_loaderStrategy;
+}
+
+CheckedPtr<PasteboardStrategy> PlatformStrategies::pasteboardStrategy()
+{
+    if (!m_pasteboardStrategy)
+        m_pasteboardStrategy = createPasteboardStrategy();
+    return m_pasteboardStrategy;
+}
+
+CheckedRef<MediaStrategy> PlatformStrategies::mediaStrategy()
+{
+    std::call_once(m_onceKeyForMediaStrategies, [&] {
+        m_mediaStrategy = createMediaStrategy();
+    });
+    return *m_mediaStrategy;
+}
+
+CheckedPtr<BlobRegistry> PlatformStrategies::blobRegistry()
+{
+    if (!m_blobRegistry)
+        m_blobRegistry = createBlobRegistry();
+    return m_blobRegistry;
+}
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+CheckedPtr<PushStrategy> PlatformStrategies::pushStrategy()
+{
+    if (!m_pushStrategy)
+        m_pushStrategy = createPushStrategy();
+    return m_pushStrategy;
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/PlatformStrategies.h
+++ b/Source/WebCore/platform/PlatformStrategies.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <mutex>
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -39,66 +40,34 @@ class PushStrategy;
 
 class PlatformStrategies {
 public:
-    LoaderStrategy* loaderStrategy()
-    {
-        if (!m_loaderStrategy)
-            m_loaderStrategy = createLoaderStrategy();
-        return m_loaderStrategy;
-    }
-
-    PasteboardStrategy* pasteboardStrategy()
-    {
-        if (!m_pasteboardStrategy)
-            m_pasteboardStrategy = createPasteboardStrategy();
-        return m_pasteboardStrategy;
-    }
-
-    MediaStrategy& mediaStrategy()
-    {
-        std::call_once(m_onceKeyForMediaStrategies, [&] {
-            m_mediaStrategy = createMediaStrategy();
-        });
-        return *m_mediaStrategy;
-    }
-
-    BlobRegistry* blobRegistry()
-    {
-        if (!m_blobRegistry)
-            m_blobRegistry = createBlobRegistry();
-        return m_blobRegistry;
-    }
-
+    WEBCORE_EXPORT CheckedPtr<LoaderStrategy> loaderStrategy();
+    WEBCORE_EXPORT CheckedPtr<PasteboardStrategy> pasteboardStrategy();
+    WEBCORE_EXPORT CheckedRef<MediaStrategy> mediaStrategy();
+    WEBCORE_EXPORT CheckedPtr<BlobRegistry> blobRegistry();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    PushStrategy* pushStrategy()
-    {
-        if (!m_pushStrategy)
-            m_pushStrategy = createPushStrategy();
-        return m_pushStrategy;
-    }
+    WEBCORE_EXPORT CheckedPtr<PushStrategy> pushStrategy();
 #endif
 
 protected:
-    PlatformStrategies() = default;
-
-    virtual ~PlatformStrategies()
-    {
-    }
+    WEBCORE_EXPORT PlatformStrategies();
+    WEBCORE_EXPORT virtual ~PlatformStrategies();
 
 private:
     virtual LoaderStrategy* createLoaderStrategy() = 0;
     virtual PasteboardStrategy* createPasteboardStrategy() = 0;
     virtual MediaStrategy* createMediaStrategy() = 0;
     virtual BlobRegistry* createBlobRegistry() = 0;
-
-    LoaderStrategy* m_loaderStrategy { };
-    PasteboardStrategy* m_pasteboardStrategy { };
-    std::once_flag m_onceKeyForMediaStrategies;
-    MediaStrategy* m_mediaStrategy { };
-    BlobRegistry* m_blobRegistry { };
-
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     virtual PushStrategy* createPushStrategy() = 0;
-    PushStrategy* m_pushStrategy { };
+#endif
+
+    CheckedPtr<LoaderStrategy> m_loaderStrategy;
+    CheckedPtr<PasteboardStrategy> m_pasteboardStrategy;
+    std::once_flag m_onceKeyForMediaStrategies;
+    CheckedPtr<MediaStrategy> m_mediaStrategy;
+    CheckedPtr<BlobRegistry> m_blobRegistry;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    CheckedPtr<PushStrategy> m_pushStrategy;
 #endif
 };
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -84,7 +84,7 @@ RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::opt
 #endif // !PLATFORM(MAC)
 
 MediaSessionManagerCocoa::MediaSessionManagerCocoa()
-    : m_nowPlayingManager(hasPlatformStrategies() ? platformStrategies()->mediaStrategy().createNowPlayingManager() : nullptr)
+    : m_nowPlayingManager(hasPlatformStrategies() ? platformStrategies()->mediaStrategy()->createNowPlayingManager() : nullptr)
     , m_delayCategoryChangeTimer(RunLoop::mainSingleton(), "MediaSessionManagerCocoa::DelayCategoryChangeTimer"_s, this, &MediaSessionManagerCocoa::possiblyChangeAudioCategory)
 {
 }

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -128,7 +128,7 @@ RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::opt
 
 MediaSessionManagerGLib::MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&& mprisInterface)
     : m_mprisInterface(WTFMove(mprisInterface))
-    , m_nowPlayingManager(platformStrategies()->mediaStrategy().createNowPlayingManager())
+    , m_nowPlayingManager(platformStrategies()->mediaStrategy()->createNowPlayingManager())
 {
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -299,14 +299,14 @@ static void buildMediaEnginesVector() WTF_REQUIRES_LOCK(mediaEngineVectorLock)
 #if USE(AVFOUNDATION)
     auto& registerRemoteEngine = registerRemotePlayerCallback();
 #if ENABLE(MEDIA_SOURCE)
-    if (registerRemoteEngine && platformStrategies()->mediaStrategy().mockMediaSourceEnabled())
+    if (registerRemoteEngine && platformStrategies()->mediaStrategy()->mockMediaSourceEnabled())
         registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::MockMSE);
 #endif
 
     if (DeprecatedGlobalSettings::isAVFoundationEnabled()) {
 
 #if ENABLE(COCOA_WEBM_PLAYER)
-        if (!hasPlatformStrategies() || platformStrategies()->mediaStrategy().enableWebMMediaPlayer()) {
+        if (!hasPlatformStrategies() || platformStrategies()->mediaStrategy()->enableWebMMediaPlayer()) {
             if (registerRemoteEngine)
                 registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::CocoaWebM);
             else

--- a/Source/WebCore/platform/network/BlobRegistry.cpp
+++ b/Source/WebCore/platform/network/BlobRegistry.cpp
@@ -28,10 +28,13 @@
 
 #include "PlatformStrategies.h"
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-BlobRegistry& blobRegistry()
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(BlobRegistry);
+
+CheckedRef<BlobRegistry> blobRegistry()
 {
     ASSERT(isMainThread());
     return *platformStrategies()->blobRegistry();

--- a/Source/WebCore/platform/network/BlobRegistry.h
+++ b/Source/WebCore/platform/network/BlobRegistry.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <optional>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -44,10 +45,12 @@ class SecurityOriginData;
 
 struct PolicyContainer;
 
-WEBCORE_EXPORT BlobRegistry& blobRegistry();
+WEBCORE_EXPORT CheckedRef<BlobRegistry> blobRegistry();
 
 // BlobRegistry is not thread-safe. It should only be called from main thread.
-class WEBCORE_EXPORT BlobRegistry {
+class WEBCORE_EXPORT BlobRegistry : public CanMakeCheckedPtr<BlobRegistry> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(BlobRegistry);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BlobRegistry);
 public:
 
     // Registers a blob URL referring to the specified file.

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -62,13 +62,13 @@ BlobRegistryImpl::~BlobRegistryImpl() = default;
 
 static Ref<ResourceHandle> createBlobResourceHandle(const ResourceRequest& request, ResourceHandleClient* client)
 {
-    return blobRegistry().blobRegistryImpl()->createResourceHandle(request, client);
+    return blobRegistry()->blobRegistryImpl()->createResourceHandle(request, client);
 }
 
 static void loadBlobResourceSynchronously(NetworkingContext*, const ResourceRequest& request, StoredCredentialsPolicy, ResourceError& error, ResourceResponse& response, Vector<uint8_t>& data)
 {
     // This seems like it is only used from WebKitLegacy, so it does not support blob registry partitioning
-    RefPtr blobData = blobRegistry().blobRegistryImpl()->blobDataFromURL(request.url());
+    RefPtr blobData = blobRegistry()->blobRegistryImpl()->blobDataFromURL(request.url());
     BlobResourceHandle::loadResourceSynchronously(blobData.get(), request, error, response, data);
 }
 

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -353,7 +353,7 @@ Ref<FormData> FormData::resolveBlobReferences(BlobRegistryImpl* blobRegistryImpl
             }, [&] (const FormDataElement::EncodedFileData& fileData) {
                 newFormData->appendFileRange(fileData.filename, fileData.fileStart, fileData.fileLength, fileData.expectedFileModificationTime);
             }, [&] (const FormDataElement::EncodedBlobData& blobData) {
-                appendBlobResolved(blobRegistryImpl ? blobRegistryImpl : blobRegistry().blobRegistryImpl(), newFormData.get(), blobData.url);
+                appendBlobResolved(blobRegistryImpl ? blobRegistryImpl : blobRegistry()->blobRegistryImpl(), newFormData.get(), blobData.url);
             }
         );
     }

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
@@ -369,7 +369,7 @@ RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData& formData)
     unsigned long long length = 0;
     for (auto& element : dataForUpload.data().elements()) {
         length += element.lengthInBytes([](auto& url) {
-            return blobRegistry().blobRegistryImpl()->blobSize(url);
+            return blobRegistry()->blobRegistryImpl()->blobSize(url);
         });
     }
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
@@ -50,7 +50,7 @@ CurlFormDataStream::CurlFormDataStream(const RefPtr<FormData>& formData)
     m_formData = formData->isolatedCopy();
 
     // Resolve the blob elements so the formData can correctly report it's size.
-    m_formData = m_formData->resolveBlobReferences(blobRegistry().blobRegistryImpl());
+    m_formData = m_formData->resolveBlobReferences(blobRegistry()->blobRegistryImpl());
 }
 
 CurlFormDataStream::~CurlFormDataStream()

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4862,7 +4862,7 @@ void Internals::initializeMockMediaSource()
     if (!document || (!document->settings().mediaSourceEnabled() && !document->settings().managedMediaSourceEnabled()))
         return;
 
-    platformStrategies()->mediaStrategy().enableMockMediaSource();
+    platformStrategies()->mediaStrategy()->enableMockMediaSource();
 }
 
 void Internals::setMaximumSourceBufferSize(SourceBuffer& buffer, uint64_t maximumSize, DOMPromiseDeferred<void>&& promise)

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(BlobRegistryProxy);
+
 void BlobRegistryProxy::registerInternalFileBlobURL(const URL& url, Ref<BlobDataFileReference>&& file, const String& path, const String& contentType)
 {
     SandboxExtension::Handle extensionHandle;

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h
@@ -30,6 +30,8 @@
 namespace WebKit {
 
 class BlobRegistryProxy final : public WebCore::BlobRegistry {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(BlobRegistryProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BlobRegistryProxy);
 public:
     void registerInternalFileBlobURL(const URL&, Ref<WebCore::BlobDataFileReference>&&, const String& path, const String& contentType) final;
     void registerInternalBlobURL(const URL&, Vector<WebCore::BlobPart>&&, const String& contentType) final;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1020,7 +1020,7 @@ void MediaPlayerPrivateRemote::remoteVideoTrackConfigurationChanged(TrackID trac
 void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options, MediaSourcePrivateClient& client)
 {
     if (m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE
-        || (platformStrategies()->mediaStrategy().mockMediaSourceEnabled() && m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::MockMSE)) {
+        || (platformStrategies()->mediaStrategy()->mockMediaSourceEnabled() && m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::MockMSE)) {
 
         RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateRemote>(client.mediaSourcePrivate());
         RemoteMediaSourceIdentifier identifier = [&] {

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -50,6 +50,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebMediaStrategy);
+
 WebMediaStrategy::~WebMediaStrategy() = default;
 
 #if ENABLE(WEB_AUDIO)

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -31,6 +31,8 @@
 namespace WebKit {
 
 class WebMediaStrategy final : public WebCore::MediaStrategy {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebMediaStrategy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebMediaStrategy);
 public:
     virtual ~WebMediaStrategy();
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -52,6 +52,7 @@ class WebURLSchemeTaskProxy;
 class WebLoaderStrategy final : public WebCore::LoaderStrategy {
     WTF_MAKE_TZONE_ALLOCATED(WebLoaderStrategy);
     WTF_MAKE_NONCOPYABLE(WebLoaderStrategy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebLoaderStrategy);
 public:
     explicit WebLoaderStrategy(WebProcess&);
     ~WebLoaderStrategy() final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -72,6 +72,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebPlatformStrategies);
+
 class RemoteAudioDestination;
 
 void WebPlatformStrategies::initialize()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -39,6 +39,8 @@ class WebPlatformStrategies :
     , public WebCore::PushStrategy
 #endif
 {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebPlatformStrategies);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPlatformStrategies);
     friend NeverDestroyed<WebPlatformStrategies>;
 public:
     static void initialize();
@@ -114,6 +116,11 @@ private:
     void windowUnsubscribeFromPushService(const URL& scope, std::optional<WebCore::PushSubscriptionIdentifier>, UnsubscribeFromPushServiceCallback&&) override;
     void windowGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&&) override;
     void windowGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) override;
+
+    uint32_t checkedPtrCount() const final { return WebCore::PasteboardStrategy::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return WebCore::PasteboardStrategy::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { WebCore::PasteboardStrategy::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { WebCore::PasteboardStrategy::decrementCheckedPtrCount(); }
 #endif
 };
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -42,7 +42,7 @@ class WebResourceLoadScheduler;
 
 WebResourceLoadScheduler& webResourceLoadScheduler();
 
-class WebResourceLoadScheduler final : public WebCore::LoaderStrategy, public CanMakeCheckedPtr<WebResourceLoadScheduler> {
+class WebResourceLoadScheduler final : public WebCore::LoaderStrategy {
     WTF_MAKE_TZONE_ALLOCATED(WebResourceLoadScheduler);
     WTF_MAKE_NONCOPYABLE(WebResourceLoadScheduler);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebResourceLoadScheduler);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
@@ -34,12 +34,13 @@ struct PasteboardImage;
 struct PasteboardWebContent;
 
 class WebPlatformStrategies : public WebCore::PlatformStrategies, private WebCore::PasteboardStrategy {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebPlatformStrategies);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPlatformStrategies);
 public:
     static void initializeIfNecessary();
-    
-private:
     WebPlatformStrategies();
-    
+
+private:
     // WebCore::PlatformStrategies
     WebCore::LoaderStrategy* createLoaderStrategy() override;
     WebCore::PasteboardStrategy* createPasteboardStrategy() override;


### PR DESCRIPTION
#### 88a72e722ff1a8d40429c03cee9e35d9eb6216f1
<pre>
Address safer CPP warnings in PlatformStrategies.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=298859">https://bugs.webkit.org/show_bug.cgi?id=298859</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/CheckedRef.h:
(WTF::downcast):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::enabledForContext):
(WebCore::MediaSource::canConstructInDedicatedWorker):
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::createImageBitmap):
* Source/WebCore/Modules/push-api/PushStrategy.h:
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::DefaultAudioDestinationNode::createDestination):
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::SerializedScriptValue::writeBlobsToDiskForIndexedDB):
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::ThreadableBlobRegistry::registerInternalFileBlobURL):
(WebCore::ThreadableBlobRegistry::registerInternalBlobURL):
(WebCore::ThreadableBlobRegistry::registerBlobURL):
(WebCore::ThreadableBlobRegistry::registerInternalBlobURLOptionallyFileBacked):
(WebCore::ThreadableBlobRegistry::registerInternalBlobURLForSlice):
(WebCore::ThreadableBlobRegistry::blobType):
(WebCore::ThreadableBlobRegistry::blobSize):
(WebCore::ThreadableBlobRegistry::unregisterBlobURL):
(WebCore::ThreadableBlobRegistry::registerBlobURLHandle):
(WebCore::ThreadableBlobRegistry::unregisterBlobURLHandle):
* Source/WebCore/loader/LoaderStrategy.cpp:
* Source/WebCore/loader/LoaderStrategy.h:
* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::setAVFoundationEnabled):
(WebCore::DeprecatedGlobalSettings::setGStreamerEnabled):
* Source/WebCore/platform/MediaStrategy.cpp:
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/Pasteboard.cpp:
(WebCore::Pasteboard::allPasteboardItemInfo const):
(WebCore::Pasteboard::pasteboardItemInfo const):
(WebCore::Pasteboard::readString):
(WebCore::Pasteboard::readBuffer):
(WebCore::Pasteboard::readURL):
* Source/WebCore/platform/PasteboardStrategy.h:
* Source/WebCore/platform/PlatformStrategies.cpp:
(WebCore::PlatformStrategies::loaderStrategy):
(WebCore::PlatformStrategies::pasteboardStrategy):
(WebCore::PlatformStrategies::mediaStrategy):
(WebCore::PlatformStrategies::blobRegistry):
(WebCore::PlatformStrategies::pushStrategy):
* Source/WebCore/platform/PlatformStrategies.h:
(WebCore::PlatformStrategies::loaderStrategy): Deleted.
(WebCore::PlatformStrategies::pasteboardStrategy): Deleted.
(WebCore::PlatformStrategies::mediaStrategy): Deleted.
(WebCore::PlatformStrategies::blobRegistry): Deleted.
(WebCore::PlatformStrategies::pushStrategy): Deleted.
(WebCore::PlatformStrategies::~PlatformStrategies): Deleted.
(): Deleted.
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::MediaSessionManagerCocoa):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::MediaSessionManagerGLib::MediaSessionManagerGLib):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::readPlatformValuesAsStrings):
(WebCore::Pasteboard::readFilePaths):
* Source/WebCore/platform/network/BlobRegistry.cpp:
(WebCore::blobRegistry):
* Source/WebCore/platform/network/BlobRegistry.h:
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::createBlobResourceHandle):
(WebCore::loadBlobResourceSynchronously):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::resolveBlobReferences):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::createHTTPBodyCFReadStream):
* Source/WebCore/platform/network/curl/CurlFormDataStream.cpp:
(WebCore::CurlFormDataStream::CurlFormDataStream):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::initializeMockMediaSource):
* Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp:
* Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm:
(WebPlatformStrategies::initializeIfNecessary):

Canonical link: <a href="https://commits.webkit.org/300024@main">https://commits.webkit.org/300024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/807dd1f12228e1c796055fed820d5420fcf1a3fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121069 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73150 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d205d72-b3e5-4270-92ff-74402545f680) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91962 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61177 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6628580b-312c-4cd5-b47c-bc7f9286141b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72646 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05bc26c9-0960-4ff2-b0f8-8db1d8743c15) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26631 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71079 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113199 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130341 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119589 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100572 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53567 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149748 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47325 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37985 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49009 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->