### PR TITLE
Re-fix -Wpreferred-type-bitfield-enum-conversion warnings in WebCore

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -349,6 +349,8 @@ enum class FillBox : uint8_t {
     NoClip
 };
 
+constexpr unsigned FillBoxBitWidth = 3;
+
 constexpr inline FillBox clipMax(FillBox clipA, FillBox clipB)
 {
     if (clipA == FillBox::BorderBox || clipB == FillBox::BorderBox)

--- a/Source/WebCore/style/values/backgrounds/StyleBackgroundLayer.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBackgroundLayer.h
@@ -106,11 +106,11 @@ private:
     RepeatStyle m_repeat;
 
     PREFERRED_TYPE(FillAttachment) unsigned m_attachment : 2;
-    PREFERRED_TYPE(FillBox) unsigned m_clip : 3;
-    PREFERRED_TYPE(FillBox) unsigned m_origin : 2;
+    PREFERRED_TYPE(FillBox) unsigned m_clip : FillBoxBitWidth;
+    PREFERRED_TYPE(FillBox) unsigned m_origin : FillBoxBitWidth;
     PREFERRED_TYPE(BlendMode) unsigned m_blendMode : 5;
 
-    PREFERRED_TYPE(FillBox) mutable unsigned m_clipMax : 2; // maximum m_clip value from this to bottom layer
+    PREFERRED_TYPE(FillBox) mutable unsigned m_clipMax : FillBoxBitWidth; // maximum m_clip value from this to bottom layer
 };
 
 using BackgroundLayers = FillLayers<BackgroundLayer>;

--- a/Source/WebCore/style/values/masking/StyleMaskLayer.h
+++ b/Source/WebCore/style/values/masking/StyleMaskLayer.h
@@ -109,12 +109,12 @@ private:
     BackgroundSize m_size;
     RepeatStyle m_repeat;
 
-    PREFERRED_TYPE(FillBox) unsigned m_clip : 3;
-    PREFERRED_TYPE(FillBox) unsigned m_origin : 2;
+    PREFERRED_TYPE(FillBox) unsigned m_clip : FillBoxBitWidth;
+    PREFERRED_TYPE(FillBox) unsigned m_origin : FillBoxBitWidth;
     PREFERRED_TYPE(CompositeOperator) unsigned m_composite : 4;
     PREFERRED_TYPE(MaskMode) unsigned m_maskMode : 2;
 
-    PREFERRED_TYPE(FillBox) mutable unsigned m_clipMax : 2; // maximum m_clip value from this to bottom layer
+    PREFERRED_TYPE(FillBox) mutable unsigned m_clipMax : FillBoxBitWidth; // maximum m_clip value from this to bottom layer
 };
 
 using MaskLayers = FillLayers<MaskLayer>;


### PR DESCRIPTION
#### 933234e9d4863a267333aa872e3a3d040703531e
<pre>
Re-fix -Wpreferred-type-bitfield-enum-conversion warnings in WebCore
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=298883">https://bugs.webkit.org/show_bug.cgi?id=298883</a>&gt;
&lt;<a href="https://rdar.apple.com/160626315">rdar://160626315</a>&gt;

Reviewed by Ryosuke Niwa.

This was originally fixed by 298737@main, but was then accidentally
regressed by 299407@main.

No test since this is caught by new clang compilers as a warning.

* Source/WebCore/rendering/style/RenderStyleConstants.h:
(WebCore::FillBoxBitWidth): Add.
- Defines bit width required to store enum class FillBox.
* Source/WebCore/style/values/backgrounds/StyleBackgroundLayer.h:
(WebCore::Style::BackgroundLayer):
- Update PREFERRED_TYPE(FillBox) fields to use FillBoxBitWidth.
* Source/WebCore/style/values/masking/StyleMaskLayer.h:
(WebCore::Style::MaskLayer):
- Update PREFERRED_TYPE(FillBox) fields to use FillBoxBitWidth.

Canonical link: <a href="https://commits.webkit.org/299975@main">https://commits.webkit.org/299975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7b5adc2ae28e9d451069bdb2830cde1dde73255

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73036 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/405e24e5-399a-4a3c-8240-291cbdfba561) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49231 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91877 "30 flakes 70 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1cbf4ee6-9d5e-4f0f-89b5-ed24bdf5957b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c3aa768-38ad-4d2e-886a-0b7caf283459) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26534 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70960 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130228 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47883 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100386 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45792 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44571 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19187 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47741 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53454 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47212 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->