### PR TITLE
Web Inspector: Can't view js file on reddit.com

### DIFF
--- a/LayoutTests/inspector/formatting/resources/javascript-tests/for-statements-expected.js
+++ b/LayoutTests/inspector/formatting/resources/javascript-tests/for-statements-expected.js
@@ -39,6 +39,70 @@ for (;;) {
 }
 1
 x
+// optional chaining
+
+for(;a?.b;)
+    1
+for (a;b?.c;)
+    1
+for (a;b?.c; d)
+    1
+for(;b?.c; d)
+    1
+for(a?.b;;)
+    1
+for(a?.b; c;)
+    1
+for(a?.b;; d)
+    1
+for(a?.b; c; d)
+    1
+for(;;c?.d)
+    1
+for (a;;c?.d)
+    1
+for (; b;c?.d)
+    1
+for (a; b;c?.d)
+    1
+
+for(;a?.b;) {
+    1
+}
+for (a;b?.c;) {
+    1
+}
+for (a;b?.c; d) {
+    1
+}
+for(;b?.c; d) {
+    1
+}
+for(a?.b;;) {
+    1
+}
+for(a?.b; c;) {
+    1
+}
+for(a?.b;; d) {
+    1
+}
+for(a?.b; c; d) {
+    1
+}
+for(;;c?.d) {
+    1
+}
+for (a;;c?.d) {
+    1
+}
+for (; b;c?.d) {
+    1
+}
+for (a; b;c?.d) {
+    1
+}
+
 // for
 
 for (1; 2; 3)

--- a/LayoutTests/inspector/formatting/resources/javascript-tests/for-statements.js
+++ b/LayoutTests/inspector/formatting/resources/javascript-tests/for-statements.js
@@ -20,6 +20,34 @@ for(;;){}for(;;){}
 for(;;){1}1
 x
 
+// optional chaining
+
+for(;a?.b;)1
+for(a;b?.c;)1
+for(a;b?.c;d)1
+for(;b?.c;d)1
+for(a?.b;;)1
+for(a?.b;c;)1
+for(a?.b;;d)1
+for(a?.b;c;d)1
+for(;;c?.d)1
+for(a;;c?.d)1
+for(;b;c?.d)1
+for(a;b;c?.d)1
+
+for(;a?.b;){1}
+for(a;b?.c;){1}
+for(a;b?.c;d){1}
+for(;b?.c;d){1}
+for(a?.b;;){1}
+for(a?.b;c;){1}
+for(a?.b;;d){1}
+for(a?.b;c;d){1}
+for(;;c?.d){1}
+for(a;;c?.d){1}
+for(;b;c?.d){1}
+for(a;b;c?.d){1}
+
 // for
 
 for(1;2;3)1;

--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/JSFormatter.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/JSFormatter.js
@@ -244,11 +244,11 @@ JSFormatter = class JSFormatter
             if (nodeType === "ForStatement") {
                 builder.appendToken(tokenValue, tokenOffset);
                 // Do not include spaces in empty for loop header sections: for(;;)
-                if (node.test || node.update) {
-                    if (node.test && this._isRangeWhitespace(token.range[1], node.test.range[0]))
+                for (let value of [node.test, node.test?.expression, node.update]) {
+                    if (value?.range?.length && this._isRangeWhitespace(token.range[1], value.range[0])) {
                         builder.appendSpace();
-                    else if (node.update && this._isRangeWhitespace(token.range[1], node.update.range[0]))
-                        builder.appendSpace();
+                        break;
+                    }
                 }
                 return;
             }


### PR DESCRIPTION
#### 0a0601825925359bd980aa5c47a43839ce085ea7
<pre>
Web Inspector: Can&apos;t view js file on reddit.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=298821">https://bugs.webkit.org/show_bug.cgi?id=298821</a>
<a href="https://rdar.apple.com/160617913">rdar://160617913</a>

Reviewed by BJ Burg and Devin Rousso.

The current checkout of esprima-next used by Web Inspector does not immediately identify
a statement like `for(;x?.y;){}` as a ForStatement. This leads to an unhandled exception
when attempting to accesss the `range` member of its test condition.

This occurs when the `for` statement 1) does not have an initializer and
2) its test condition is an optional chaining expression.

According to the Esprima documentation, the `range` member is an optional member:
<a href="https://docs.esprima.org/en/stable/syntax-tree-format.html?highlight=ForStatement#for-statement">https://docs.esprima.org/en/stable/syntax-tree-format.html?highlight=ForStatement#for-statement</a>

This patch guards for this, checking that `range` exists before using it.

* LayoutTests/inspector/formatting/resources/javascript-tests/for-statements-expected.js:
(c.d.1):
* LayoutTests/inspector/formatting/resources/javascript-tests/for-statements.js:
(c.d.1):

Add tests for `for` with optional chaining expressions.

* Source/WebInspectorUI/UserInterface/Workers/Formatter/JSFormatter.js:
(JSFormatter.prototype._handleTokenAtNode):

When the test condition of a ForStatement is an optional chaining expression,
its `test` member doesn&apos;t have a `range`. Instead, it has an `expression` which itself has a `range`.

Canonical link: <a href="https://commits.webkit.org/301197@main">https://commits.webkit.org/301197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3542cebd2f1620969e9dafc3447d1fa0a2249ce0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77056 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd1a9f92-a157-438b-94df-d9d81f326b8e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95205 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3b11b50-02c4-4ae7-9992-c2d086047554) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75747 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68fa2c98-f596-40fd-8011-227cdfc502fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30010 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75399 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134596 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51888 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39681 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103675 "Failed to checkout and rebase branch from PR 50751") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48794 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48941 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57567 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54503 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->