### PR TITLE
[JSC] WASM IPInt SIMD: x86_64: implement load/store instructions

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -4090,11 +4090,14 @@ end)
 ipintOp(_simd_v128_load_8x8s_mem, macro()
     # v128.load8x8_s - load 8 8-bit values, sign-extend each to i16
     simdMemoryOp(8, macro()
-        loadd [memoryBase, t0], ft0
         if ARM64 or ARM64E
+            loadd [memoryBase, t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "sxtl v16.8h, v0.8b"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "pmovsxbw (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4105,11 +4108,14 @@ end)
 ipintOp(_simd_v128_load_8x8u_mem, macro()
     # v128.load8x8_u - load 8 8-bit values, zero-extend each to i16
     simdMemoryOp(8, macro()
-        loadd [memoryBase, t0], ft0
         if ARM64 or ARM64E
+            loadd [memoryBase, t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "uxtl v16.8h, v0.8b"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "pmovzxbw (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4120,11 +4126,14 @@ end)
 ipintOp(_simd_v128_load_16x4s_mem, macro()
     # v128.load16x4_s - load 4 16-bit values, sign-extend each to i32
     simdMemoryOp(8, macro()
-        loadd [memoryBase, t0], ft0
         if ARM64 or ARM64E
+            loadd [memoryBase, t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "sxtl v16.4s, v0.4h"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "pmovsxwd (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4135,11 +4144,14 @@ end)
 ipintOp(_simd_v128_load_16x4u_mem, macro()
     # v128.load16x4_u - load 4 16-bit values, zero-extend each to i32
     simdMemoryOp(8, macro()
-        loadd [memoryBase, t0], ft0
         if ARM64 or ARM64E
+            loadd [memoryBase, t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "uxtl v16.4s, v0.4h"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "pmovzxwd (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4150,11 +4162,14 @@ end)
 ipintOp(_simd_v128_load_32x2s_mem, macro()
     # v128.load32x2_s - load 2 32-bit values, sign-extend each to i64
     simdMemoryOp(8, macro()
-        loadd [memoryBase, t0], ft0
         if ARM64 or ARM64E
+            loadd [memoryBase, t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "sxtl v16.2d, v0.2s"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "pmovsxdq (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4165,11 +4180,14 @@ end)
 ipintOp(_simd_v128_load_32x2u_mem, macro()
     # v128.load32x2_u - load 2 32-bit values, zero-extend each to i64
     simdMemoryOp(8, macro()
-        loadd [memoryBase, t0], ft0
         if ARM64 or ARM64E
+            loadd [memoryBase, t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "uxtl v16.2d, v0.2s"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "pmovzxdq (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4180,9 +4198,12 @@ end)
 ipintOp(_simd_v128_load8_splat_mem, macro()
     # v128.load8_splat - load 1 8-bit value and splat to all 16 lanes
     simdMemoryOp(1, macro()
-        loadb [memoryBase, t0], t1
         if ARM64 or ARM64E
+            loadb [memoryBase, t0], t1
             emit "dup v16.16b, w1"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "vpbroadcastb (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4193,9 +4214,12 @@ end)
 ipintOp(_simd_v128_load16_splat_mem, macro()
     # v128.load16_splat - load 1 16-bit value and splat to all 8 lanes
     simdMemoryOp(2, macro()
-        loadh [memoryBase, t0], t1
         if ARM64 or ARM64E
+            loadh [memoryBase, t0], t1
             emit "dup v16.8h, w1"
+        elsif X86_64
+            # memoryBase is r14, t0 is eax
+            emit "vpbroadcastw (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4206,9 +4230,13 @@ end)
 ipintOp(_simd_v128_load32_splat_mem, macro()
     # v128.load32_splat - load 1 32-bit value and splat to all 4 lanes
     simdMemoryOp(4, macro()
-        loadi [memoryBase, t0], t1
         if ARM64 or ARM64E
+            loadi [memoryBase, t0], t1
             emit "dup v16.4s, w1"
+        elsif X86_64
+            # Load and broadcast 32-bit value directly from memory to all 4 dwords
+            # memoryBase is r14, t0 is eax
+            emit "vpbroadcastd (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4219,9 +4247,13 @@ end)
 ipintOp(_simd_v128_load64_splat_mem, macro()
     # v128.load64_splat - load 1 64-bit value and splat to all 2 lanes
     simdMemoryOp(8, macro()
-        loadq [memoryBase, t0], t1
         if ARM64 or ARM64E
+            loadq [memoryBase, t0], t1
             emit "dup v16.2d, x1"
+        elsif X86_64
+            # Load and broadcast 64-bit value directly from memory to both qwords
+            # memoryBase is r14, t0 is eax
+            emit "vpbroadcastq (%r14,%rax), %xmm0"
         else
             break # Not implemented
         end


### PR DESCRIPTION
#### 8d4c7e313d88a2871705c0b430822ed297ccb78e
<pre>
[JSC] WASM IPInt SIMD: x86_64: implement load/store instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=298871">https://bugs.webkit.org/show_bug.cgi?id=298871</a>
<a href="https://rdar.apple.com/160617752">rdar://160617752</a>

Reviewed by Yusuke Suzuki.

Implement SIMD IPInt load/store instructions on x86_64.
The load lane instructions were implemented with architecture
independent emulation already. This allows simd-instructions-load-store.js
test to pass on x86_64.

Testing: On Intel:
  jsc --validateOptions=1 --useDollarVM=true  --useConcurrentJIT=false
      --useWasmIPIntSIMD=1 -m simd-instructions-load-store.js

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/299992@main">https://commits.webkit.org/299992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e582ae3eb9f9486a701ad322a7c4e058afc451d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72998 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c9d2a43-ceef-4aea-a286-27d72f4497cf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61093 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8f53a89-5cb1-4b92-a342-d03310fbe89d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72535 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0dbdaf99-afe7-41e4-91cb-958aa523cebc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26496 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70924 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113060 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130190 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119438 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100468 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25453 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47705 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53410 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149601 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47176 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37957 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->