### PR TITLE
[JSC] Fix `ToIndex(value)` to Align with TC39 spec

### DIFF
--- a/JSTests/stress/SharedArrayBuffer.js
+++ b/JSTests/stress/SharedArrayBuffer.js
@@ -107,7 +107,7 @@ for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
     shouldFail(() => waiterListSize(i32a, idx), RangeError);
 }
 
-for (idx of ["hello"]) {
+for (idx of ["hello", -Number.EPSILON, -0.1, -0.9, -1 + Number.EPSILON]) {
     for (a of [i8a, i16a, i32a, u8a, u16a, u32a]) {
         shouldSucceed(() => Atomics.add(a, idx, 0));
         shouldSucceed(() => Atomics.and(a, idx, 0));

--- a/JSTests/stress/bigint-asintn.js
+++ b/JSTests/stress/bigint-asintn.js
@@ -48,6 +48,14 @@ shouldThrow(() => {
     shouldBe(toBigInt, true);
 }
 
+shouldThrow(() => {
+    BigInt.asIntN(-Infinity, 2n ** 64n - 1n)
+}, `RangeError: number of bits cannot be negative`);
+shouldBe(BigInt.asIntN(-Number.EPSILON, 2n ** 64n - 1n), 0n);
+shouldBe(BigInt.asIntN(-0.1, 2n ** 64n - 1n), 0n);
+shouldBe(BigInt.asIntN(-0.9, 2n ** 64n - 1n), 0n);
+shouldBe(BigInt.asIntN(-1 + Number.EPSILON, 2n ** 64n - 1n), 0n);
+
 shouldBe(BigInt.asIntN(-0, 0n), 0n);
 
 shouldBe(BigInt.asIntN(0, 0n), 0n);
@@ -107,3 +115,15 @@ shouldBe(BigInt.asIntN(63, -0x800000000000001n), -576460752303423489n);
 shouldBe(BigInt.asIntN(64, -0x800000000000001n), -576460752303423489n);
 shouldBe(BigInt.asIntN(65, -0x800000000000001n), -576460752303423489n);
 shouldBe(BigInt.asIntN(66, -0x800000000000001n), -576460752303423489n);
+
+shouldBe(BigInt.asIntN(2 ** 32 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asIntN(2 ** 32, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asIntN(2 ** 32 + 1, 2n ** 64n - 1n), 18446744073709551615n);
+
+shouldBe(BigInt.asIntN(2 ** 53 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldThrow(() => {
+    BigInt.asIntN(2 ** 53, 2n ** 64n - 1n)
+}, `RangeError: number of bits larger than (2 ** 53) - 1`);
+shouldThrow(() => {
+    BigInt.asIntN(Infinity, 2n ** 64n - 1n)
+}, `RangeError: number of bits larger than (2 ** 53) - 1`);

--- a/JSTests/stress/bigint-asuintn.js
+++ b/JSTests/stress/bigint-asuintn.js
@@ -48,6 +48,14 @@ shouldThrow(() => {
     shouldBe(toBigInt, true);
 }
 
+shouldThrow(() => {
+    BigInt.asUintN(-Infinity, 2n ** 64n - 1n)
+}, `RangeError: number of bits cannot be negative`);
+shouldBe(BigInt.asUintN(-Number.EPSILON, 2n ** 64n - 1n), 0n);
+shouldBe(BigInt.asUintN(-0.1, 2n ** 64n - 1n), 0n);
+shouldBe(BigInt.asUintN(-0.9, 2n ** 64n - 1n), 0n);
+shouldBe(BigInt.asUintN(-1 + Number.EPSILON, 2n ** 64n - 1n), 0n);
+
 shouldBe(BigInt.asUintN(-0, 0n), 0n);
 shouldBe(BigInt.asUintN(0, 0n), 0n);
 shouldBe(BigInt.asUintN(1, 0n), 0n);
@@ -131,3 +139,15 @@ shouldBe(BigInt.asUintN(64, -0xffffffffffffffffn), 1n);
 shouldBe(BigInt.asUintN(65, -0xffffffffffffffffn), 18446744073709551617n);
 shouldBe(BigInt.asUintN(66, -0xffffffffffffffffn), 55340232221128654849n);
 shouldBe(BigInt.asUintN(67, -0xffffffffffffffffn), 129127208515966861313n);
+
+shouldBe(BigInt.asUintN(2 ** 32 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asUintN(2 ** 32, 2n ** 64n - 1n), 18446744073709551615n);
+shouldBe(BigInt.asUintN(2 ** 32 + 1, 2n ** 64n - 1n), 18446744073709551615n);
+
+shouldBe(BigInt.asUintN(2 ** 53 - 1, 2n ** 64n - 1n), 18446744073709551615n);
+shouldThrow(() => {
+    BigInt.asUintN(2 ** 53, 2n ** 64n - 1n)
+}, `RangeError: number of bits larger than (2 ** 53) - 1`);
+shouldThrow(() => {
+    BigInt.asUintN(Infinity, 2n ** 64n - 1n)
+}, `RangeError: number of bits larger than (2 ** 53) - 1`);

--- a/JSTests/stress/data-view-bigint.js
+++ b/JSTests/stress/data-view-bigint.js
@@ -1,25 +1,69 @@
 function shouldBe(actual, expected) {
-    if (actual !== expected)
-        throw new Error('bad value: ' + actual);
+    if (actual !== expected) throw new Error("bad value: " + actual);
 }
 
-var array = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 0x80, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]);
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown) {
+        throw new Error("not thrown");
+    }
+    if (String(error) !== errorMessage) {
+        throw new Error(`bad error: ${String(error)}`);
+    }
+}
+
+var array = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 0x80, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 var dataView = new DataView(array.buffer);
 
-shouldBe(dataView.getBigInt64(0), 0x01020304050607n);
-shouldBe(dataView.getBigUint64(0), 0x01020304050607n);
+// values in the range (-1, 0], i.e., 0 inclusive, -1 exclusive
+var values0ToMinus1Exclusive = [0, -Number.EPSILON, -0.1, -0.9, -1 + Number.EPSILON];
+
 shouldBe(dataView.getBigInt64(8), -9223088349902469625n);
 shouldBe(dataView.getBigUint64(8), 9223655723807081991n);
+shouldBe(dataView.getBigInt64(11), 217304205466536202n);
+shouldBe(dataView.getBigUint64(11), 217304205466536202n);
+shouldThrow(() => {
+    dataView.getBigInt64(12);
+}, "RangeError: Out of bounds access");
+shouldThrow(() => {
+    dataView.getBigUint64(12);
+}, "RangeError: Out of bounds access");
+for (let val of values0ToMinus1Exclusive) {
+    shouldBe(dataView.getBigInt64(val), 0x01020304050607n);
+    shouldBe(dataView.getBigUint64(val), 0x01020304050607n);
+}
 
 shouldBe(dataView.setBigInt64(0, -1n), undefined);
-shouldBe(dataView.getBigInt64(0), -1n);
-shouldBe(dataView.getBigUint64(0), 0xffffffffffffffffn);
+for (let innerVal of values0ToMinus1Exclusive) {
+    shouldBe(dataView.getBigInt64(innerVal), -1n);
+    shouldBe(dataView.getBigUint64(innerVal), 0xffffffffffffffffn);
+}
 
-shouldBe(dataView.setBigUint64(0, 0xfffffffffffffffen), undefined);
-shouldBe(dataView.getBigInt64(0), -2n);
-shouldBe(dataView.getBigUint64(0), 0xfffffffffffffffen);
+for (let outerVal of values0ToMinus1Exclusive) {
+    shouldBe(dataView.setBigUint64(outerVal, 0xfffffffffffffffen), undefined);
+    shouldBe(dataView.getBigInt64(0), -2n);
+    shouldBe(dataView.getBigUint64(0), 0xfffffffffffffffen);
+    shouldBe(dataView.getUint8(0), 0xff);
+    for (let innerVal of values0ToMinus1Exclusive) {
+        shouldBe(dataView.getBigInt64(innerVal), -2n);
+        shouldBe(dataView.getBigUint64(innerVal), 0xfffffffffffffffen);
+    }
+}
 
-shouldBe(dataView.setBigUint64(0, 0x1fffffffffffffffen), undefined);
-shouldBe(dataView.getBigInt64(0), -2n);
-shouldBe(dataView.getBigUint64(0), 0xfffffffffffffffen);
-shouldBe(dataView.getUint8(0), 0xff);
+for (let outerVal of values0ToMinus1Exclusive) {
+    shouldBe(dataView.setBigUint64(outerVal, 0x1fffffffffffffffen), undefined);
+    shouldBe(dataView.getBigInt64(0), -2n);
+    shouldBe(dataView.getBigUint64(0), 0xfffffffffffffffen);
+    shouldBe(dataView.getUint8(0), 0xff);
+    for (let innerVal of values0ToMinus1Exclusive) {
+        shouldBe(dataView.getBigInt64(innerVal), -2n);
+        shouldBe(dataView.getBigUint64(innerVal), 0xfffffffffffffffen);
+    }
+}

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -101,7 +101,7 @@ void AtomicsObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
 namespace {
 
 template<typename Adaptor, typename Func>
-EncodedJSValue atomicReadModifyWriteCase(JSGlobalObject* globalObject, VM& vm, const JSValue* args, JSArrayBufferView* typedArrayView, unsigned accessIndex, const Func& func)
+EncodedJSValue atomicReadModifyWriteCase(JSGlobalObject* globalObject, VM& vm, const JSValue* args, JSArrayBufferView* typedArrayView, uint64_t accessIndex, const Func& func)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -121,10 +121,10 @@ EncodedJSValue atomicReadModifyWriteCase(JSGlobalObject* globalObject, VM& vm, c
     RELEASE_AND_RETURN(scope, JSValue::encode(Adaptor::toJSValue(globalObject, result)));
 }
 
-static unsigned validateAtomicAccess(JSGlobalObject* globalObject, VM& vm, JSArrayBufferView* typedArrayView, JSValue accessIndexValue)
+static uint64_t validateAtomicAccess(JSGlobalObject* globalObject, VM& vm, JSArrayBufferView* typedArrayView, JSValue accessIndexValue)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    unsigned accessIndex = 0;
+    uint64_t accessIndex = 0;
     size_t length = typedArrayView->length();
     if (accessIndexValue.isUInt32()) [[likely]]
         accessIndex = accessIndexValue.asUInt32();
@@ -187,7 +187,7 @@ EncodedJSValue atomicReadModifyWrite(JSGlobalObject* globalObject, VM& vm, const
     JSArrayBufferView* typedArrayView = validateIntegerTypedArray<TypedArrayOperationMode::ReadWrite>(globalObject, args[0]);
     RETURN_IF_EXCEPTION(scope, { });
 
-    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, args[1]);
+    uint64_t accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, args[1]);
     RETURN_IF_EXCEPTION(scope, { });
 
     scope.release();
@@ -329,7 +329,7 @@ EncodedJSValue isLockFree(JSGlobalObject* globalObject, JSValue arg)
 }
 
 template<typename Adaptor>
-EncodedJSValue atomicStoreCase(JSGlobalObject* globalObject, VM& vm, JSValue operand, JSArrayBufferView* typedArrayView, unsigned accessIndex)
+EncodedJSValue atomicStoreCase(JSGlobalObject* globalObject, VM& vm, JSValue operand, JSArrayBufferView* typedArrayView, uint64_t accessIndex)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -365,7 +365,7 @@ EncodedJSValue atomicStore(JSGlobalObject* globalObject, VM& vm, JSValue base, J
     JSArrayBufferView* typedArrayView = validateIntegerTypedArray<TypedArrayOperationMode::ReadWrite>(globalObject, base);
     RETURN_IF_EXCEPTION(scope, { });
 
-    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, index);
+    uint64_t accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, index);
     RETURN_IF_EXCEPTION(scope, { });
 
     scope.release();
@@ -441,7 +441,7 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncSub, (JSGlobalObject* globalObject, CallFram
 
 
 template<typename ValueType, typename JSArrayType>
-JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, unsigned accessIndex, ValueType expectedValue, JSValue timeoutValue, AtomicsWaitType type)
+JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, uint64_t accessIndex, ValueType expectedValue, JSValue timeoutValue, AtomicsWaitType type)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -489,7 +489,7 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncWait, (JSGlobalObject* globalObject, CallFra
     if (!typedArrayView->isShared())
         return throwVMTypeError(globalObject, scope, "Typed array for wait/waitAsync/notify must wrap a SharedArrayBuffer."_s);
 
-    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
+    uint64_t accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
     switch (typedArrayView->type()) {
@@ -521,7 +521,7 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncWaitAsync, (JSGlobalObject* globalObject, Ca
     if (!typedArrayView->isShared())
         return throwVMTypeError(globalObject, scope, "Typed array for wait/waitAsync/notify must wrap a SharedArrayBuffer."_s);
 
-    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
+    uint64_t accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
     switch (typedArrayView->type()) {
@@ -572,7 +572,7 @@ EncodedJSValue getWaiterListSize(JSGlobalObject* globalObject, CallFrame* callFr
     if (!typedArrayView->isShared())
         return throwVMTypeError(globalObject, scope, "Typed array for waiterListSize must wrap a SharedArrayBuffer."_s);
 
-    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
+    uint64_t accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
     switch (typedArrayView->type()) {
@@ -600,7 +600,7 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncNotify, (JSGlobalObject* globalObject, CallF
     auto* typedArrayView = validateIntegerTypedArray<TypedArrayOperationMode::Wait>(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
+    uint64_t accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue countValue = callFrame->argument(2);

--- a/Source/JavaScriptCore/runtime/BigIntConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/BigIntConstructor.cpp
@@ -111,7 +111,7 @@ JSC_DEFINE_HOST_FUNCTION(bigIntConstructorFuncAsUintN, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits"_s);
+    uint64_t numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue bigInt = callFrame->argument(1).toBigInt(globalObject);
@@ -131,7 +131,7 @@ JSC_DEFINE_HOST_FUNCTION(bigIntConstructorFuncAsIntN, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits"_s);
+    uint64_t numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue bigInt = callFrame->argument(1).toBigInt(globalObject);

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -321,7 +321,7 @@ public:
     double toIntegerOrInfinity(JSGlobalObject*) const;
     int32_t toInt32(JSGlobalObject*) const;
     uint32_t toUInt32(JSGlobalObject*) const;
-    uint32_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const;
+    uint64_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const;
     size_t toTypedArrayIndex(JSGlobalObject*, ASCIILiteral) const;
     uint64_t toLength(JSGlobalObject*) const;
 

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -65,27 +65,34 @@ inline uint32_t JSValue::toUInt32(JSGlobalObject* globalObject) const
     return toInt32(globalObject);
 }
 
-inline uint32_t JSValue::toIndex(JSGlobalObject* globalObject, ASCIILiteral errorName) const
+// https://tc39.es/ecma262/#sec-toindex
+inline uint64_t JSValue::toIndex(JSGlobalObject* globalObject, ASCIILiteral errorName) const
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    double d = toNumber(globalObject);
+    if (isInt32()) {
+        int32_t integer = asInt32();
+        if (integer < 0) [[unlikely]] {
+            throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " cannot be negative"_s)));
+            return 0;
+        }
+        return integer;
+    }
+
+    double d = toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, 0);
-    if (d <= -1) {
+    if (d < 0) [[unlikely]] {
         throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " cannot be negative"_s)));
         return 0;
     }
 
-    if (isInt32())
-        return asInt32();
-
-    if (d > static_cast<double>(std::numeric_limits<unsigned>::max())) {
-        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " too large"_s)));
+    if (d > maxSafeInteger()) [[unlikely]] {
+        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " larger than (2 ** 53) - 1"_s)));
         return 0;
     }
 
-    RELEASE_AND_RETURN(scope, JSC::toInt32(d));
+    RELEASE_AND_RETURN(scope, d);
 }
 
 inline size_t JSValue::toTypedArrayIndex(JSGlobalObject* globalObject, ASCIILiteral errorName) const

--- a/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
@@ -143,7 +143,7 @@ EncodedJSValue getData(JSGlobalObject* globalObject, CallFrame* callFrame)
     if (!dataView)
         return throwVMTypeError(globalObject, scope, "Receiver of DataView method must be a DataView"_s);
     
-    size_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset"_s);
+    uint64_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset"_s);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     
     bool littleEndian = false;
@@ -187,7 +187,7 @@ EncodedJSValue setData(JSGlobalObject* globalObject, CallFrame* callFrame)
     if (!dataView)
         return throwVMTypeError(globalObject, scope, "Receiver of DataView method must be a DataView"_s);
     
-    size_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset"_s);
+    uint64_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset"_s);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     constexpr unsigned dataSize = sizeof(typename Adaptor::Type);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -109,7 +109,7 @@ public:
     std::span<const typename Adaptor::Type> typedSpan() const { return unsafeMakeSpan(typedVector(), length()); }
     std::span<typename Adaptor::Type> typedSpan() { return unsafeMakeSpan(typedVector(), length()); }
 
-    inline bool inBounds(size_t) const;
+    inline bool inBounds(uint64_t) const;
 
     // These methods are meant to match indexed access methods that JSObject
     // supports - hence the slight redundancy.

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -793,7 +793,7 @@ template<typename Adaptor> inline typename Adaptor::Type* JSGenericTypedArrayVie
     return std::bit_cast<typename Adaptor::Type*>(vector());
 }
 
-template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::inBounds(size_t i) const
+template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::inBounds(uint64_t i) const
 {
     if (canUseRawFieldsDirectly()) [[likely]]
         return i < lengthRaw();


### PR DESCRIPTION
#### a0a071d660a164dc5e4e40ec7bd0219a97f6db19
<pre>
[JSC] Fix `ToIndex(value)` to Align with TC39 spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=298894">https://bugs.webkit.org/show_bug.cgi?id=298894</a>

Reviewed by Darin Adler and Yusuke Suzuki.

This patch fixes `ToIndex(value)` implementation to align with TC39 [1].
This fix indirectly corrects functions that rely on `ToIndex(value)`,
such as
- `BigInt.asUintN` [2]
- `BigInt.asIntN` [3]
- `GetViewValue` [4]
- `SetViewValue` [5]
- `ValidateAtomicAccess` [6]

[1]: <a href="https://tc39.es/ecma262/#sec-toindex">https://tc39.es/ecma262/#sec-toindex</a>
[2]: <a href="https://tc39.es/ecma262/#sec-bigint.asuintn">https://tc39.es/ecma262/#sec-bigint.asuintn</a>
[3]: <a href="https://tc39.es/ecma262/#sec-bigint.asintn">https://tc39.es/ecma262/#sec-bigint.asintn</a>
[4]: <a href="https://tc39.es/ecma262/#sec-getviewvalue">https://tc39.es/ecma262/#sec-getviewvalue</a>
[5]: <a href="https://tc39.es/ecma262/#sec-setviewvalue">https://tc39.es/ecma262/#sec-setviewvalue</a>
[6]: <a href="https://tc39.es/ecma262/#sec-validateatomicaccess">https://tc39.es/ecma262/#sec-validateatomicaccess</a>

* JSTests/stress/SharedArrayBuffer.js:
* JSTests/stress/bigint-asintn.js:
(shouldThrow):
* JSTests/stress/bigint-asuintn.js:
(shouldThrow):
* JSTests/stress/data-view-bigint.js:
(shouldBe):
(shouldThrow):
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::atomicsWaitImpl):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::getWaiterListSize):
* Source/JavaScriptCore/runtime/BigIntConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toIndex const):
* Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp:
(JSC::getData):
(JSC::setData):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::inBounds const):

Canonical link: <a href="https://commits.webkit.org/300157@main">https://commits.webkit.org/300157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a6d07b698cb9f38a7bb7af8d74504c1f739b5b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92273 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61389 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26986 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71511 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113617 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130762 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120007 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100860 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25557 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24256 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45111 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53986 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150169 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47745 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->