### PR TITLE
[view-transitions] Use `position: absolute` on `::view-transition`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup.html
@@ -37,7 +37,7 @@ promise_test(async t => {
       requestAnimationFrame(() => {
         t.step_timeout(() => {
           assert_equals(getComputedStyle(document.documentElement, "::view-transition").display, "block");
-          assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed");
+          assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "absolute");
           resolve();
         }, 0);
       });

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-clean-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-clean-style-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL properties of pseudo elements in update callback assert_equals: ::view-transition expected "absolute" but got "fixed"
+PASS properties of pseudo elements in update callback
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL properties of pseudo elements in update callback assert_equals: ::view-transition expected "absolute" but got "fixed"
-FAIL properties of pseudo elements outside of transition assert_equals: expected "absolute" but got "fixed"
+PASS properties of pseudo elements in update callback
+PASS properties of pseudo elements outside of transition
 

--- a/Source/WebCore/css/viewTransitions.css
+++ b/Source/WebCore/css/viewTransitions.css
@@ -29,7 +29,7 @@
 }
 
 :root::view-transition {
-    position: fixed;
+    position: absolute;
     inset: 0;
 }
 


### PR DESCRIPTION
#### 7cc0564033d816cf35e25151006576449a5a312d
<pre>
[view-transitions] Use `position: absolute` on `::view-transition`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298878">https://bugs.webkit.org/show_bug.cgi?id=298878</a>
<a href="https://rdar.apple.com/160622000">rdar://160622000</a>

Reviewed by Matt Woodrow.

Spec change: <a href="https://github.com/w3c/csswg-drafts/commit/65c2d5f9c3e43d656347c392b18cc6e7659e6345">https://github.com/w3c/csswg-drafts/commit/65c2d5f9c3e43d656347c392b18cc6e7659e6345</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-clean-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt:
* Source/WebCore/css/viewTransitions.css:
(:root::view-transition):

Canonical link: <a href="https://commits.webkit.org/300008@main">https://commits.webkit.org/300008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02ce911ff13b9c6b8a49bdf6760231d0e49fb85f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73122 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7926ace-e950-4284-9259-6c20fc64ec9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f216a950-22c8-452d-a7d6-d53ec74d1c9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72621 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/104bd23e-94a0-4bd3-bcf5-5a918afa09c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71050 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130314 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100542 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45849 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44657 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53540 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->