### PR TITLE
[WPT] Sync css-cascade, css-syntax and css-nesting

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL The revert-rule keyword rolls back to the previous rule assert_true: expected true got false
+FAIL Cascade order determines the previous rule, not order of appearance assert_true: expected true got false
+FAIL Reverting from style attribute reverts to regular rules assert_true: expected true got false
+FAIL A chain of revert-rule works assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic.tentative.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<title>The revert-rule keyword: basic behavior</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10443">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #test1 {
+    color: green;
+  }
+  #test1 {
+    color: red;
+    color: revert-rule;
+  }
+</style>
+<div id=test1></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test1).color, 'rgb(0, 128, 0)')
+  }, 'The revert-rule keyword rolls back to the previous rule');
+</script>
+
+
+<style>
+  #test2 { /* Specificity: (0, 0, 1) */
+    color: red;
+  }
+  #test2#test2#test2 { /* Specificity: (0, 0, 3) */
+    color: red;
+    color: revert-rule;
+  }
+  #test2#test2 { /* Specificity: (0, 0, 2) */
+    color: green;
+  }
+</style>
+<div id=test2></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test2).color, 'rgb(0, 128, 0)')
+  }, 'Cascade order determines the previous rule, not order of appearance');
+</script>
+
+
+<style>
+  #test3 {
+    color: red;
+  }
+  #test3 {
+    color: green;
+  }
+</style>
+<div id=test3 style="color:red; color:revert-rule"></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test3).color, 'rgb(0, 128, 0)')
+  }, 'Reverting from style attribute reverts to regular rules');
+</script>
+
+
+<style>
+  #test4 {              z-index: 1; }
+  #test4 {              z-index: 2; }
+  #test4 { z-index: -1; z-index: revert-rule; }
+  #test4 { z-index: -1; z-index: revert-rule; }
+  #test4 { z-index: -1; z-index: revert-rule; }
+</style>
+<div id=test4></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('z-index:revert-rule'));
+    assert_equals(getComputedStyle(test4).zIndex, '2')
+  }, 'A chain of revert-rule works');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL The revert-rule keyword can cross layers assert_true: expected true got false
+FAIL The revert-rule does not unconditionally cross layers assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer.tentative.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<title>The revert-rule keyword: interaction with @layer</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10443">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  @layer {
+    #test1 {
+      color: green;
+    }
+  }
+  @layer {
+    #test1 {
+      color: red;
+      color: revert-rule;
+    }
+  }
+</style>
+<div id=test1></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test1).color, 'rgb(0, 128, 0)')
+  }, 'The revert-rule keyword can cross layers');
+</script>
+
+
+<style>
+  @layer {
+    #test2 {
+      color: red;
+    }
+  }
+  @layer {
+    #test2 {
+      color: green;
+    }
+    #test2 {
+      color: red;
+      color: revert-rule;
+    }
+  }
+</style>
+<div id=test2></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test2).color, 'rgb(0, 128, 0)')
+  }, 'The revert-rule does not unconditionally cross layers');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -24,5 +24,5 @@ PASS :nth-child() in scope root
 PASS :nth-child() in scope limit
 PASS Modifying selectorText invalidates affected elements
 PASS Modifying selectorText invalidates affected elements (>)
-PASS Relative selectors set with selectorText are relative to :scope, not &
+FAIL Relative selectors set with selectorText are relative to :scope and & assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html
@@ -861,12 +861,9 @@ test_scope_invalidation(document.currentScript, () => {
   assert_green(c);
   let scope_rule = main.querySelector('style').sheet.cssRules[1];
   assert_true(scope_rule instanceof CSSScopeRule);
-  // Note: relative selectors imply a :where(:scope) selector to the left,
-  // which is observably different from an implicit '&' selector through
-  // specificity.
   scope_rule.cssRules[0].selectorText = '> .b'; /* Still (0, 1, 0) */
-  scope_rule.cssRules[1].selectorText = '& > .c'; /* (0, 3, 0) */
+  scope_rule.cssRules[1].selectorText = '& > .c'; /* Still (0, 1, 0) */
   assert_green(b);
-  assert_red(c);
-}, 'Relative selectors set with selectorText are relative to :scope, not &');
+  assert_green(c);
+}, 'Relative selectors set with selectorText are relative to :scope and &');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -2,12 +2,11 @@
 PASS Nesting-selector in <scope-end>
 PASS Implicit :scope in <scope-end>
 PASS Relative selectors in <scope-end>
-PASS Nesting-selector in the scope's <stylesheet>
+PASS Nested nesting-selectors within scope's <stylesheet> select inclusive descendants of the scope root
 PASS Nesting-selector within :scope rule
 PASS Nesting-selector within :scope rule (double nested)
 PASS @scope nested within style rule
 PASS Parent pseudo class within scope-start
-PASS Parent pseudo class within scope-end
 PASS Parent pseudo class within body of nested @scope
 PASS Implicit rule within nested @scope
 PASS Implicit rule within nested @scope (proximity)
@@ -18,7 +17,7 @@ PASS :scope within nested and scoped rule (relative)
 PASS Scoped nested group rule
 PASS Scoped nested within another scope
 PASS Implicit (prelude-less) @scope as a nested group rule
-PASS Insert a nested style rule within @scope, &
+FAIL Insert a nested style rule within @scope, & assert_equals: expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
 PASS Insert a nested style rule within @scope, :scope
 PASS Insert a CSSNestedDeclarations rule directly in top-level @scope
 PASS Mutating selectorText on outer style rule causes correct inner specificity

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html
@@ -2,6 +2,7 @@
 <title>@scope - nesting (&)</title>
 <link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scope-atrule">
 <link rel="help" href="https://drafts.csswg.org/css-nesting-1/#nest-selector">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9740">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <main id=main></main>
@@ -9,12 +10,18 @@
 <template id=test_nest_scope_end>
   <div>
     <style>
-      @scope (.a) to (& > &) {
-        * { z-index:1; }
+      /* (& > .b) behaves like (:where(:scope) > .b), due & mapping to :where(:scope).*/
+      @scope (.a) to (& > .b) {
+        :scope { z-index:1; }
+      }
+
+      /* Should not match, since <scope-end> refers to the scope itself. */
+      @scope (.a) to (.b&) {
+        :scope { z-index:42; }
       }
     </style>
-    <div class=a> <!-- This scope is limited by the element below. -->
-      <div class=a> <!-- This scope is limited by its own root. -->
+    <div class="a b">
+      <div class=b>
         <div id=below></div>
       </div>
     </div>
@@ -25,7 +32,10 @@
 test((t) => {
   t.add_cleanup(() => main.replaceChildren());
   main.append(test_nest_scope_end.content.cloneNode(true));
-
+  let a = document.querySelector('.a');
+  let b = document.querySelector('.a > .b');
+  assert_equals(getComputedStyle(a).zIndex, '1');
+  assert_equals(getComputedStyle(b).zIndex, 'auto');
   assert_equals(getComputedStyle(below).zIndex, 'auto');
   assert_equals(getComputedStyle(outside).zIndex, 'auto');
 }, 'Nesting-selector in <scope-end>');
@@ -97,16 +107,16 @@ test((t) => {
 <template id=test_inner_nest>
   <div>
     <style>
-      @scope (.a) {
-        & + & {
-          z-index:1;
+      @scope (#div) {
+        & {
+          z-index: 1;
+          & {
+            z-index: 2;
+          }
         }
       }
     </style>
-    <div class=a>
-      <div id=inner1 class=a></div>
-      <div id=inner2 class=a></div>
-    </div>
+    <div id=div></div>
   </div>
 </template>
 <script>
@@ -114,9 +124,8 @@ test((t) => {
   t.add_cleanup(() => main.replaceChildren());
   main.append(test_inner_nest.content.cloneNode(true));
 
-  assert_equals(getComputedStyle(inner1).zIndex, 'auto');
-  assert_equals(getComputedStyle(inner2).zIndex, '1');
-}, 'Nesting-selector in the scope\'s <stylesheet>');
+  assert_equals(getComputedStyle(div).zIndex, '2');
+}, 'Nested nesting-selectors within scope\'s <stylesheet> select inclusive descendants of the scope root');
 </script>
 
 <template id=test_parent_in_pseudo_scope>
@@ -227,38 +236,6 @@ test((t) => {
 }, 'Parent pseudo class within scope-start');
 </script>
 
-<template id=test_parent_pseudo_in_nested_scope_end>
-  <div>
-    <style>
-      .a {
-        /* Note that & in <scope-end> refers to <scope-start>,
-           not the outer style rule. */
-        @scope (&.b) to (&.c) {
-           :scope, * { z-index: 1; }
-        }
-      }
-    </style>
-    <div class="a b">
-      <div class="a c">
-        <div class="a b c">
-        </div>
-      </div>
-    </div>
-  </div>
-</template>
-<script>
-test((t) => {
-  t.add_cleanup(() => main.replaceChildren());
-  main.append(test_parent_pseudo_in_nested_scope_end.content.cloneNode(true));
-
-  let ab = document.querySelector('.a.b:not(.c)');
-  let ac = document.querySelector('.a.c:not(.b)');
-  let abc = document.querySelector('.a.b.c');
-  assert_equals(getComputedStyle(ab).zIndex, '1');
-  assert_equals(getComputedStyle(ac).zIndex, '1');
-  assert_equals(getComputedStyle(abc).zIndex, 'auto', 'limit element is not in scope');
-}, 'Parent pseudo class within scope-end');
-</script>
 
 <template id=test_parent_pseudo_in_nested_scope_body>
   <div>
@@ -621,7 +598,12 @@ test((t) => {
   main.append(test_insert_ampersand_rule_within_scope.content.cloneNode(true));
   assert_equals(getComputedStyle(child).color, 'rgb(255, 0, 0)');
   let scope_rule = main.querySelector('style').sheet.cssRules[0].cssRules[0];
-  scope_rule.insertRule('& #child { color: green; }');
+  // & does not add specificity - inserting it up front does nothing...
+  scope_rule.insertRule('& #child { color: green; }', 0);
+  assert_equals(getComputedStyle(child).color, 'rgb(255, 0, 0)');
+  scope_rule.deleteRule(0);
+  // ... But inserting it at the end makes it win by order of appearance.
+  scope_rule.insertRule('& #child { color: green; }', scope_rule.cssRules.length);
   assert_equals(getComputedStyle(child).color, 'rgb(0, 128, 0)');
 }, 'Insert a nested style rule within @scope, &');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -4,7 +4,7 @@ PASS @scope (#main) to (.b) { .a {  } } and .a
 PASS @scope (#main, .foo, .bar) { #a {  } } and #a
 PASS @scope (#main) { div.b {  } } and div.b
 PASS @scope (#main) { :scope .b {  } } and .a .b
-PASS @scope (#main) { & .b {  } } and #main .b
+FAIL @scope (#main) { & .b {  } } and :where(#main) .b assert_equals: unscoped + scoped expected "2" but got "1"
 PASS @scope (#main) { div .b {  } } and div .b
 PASS @scope (#main) { @scope (.a) { .b {  } } } and .b
 PASS @scope (#main) { :scope .b {  } } and :scope .b

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity.html
@@ -79,15 +79,14 @@ test_scope_specificity(['@scope (#main) to (.b)', '.a'], '.a');
 test_scope_specificity(['@scope (#main, .foo, .bar)', '#a'], '#a');
 test_scope_specificity(['@scope (#main)', 'div.b'], 'div.b');
 test_scope_specificity(['@scope (#main)', ':scope .b'], '.a .b');
-// Inherit the specificity of the scope-start selector.
-test_scope_specificity(['@scope (#main)', '& .b'], '#main .b');
+// & behaves like :where(:scope) - No specificity is added.
+// See https://github.com/w3c/csswg-drafts/issues/9740
+test_scope_specificity(['@scope (#main)', '& .b'], ':where(#main) .b');
 test_scope_specificity(['@scope (#main)', 'div .b'], 'div .b');
 test_scope_specificity(['@scope (#main)', '@scope (.a)', '.b'], '.b');
 // Explicit `:scope` adds specficity.
 test_scope_specificity(['@scope (#main)', ':scope .b'], ':scope .b');
-// Using & in scoped style with implicit scope root matches the same elements
-// as `:scope`, but does not add any specificity.
-// https://github.com/w3c/csswg-drafts/issues/10196
+// & behaves like :where(:scope), even for implicit scope roots.
 test_scope_specificity(['@scope', '& .b'], ':where(:scope) .b', styleImplicit);
 // Using relative selector syntax does not add specificity
 test_scope_specificity(['@scope (#main)', '> .a'], ':where(#main) > .a');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log
@@ -9,11 +9,11 @@ Do NOT modify or remove this file.
 
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
+mask-position-x
 box-decoration-break
-user-select
 mask-position-y
 text-size-adjust
-mask-position-x
+user-select
 initial-letter
 Property values requiring vendor prefixes:
 None
@@ -127,6 +127,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-layer-015-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-layer-015-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-layer-015.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-val-001-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-val-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-val-002-expected.xht

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/META.yml
@@ -1,0 +1,1 @@
+spec: https://drafts.csswg.org/css-nesting/

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/double-parent-pseudo-in-placeholder-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/double-parent-pseudo-in-placeholder-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>CSS Nesting: Crash with multi-level '&' inside ::placeholder</title>
+<link rel="help" href="https://issues.chromium.org/issues/433073118">
+<style>
+::placeholder { & { & {} } }
+::placeholder, .a { & { & {} } }
+.a, ::placeholder { & { & {} } }
+.a, ::placeholder { &, .b { & {} } }
+.a, ::placeholder { .b, & { & {} } }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL The revert-rule keyword can revert to a nested rule assert_true: expected true got false
+FAIL The revert-rule keyword can revert to a CSSNestedDeclarationsRule assert_true: expected true got false
+FAIL The revert-rule keyword can revert from a CSSNestedDeclarationsRule assert_true: expected true got false
+FAIL The revert-rule keyword can revert to scoped declarations assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<title>The revert-rule keyword: interaction with nesting</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10443">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  :root {
+    #test1 {
+      color: green;
+    }
+    #test1 {
+      color: red;
+      color: revert-rule;
+    }
+  }
+</style>
+<div id=test1></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test1).color, 'rgb(0, 128, 0)')
+  }, 'The revert-rule keyword can revert to a nested rule');
+</script>
+
+
+<style>
+  :root {
+    #test2 {
+      /* CSSNestedDeclarationsRule { */
+        color: green;
+      /* } */
+      & {
+        color: red;
+        color: revert-rule;
+      }
+    }
+  }
+</style>
+<div id=test2></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test2).color, 'rgb(0, 128, 0)')
+  }, 'The revert-rule keyword can revert to a CSSNestedDeclarationsRule');
+</script>
+
+
+<style>
+  :root {
+    #test3 {
+      /* CSSNestedDeclarationsRule { */
+        color: green;
+      /* } */
+      .something {}
+      /* CSSNestedDeclarationsRule { */
+        color: red;
+        color: revert-rule;
+      /* } */
+    }
+  }
+</style>
+<div id=test3></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test3).color, 'rgb(0, 128, 0)')
+  }, 'The revert-rule keyword can revert from a CSSNestedDeclarationsRule');
+</script>
+
+
+<style>
+  @scope (#test4) {
+    /* CSSNestedDeclarationsRule { */
+      color: green;
+    /* } */
+  }
+
+  #test4 {
+    color: red;
+    color: revert-rule;
+  }
+</style>
+<div id=test4></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test4).color, 'rgb(0, 128, 0)')
+  }, 'The revert-rule keyword can revert to scoped declarations');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/block-skipping.css
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/block-skipping.html
@@ -31,6 +32,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/contextually-invalid-selectors-003.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/delete-other-rule-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/double-parent-pseudo-in-placeholder-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/has-nesting-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/has-nesting-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/has-nesting.html
@@ -68,6 +70,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-layer.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-type-selector-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-type-selector.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parent-pseudo-in-placeholder-crash.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens-expected.txt
@@ -67,4 +67,8 @@ PASS Serialization of consecutive / and * tokens.
 FAIL Comments are handled correctly when computing a/* comment */b using t1:. assert_equals: expected "a/* comment */b" but got "a/**/b"
 PASS Comments are handled correctly when computing a/* comment */var(--t1) using t1:b.
 PASS Comments are handled correctly when computing var(--t1)b using t1:a/* comment */.
+FAIL Comments are handled correctly when computing var(--t1)b using t1:'a/* unfinished '. assert_equals: expected "'a/* unfinished 'b" but got "\"a/* unfinished \"b"
+PASS Comments are handled correctly when computing var(--t1)b using t1:"a/* unfinished ".
+FAIL Comments are handled correctly when computing var(--t1)b using t1:'a " '/* comment */. assert_equals: expected "'a \" 'b" but got "\"a \\\" \"b"
+PASS Empty fallback between tokens must not disturb comment insertion
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html
@@ -118,4 +118,20 @@ testComments("a/* comment */b", "", "a/* comment */b");
 testComments("a/* comment */var(--t1)", "b", "a/**/b");
 testComments("var(--t1)b", "a/* comment */", "a/**/b");
 
+// Test comments within quotes.
+testComments("var(--t1)b", "'a/* unfinished '", "'a/* unfinished 'b");
+testComments("var(--t1)b", "\"a/* unfinished \"", "\"a/* unfinished \"b");
+testComments("var(--t1)b", "'a \" '/* comment */", "'a \" 'b");
+
+test(()=>{
+    const b = document.body;
+    b.style.setProperty("--t1", "a");
+    b.style.setProperty("--t2", "b");
+    b.style.setProperty("--result", "var(--t1)var(--does-not-exist,)var(--t2)");
+    const result = getComputedStyle(b).getPropertyValue("--result");
+    assert_equals(result[0], "a", `Result must start with a`);
+    assert_equals(result[result.length - 1], "b", `Result must end with b`);
+    assert_not_equals(result, "ab", `Result must have a comment between a and b`);
+}, 'Empty fallback between tokens must not disturb comment insertion');
+
 </script>


### PR DESCRIPTION
#### 91a8c7f283a99962deccf31150f7a9d3c368a990
<pre>
[WPT] Sync css-cascade, css-syntax and css-nesting
<a href="https://bugs.webkit.org/show_bug.cgi?id=298862">https://bugs.webkit.org/show_bug.cgi?id=298862</a>

Reviewed by Anne van Kesteren.

WPT @ cf4fbd776ba1883d8c79313af58b969b949c5380

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/META.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/double-parent-pseudo-in-placeholder-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-consecutive-tokens.html:

Canonical link: <a href="https://commits.webkit.org/299955@main">https://commits.webkit.org/299955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d81046323d581bc393b6298dc5801bf2e0b97a86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72971 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c60d4dd5-c0ca-43ef-b20b-d0a5b43e9292) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91818 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61065 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25a0afe4-b593-45cc-a51f-be6e624cf81e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72514 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18424f8c-1d14-4468-833e-3e049220c2cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70897 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130163 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47816 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100435 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100338 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44507 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47678 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47149 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->