### PR TITLE
[JSC] Fix stale ASSERT by inserting exception check for termination exception

### DIFF
--- a/JSTests/stress/termination-error-in-array-index-of.js
+++ b/JSTests/stress/termination-error-in-array-index-of.js
@@ -1,0 +1,13 @@
+//@ runDefault("--jitPolicyScale=0.1", "--watchdog-exception-ok", "--watchdog=500")
+try {
+  String.prototype.replace(''.repeat(2 ** 20) + '' + `
+class cl_1_ {
+` + '0o1' + (() => '65432' + 'n')() + '');
+} catch {}
+var var_4_ = '..';
+for (let var_1_ = 0; (() => var_1_)() < 1000000; var_1_++) {
+  this.g ??= createGlobalObject();
+  var var_5_ = new this.g.Set(['', ...[Math.atan2(-0, 1), , false ? 1 : -Math.LN10 / 0]]);
+  var var_6_ = Set.prototype.clear.call(var_5_, var_4_, this, '', new ArrayBuffer());
+  var var_2_ = ['xy']?.indexOf('\uFDFD\u200B1జ్ఞా\u2593\u2004ΐㅤ\uFF0F\t?\u2032ᴮ\u2032ᴮσ\u202E\uFFFC\uFF06ㅤaᅟ\uFFFD.\uFF1F\uD809\uDC2B\uFFFDa\uFFFC\uD809\uDC2B\u200B\u202EﷺᴮAᴮΐKజ్ఞా\uFF06జ్ఞాᅟſ\t\u202Eﬃㅤ\u2593 \u180Eσ.K?ΐaſΐΐﾉİﾉ\uFDFDσ\uFE64\uFE64ᴮ\u2032Aᅟﬆᅟ\uFDFD\u3000ᅟ\uFE64#ΐ\u3000\u3000N̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕\u180E\u3000\uFFFC\u2004\uFFFC\u3000aAı\u202E\uFFFCA\tᴮᴮﬆ \u202E 1\u2004\uFF0F\uFE64జ్ఞాﬆㅤ\uFF0Fİ\u2032\u202EA#aA\uFFFCﷺı\u180EİA\u180E.N̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕\u2004ﬃ\u202E\uFFFCſ\uFE64\u180Ea\uFFFD#ı\uFFFCᴮ\uFDFD\u2004\uFFFCσ\uFE64జ్ఞాﬆㅤ\u2593\uFF06\u3000\uFDFD\u2004ﬆ?\u200BΐK\uFF0Fㅤ\uFFFD#\u2593జ్ఞాİ\uFF06\u3000N̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕\uFFFCN̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕\uFF06ſ\uFFFD\uD809\uDC2B\uD809\uDC2Bﾉﬆﬆ\uFDFD\u180Eﷺ?\u2004\u3000ᅟ.ﾉAᅟ\uFFFC\uFF1F\u200Bßß#\u2593 ﬃ\u2593σ\u2593σ\uFDFD\u2032\u180EN̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕ﬆᴮㅤN̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕\u180Eﬃı ?1N̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕\uFF06ﬆﬃ\uFDFD#aᅟﬃ\uFE64\uFDFD\uFDFDİ\uFFFCſ\u2593ㅤ\uFF0FAİ\u202E\u2032ﬃ\u2032ΐ\uFFFC\uFF0F?Ka?\u180E\uFFFD\u2004ﬃజ్ఞా\u200B?\u180E\u2032\u202EKa?A\uFF0Fß\uFE64İ\uFE64\uFF1F\u180Eﷺ#\uFF0F\uFE64ᅟſ\u180E\u2004\uFFFCKıK\uFF1Fﬃ\uD809\uDC2B\u3000 ㅤ\tᴮᅟ#?\uFE64\uFF06\t1ᅟﾉ\u3000ﾉK \uFDFDﬃ ﷺσజ్ఞా\u2032İ\uFFFC\uFE64\u2032a\uFFFCſﬃ\u2593\uFFFCİ\uFFFDA\t1.జ్ఞా?\uFF06 ᴮᅟıﬃﷺ1a\uFDFD\uD809\uDC2Bᴮ\uFDFD1\uFE64N̯̱̣͇̖̦̦̣ͥͮͩͪ̐͑͂̈̅ͦ͋̆̔͆̀̆̀̚̚̕ᅟA\uFF0Fﬆİ1ı\u180Eﬆ\uFF1F\u2004#a\uFFFC\uD809\uDC2Bᴮ\uFDFDﾉﬆİ\uFE64\uD809\uDC2Bﬆ\u2004\uFFFC\uFF0Fﬆ\uFFFD?ㅤ\u2032Kİ\uFDFD\u3000ıA\uFF06ı\uFFFD\u2004ı\uFDFD'.substring({var_3_: 0}.var_3_, 2));
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4185,6 +4185,7 @@ JSC_DEFINE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32
         }
 #if ASSERT_ENABLED
         UCPUStrictInt32 expected = arrayIndexOfString(globalObject, butterfly, searchElement, index);
+        OPERATION_RETURN_IF_EXCEPTION(scope, 0);
         ASSERT(expected == result);
 #endif
         OPERATION_RETURN(scope, result);


### PR DESCRIPTION
#### b6b685363099a0ad69b96172e53733312916787c
<pre>
[JSC] Fix stale ASSERT by inserting exception check for termination exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=298898">https://bugs.webkit.org/show_bug.cgi?id=298898</a>
<a href="https://rdar.apple.com/160097564">rdar://160097564</a>

Reviewed by Yijia Huang.

When termination exception happens inside this ASSERT_ENABLED&apos;s
arrayIndexOfString, we need to return since the returned value is
not the right value. This is just a stale ASSERT issue.

Test: JSTests/stress/termination-error-in-array-index-of.js
* JSTests/stress/termination-error-in-array-index-of.js: Added.
(try.String.prototype.replace.string_appeared_here.repeat.2.20.string_appeared_here.cl_1_):
(try.var_1_):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/299998@main">https://commits.webkit.org/299998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/354250308056a3e6fb12527fa9a7c06f9098f019

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73074 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54b4709b-eee5-4ef2-a240-fb1e5ed8b6d8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cf200fa-560c-4110-bc3d-c65c3d01ee89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72589 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a84539d-c2a1-4216-8076-2487b8121bb7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71000 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113124 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130266 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119514 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100511 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100413 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45817 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44609 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19199 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53492 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149673 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47250 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37971 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50597 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->