### PR TITLE
Fix absolutely positioned SVGs when ancestor has padding

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://www.w3.org/TR/SVG2/coords.html">
+<style>
+    section { margin-bottom: 10px; }
+    div { background: rgba(255, 0, 0, 0.15) }
+    svg { background: rgba(0, 0, 255, 0.15) }
+</style>
+<body>
+    <section>
+        <div style="position: relative; width: 240px; height: 340px;">
+            <svg style="position: absolute;" width="240" height="240"
+                xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
+    </section>
+    <section>
+        <div style="position: relative; width: 300px; height: 200px">
+            <div style="position: absolute; width: 300px; height: 200px;">
+                <svg style="position: absolute;" width="200" height="200"
+                    xmlns="http://www.w3.org/2000/svg"></svg>
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://www.w3.org/TR/SVG2/coords.html">
+<style>
+    section { margin-bottom: 10px; }
+    div { background: rgba(255, 0, 0, 0.15) }
+    svg { background: rgba(0, 0, 255, 0.15) }
+</style>
+<body>
+    <section>
+        <div style="position: relative; width: 240px; height: 340px;">
+            <svg style="position: absolute;" width="240" height="240"
+                xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
+    </section>
+    <section>
+        <div style="position: relative; width: 300px; height: 200px">
+            <div style="position: absolute; width: 300px; height: 200px;">
+                <svg style="position: absolute;" width="200" height="200"
+                    xmlns="http://www.w3.org/2000/svg"></svg>
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://www.w3.org/TR/SVG2/coords.html">
+<link rel="match"  href="out-of-flow-svg-root-ref.html">
+<style>
+    section { margin-bottom: 10px; }
+    div { background: rgba(255, 0, 0, 0.15) }
+    svg { background: rgba(0, 0, 255, 0.15) }
+</style>
+<body>
+    <section>
+        <div style="position: relative; width: 200px; height: 300px; padding: 20px">
+            <svg style="position: absolute; top: 0; left: 0; right: 0" viewBox="0 0 1 1"
+                xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
+    </section>
+    <section>
+        <div style="position: relative; width: 300px; height: 200px">
+            <div style="position: absolute; top: 0; left: 0; bottom: 0; right: 0; padding: 20px;">
+                <svg style="position: absolute; top: 0; left: 0; height: 100%" viewBox="0 0 1 1"
+                    xmlns="http://www.w3.org/2000/svg"></svg>
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4083,7 +4083,8 @@ template<typename SizeType> LayoutUnit RenderBox::computeReplacedLogicalHeightUs
             && !(container->style().top().isAuto() || container->style().bottom().isAuto())) {
             auto& block = downcast<RenderBlock>(*container);
             auto computedValues = block.computeLogicalHeight(block.logicalHeight(), 0);
-            LayoutUnit newContentHeight = computedValues.m_extent - block.borderAndPaddingLogicalHeight() - block.scrollbarLogicalHeight();
+            LayoutUnit borderPaddingAdjustment = isOutOfFlowPositioned() ? block.borderLogicalHeight() : block.borderAndPaddingLogicalHeight();
+            LayoutUnit newContentHeight = computedValues.m_extent - block.scrollbarLogicalHeight() - borderPaddingAdjustment;
             return adjustContentBoxLogicalHeightForBoxSizing(Style::evaluate(logicalHeight, newContentHeight));
         }
         

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -606,8 +606,8 @@ LayoutUnit RenderReplaced::computeConstrainedLogicalWidth() const
     // 'padding-right' + 'border-right-width' + 'margin-right' = width of
     // containing block
     // see https://www.w3.org/TR/CSS22/visudet.html#blockwidth
-    LayoutUnit logicalWidth = containingBlock()->contentBoxLogicalWidth();
-    
+    LayoutUnit logicalWidth = isOutOfFlowPositioned() ? containingBlock()->clientLogicalWidth() : containingBlock()->contentBoxLogicalWidth();
+
     // This solves above equation for 'width' (== logicalWidth).
     LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), logicalWidth);
     LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), logicalWidth);


### PR DESCRIPTION
#### f8ed5934eb9ee144af6da58a2e049079c273f46c
<pre>
Fix absolutely positioned SVGs when ancestor has padding
<a href="https://bugs.webkit.org/show_bug.cgi?id=273759">https://bugs.webkit.org/show_bug.cgi?id=273759</a>
<a href="https://rdar.apple.com/127608838">rdar://127608838</a>

Reviewed by Simon Fraser.

When the SVG root is positioned as an out-of-flow element, its size was
previously resolved without considering the padding of the
containing block.

To fix this, we now use the containing block&apos;s padding box.

* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/out-of-flow-svg-root.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeReplacedLogicalHeightUsingGeneric const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):

Canonical link: <a href="https://commits.webkit.org/300054@main">https://commits.webkit.org/300054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bf61d5271f64883b3eee1c1b39ec0c4d5b8181d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73236 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30eab643-212b-471f-9fe9-8f01a648fd73) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6211a971-9e44-496d-90e5-f9f7bc3a6eb5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72714 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57f573e7-aa59-4396-abf5-bfdbecdf6379) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71167 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130427 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100637 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100541 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25485 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24004 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44776 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53653 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47411 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->