### PR TITLE
[AutoFill Debugging] Add a way for clients to request a debug description from _WKTextExtractionInteraction

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -70,6 +70,7 @@
 #include "SimpleRange.h"
 #include "Text.h"
 #include "TextIterator.h"
+#include "TypedElementDescendantIteratorInlines.h"
 #include "UserGestureIndicator.h"
 #include "UserTypingGestureIndicator.h"
 #include "VisibleSelection.h"
@@ -1253,6 +1254,209 @@ void handleInteraction(Interaction&& interaction, Page& page, CompletionHandler<
         break;
     }
     completion(false, "Invalid action"_s);
+}
+
+static constexpr auto maxDescriptionLength = 512;
+
+static String normalizeText(const String& string)
+{
+    auto result = makeStringByReplacingAll(string, '\'', ""_s);
+    result = makeStringByReplacingAll(string, '\"', ""_s);
+    result = makeStringByReplacingAll(result, '\n', " "_s);
+    result = makeStringByReplacingAll(result, '\r', ""_s);
+    result = result.trim(isASCIIWhitespace<char16_t>);
+    if (result.length() <= maxDescriptionLength)
+        return result;
+
+    return makeString(result.left(maxDescriptionLength / 2 - 2), "..."_s, result.right(maxDescriptionLength / 2 - 1));
+}
+
+static String normalizedLabelText(const Element& element)
+{
+    for (auto attribute : { HTMLNames::aria_labelAttr.get(), HTMLNames::labelAttr.get() }) {
+        auto text = normalizeText(element.attributeWithoutSynchronization(attribute));
+        if (!text.isEmpty())
+            return text;
+    }
+
+    return { };
+}
+
+static String textDescription(const Element& element, Vector<String>& stringsToValidate, bool isTargetElement = true)
+{
+    StringBuilder description;
+
+    if (element.hasEditableStyle())
+        description.append("editable "_s);
+
+    auto tagName = element.tagName().convertToASCIILowercase();
+    if (element.isLink())
+        description.append("link"_s);
+    else
+        description.append(tagName);
+
+    bool needsParentContext = true;
+
+    if (element.isLink()) {
+        if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::hrefAttr)); !text.isEmpty()) {
+            description.append(makeString(" with href '"_s, text, '\''));
+            stringsToValidate.append(WTFMove(text));
+            needsParentContext = false;
+        }
+    }
+
+    if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::roleAttr)); !text.isEmpty() && text != tagName) {
+        description.append(makeString(" with role "_s, text));
+        needsParentContext = false;
+    }
+
+    if (auto text = normalizedLabelText(element); !text.isEmpty()) {
+        description.append(makeString(" labeled '"_s, text, '\''));
+        stringsToValidate.append(WTFMove(text));
+        needsParentContext = false;
+    }
+
+    if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::titleAttr)); !text.isEmpty()) {
+        description.append(makeString(" titled '"_s, text, '\''));
+        stringsToValidate.append(WTFMove(text));
+        needsParentContext = false;
+    }
+
+    if (auto text = element.attributeWithoutSynchronization(HTMLNames::typeAttr); !text.isEmpty() && text != tagName)
+        description.append(makeString(" of type "_s, text));
+
+    if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::placeholderAttr)); !text.isEmpty()) {
+        description.append(makeString(" with placeholder '"_s, text, '\''));
+        stringsToValidate.append(WTFMove(text));
+        needsParentContext = false;
+    }
+
+    auto elementDescription = description.toString();
+    if (!needsParentContext)
+        return elementDescription;
+
+    RefPtr parent = element.parentElementInComposedTree();
+    if (!parent)
+        return elementDescription;
+
+    auto parentDescription = textDescription(*parent, stringsToValidate, false);
+    if (parentDescription.isEmpty())
+        return elementDescription;
+
+    if (isTargetElement)
+        return makeString(WTFMove(elementDescription), " under "_s, WTFMove(parentDescription));
+
+    return parentDescription;
+}
+
+static String textDescription(std::optional<NodeIdentifier> identifier, Vector<String>& stringsToValidate)
+{
+    if (!identifier)
+        return { };
+
+    RefPtr node = Node::fromIdentifier(*identifier);
+    if (!node)
+        return { };
+
+    auto addRenderedTextOrLabeledChild = [&](const String& description) {
+        StringBuilder extendedDescription;
+        extendedDescription.append(description);
+
+        String renderedTextSuffix;
+        auto range = makeRangeSelectingNodeContents(*node);
+        if (auto text = normalizeText(plainText(range, TextIteratorBehavior::EntersTextControls)); !text.isEmpty()) {
+            stringsToValidate.append(text);
+            extendedDescription.append(makeString(", with rendered text '"_s, WTFMove(text), '\''));
+        }
+
+        String labeledChildSuffix;
+        if (RefPtr container = dynamicDowncast<ContainerNode>(node)) {
+            for (Ref child : descendantsOfType<Element>(*container)) {
+                auto label = normalizedLabelText(child);
+                if (label.isEmpty())
+                    continue;
+
+                stringsToValidate.append(label);
+                extendedDescription.append(makeString(", containing child labeled '"_s, WTFMove(label), '\''));
+                break;
+            }
+        }
+
+        return extendedDescription.toString();
+    };
+
+    if (RefPtr element = dynamicDowncast<Element>(*node))
+        return addRenderedTextOrLabeledChild(textDescription(*element, stringsToValidate));
+
+    if (RefPtr parentElement = node->parentElementInComposedTree())
+        return addRenderedTextOrLabeledChild(makeString("child node of "_s, textDescription(*parentElement, stringsToValidate)));
+
+    return { };
+}
+
+InteractionDescription interactionDescription(const Interaction& interaction)
+{
+    auto action = interaction.action;
+    bool isSingleKeyPress = action == Action::KeyPress && PlatformKeyboardEvent::syntheticEventFromText(PlatformEvent::Type::KeyUp, interaction.text);
+
+    StringBuilder description;
+    description.append([&] -> String {
+        if (isSingleKeyPress)
+            return makeString("Press the "_s, interaction.text, " key"_s);
+
+        switch (action) {
+        case Action::Click:
+            return "Click"_s;
+        case Action::SelectText:
+            return "Select text"_s;
+        case Action::SelectMenuItem:
+            return "Select menu item"_s;
+        case Action::TextInput:
+        case Action::KeyPress:
+            return "Enter text"_s;
+        }
+        ASSERT_NOT_REACHED();
+        return { };
+    }());
+
+    Vector<String> stringsToValidate;
+    if (!isSingleKeyPress) {
+        if (auto escapedString = normalizeText(interaction.text); !escapedString.isEmpty()) {
+            if (action == Action::Click)
+                description.append(" over text"_s);
+            description.append(makeString(" '"_s, escapedString, '\''));
+            stringsToValidate.append(WTFMove(escapedString));
+        }
+    }
+
+    if (auto location = interaction.locationInRootView) {
+        auto roundedLocation = roundedIntPoint(*location);
+        description.append(" at coordinates ("_s, roundedLocation.x(), ", "_s, roundedLocation.y(), ')');
+    }
+
+    if (auto elementString = textDescription(interaction.nodeIdentifier, stringsToValidate); !elementString.isEmpty()) {
+        auto prefix = [action] -> String {
+            switch (action) {
+            case Action::Click:
+                return " on "_s;
+            case Action::SelectText:
+                return " inside "_s;
+            case Action::SelectMenuItem:
+            case Action::KeyPress:
+                return " in "_s;
+            case Action::TextInput:
+                return " into "_s;
+            }
+            ASSERT_NOT_REACHED();
+            return { };
+        }();
+        description.append(makeString(WTFMove(prefix), WTFMove(elementString)));
+    }
+
+    if ((action == Action::KeyPress || action == Action::TextInput) && interaction.replaceAll)
+        description.append(", replacing any existing content"_s);
+
+    return { description.toString(), WTFMove(stringsToValidate) };
 }
 
 } // namespace TextExtraction

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -42,6 +42,7 @@ WEBCORE_EXPORT Item extractItem(Request&&, Page&);
 WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
 
 WEBCORE_EXPORT void handleInteraction(Interaction&&, Page&, CompletionHandler<void(bool, String&&)>&&);
+WEBCORE_EXPORT InteractionDescription interactionDescription(const Interaction&);
 
 struct RenderedText {
     String textWithReplacedContent;

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -51,6 +51,11 @@ struct Interaction {
     bool replaceAll { false };
 };
 
+struct InteractionDescription {
+    String description;
+    Vector<String> stringsToValidate;
+};
+
 enum class EventListenerCategory : uint8_t {
     Click       = 1 << 0,
     Hover       = 1 << 1,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7061,6 +7061,12 @@ header: <WebCore/TextExtractionTypes.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::InteractionDescription {
+    String description;
+    Vector<String> stringsToValidate;
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Request {
     std::optional<WebCore::FloatRect> collectionRectInRootView;
     bool mergeParagraphs;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -155,6 +155,7 @@ enum class HideScrollPocketReason : uint8_t {
 @class WKPasswordView;
 @class WKScrollGeometry;
 @class WKScrollView;
+@class WKTextExtractionInteraction;
 @class WKWebViewContentProviderRegistry;
 @class _WKFrameHandle;
 @class _WKWarningView;
@@ -650,5 +651,6 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
 - (void)_scrollToEdge:(_WKRectEdge)edge animated:(BOOL)animated;
 
 - (void)_requestTextExtraction:(_WKTextExtractionConfiguration *)configuration completionHandler:(void (^)(WKTextExtractionResult *))completionHandler;
+- (void)_describeInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(void (^)(NSString *, NSError *))completionHandler;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -29,6 +29,8 @@
 
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
+@class WKWebView;
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
 
@@ -56,6 +58,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithAction:(_WKTextExtractionAction)action NS_DESIGNATED_INITIALIZER;
+
+- (void)debugDescriptionInWebView:(WKWebView *)webView completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))completionHandler;
 
 @property (nonatomic, readonly) _WKTextExtractionAction action;
 @property (nonatomic, copy, nullable) NSString *nodeIdentifier;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "_WKTextExtractionInternal.h"
 
+#import "WKWebViewInternal.h"
 #import <WebKit/WKError.h>
 #import <wtf/RetainPtr.h>
 
@@ -88,6 +89,11 @@
 {
     _hasSetLocation = YES;
     _location = location;
+}
+
+- (void)debugDescriptionInWebView:(WKWebView *)webView completionHandler:(void (^)(NSString *, NSError *))completionHandler
+{
+    [webView _describeInteraction:self completionHandler:completionHandler];
 }
 
 @end

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16631,6 +16631,16 @@ void WebPageProxy::handleTextExtractionInteraction(TextExtraction::Interaction&&
     sendWithAsyncReply(Messages::WebPage::HandleTextExtractionInteraction(WTFMove(interaction)), WTFMove(completion));
 }
 
+void WebPageProxy::describeTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(TextExtraction::InteractionDescription&&)>&& completion)
+{
+    if (!hasRunningProcess()) {
+        ASSERT_NOT_REACHED();
+        return completion({ "Internal inconsistency / unexpected state. Please file a bug"_s, { } });
+    }
+
+    sendWithAsyncReply(Messages::WebPage::DescribeTextExtractionInteraction(WTFMove(interaction)), WTFMove(completion));
+}
+
 void WebPageProxy::addConsoleMessage(FrameIdentifier frameID, MessageSource messageSource, MessageLevel messageLevel, const String& message, std::optional<ResourceLoaderIdentifier> coreIdentifier)
 {
     send(Messages::WebPage::AddConsoleMessage { frameID, messageSource, messageLevel, message, coreIdentifier });

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -336,6 +336,7 @@ struct OpenID4VPRequest;
 #endif
 
 namespace TextExtraction {
+struct InteractionDescription;
 struct Interaction;
 struct Item;
 struct Request;
@@ -2622,6 +2623,7 @@ public:
 
     void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
     void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
+    void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
 
     void hasVideoInPictureInPictureDidChange(bool);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10064,6 +10064,11 @@ void WebPage::requestTextExtraction(TextExtraction::Request&& request, Completio
     completion(TextExtraction::extractItem(WTFMove(request), Ref { *corePage() }));
 }
 
+void WebPage::describeTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(TextExtraction::InteractionDescription&&)>&& completion)
+{
+    completion(TextExtraction::interactionDescription(interaction));
+}
+
 void WebPage::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool, String&&)>&& completion)
 {
     TextExtraction::handleInteraction(WTFMove(interaction), Ref { *corePage() }, WTFMove(completion));

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -349,6 +349,7 @@ using ScrollOffset = IntPoint;
 using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierType>;
 
 namespace TextExtraction {
+struct InteractionDescription;
 struct Interaction;
 struct Item;
 struct Request;
@@ -2598,6 +2599,7 @@ private:
 
     void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
     void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
+    void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
 
 #if HAVE(SANDBOX_STATE_FLAGS)
     static void setHasLaunchedWebContentProcess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -815,6 +815,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Item item)
     HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool succeeded, String description)
+    DescribeTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (struct WebCore::TextExtraction::InteractionDescription description)
 
 #if PLATFORM(IOS_FAMILY)
     ShouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint point) -> (bool shouldDismiss)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -33,6 +33,11 @@
 
 @interface WKWebView (TextExtractionTests)
 - (NSString *)synchronouslyGetDebugText:(_WKTextExtractionConfiguration *)configuration;
+- (_WKTextExtractionInteractionResult *)synchronouslyPerformInteraction:(_WKTextExtractionInteraction *)interaction;
+@end
+
+@interface _WKTextExtractionInteraction (TextExtractionTests)
+- (NSString *)debugDescriptionInWebView:(WKWebView *)webView error:(NSError **)outError;
 @end
 
 @implementation WKWebView (TextExtractionTests)
@@ -53,11 +58,41 @@
     return result.autorelease();
 }
 
+- (_WKTextExtractionInteractionResult *)synchronouslyPerformInteraction:(_WKTextExtractionInteraction *)interaction
+{
+    __block bool done = false;
+    __block RetainPtr<_WKTextExtractionInteractionResult> result;
+    [self _performInteraction:interaction completionHandler:^(_WKTextExtractionInteractionResult *theResult) {
+        result = theResult;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result.autorelease();
+}
+
+@end
+
+@implementation _WKTextExtractionInteraction (TextExtractionTests)
+
+- (NSString *)debugDescriptionInWebView:(WKWebView *)webView error:(NSError **)outError
+{
+    __block bool done = false;
+    __block RetainPtr<NSString> result;
+    __block RetainPtr<NSError> error;
+    [self debugDescriptionInWebView:webView completionHandler:^(NSString *description, NSError *theError) {
+        result = description;
+        error = theError;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    if (outError)
+        *outError = error.autorelease();
+    return result.autorelease();
+}
+
 @end
 
 namespace TestWebKitAPI {
-
-#if PLATFORM(MAC)
 
 static NSString *extractNodeIdentifier(NSString *debugText, NSString *searchText)
 {
@@ -76,6 +111,8 @@ static NSString *extractNodeIdentifier(NSString *debugText, NSString *searchText
 
     return nil;
 }
+
+#if PLATFORM(MAC)
 
 TEST(TextExtractionTests, SelectPopupMenu)
 {
@@ -109,5 +146,66 @@ TEST(TextExtractionTests, SelectPopupMenu)
 }
 
 #endif // PLATFORM(MAC)
+
+TEST(TextExtractionTests, InteractionDebugDescription)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
+    RetainPtr testButtonID = extractNodeIdentifier(debugText.get(), @"Test");
+    RetainPtr emailID = extractNodeIdentifier(debugText.get(), @"email");
+    RetainPtr composeID = extractNodeIdentifier(debugText.get(), @"Compose");
+    RetainPtr selectID = extractNodeIdentifier(debugText.get(), @"select");
+
+    NSError *error = nil;
+    NSString *description = nil;
+    {
+        RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+
+        [interaction setNodeIdentifier:testButtonID.get()];
+        description = [interaction debugDescriptionInWebView:webView.get() error:&error];
+        EXPECT_WK_STREQ("Click on button labeled 'Click Me', with rendered text 'Test'", description);
+        EXPECT_NULL(error);
+
+        [interaction setNodeIdentifier:emailID.get()];
+        description = [interaction debugDescriptionInWebView:webView.get() error:&error];
+        EXPECT_WK_STREQ("Click on input of type email with placeholder 'Recipient address'", description);
+        EXPECT_NULL(error);
+
+        [interaction setNodeIdentifier:composeID.get()];
+        description = [interaction debugDescriptionInWebView:webView.get() error:&error];
+        EXPECT_WK_STREQ("Click on editable div labeled 'Compose a new message', with rendered text 'Subject  Hello world.', containing child labeled 'Heading'", description);
+        EXPECT_NULL(error);
+    }
+    {
+        RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionTextInput]);
+
+        [interaction setNodeIdentifier:emailID.get()];
+        [interaction setText:@"squirrelfish@webkit.org"];
+        [interaction setReplaceAll:YES];
+        description = [interaction debugDescriptionInWebView:webView.get() error:&error];
+        EXPECT_WK_STREQ("Enter text 'squirrelfish@webkit.org' into input of type email with placeholder 'Recipient address', replacing any existing content", description);
+        EXPECT_NULL(error);
+
+        [interaction setNodeIdentifier:composeID.get()];
+        [interaction setText:@"Hello world"];
+        [interaction setReplaceAll:NO];
+        description = [interaction debugDescriptionInWebView:webView.get() error:&error];
+        EXPECT_WK_STREQ("Enter text 'Hello world' into editable div labeled 'Compose a new message', with rendered text 'Subject  Hello world.', containing child labeled 'Heading'", description);
+        EXPECT_NULL(error);
+    }
+    {
+        RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionSelectMenuItem]);
+        [interaction setNodeIdentifier:selectID.get()];
+        [interaction setText:@"Three"];
+        description = [interaction debugDescriptionInWebView:webView.get() error:&error];
+        EXPECT_WK_STREQ("Select menu item 'Three' in select with role menu", description);
+        EXPECT_NULL(error);
+    }
+}
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
@@ -6,13 +6,13 @@
 </head>
 <body>
     <button id="test-button" aria-label="Click Me">Test</button>
-    <input type="email" placeholder="Enter some text" value="foo" />
+    <input type="email" placeholder="Recipient address" value="foo" />
     <select role="menu">
         <option>One</option>
         <option selected>Two</option>
         <option>Three</option>
     </select>
-    <div contenteditable="plaintext-only">
+    <div aria-label="Compose a new message" contenteditable="plaintext-only">
         <h3 aria-label="Heading">Subject</h3>
         <p>Hello world.</p>
     </div>


### PR DESCRIPTION
#### 2ac3f90d2a240adb62ae5744b557c8a9f659bff2
<pre>
[AutoFill Debugging] Add a way for clients to request a debug description from _WKTextExtractionInteraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=298874">https://bugs.webkit.org/show_bug.cgi?id=298874</a>
<a href="https://rdar.apple.com/160618921">rdar://160618921</a>

Reviewed by Abrar Rahman Protyasha and Timothy Hatcher.

Add support for `-[_WKTextExtractionInteraction debugDescriptionInWebView:completionHandler:]`. See
below for more details.

Test: TextExtractionTests.InteractionDebugDescription

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::normalizeText):
(WebCore::TextExtraction::normalizedLabelText):
(WebCore::TextExtraction::textDescription):

Add a helper function to return a debug description for a given `NodeIdentifier`, based on the
identified node&apos;s accessibility label (and several other attributes), tag name, role, visible text,
as well as any parent or descendent elements that are labeled.

(WebCore::TextExtraction::interactionDescription):

Add a utility function to describe the given interaction, using the `textDescription` function above
as well as the interaction&apos;s `action` type. The result is both the description string, as well as
any variable-length strings embedded inside the description that require additional filtering.

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _convertToWebCoreInteraction:]):

Pull common logic for converting `_WKTextExtractionInteraction` to its corresponding WebCore struct.

(-[WKWebView _performInteraction:completionHandler:]):
(-[WKWebView _describeInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionInteraction debugDescriptionInWebView:completionHandler:]):

Add the new SPI method — this asynchronously maps the interaction into human-readable debug text, in
the context of the given web view.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::describeTextExtractionInteraction):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::describeTextExtractionInteraction):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Add plumbing for `DescribeTextExtractionInteraction`. See above.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(-[WKWebView synchronouslyPerformInteraction:]):
(-[_WKTextExtractionInteraction debugDescriptionInWebView:error:]):
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDebugDescription)):

Add an API test for this new method.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html:

Canonical link: <a href="https://commits.webkit.org/299981@main">https://commits.webkit.org/299981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96d6b081f005943607c6cbe62c03bddacf1ad657

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73058 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5b4609c-b428-4b42-8896-409e682ae16d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91891 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afcb4f8e-86ed-40dd-b86e-bd62bab9eeb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108451 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72579 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a3d9f8b-32c2-4346-a2aa-f89ebe5cf157) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26553 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70984 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130250 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36401 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100500 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44593 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47763 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53476 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47234 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->