### PR TITLE
WebKit doesn't build with clang stable/21.x branch

### DIFF
--- a/Source/ThirdParty/ANGLE/Configurations/Base.xcconfig
+++ b/Source/ThirdParty/ANGLE/Configurations/Base.xcconfig
@@ -61,7 +61,7 @@ PREBINDING = NO;
 WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wglobal-constructors -Wno-unknown-warning-option;
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
-WK_FIXME_WARNING_CFLAGS = -Wno-deprecated-declarations -Wno-inconsistent-missing-override -Wno-macro-redefined -Wno-undef -Wno-unused-parameter;
+WK_FIXME_WARNING_CFLAGS = -Wno-deprecated-declarations -Wno-inconsistent-missing-override -Wno-macro-redefined -Wno-undef -Wno-unused-parameter -Wno-nontrivial-memcall -Wno-uninitialized-const-pointer;
 
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
@@ -51,7 +51,7 @@ class RTCRtpTransceiver final : public RefCounted<RTCRtpTransceiver>, public Scr
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCRtpTransceiver);
 public:
     static Ref<RTCRtpTransceiver> create(Ref<RTCRtpSender>&& sender, Ref<RTCRtpReceiver>&& receiver, std::unique_ptr<RTCRtpTransceiverBackend>&& backend) { return adoptRef(*new RTCRtpTransceiver(WTFMove(sender), WTFMove(receiver), WTFMove(backend))); }
-    virtual ~RTCRtpTransceiver();
+    ~RTCRtpTransceiver();
 
     bool hasSendingDirection() const;
     void enableSendingDirection();

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
@@ -62,7 +62,7 @@ public:
 
 protected:
     explicit DynamicsCompressorNode(BaseAudioContext&, const DynamicsCompressorOptions& = { });
-    virtual void setReduction(float reduction) { m_reduction = reduction; }
+    void setReduction(float reduction) { m_reduction = reduction; }
 
 private:
     double tailTime() const final;

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -64,7 +64,7 @@ class CSSFontFace final : public RefCountedAndCanMakeWeakPtr<CSSFontFace> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSFontFace, CSSFontFace);
 public:
     static Ref<CSSFontFace> create(CSSFontSelector&, StyleRuleFontFace* cssConnection = nullptr, FontFace* wrapper = nullptr, bool isLocalFallback = false);
-    virtual ~CSSFontFace();
+    ~CSSFontFace();
 
     void setFamily(CSSValue&);
     void setStyle(CSSValue&);

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -54,7 +54,7 @@ public:
     static const AtomString& signKeyword();
 
     bool selected() const { return m_selected; }
-    virtual void setSelected(const bool);
+    void setSelected(const bool);
 
     void addClient(VideoTrackClient&);
     void clearClient(VideoTrackClient&);

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -115,7 +115,7 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
         data = nullptr;
 
     constexpr uint8_t pdfMagicNumber[] = { '%', 'P', 'D', 'F' };
-    if (data && data->startsWith(std::span(pdfMagicNumber, std::size(pdfMagicNumber)))) {
+    if (data && data->startsWith(unsafeMakeSpan(pdfMagicNumber, std::size(pdfMagicNumber)))) {
         LOG(IconDatabase, "IconLoader::finishLoading() - Ignoring icon at %s because it appears to be a PDF", m_resource->url().string().ascii().data());
         data = nullptr;
     }

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -265,9 +265,8 @@ float toRelatedAcuteAngle(float angle)
     angle = toPositiveAngle(angle);
     if (angle < 90)
         return angle;
-    if (angle > 90 || angle < 180)
-        return std::abs(180 - angle);
-    return std::abs(360 - angle);
+    // FIXME: webkit.org/b/298890 toRelatedAcuteAngle in GeometryUtilities.cpp doesn't handle an angle greater than 270 degrees
+    return std::abs(180 - angle);
 }
 
 RectEdges<double> distanceOfPointToSidesOfRect(const FloatRect& box, const FloatPoint& position)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -106,7 +106,6 @@ private:
     RetainPtr<NSData> m_expiredSession;
     Vector<int> m_protocolVersions;
     int m_cdmVersion;
-    int32_t m_protectedTrackID { 1 };
     enum { Normal, KeyRelease } m_mode;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -199,7 +199,7 @@ private:
 
     void createAVPlayer() final;
     void createAVPlayerItem() final;
-    virtual void createAVPlayerLayer();
+    void createAVPlayerLayer();
     void createAVAssetForURL(const URL&) final;
     void createAVAssetForURL(const URL&, RetainPtr<NSMutableDictionary>);
     MediaPlayerPrivateAVFoundation::ItemStatus playerItemStatus() const final;

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -162,7 +162,6 @@ private:
     RealtimeMediaSourceSettings m_settings;
     Timer m_readyTimer;
     bool m_isRunning { false };
-    bool m_didReceiveVideoFrame { false };
     CompletionHandler<void(CaptureSourceError&&)> m_whenReadyCallback;
 };
 

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -109,7 +109,6 @@ private:
     void autoscroll(const IntPoint&) override;
     void stopAutoscroll() override;
 
-    virtual bool shouldPanScroll() const { return true; }
     void panScroll(const IntPoint&) override;
 
     int verticalScrollbarWidth() const override;

--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.h
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.h
@@ -54,13 +54,7 @@ private:
     template<typename DataType>
     void writeType(const DataType& data)
     {
-        typedef union {
-            DataType value;
-            uint8_t bytes[sizeof(DataType)];
-        } ByteType;
-
-        ByteType type = { data };
-        m_byteStream->append(std::span { type.bytes, sizeof(ByteType) });
+        m_byteStream->append(asByteSpan(data));
     }
 
     void writeSegmentType(SVGPathSegType type)

--- a/Source/WebCore/svg/SVGStyleElement.h
+++ b/Source/WebCore/svg/SVGStyleElement.h
@@ -52,7 +52,7 @@ private:
 
     void finishParsingChildren() final;
 
-    virtual bool isLoading() const { return m_styleSheetOwner.isLoading(); }
+    bool isLoading() const { return m_styleSheetOwner.isLoading(); }
     bool sheetLoaded() final { return m_styleSheetOwner.sheetLoaded(*this); }
     void startLoadingDynamicSheet() final { m_styleSheetOwner.startLoadingDynamicSheet(*this); }
     Timer* loadEventTimer() final { return &m_loadEventTimer; }

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -76,7 +76,7 @@ public:
         DONE = 4
     };
 
-    virtual void didReachTimeout();
+    void didReachTimeout();
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::XMLHttpRequest; }
     ScriptExecutionContext* scriptExecutionContext() const final;

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -163,7 +163,6 @@ private:
     Reflection::EntryPointInformation* m_entryPointInformation { nullptr };
     HashMap<uint32_t, uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_generateLayoutGroupMapping;
     PipelineLayout* m_generatedLayout { nullptr };
-    unsigned m_constantId { 0 };
     unsigned m_currentStatementIndex { 0 };
     unsigned m_entryPointID { 0 };
     Vector<Insertion> m_pendingInsertions;

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -229,7 +229,6 @@ private:
     std::optional<AST::ParameterRole> m_parameterRole;
     std::optional<ShaderStage> m_entryPointStage;
     AST::Function* m_currentFunction { nullptr };
-    unsigned m_functionConstantIndex { 0 };
     AST::Continuing*m_continuing { nullptr };
     HashSet<AST::Function*> m_visitedFunctions;
     PrepareResult& m_prepareResult;

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -186,9 +186,6 @@ private PUBLIC_IN_WEBGPU_SWIFT:
     NSMutableSet<id<MTLBuffer>> *m_managedBuffers { nil };
 #endif
 private:
-    id<MTLSharedEvent> m_abortCommandBuffer { nil };
-
-
     NSMutableSet<id<MTLIndirectCommandBuffer>> *m_retainedICBs { nil };
     NSMutableSet<id<MTLTexture>> *m_retainedTextures { nil };
     NSMutableSet<id<MTLBuffer>> *m_retainedBuffers { nil };

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1201,7 +1201,7 @@ typedef struct WGPUComputePassDescriptor {
     WGPU_NULLABLE WGPUComputePassTimestampWrites const * timestampWrites;
 } SWIFT_ESCAPABLE WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
-static inline WGPU_NULLABLE WGPUComputePassTimestampWrites const * _Nullable __counted_by(1) wgpuGetComputePassDescriptorTimestampWrites(const WGPUComputePassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor) {
+static inline WGPU_NULLABLE WGPUComputePassTimestampWrites const * _Nullable __counted_by(1) wgpuGetComputePassDescriptorTimestampWrites(const WGPUComputePassDescriptor * __counted_by(1) descriptor LIFETIME_BOUND) {
     return descriptor->timestampWrites;
 }
 
@@ -1334,16 +1334,16 @@ typedef struct WGPURenderPassDescriptor {
     auto colorAttachmentsSpan() const { return unsafeMakeSpan(colorAttachments, colorAttachmentCount); }
 } SWIFT_ESCAPABLE WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
-inline WGPURenderPassTimestampWrites const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorTimestampWrites(const WGPURenderPassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor) {
+inline WGPURenderPassTimestampWrites const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorTimestampWrites(const WGPURenderPassDescriptor * __counted_by(1) descriptor LIFETIME_BOUND) {
     return descriptor->timestampWrites;
 }
 
-inline WGPURenderPassColorAttachment const * __counted_by(count) wgpuGetRenderPassDescriptorColorAttachments(const WGPURenderPassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor, size_t count) {
+inline WGPURenderPassColorAttachment const * __counted_by(count) wgpuGetRenderPassDescriptorColorAttachments(const WGPURenderPassDescriptor * __counted_by(1) descriptor LIFETIME_BOUND, size_t count) {
     ((void)count);
     return descriptor->colorAttachments;
 }
 
-inline WGPURenderPassDepthStencilAttachment const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorDepthSencilAttachment(const WGPURenderPassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor) {
+inline WGPURenderPassDepthStencilAttachment const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorDepthSencilAttachment(const WGPURenderPassDescriptor * __counted_by(1) descriptor LIFETIME_BOUND) {
     return descriptor->depthStencilAttachment;
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -447,7 +447,6 @@ private:
     bool m_isObservingMedia { false };
     bool m_isStopped { false };
     bool m_isEnded { false };
-    bool m_shouldApplyRotation { false };
     std::atomic<bool> m_shouldReset { false };
 
     RealtimeMediaSourceIdentifier m_id;

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -107,7 +107,7 @@ public:
         return adoptRef(*new ResourceLoadStatisticsStore(webResourceLoadStatisticsStore, suspendableWorkQueue, shouldIncludeLocalhost, storageDirectoryPath, sessionID));
     }
 
-    virtual ~ResourceLoadStatisticsStore();
+    ~ResourceLoadStatisticsStore();
 
     void clear(CompletionHandler<void()>&&);
     bool isEmpty() const;


### PR DESCRIPTION
#### a24facd1f7d97b1895f5732489014d346034eb8f
<pre>
WebKit doesn&apos;t build with clang stable/21.x branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=298854">https://bugs.webkit.org/show_bug.cgi?id=298854</a>

Reviewed by Chris Dumez.

This PR fixes a bunch of compiler warnings in WebKit emitted by clang stable/21.x branch.

No new tests since there should be no behavioral change.

* Source/ThirdParty/ANGLE/Configurations/Base.xcconfig: Disable nontrivial-memcall and
uninitialized-const-pointer warnings in ANGLE as they result in a compiler error.
* Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h: Made the destructor non-virtual
since this class is final.
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h: Ditto for a member function.
* Source/WebCore/css/CSSFontFace.h: Ditto.
* Source/WebCore/html/track/VideoTrack.h: Ditto.
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::notifyFinished): Use unsafeMakeSpan instead of std::span constructor
since the latter will result in a warning.
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::toRelatedAcuteAngle): Simplified the code since angle &gt; 90 || angle &lt; 180 is
always true.
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
Removed the unused member variable.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
Made a member function non-virtual since this class is final.
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp: Removed the unused
member variable.
* Source/WebCore/rendering/RenderListBox.h: Made a member function non-virtual since this
class is final.
* Source/WebCore/svg/SVGPathByteStreamBuilder.h:
(WebCore::SVGPathByteStreamBuilder::writeType): Use asByteSpan instead of std::span
constructor since the latter results a warning.
* Source/WebCore/svg/SVGStyleElement.h: Made a member function non-virtual since this
class is final.
* Source/WebCore/xml/XMLHttpRequest.h: Ditto.
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp: Removed an unused member variable.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp: Ditto.
* Source/WebGPU/WebGPU/CommandEncoder.h: Ditto.
* Source/WebGPU/WebGPU/WebGPU.h:
(wgpuGetComputePassDescriptorTimestampWrites): Replaced __attribute__((lifetimebound))
annotation with LIFETIME_BOUND macro and moved it to after the parameter name as this
attribute only applies there. Also dropped noescape attribute since the parameter does
escape the function via its return value.
(wgpuGetRenderPassDescriptorTimestampWrites): Ditto.
(wgpuGetRenderPassDescriptorColorAttachments): Ditto.
(wgpuGetRenderPassDescriptorDepthSencilAttachment): Ditto.
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp: Removed an unused
member variable.
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h: Made the
destructor non-virtual since this class is final.

Canonical link: <a href="https://commits.webkit.org/300006@main">https://commits.webkit.org/300006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/801eaff8294e721063f28e65b204a618346c5422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73057 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02d324ae-4ea0-4312-9b6a-82da65d9d301) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49252 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91889 "10 flakes 57 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61128 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3408ff95-15b0-4a5c-91cb-f9aea88a0879) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72577 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72a8cc9f-287e-4d8e-b8aa-9be82c454e85) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70983 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130249 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100399 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23855 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44592 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53475 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47233 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48917 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->