### PR TITLE
AX: When running tests, force default accessibility settings to avoid failures due to the machine's local settings

### DIFF
--- a/Source/WebKit/Shared/AccessibilityPreferences.h
+++ b/Source/WebKit/Shared/AccessibilityPreferences.h
@@ -76,20 +76,44 @@ inline AXValueState fromWebKitAXValueState(WebKitAXValueState value)
 }
 #endif
 
+inline constexpr bool initialImageAnimationEnabled = true;
+inline constexpr bool initialShouldEnhanceTextLegibilityOverall = false;
+inline constexpr bool initialPrefersNonBlinkingCursor = false;
+#if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
+inline constexpr WebKitAXValueState initialPerAppSettingsState = WebKitAXValueState::AXValueStateEmpty;
+#endif
+
 struct AccessibilityPreferences {
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
-    WebKitAXValueState reduceMotionEnabled { WebKitAXValueState::AXValueStateEmpty };
-    WebKitAXValueState increaseButtonLegibility { WebKitAXValueState::AXValueStateEmpty };
-    WebKitAXValueState enhanceTextLegibility { WebKitAXValueState::AXValueStateEmpty };
-    WebKitAXValueState darkenSystemColors { WebKitAXValueState::AXValueStateEmpty };
-    WebKitAXValueState invertColorsEnabled { WebKitAXValueState::AXValueStateEmpty };
+    WebKitAXValueState reduceMotionEnabled { initialPerAppSettingsState };
+    WebKitAXValueState increaseButtonLegibility { initialPerAppSettingsState };
+    WebKitAXValueState enhanceTextLegibility { initialPerAppSettingsState };
+    WebKitAXValueState darkenSystemColors { initialPerAppSettingsState };
+    WebKitAXValueState invertColorsEnabled { initialPerAppSettingsState };
 
 #endif
-    bool imageAnimationEnabled { true };
-    bool enhanceTextLegibilityOverall { false };
+    bool imageAnimationEnabled { initialImageAnimationEnabled };
+    bool enhanceTextLegibilityOverall { initialShouldEnhanceTextLegibilityOverall };
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
-    bool prefersNonBlinkingCursor { false };
+    bool prefersNonBlinkingCursor { initialPrefersNonBlinkingCursor };
 #endif
 };
 
 } // namespace WebKit
+
+namespace AXPreferenceHelpers {
+#if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
+WebKit::WebKitAXValueState reduceMotionEnabled();
+WebKit::WebKitAXValueState increaseButtonLegibility();
+WebKit::WebKitAXValueState enhanceTextLegibility();
+WebKit::WebKitAXValueState darkenSystemColors();
+WebKit::WebKitAXValueState invertColorsEnabled();
+#endif // HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
+
+bool imageAnimationEnabled();
+bool enhanceTextLegibilityOverall();
+
+#if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
+bool prefersNonBlinkingCursor();
+#endif
+} // namespace AXPreferenceHelpers

--- a/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
+++ b/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "AccessibilityPreferences.h"
+
+#import "AccessibilitySupportSPI.h"
+#import <wtf/SoftLinking.h>
+
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+SOFT_LINK_LIBRARY_OPTIONAL(libAccessibility)
+SOFT_LINK_OPTIONAL(libAccessibility, _AXSReduceMotionAutoplayAnimatedImagesEnabled, Boolean, (), ());
+#endif
+
+#import <pal/spi/cocoa/AccessibilitySupportSoftLink.h>
+
+namespace AXPreferenceHelpers {
+
+static bool shouldUseDefault()
+{
+    RetainPtr forceDefault = [[NSUserDefaults standardUserDefaults] objectForKey:@"ForceDefaultAccessibilitySettings"];
+    return forceDefault ? [forceDefault boolValue] : false;
+}
+
+#if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
+WebKit::WebKitAXValueState reduceMotionEnabled()
+{
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialPerAppSettingsState;
+    RetainPtr appId = applicationBundleIdentifier().createCFString();
+    return WebKit::toWebKitAXValueState(_AXSReduceMotionEnabledApp(appId.get()));
+}
+
+WebKit::WebKitAXValueState increaseButtonLegibility()
+{
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialPerAppSettingsState;
+    RetainPtr appId = applicationBundleIdentifier().createCFString();
+    return WebKit::toWebKitAXValueState(_AXSIncreaseButtonLegibilityApp(appId.get()));
+}
+
+WebKit::WebKitAXValueState enhanceTextLegibility()
+{
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialPerAppSettingsState;
+    RetainPtr appId = applicationBundleIdentifier().createCFString();
+    return WebKit::toWebKitAXValueState(_AXSEnhanceTextLegibilityEnabledApp(appId.get()));
+}
+
+WebKit::WebKitAXValueState darkenSystemColors()
+{
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialPerAppSettingsState;
+    RetainPtr appId = applicationBundleIdentifier().createCFString();
+    return WebKit::toWebKitAXValueState(_AXDarkenSystemColorsApp(appId.get()));
+}
+
+WebKit::WebKitAXValueState invertColorsEnabled()
+{
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialPerAppSettingsState;
+    RetainPtr appId = applicationBundleIdentifier().createCFString();
+    return WebKit::toWebKitAXValueState(_AXSInvertColorsEnabledApp(appId.get()));
+}
+#endif // HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
+
+bool imageAnimationEnabled()
+{
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialImageAnimationEnabled;
+    if (auto* functionPointer = _AXSReduceMotionAutoplayAnimatedImagesEnabledPtr())
+        return functionPointer();
+#endif
+    return true;
+}
+
+bool enhanceTextLegibilityOverall()
+{
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialShouldEnhanceTextLegibilityOverall;
+    return _AXSEnhanceTextLegibilityEnabled();
+}
+
+#if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
+bool prefersNonBlinkingCursor()
+{
+    if (shouldUseDefault()) [[unlikely]]
+        return WebKit::initialPrefersNonBlinkingCursor;
+    return _AXSPrefersNonBlinkingCursorIndicator();
+}
+#endif
+
+} // namespace Accessibility

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -69,7 +69,6 @@
 #import <pal/cf/AudioToolboxSoftLink.h>
 
 #if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE)
-SOFT_LINK_LIBRARY_OPTIONAL(libAccessibility)
 SOFT_LINK_OPTIONAL(libAccessibility, _AXSUpdateWebAccessibilitySettings, void, (), ());
 #endif
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -169,6 +169,7 @@ Shared/Extensions/Cocoa/WebExtensionFrameIdentifierCocoa.mm
 Shared/Cocoa/APIDataCocoa.mm
 Shared/Cocoa/APIObject.mm
 Shared/Cocoa/ARKitSoftLink.mm
+Shared/Cocoa/AccessibilityPreferences.mm
 Shared/Cocoa/AuxiliaryProcessCocoa.mm
 Shared/Cocoa/CodeSigning.mm
 Shared/Cocoa/CompletionHandlerCallChecker.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -32,6 +32,7 @@
 #import "APIPageConfiguration.h"
 #import "APISecurityOrigin.h"
 #import "AboutSchemeHandler.h"
+#import "AccessibilityPreferences.h"
 #import "BrowsingWarning.h"
 #import "CocoaImage.h"
 #import "CompletionHandlerCallChecker.h"
@@ -273,12 +274,6 @@ static const BOOL defaultFastClickingEnabled = NO;
 
 #if ENABLE(SCREEN_TIME)
 static void *screenTimeWebpageControllerBlockedKVOContext = &screenTimeWebpageControllerBlockedKVOContext;
-#endif
-
-#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-#import <wtf/SoftLinking.h>
-SOFT_LINK_LIBRARY_OPTIONAL(libAccessibility)
-SOFT_LINK_OPTIONAL(libAccessibility, _AXSReduceMotionAutoplayAnimatedImagesEnabled, Boolean, (), ());
 #endif
 
 #if ENABLE(GAMEPAD) && PLATFORM(VISION) && __has_include(<GameController/GCEventInteraction.h>)
@@ -4398,8 +4393,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
     THROW_IF_SUSPENDED;
 
     // Only show animation controls if autoplay of animated images has been disabled.
-    auto* autoplayAnimatedImagesFunction = _AXSReduceMotionAutoplayAnimatedImagesEnabledPtr();
-    return autoplayAnimatedImagesFunction && !autoplayAnimatedImagesFunction();
+    return !AXPreferenceHelpers::imageAnimationEnabled();
 }
 #else // !ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 - (void)_pauseAllAnimationsWithCompletionHandler:(void(^)(void))completionHandler

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -189,7 +189,6 @@ SOFT_LINK(BackBoardServices, BKSDisplayBrightnessGetCurrent, float, (), ());
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 SOFT_LINK_LIBRARY_OPTIONAL(libAccessibility)
-SOFT_LINK_OPTIONAL(libAccessibility, _AXSReduceMotionAutoplayAnimatedImagesEnabled, Boolean, (), ());
 SOFT_LINK_CONSTANT_MAY_FAIL(libAccessibility, kAXSReduceMotionAutoplayAnimatedImagesChangedNotification, CFStringRef)
 #endif
 
@@ -272,22 +271,20 @@ NSMutableDictionary *WebProcessPool::ensureBundleParameters()
 static AccessibilityPreferences accessibilityPreferences()
 {
     AccessibilityPreferences preferences;
-#if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
-    auto appId = applicationBundleIdentifier().createCFString();
 
-    preferences.reduceMotionEnabled = toWebKitAXValueState(_AXSReduceMotionEnabledApp(appId.get()));
-    preferences.increaseButtonLegibility = toWebKitAXValueState(_AXSIncreaseButtonLegibilityApp(appId.get()));
-    preferences.enhanceTextLegibility = toWebKitAXValueState(_AXSEnhanceTextLegibilityEnabledApp(appId.get()));
-    preferences.darkenSystemColors = toWebKitAXValueState(_AXDarkenSystemColorsApp(appId.get()));
-    preferences.invertColorsEnabled = toWebKitAXValueState(_AXSInvertColorsEnabledApp(appId.get()));
+#if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
+    preferences.reduceMotionEnabled = AXPreferenceHelpers::reduceMotionEnabled();
+    preferences.increaseButtonLegibility = AXPreferenceHelpers::increaseButtonLegibility();
+    preferences.enhanceTextLegibility = AXPreferenceHelpers::enhanceTextLegibility();
+    preferences.darkenSystemColors = AXPreferenceHelpers::darkenSystemColors();
+    preferences.invertColorsEnabled = AXPreferenceHelpers::invertColorsEnabled();
 #endif
-    preferences.enhanceTextLegibilityOverall = _AXSEnhanceTextLegibilityEnabled();
+    preferences.enhanceTextLegibilityOverall = AXPreferenceHelpers::enhanceTextLegibilityOverall();
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-    if (auto* functionPointer = _AXSReduceMotionAutoplayAnimatedImagesEnabledPtr())
-        preferences.imageAnimationEnabled = functionPointer();
+    preferences.imageAnimationEnabled = AXPreferenceHelpers::imageAnimationEnabled();
 #endif
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
-    preferences.prefersNonBlinkingCursor = _AXSPrefersNonBlinkingCursorIndicator();
+    preferences.prefersNonBlinkingCursor = AXPreferenceHelpers::prefersNonBlinkingCursor();
 #endif
     return preferences;
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5683,6 +5683,7 @@
 		46F96C662B02A58100253A2B /* WebContextMenuItemData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebContextMenuItemData.serialization.in; sourceTree = "<group>"; };
 		46F9B26223526ED0006FE5FA /* WebBackForwardCacheEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackForwardCacheEntry.h; sourceTree = "<group>"; };
 		46FA2E752A04240300912BFE /* RemoteWorkerType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWorkerType.serialization.in; sourceTree = "<group>"; };
+		48B188FE2E789A3B009B57A9 /* AccessibilityPreferences.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = AccessibilityPreferences.mm; sourceTree = "<group>"; };
 		493102BC2683F3A5002BB885 /* AppPrivacyReport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppPrivacyReport.h; sourceTree = "<group>"; };
 		4955A6E528076D4C00BB91C4 /* ArrayReferenceTuple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayReferenceTuple.h; sourceTree = "<group>"; };
 		4973DF472422941F00E4C26A /* NavigatingToAppBoundDomain.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigatingToAppBoundDomain.h; sourceTree = "<group>"; };
@@ -12589,6 +12590,7 @@
 		37C4C0901814B37B003688B9 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				48B188FE2E789A3B009B57A9 /* AccessibilityPreferences.mm */,
 				E3C3D1AE2E007922004B306A /* AnnotatedMachSendRight.mm */,
 				1A1EF1971A1D5B420023200A /* APIDataCocoa.mm */,
 				378E1A3B181ED6FF0031007A /* APIObject.mm */,

--- a/Tools/WebKitTestRunner/mac/main.mm
+++ b/Tools/WebKitTestRunner/mac/main.mm
@@ -50,6 +50,7 @@ static void setDefaultsToConsistentValuesForTesting()
 #else
         @"WebKit2UseRemoteLayerTreeDrawingArea": @NO,
 #endif
+        @"ForceDefaultAccessibilitySettings": @YES,
     };
 
     [[NSUserDefaults standardUserDefaults] setValuesForKeysWithDictionary:dict];


### PR DESCRIPTION
#### 71884ba628172c0ad09a16ee45cd22865a749a90
<pre>
AX: When running tests, force default accessibility settings to avoid failures due to the machine&apos;s local settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=298897">https://bugs.webkit.org/show_bug.cgi?id=298897</a>
<a href="https://rdar.apple.com/148661873">rdar://148661873</a>

Reviewed by Joshua Hoffman.

Add a new ForceDefaultAccessibilitySettings defaults value and read it in new AXPreferenceHelpers methods to avoid
calling into accessibility frameworks for the system-local setting value.

* Source/WebKit/Shared/AccessibilityPreferences.h:
* Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm: Added.
(AXPreferenceHelpers::shouldUseDefault):
(AXPreferenceHelpers::reduceMotionEnabled):
(AXPreferenceHelpers::increaseButtonLegibility):
(AXPreferenceHelpers::enhanceTextLegibility):
(AXPreferenceHelpers::darkenSystemColors):
(AXPreferenceHelpers::invertColorsEnabled):
(AXPreferenceHelpers::imageAnimationEnabled):
(AXPreferenceHelpers::enhanceTextLegibilityOverall):
(AXPreferenceHelpers::prefersNonBlinkingCursor):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _allowAnimationControls]):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::accessibilityPreferences):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/mac/main.mm:
(setDefaultsToConsistentValuesForTesting):

Canonical link: <a href="https://commits.webkit.org/300007@main">https://commits.webkit.org/300007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/560457fa62811cd92c1c19793ba4b561d3528915

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73121 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5bd3177-abff-4aa7-9430-f4d5f6402f79) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91932 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aefe42e9-0ec4-4215-a975-27f3ffc7fb82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72620 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7ee1a04-1a4a-443f-ab79-874b26445e6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71049 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130313 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100541 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100443 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44656 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53539 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47297 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50644 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48981 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->