### PR TITLE
Make performance.measure() signpost unconditional

### DIFF
--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -69,20 +69,6 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Performance);
 
 static Seconds timePrecision { 1_ms };
 
-static bool isSignpostEnabled()
-{
-    static bool flag = false;
-    static std::once_flag onceKey;
-    std::call_once(onceKey, [&] {
-        const char* value = getenv("WebKitPerformanceSignpostEnabled");
-        if (value) {
-            if (auto result = parseInteger<int>(StringView::fromLatin1(value)); result && result.value())
-                flag = true;
-        }
-    });
-    return flag;
-}
-
 Performance::Performance(ScriptExecutionContext* context, MonotonicTime timeOrigin)
     : ContextDestructionObserver(context)
     , m_resourceTimingBufferFullTimer(*this, &Performance::resourceTimingBufferFullTimerFired) // FIXME: Migrate this to the event loop as well. https://bugs.webkit.org/show_bug.cgi?id=229044
@@ -489,31 +475,29 @@ ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& g
     if (measure.hasException())
         return measure.releaseException();
 
-    if (isSignpostEnabled()) {
-        Ref entry { measure.returnValue() };
-        auto message = measureName.utf8();
+    Ref entry { measure.returnValue() };
+    auto message = measureName.utf8();
 #if OS(DARWIN)
-        {
-            auto startTime = m_continuousTimeOrigin + Seconds::fromMilliseconds(entry->startTime());
-            auto endTime = m_continuousTimeOrigin + Seconds::fromMilliseconds(entry->startTime() + entry->duration());
-            uint64_t platformStartTime = startTime.toMachContinuousTime();
-            uint64_t platformEndTime = endTime.toMachContinuousTime();
-            uint64_t correctedStartTime = std::min(platformStartTime, platformEndTime);
-            uint64_t correctedEndTime = std::max(platformStartTime, platformEndTime);
-            // Because signpost intervals are closed invervals [start, end], we decrease the endTime by 1 if startTime and endTime is not the same.
-            if (correctedStartTime != correctedEndTime)
-                correctedEndTime -= 1;
+    {
+        auto startTime = m_continuousTimeOrigin + Seconds::fromMilliseconds(entry->startTime());
+        auto endTime = m_continuousTimeOrigin + Seconds::fromMilliseconds(entry->startTime() + entry->duration());
+        uint64_t platformStartTime = startTime.toMachContinuousTime();
+        uint64_t platformEndTime = endTime.toMachContinuousTime();
+        uint64_t correctedStartTime = std::min(platformStartTime, platformEndTime);
+        uint64_t correctedEndTime = std::max(platformStartTime, platformEndTime);
+        // Because signpost intervals are closed invervals [start, end], we decrease the endTime by 1 if startTime and endTime is not the same.
+        if (correctedStartTime != correctedEndTime)
+            correctedEndTime -= 1;
 
-            WTFBeginSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedStartTime, "%" PUBLIC_LOG_STRING, message.data());
-            WTFEndSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedEndTime, "%" PUBLIC_LOG_STRING, message.data());
-        }
+        WTFBeginSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedStartTime, "%" PUBLIC_LOG_STRING, message.data());
+        WTFEndSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedEndTime, "%" PUBLIC_LOG_STRING, message.data());
+    }
 #endif
-        {
-            auto timeOrigin = m_continuousTimeOrigin.approximateMonotonicTime();
-            auto startTime = timeOrigin + Seconds::fromMilliseconds(entry->startTime());
-            auto endTime = timeOrigin + Seconds::fromMilliseconds(entry->startTime() + entry->duration());
-            JSC::ProfilerSupport::markInterval(entry.ptr(), JSC::ProfilerSupport::Category::WebKitPerformanceSignpost, startTime, endTime, WTFMove(message));
-        }
+    {
+        auto timeOrigin = m_continuousTimeOrigin.approximateMonotonicTime();
+        auto startTime = timeOrigin + Seconds::fromMilliseconds(entry->startTime());
+        auto endTime = timeOrigin + Seconds::fromMilliseconds(entry->startTime() + entry->duration());
+        JSC::ProfilerSupport::markInterval(entry.ptr(), JSC::ProfilerSupport::Category::WebKitPerformanceSignpost, startTime, endTime, WTFMove(message));
     }
 
     queueEntry(measure.returnValue().get());

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_minibrowser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_minibrowser_driver.py
@@ -38,7 +38,6 @@ class OSXMiniDriver(OSXBrowserDriver):
             env['WEBKIT_SIGNPOSTS_ENABLED'] = '1'
             env['__XPC_WEBKIT_SIGNPOSTS_ENABLED'] = '1'
             env['__XPC_JSC_exposeProfilersOnGlobalObject'] = '1'
-            env['__XPC_WebKitPerformanceSignpostEnabled'] = '1'
         if browser_build_path or browser_path:
             self._launch_url_with_custom_path(url, options, browser_build_path, browser_path, env)
             return

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
@@ -32,7 +32,6 @@ class OSXSafariDriver(OSXBrowserDriver):
             env['WEBKIT_SIGNPOSTS_ENABLED'] = '1'
             env['__XPC_WEBKIT_SIGNPOSTS_ENABLED'] = '1'
             env['__XPC_JSC_exposeProfilersOnGlobalObject'] = '1'
-            env['__XPC_WebKitPerformanceSignpostEnabled'] = '1'
         if browser_build_path or browser_path:
             self._launch_url_with_custom_path(url, options, browser_build_path, browser_path, env)
             return


### PR DESCRIPTION
#### ad6570c8f8d356d2b7955f4693b40e349a5b354b
<pre>
Make performance.measure() signpost unconditional
<a href="https://bugs.webkit.org/show_bug.cgi?id=298866">https://bugs.webkit.org/show_bug.cgi?id=298866</a>

Reviewed by NOBODY (OOPS!).

See rationale in the linked bug.

No new tests (OOPS!).
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::measure):
(WebCore::isSignpostEnabled): Deleted.
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad6570c8f8d356d2b7955f4693b40e349a5b354b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49185 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61084 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108391 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120271 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130182 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100451 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100354 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23804 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44526 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53402 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->