### PR TITLE
[WebXR] Cannot set the baseLayer to null when updating the render state

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL XRSession requestAnimationFrame must fail if the session has no baseLayer for immersive - webgl assert_equals: expected object "[object XRWebGLLayer]" but got object "[object XRWebGLLayer]"
-FAIL XRSession requestAnimationFrame must fail if the session has no baseLayer for immersive - webgl2 assert_equals: expected object "[object XRWebGLLayer]" but got object "[object XRWebGLLayer]"
-FAIL XRSession requestAnimationFrame must fail if the session has no baseLayer for non immersive - webgl assert_equals: expected object "[object XRWebGLLayer]" but got object "[object XRWebGLLayer]"
-FAIL XRSession requestAnimationFrame must fail if the session has no baseLayer for non immersive - webgl2 assert_equals: expected object "[object XRWebGLLayer]" but got object "[object XRWebGLLayer]"
+PASS XRSession requestAnimationFrame must fail if the session has no baseLayer for immersive - webgl
+PASS XRSession requestAnimationFrame must fail if the session has no baseLayer for immersive - webgl2
+PASS XRSession requestAnimationFrame must fail if the session has no baseLayer for non immersive - webgl
+PASS XRSession requestAnimationFrame must fail if the session has no baseLayer for non immersive - webgl2
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2845,6 +2845,8 @@ webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrSession_requestRefer
 webkit.org/b/227086 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_constructor.https.html [ Pass ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https.html [ Pass ]
 
+imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https.html [ Pass ]
+
 imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https.html [ Failure ]
 
 imported/w3c/web-platform-tests/webxr/hand-input/ [ Pass ]

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -139,7 +139,7 @@ ExceptionOr<void> WebXRSession::updateRenderState(const XRRenderStateInit& newSt
 
     // 3. If newState's baseLayer was created with an XRSession other than session,
     //    throw an InvalidStateError and abort these steps.
-    if (newState.baseLayer && newState.baseLayer->session() != this)
+    if (newState.baseLayer && newState.baseLayer.value() && newState.baseLayer.value()->session() != this)
         return Exception { ExceptionCode::InvalidStateError };
 
     // 4. If newState's inlineVerticalFieldOfView is set and session is an immersive session,
@@ -193,7 +193,7 @@ ExceptionOr<void> WebXRSession::updateRenderState(const XRRenderStateInit& newSt
 
     // 12. If newState's baseLayer is set, set session's pending render state's baseLayer to newState's baseLayer.
     if (newState.baseLayer)
-        m_pendingRenderState->setBaseLayer(newState.baseLayer.get());
+        m_pendingRenderState->setBaseLayer(newState.baseLayer->get());
 
     return { };
 }

--- a/Source/WebCore/Modules/webxr/XRRenderStateInit.h
+++ b/Source/WebCore/Modules/webxr/XRRenderStateInit.h
@@ -38,7 +38,7 @@ struct XRRenderStateInit {
     std::optional<double> depthFar;
     std::optional<bool> passthroughFullyObscured;
     std::optional<double> inlineVerticalFieldOfView;
-    RefPtr<WebXRWebGLLayer> baseLayer;
+    std::optional<RefPtr<WebXRWebGLLayer>> baseLayer;
     std::optional<Vector<Ref<WebXRLayer>>> layers;
 };
 


### PR DESCRIPTION
#### 9c9d8e85dc980fd0d0e64539fdc302858ec785b8
<pre>
[WebXR] Cannot set the baseLayer to null when updating the render state
<a href="https://bugs.webkit.org/show_bug.cgi?id=298872">https://bugs.webkit.org/show_bug.cgi?id=298872</a>

Reviewed by Carlos Garcia Campos and Dan Glastonbury.

The baseLayer of the render state must be an optional so that the code
could differentiate from a null baseLayer and a non set baseLayer. WebXR
sessions can clear the baseLayer to ensure that rAF won&apos;t fire.

The exclusive_requestFrame_nolayer.https.html tests now passes.

* LayoutTests/imported/w3c/web-platform-tests/webxr/exclusive_requestFrame_nolayer.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::updateRenderState):
* Source/WebCore/Modules/webxr/XRRenderStateInit.h:

Canonical link: <a href="https://commits.webkit.org/300378@main">https://commits.webkit.org/300378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0afe4fa444618b62c26be0a2f9081550f7e100c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128964 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50676 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73676 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27734 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72458 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131705 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49318 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49692 "Failed to checkout and rebase branch from PR 50750") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101436 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25720 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24942 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54919 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->