### PR TITLE
[WebXR][GLib] Unskip some WebXR tests that are now passing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Tests requestSession accepts immersive-ar mode - webgl
-FAIL Tests requestSession accepts immersive-ar mode - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession accepts immersive-ar mode - webgl2
 PASS Tests requestSession rejects immersive-ar mode when unsupported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https-expected.txt
@@ -2,29 +2,29 @@
 PASS requestViewportScale valid viewport for inline session - webgl
 PASS requestViewportScale valid viewport for inline session - webgl2
 PASS requestViewportScale valid viewport w/ null scale for inline session - webgl
-FAIL requestViewportScale valid viewport w/ null scale for inline session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ undefined scale for inline session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ undefined scale for inline session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ very small scale for inline session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ very small scale for inline session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale applied next frame for inline session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale applied next frame for inline session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale same frame for inline session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale same frame for inline session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL recommendedViewportScale for inline session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL recommendedViewportScale for inline session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport for immersive-vr session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport for immersive-vr session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale applied next frame for immersive-vr session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale applied next frame for immersive-vr session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale same frame for immersive-vr session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL requestViewportScale same frame for immersive-vr session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL recommendedViewportScale for immersive-vr session - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL recommendedViewportScale for immersive-vr session - webgl2 promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
+PASS requestViewportScale valid viewport w/ null scale for inline session - webgl2
+PASS requestViewportScale valid viewport w/ undefined scale for inline session - webgl
+PASS requestViewportScale valid viewport w/ undefined scale for inline session - webgl2
+PASS requestViewportScale valid viewport w/ very small scale for inline session - webgl
+PASS requestViewportScale valid viewport w/ very small scale for inline session - webgl2
+NOTRUN requestViewportScale applied next frame for inline session - webgl requestViewportScale has no effect
+NOTRUN requestViewportScale applied next frame for inline session - webgl2 requestViewportScale has no effect
+NOTRUN requestViewportScale same frame for inline session - webgl requestViewportScale has no effect
+NOTRUN requestViewportScale same frame for inline session - webgl2 requestViewportScale has no effect
+NOTRUN recommendedViewportScale for inline session - webgl recommendedViewportScale not provided
+NOTRUN recommendedViewportScale for inline session - webgl2 recommendedViewportScale not provided
+PASS requestViewportScale valid viewport for immersive-vr session - webgl
+PASS requestViewportScale valid viewport for immersive-vr session - webgl2
+PASS requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl
+PASS requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl2
+PASS requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl
+PASS requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl2
+PASS requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl
+PASS requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl2
+NOTRUN requestViewportScale applied next frame for immersive-vr session - webgl requestViewportScale has no effect
+NOTRUN requestViewportScale applied next frame for immersive-vr session - webgl2 requestViewportScale has no effect
+NOTRUN requestViewportScale same frame for immersive-vr session - webgl requestViewportScale has no effect
+NOTRUN requestViewportScale same frame for immersive-vr session - webgl2 requestViewportScale has no effect
+NOTRUN recommendedViewportScale for immersive-vr session - webgl recommendedViewportScale not provided
+NOTRUN recommendedViewportScale for immersive-vr session - webgl2 recommendedViewportScale not provided
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2877,6 +2877,9 @@ webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrViewport_valid.https
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html [ Failure ]
 
 webkit.org/b/296681 imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_isSessionSupported_immersive-ar.https.html [ Pass ]
+webkit.org/b/296681 imported/w3c/web-platform-tests/webxr/ar-module/idlharness.https.window.html [ Pass ]
+webkit.org/b/296681 imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https.html [ Pass ]
+
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_immersive.https.html [ Pass ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/events_referenceSpace_reset_inline.https.html [ Pass ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrDevice_disconnect_ends.https.html [ Pass ]
@@ -2885,6 +2888,7 @@ webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrFrame_getViewerPose_
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrSession_input_events_end.https.html [ Pass ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrSession_requestReferenceSpace_features.https.html [ Pass ]
 webkit.org/b/227086 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_constructor.https.html [ Pass ]
+webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https.html [ Pass ]
 
 imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https.html [ Failure ]
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt
@@ -1,5 +1,0 @@
-
-PASS Tests requestSession accepts immersive-ar mode - webgl
-PASS Tests requestSession accepts immersive-ar mode - webgl2
-PASS Tests requestSession rejects immersive-ar mode when unsupported
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https-expected.txt
@@ -1,4 +1,0 @@
-
-FAIL XRSession requestAnimationFrame must fail if the session has no baseLayer for immersive assert_equals: expected object "[object XRWebGLLayer]" but got object "[object XRWebGLLayer]"
-FAIL XRSession requestAnimationFrame must fail if the session has no baseLayer for non immersive assert_equals: expected object "[object XRWebGLLayer]" but got object "[object XRWebGLLayer]"
-


### PR DESCRIPTION
#### f4b292cab388be99e884a7acf19f1478d3a21b57
<pre>
[WebXR][GLib] Unskip some WebXR tests that are now passing
<a href="https://bugs.webkit.org/show_bug.cgi?id=298863">https://bugs.webkit.org/show_bug.cgi?id=298863</a>

Reviewed by Adrian Perez de Castro.

Unskip some tests that are working fine now. Also provide passing expectations
for some other tests that had failures in their expected results.

* LayoutTests/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt: Removed.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/299963@main">https://commits.webkit.org/299963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8db34908afa9feb75b71b26e30be2960143c0af2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72983 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91830 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130175 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100447 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25438 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23793 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44519 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47690 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->