### PR TITLE
Add sharding groups to api-tests to allow running in parallel

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -132,8 +132,7 @@ def parse_args(args):
         optparse.make_option('--iterations', type='int', default=1, help='Number of times to run the set of tests (e.g. ABCABCABC)'),
         optparse.make_option('--repeat-each', type='int', default=1, help='Number of times to run each test (e.g. AAABBBCCC)'),
 
-        # FIXME: Remove the default, API tests should be multiprocess
-        optparse.make_option('--child-processes', default=1,
+        optparse.make_option('--child-processes', default=None,
                              help='Number of processes to run in parallel.'),
 
         # FIXME: Default should be false, API tests should not be forced to run singly

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -211,7 +211,7 @@ class Manager(object):
             runner = Runner(self._port, self._stream)
             for i in range(self._options.iterations):
                 _log.debug('\nIteration {}'.format(i + 1))
-                runner.run(test_names, int(self._options.child_processes) if self._options.child_processes else self._port.default_child_processes())
+                runner.run(test_names, int(self._options.child_processes) if self._options.child_processes else self._options.child_processes)
         except KeyboardInterrupt:
             # If we receive a KeyboardInterrupt, print results.
             self._stream.writeln('')

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -261,11 +261,11 @@ class Port(object):
 
         return paths
 
-    def sharding_groups(self):
+    def sharding_groups(self, suite=None):
         return {}
 
-    def group_for_shard(self, shard):
-        for group, filter_fn in self.sharding_groups().items():
+    def group_for_shard(self, shard, suite=None):
+        for group, filter_fn in self.sharding_groups(suite=suite).items():
             if filter_fn(shard):
                 return group
         return None

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -53,7 +53,11 @@ class DarwinPort(ApplePort):
             # with MallocStackLogging enabled.
             self.set_option_default("batch_size", 1000)
 
-    def sharding_groups(self):
+    def sharding_groups(self, suite=None):
+        if suite == 'api-tests':
+            return {
+                'system': lambda shard: shard.name.startswith('TestWebKitAPI') or shard.name.startswith('TestWGSL'),
+            }
         return {
             'media': lambda shard: 'media' in shard.name or 'webaudio' in shard.name,
         }


### PR DESCRIPTION
#### 3cecfd095c0d1ceed9d0b74a98c0a675d3d49217
<pre>
Add sharding groups to api-tests to allow running in parallel
<a href="https://bugs.webkit.org/show_bug.cgi?id=298892">https://bugs.webkit.org/show_bug.cgi?id=298892</a>
<a href="https://rdar.apple.com/160635460">rdar://160635460</a>

Reviewed by Jonathan Bedard.

This adds a mutually exclusive shard group called system that is used when api-tests are run.
Anything in the System will not be run in parallel for api-tests, this also changes the default --child-processes argument in run-api-tests to allow parallelization to be the new default.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner.run):
* Tools/Scripts/webkitpy/port/base.py:
(Port.sharding_groups):
(Port.group_for_shard):
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.sharding_groups):

Canonical link: <a href="https://commits.webkit.org/300034@main">https://commits.webkit.org/300034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a90577f44cf9e67ee4957edc5de1164a28a99b7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73203 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15956c52-adb4-42ef-803b-caee2017135a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49397 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/479c5953-5044-46ad-a997-2927fa55b21e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124074 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72691 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/220f3448-09d3-45b5-a3ed-42b46655804e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120479 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26677 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71133 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130394 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36520 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100519 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25478 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/45924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47907 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47378 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49062 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->