### PR TITLE
AX: <label>s that are targets of aria-labelledby lose their labelfor relationship when they change

### DIFF
--- a/LayoutTests/accessibility/label-for-with-aria-labelledby-expected.txt
+++ b/LayoutTests/accessibility/label-for-with-aria-labelledby-expected.txt
@@ -1,0 +1,14 @@
+This tests that the aria-labelledby pointing to a label works when the label has a `for` attribute.
+
+	AXTitle: Hello
+	AXDescription: Hello
+	AXHelp:
+Changing inner HTML of label:
+	AXTitle: World
+	AXDescription: World
+	AXHelp:
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ World

--- a/LayoutTests/accessibility/label-for-with-aria-labelledby.html
+++ b/LayoutTests/accessibility/label-for-with-aria-labelledby.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="textbox" type="text" size=20 aria-labelledby="textbox-label">
+<label id="textbox-label" for="textbox">Hello</label>
+
+<script>
+let output = "This tests that the aria-labelledby pointing to a label works when the label has a `for` attribute.\n\n";
+
+var platformText;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    var textbox = accessibilityController.accessibleElementById("textbox");
+    output += `${platformTextAlternatives(textbox)}\n`;
+
+    document.getElementById("textbox-label").innerHTML = "World";
+    output += "Changing inner HTML of label:\n";
+    setTimeout(async function() {
+        await waitFor(() => {
+            platformText = platformTextAlternatives(textbox);
+            return platformText.includes("World");
+        });
+        output += `${platformTextAlternatives(textbox)}\n`;
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/accessibility/label-for-with-aria-labelledby-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/label-for-with-aria-labelledby-expected.txt
@@ -1,0 +1,12 @@
+This tests that the aria-labelledby pointing to a label works when the label has a `for` attribute.
+
+	AXTitle: Hello
+	AXDescription:
+Changing inner HTML of label:
+	AXTitle: World
+	AXDescription:
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ World

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -728,7 +728,7 @@ private:
     bool removeRelation(Element&, AXRelation);
     void removeAllRelations(AXID);
     void removeRelationByID(AXID originID, AXID targetID, AXRelation);
-    void updateLabelFor(HTMLLabelElement&);
+    bool updateLabelFor(HTMLLabelElement&);
     void updateLabeledBy(Element*);
     void updateRelationsIfNeeded();
     void updateRelationsForTree(ContainerNode&);


### PR DESCRIPTION
#### f96d5091cd43ec126efe38ef45d06f3982274458
<pre>
AX: &lt;label&gt;s that are targets of aria-labelledby lose their labelfor relationship when they change
<a href="https://bugs.webkit.org/show_bug.cgi?id=298891">https://bugs.webkit.org/show_bug.cgi?id=298891</a>
<a href="https://rdar.apple.com/158906980">rdar://158906980</a>

Reviewed by Tyler Wilcock.

When &lt;label&gt; elements change, the handleLabelChanged method of AXObjectCache get&apos;s called to update
its labelfor relationships. In this code path, we clear all LabelFor relationships and re-add them
based on the label&apos;s `for` attribute. This is fine when a control&apos;s label just uses the `for` attribute,
but if the control itself uses aria-labelledby to point to the label element, we end up clearing this
relationship. This causes us a control&apos;s label to be stale, for example, because a text change on a label
won&apos;t know what other elements to update.

Fix this by preventing clearing LabelFor relationships when the control uses aria-label or aria-labelledby.

Test: accessibility/label-for-with-aria-labelledby.html

Test: accessibility/label-for-with-aria-labelledby.html
* LayoutTests/accessibility/label-for-with-aria-labelledby-expected.txt: Added.
* LayoutTests/accessibility/label-for-with-aria-labelledby.html: Added.
* LayoutTests/platform/glib/accessibility/label-for-with-aria-labelledby-expected.txt: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::hasAnyARIALabelling):
(WebCore::AXObjectCache::handleLabelChanged):
(WebCore::AXObjectCache::updateLabelFor):
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/300029@main">https://commits.webkit.org/300029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73ab0905f92f16e5c51b571057fcb7e81e435a60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73147 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7831b20e-ecfb-4b3f-9ffe-83c9f00d9ad2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61174 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aec5c1fc-bb54-4b3f-9aa8-2a6790d1aa42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108524 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72642 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e67cb5b9-c970-4a29-871e-683b6a3014cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71076 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130338 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100569 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25474 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44681 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47322 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->